### PR TITLE
fix: rolling upgrade VMs in error status during live-migration #71

### DIFF
--- a/core/cubectl/app/util/ceph/csi-chart.go
+++ b/core/cubectl/app/util/ceph/csi-chart.go
@@ -11,7 +11,7 @@ import (
 )
 
 func InitDefaultSubVolumeGroup() error {
-	_, outErr, err := util.ExecCmd("ceph", "fs", "subvolumegroup", "create", "cephfs", DefaultFsSubVolumeGroup)
+       _, outErr, err := util.ExecCmd("timeout", "30", "ceph", "fs", "subvolumegroup", "create", "cephfs", DefaultFsSubVolumeGroup)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to init default sub volume group(%s): %s", DefaultFsSubVolumeGroup, outErr)
 	}

--- a/core/grafana/grafana.mk
+++ b/core/grafana/grafana.mk
@@ -1,9 +1,8 @@
 # Cube SDK
 # grafana installation
 
-# Grafana 10.1.5, 10.0.9, 9.5.13, and 9.4.17. These patch releases contain a fix for CVE-2023-4822, a medium severity security vulnerability in the role-based access control (RBAC) system
 # ROOTFS_DNF += grafana
-ROOTFS_DNF_DL_FROM += https://dl.grafana.com/enterprise/release/grafana-enterprise-10.1.5-1.x86_64.rpm
+ROOTFS_DNF_DL_FROM += https://dl.grafana.com/enterprise/release/grafana-enterprise-10.1.10-1.x86_64.rpm
 
 rootfs_install::
 	$(Q)mount -t proc proc $(ROOTDIR)/proc

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -21,6 +21,7 @@ BootstrapAndClusterstart()
             echo -n "                                                            " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
             echo -n "Starting cluster" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
             bash -c "hex_sdk -v cube_cluster_start | tee -a $(hex_sdk GetKernelConsoleDevices)"
+            cubectl node exec -pn "rm -f /tmp/health_*error.count"
         fi
     fi
 }
@@ -63,24 +64,24 @@ RollingEvacuateAndReboot()
             fi
             prev_n=$N
         done
+        hex_sdk os_nova_instance_hardreboot $(hex_sdk os_nova_list ID STATUS POWERSTATE | grep -i -e error -e nostate | cut -d" " -f1)
     fi
     if [ "x$upgrading" = "xfalse" ]; then
         if hex_sdk cube_cluster_ready ; then
             echo -n "  cluster checking and repairing                                        " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
-            if hex_sdk cube_cluster_repair ; then
-                echo -n "  cluster checked and repaired                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
-                need_be_active_servers="$(cat /mnt/cephfs/nova/instances/active_running 2>/dev/null)"
-                if [ "x$need_be_active_servers" != "x" ] ; then
-                    for i in $need_be_active_servers ; do
-                        if hex_sdk os_nova_list id status powerstate |  grep -i "$i active running" ; then
-                            continue
-                        else
-                            hex_sdk os_nova_instance_reset $i
-                            hex_sdk os_nova_instance_hardreboot $i
-                            echo -n "  reset and booted non-active server: $i                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
-                        fi
-                    done
-                fi
+            hex_cli -c cluster check_repair
+            echo -n "  cluster checked and repaired                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            need_be_active_servers="$(cat /mnt/cephfs/nova/instances/active_running 2>/dev/null)"
+            if [ "x$need_be_active_servers" != "x" ] ; then
+                for i in $need_be_active_servers ; do
+                    if hex_sdk os_nova_list id status powerstate |  grep -i "$i active running" ; then
+                        continue
+                    else
+                        hex_sdk os_nova_instance_reset $i
+                        hex_sdk os_nova_instance_hardreboot $i
+                        echo -n "  reset and booted non-active server: $i                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    fi
+                done
             fi
         else
             echo -n "  cluster check and repair skipped because not all nodes are bootstrapped and synced                                           " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -184,7 +184,7 @@ cube_cluster_start()
 cube_cluster_stop()
 {
     if timeout 30 $HEX_SDK health_ceph_mds_check ; then
-        $HEX_SDK os_nova_list id status powerstate | grep -i 'active running' | cut -d' ' -f1 > $CEPHFS_NOVA_DIR/instances/active_running
+        ! $HEX_SDK os_nova_list || $HEX_SDK os_nova_list id status powerstate | grep -i 'active running' | cut -d' ' -f1 > $CEPHFS_NOVA_DIR/instances/active_running
     fi
     rm -f /var/lib/corosync/*
     rm -rf /var/lib/rabbitmq/mnesia/*
@@ -218,6 +218,9 @@ cube_cluster_power()
         remote_run ${MASTER_CONTROL:-NOMASTER} "$HEX_SDK cube_cluster_power $1"
     else
         Quiet timeout 15 cubectl node exec -p "timeout 10 umount $CEPHFS_STORE_DIR" || true
+        Quiet -n timeout 15 cubectl node exec -p -r controle "systemctl stop ceph-mds@\$HOSTNAME"
+        Quiet -n timeout 15 cubectl node exec -p -r controle "systemctl stop ceph-mgr@\$HOSTNAME"
+        Quiet -n timeout 15 cubectl node exec -p -r controle "systemctl stop ceph-mon@\$HOSTNAME"
         for N in $(cubectl node list -j | jq -r .[].hostname | tac) ; do
             timeout 3 $HEX_SDK remote_run $N "$PWRCMD" || true
         done

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2046,7 +2046,9 @@ ceph_osd_create_map()
                 datapart=$(echo $osdmap_json | jq -r ".\"$metapart_uuid\".device")
                 datapart_partuuid=$(blkid -o value -s PARTUUID $datapart)
             fi
-            echo "${metapart:-metapart} ${osd_id:-osd_id} ${metapart_uuid:-metapart_uuid} ${datapart_partuuid:-datapart_partuuid}" >> $osdmap_new
+            if [ "${datapart_partuuid:-datapart_partuuid}" != "datapart_partuuid" ] ; then
+                echo "${metapart:-metapart} ${osd_id:-osd_id} ${metapart_uuid:-metapart_uuid} ${datapart_partuuid:-datapart_partuuid}" >> $osdmap_new
+            fi
         done
         cat $osdmap_new | sort -k1 > ${osdmap_new}.sorted
         unlink $osdmap_new


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- fix: rolling upgrade VMs in error status during live-migration
- fix: ceph operation hangs at cubectl config commit k3s_last
- fix: VMs in error status after powercycle
- new: upgrade grafana to 10.1.10-1

#### Which issue(s) this PR fixes

- Fixes #71 

#### Special notes for your reviewer

#### Additional documentation
