### PR TITLE
fix(appfw): revert changes regarding the node driver name

### DIFF
--- a/core/appfw/bin/rancher_client.py
+++ b/core/appfw/bin/rancher_client.py
@@ -88,7 +88,7 @@ def create_nodeTemplate(name, flavor):
     template = client.create_nodeTemplate(
         name=name,
         description=project_name,
-        driver='CubeCOS',
+        driver='cube',
         cubeConfig={
             "00_username": project_name,
             "01_password": project_password,
@@ -112,7 +112,7 @@ def create_nodeTemplate(name, flavor):
     return template
 
 def delete_templates():
-    for n in [*(client.list_nodeTemplate(driver='cube').data), *(client.list_nodeTemplate(driver='CubeCOS').data)]:
+    for n in client.list_nodeTemplate(driver='cube').data:
         # Wait node pool to be deleted before deleting node template
         if re.match(project_name + ":.*", n.name):
             print("Deleting nodeTemplate: %s" % n.name )

--- a/core/cubectl/app/config/config_rancher.go
+++ b/core/cubectl/app/config/config_rancher.go
@@ -215,10 +215,6 @@ func rancherConfigClusterNodeDrivers() error {
 			if key == "nodeDrivers" {
 				name := data.(map[string]interface{})["name"].(string)
 				if name == "cube" {
-					// Do not take action for default node driver
-					continue
-				}
-				if name == "CubeCOS" {
 					nodeDrvFound = true
 					// Do not take action for default node driver
 					continue
@@ -249,7 +245,7 @@ func rancherConfigClusterNodeDrivers() error {
 {
 	"active": true,
 	"builtin": false,
-	"name": "CubeCOS",
+	"name": "cube",
 	"url": "http://%s:8080/static/nodedrivers/docker-machine-driver-cube"
 }
 `
@@ -474,7 +470,7 @@ func rancherDeleteToken() error {
 		); err != nil {
 			zap.L().Warn("Failed to delete token", zap.String("id", id), zap.Error(err))
 		}
-		zap.L().Info("CubeCOS token deleted", zap.Any("id", id))
+		zap.L().Info("cube token deleted", zap.Any("id", id))
 
 		//}
 	}

--- a/core/rancher/rancher-machine-driver-cube/cube/cube.go
+++ b/core/rancher/rancher-machine-driver-cube/cube/cube.go
@@ -375,7 +375,7 @@ func (d *Driver) SetClient(client Client) {
 
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
-	return "CubeCOS"
+	return "cube"
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -432,7 +432,7 @@ migrate_rancher_node_driver()
     local migrated_node_driver_setting=$(cat <<<"{
 \"active\": true,
 \"builtin\": false,
-\"name\": \"CubeCOS\",
+\"name\": \"cube\",
 \"url\": \"http://$(shared_ip):8080/static/nodedrivers/docker-machine-driver-cube\"
 }")
     $CURL -s -k \


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Revert the changes regarding renaming the node driver in Rancher from "cube" to "CubeCOS" to make App Framework installation work.

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

- Related to #88

#### Additional documentation

As shown in the source code of Rancher UI,

https://github.com/rancher/ui/blob/1da749705f93226a005aba2c30af84d1c2dc72b0/app/models/nodepool.js#L7-L23

```js
const NodePool = Resource.extend({
  type:          'nodePool',
  quantityTimer: null,

  nodeTemplate: reference('nodeTemplateId'),

  displayProvider: computed('driver', 'nodeTemplate.driver', 'intl.locale', function() {
    const intl = this.intl;
    const driver = this.driver;
    const key = `nodeDriver.displayName.${ driver }`;

    if ( intl.exists(key) ) {
      return intl.t(key);
    } else {
      return ucFirst(driver);
    }
  }),
```

https://github.com/rancher/ui/blob/1da749705f93226a005aba2c30af84d1c2dc72b0/lib/shared/addon/utils/util.js#L192-L196

```js
export function ucFirst(str) {
  str = str || '';

  return str.substr(0, 1).toUpperCase() + str.substr(1);
}
```

https://github.com/rancher/ui/blob/1da749705f93226a005aba2c30af84d1c2dc72b0/translations/ru-ru.yaml#L2862-L2866

```yaml
nodeDriver:
  displayName:
    aliyunecs: Alicloud ECS
    amazonec2: Amazon EC2
    azure: Azure
```

The display name is only capitalizing the first letter of the registered driver name, e.g., "cube" -> "Cube". If we want to set the name to "CubeCOS", we would need to edit the translation yaml configurations and rebuild Rancher UI, which is not really feasible under the current stage. So, I would like to revert the changes back to "cube" to make App Framework installation work.
