### PR TITLE
fix(hex_sdk): open output from hex_sdk os_nova_instance_ping to telegraf for grafana vm instance ping graph

### DIFF
--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2491,7 +2491,7 @@ os_nova_instance_ping()
             if [ -z "$resp_time" ] ; then
                 resp_time=-1
             fi
-            if [ "$format" == "line" ] ; then
+            if [ "$FORMAT" == "line" ] ; then
                 echo "vm.health,host=$HOSTNAME,proto=arping,id=$dev_id,ip=$ip resp=$resp_time"
             fi
         done


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Open the output from `hex_sdk os_nova_instance_ping` to Telegraf for the missing VM instance ping graph on Grafana

#### Which issue(s) this PR fixes

- Fix #91 

#### Special notes for your reviewer

#### Additional documentation
