### PR TITLE
fix(skyline): unable to open unix socket on ext4 with kernel > 6.1.123

### DIFF
--- a/core/nginx/nginx.conf.in
+++ b/core/nginx/nginx.conf.in
@@ -61,7 +61,7 @@ http {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
     upstream skyline {
-        server unix:/var/lib/skyline/skyline.sock fail_timeout=0;
+        server 127.0.0.1:9998 fail_timeout=0;
     }
 
     ##

--- a/core/skyline/skyline.mk
+++ b/core/skyline/skyline.mk
@@ -3,7 +3,6 @@
 
 SKYLINE_CONF_DIR := /etc/skyline
 SKYLINE_POLICY_DIR := $(SKYLINE_CONF_DIR)/policy
-SKYLINE_APP_DIR := /var/lib/skyline
 SKYLINE_LOG_DIR := /var/log/skyline
 
 # refer to skyline-apiserver/requirements.txt, need to be installed before openstack deps
@@ -11,7 +10,7 @@ ROOTFS_PIP_NC += gunicorn
 
 # skyline user/group/directory
 rootfs_install::
-	$(Q)chroot $(ROOTDIR) mkdir -p $(SKYLINE_CONF_DIR) $(SKYLINE_POLICY_DIR) $(SKYLINE_APP_DIR) $(SKYLINE_LOG_DIR)
+	$(Q)chroot $(ROOTDIR) mkdir -p $(SKYLINE_CONF_DIR) $(SKYLINE_POLICY_DIR) $(SKYLINE_LOG_DIR)
 
 # note: ROOTFS_PIP_DL_FROM is not used since we clone source from master branch instead of targeted openstack branch (stable/yoga)
 # skyline-apiserver installation


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Change the binding from an Unix socket to a TCP port

#### Which issue(s) this PR fixes

- With kernel version > 6.1.123, Gunicorn of skyline-apiserver failed to open the unix socket on the file system ext4.

#### Special notes for your reviewer

- This PR needs https://github.com/bigstack-oss/skyline-apiserver/pull/2

#### Additional documentation
