### PR TITLE
chore(image): pull the fix for image import as a cinder volume

### DIFF
--- a/core/modules/cli_image.cpp
+++ b/core/modules/cli_image.cpp
@@ -114,14 +114,17 @@ ImageImportMain(int argc, const char** argv)
             return CLI_INVALID_ARGS;
         }
 
-        if (CliMatchCmdHelper(argc, argv, 6, "echo 'public\nprivate'", &index, &visibility, "Visibility: ") != CLI_SUCCESS) {
-            CliPrintf("Unknown visibility");
+        if (CliMatchCmdHelper(argc, argv, 6, "echo 'glance-images\ncinder-volumes'", &index, &pool, "Bootable image or volume: ") != CLI_SUCCESS) {
+            CliPrintf("Invalid option");
             return CLI_INVALID_ARGS;
         }
 
-        if (CliMatchCmdHelper(argc, argv, 7, "echo 'glance-images\ncinder-volumes'", &index, &pool, "Bootable image or volume: ") != CLI_SUCCESS) {
-            CliPrintf("Unknown visibility");
-            return CLI_INVALID_ARGS;
+        if (strcmp(pool.c_str(), "glance-images") == 0) {
+            // Only glance-images has the public/private visibility setting.
+            if (CliMatchCmdHelper(argc, argv, 7, "echo 'public\nprivate'", &index, &visibility, "Visibility: ") != CLI_SUCCESS) {
+                CliPrintf("Unknown visibility");
+                return CLI_INVALID_ARGS;
+            }
         }
     }
 
@@ -147,7 +150,7 @@ ImageImportMain(int argc, const char** argv)
         ret = HexSpawnNoSig(UnInterruptibleHdr, (int)true, 0,
                             HEX_SDK, "os_image_import_with_attrs",
                             attrsType.c_str(), dir.c_str(), file.c_str(), name.c_str(),
-                            domain.c_str(), tenant.c_str(), visibility.c_str(), pool.c_str(), NULL);
+                            domain.c_str(), tenant.c_str(), pool.c_str(), visibility.c_str(), NULL);
 
 
     if (type == 0 /* usb */) {

--- a/core/webapp/lmi/api/controllers/manage.control.js
+++ b/core/webapp/lmi/api/controllers/manage.control.js
@@ -66,7 +66,7 @@ exports.imageAdd = async (req, res, next) => {
         // On finish of the upload
         fstream.on('close', () => {
             logger.info(`Upload of '${filename}' finished and starts importing to ${req.query.project} as ${req.query.name} in the background`);
-            spawn('/usr/sbin/hex_sdk', ['os_image_import_with_attrs', 'scsi', uploadPath, filename, req.query.name, 'default', req.query.project, 'private' ], {
+            spawn('/usr/sbin/hex_sdk', ['os_image_import_with_attrs', 'scsi', uploadPath, filename, req.query.name, 'default', req.query.project, 'glance-images', 'private' ], {
                 detached: true
             });
             res.redirect('back');


### PR DESCRIPTION
#### What type of PR is this?

chore

#### What this PR does / why we need it

- Pull the fix for image import as a cinder volume.

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

> Note
>
> Before this PR going through the merge, we would need `tests/e2e/template/image-import.xp` in repo triangle to change the script,

```diff
-     hex_cli -c image import local ubuntu2204.qcow2 $IMG_NAME default admin public
+     hex_cli -c image import local ubuntu2204.qcow2 $IMG_NAME default admin glance-images public
```

Should we send the PR there also to reflect the change?

#### Additional documentation
