### PR TITLE
fix(nginx): include the full path for path rewrite in skyline-console nginx proxy to cube-cos-api

### DIFF
--- a/core/nginx/nginx.conf.in
+++ b/core/nginx/nginx.conf.in
@@ -92,7 +92,7 @@ http {
         }
 
         location /cos-api/ {
-            rewrite /cos-api/([^/]+) /api/$1 break;
+            rewrite /cos-api/(.*) /api/$1 break;
             proxy_pass http://cube-cos-api/;
             proxy_redirect off;
             proxy_buffering off;


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Include the full path after `/cos-api/` for the path rewrite in `skyline-console` Nginx proxy for `cube-cos-api`

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/skyline-console/issues/51
- Path after `/cos-api/v1` would be trimmed and caused `/cos-api/v1/datacenters` not auth free.

#### Special notes for your reviewer

#### Additional documentation
