### PR TITLE
fix(haproxy): separate cookie name token from different backends

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bigstack-oss/back-end

--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -20,11 +20,12 @@ API_SPEC_FILE := $(API_RPMBUILD_DIR)/SPECS/cube-cos-api.spec
 API_RPM_BUILD := $(API_RPMBUILD_DIR)/RPMS/x86_64/cube-cos-api-$(API_VERSION)-1.el9.$(API_BUILD_NUMBER).x86_64.rpm
 
 # prepare the api source code, being pulled from GitHub using the default branch
+# For RC: git clone -b v3.0.0-rc4
 $(API_GIT_DIR):
 	$(Q)mkdir $(API_GIT_DIR)
 	$(call RUN_CMD_TIMED, \
 		for i in {1..10} ; do \
-		timeout 30 git clone -b v3.0.0-rc4 --depth 1 https://github.com/bigstack-oss/cube-cos-api.git $(API_GIT_DIR) && break ; \
+		timeout 30 git clone --depth 1 https://github.com/bigstack-oss/cube-cos-api.git $(API_GIT_DIR) && break ; \
 		done,\
 		"  CLONE   github.com/bigstack-oss/cube-cos-api.git")
 

--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -31,11 +31,12 @@ LOGIN_SPEC_FILE := $(LOGIN_RPMBUILD_DIR)/SPECS/cube-cos-login.spec
 LOGIN_RPM_BUILD := $(LOGIN_RPMBUILD_DIR)/RPMS/x86_64/cube-cos-login-$(LOGIN_VERSION)-1.el9.$(LOGIN_BUILD_NUMBER).x86_64.rpm
 
 # prepare the login source code, being pulled from GitHub using the default branch
+# For RC: git clone -b v3.0.0-rc4
 $(LOGIN_GIT_DIR):
 	$(Q)mkdir $(LOGIN_GIT_DIR)
 	$(call RUN_CMD_TIMED, \
 		for i in {1..10} ; do \
-		timeout 30 git clone -b v3.0.0-rc4 --depth 1 https://github.com/bigstack-oss/cube-cos-ui.git $(LOGIN_GIT_DIR) && break ; \
+		timeout 30 git clone --depth 1 https://github.com/bigstack-oss/cube-cos-ui.git $(LOGIN_GIT_DIR) && break ; \
 		done,\
 		"  CLONE   github.com/bigstack-oss/cube-cos-ui.git")
 

--- a/core/main/Makefile
+++ b/core/main/Makefile
@@ -9,8 +9,8 @@ include ../../build.mk
 ##################################################################################
 
 # Product Release Version Numbers
-RELEASE_VERSION := 3.0.0
-PRE_RELEASE_VERSION := 2.5.0
+RELEASE_VERSION := 3.1.0
+PRE_RELEASE_VERSION := 3.0.0
 
 ##################################################################################
 #

--- a/core/modules/config_haproxy.cpp
+++ b/core/modules/config_haproxy.cpp
@@ -145,6 +145,9 @@ WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
     fprintf(fout, "  mode http\n");
     fprintf(fout, "  option forwardfor\n");
     fprintf(fout, "  option http-server-close\n");
+    fprintf(fout, "  http-request replace-header Cookie (^|;)token=[^;]+;+(.*) \\1\\2\n");
+    fprintf(fout, "  http-request replace-header Cookie (^|;)ceph_token=([^;]+)(.*) \\1token=\\2\\3\n");
+    fprintf(fout, "  http-response replace-header Set-Cookie token=(.*) ceph_token=\\1\n");
     if (ha) {
         fprintf(fout, "  server localhost %s:7443 check ssl verify none\n", sharedId.c_str());
     } else {
@@ -170,6 +173,9 @@ WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
     fprintf(fout, "  option forwardfor\n");
     fprintf(fout, "  option http-server-close\n");
     fprintf(fout, "  redirect scheme https if !{ ssl_fc }\n");
+    fprintf(fout, "  http-request replace-header Cookie (^|;)token=[^;]+;+(.*) \\1\\2\n");
+    fprintf(fout, "  http-request replace-header Cookie (^|;)cos_token=([^;]+)(.*) \\1token=\\2\\3\n");
+    fprintf(fout, "  http-response replace-header Set-Cookie token=(.*) cos_token=\\1\n");
     fprintf(fout, "  server localhost %s:8082 check\n", myip.c_str());
     fprintf(fout, "  \n");
 
@@ -201,6 +207,7 @@ WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
     fprintf(fout, "  default_backend cube_cos_ui\n");
     fprintf(fout, "  \n");
 
+    // backend ceph_dashboard_backend and cube_cos_api should not use the same cookie name "token"
     fprintf(fout, "frontend cube_cos_https\n");
     fprintf(fout, "  bind :443 ssl crt %s\n", KEYFILE);
     fprintf(fout, "  mode http\n");

--- a/core/skyline/skyline.mk
+++ b/core/skyline/skyline.mk
@@ -21,7 +21,7 @@ heavyfs_install::
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) pip3 uninstall -y skyline-apiserver
 	$(Q)chroot $(ROOTDIR) pip3 cache remove skyline-apiserver
-	$(Q)for i in {1..10} ; do timeout 30 git clone -b v3.0.0-rc4 --depth 1 https://github.com/bigstack-oss/skyline-apiserver.git $(ROOTDIR)/skyline-apiserver && break ; done
+	$(Q)for i in {1..10} ; do timeout 30 git clone --depth 1 https://github.com/bigstack-oss/skyline-apiserver.git $(ROOTDIR)/skyline-apiserver && break ; done
 	$(Q)chroot $(ROOTDIR) sh -c "cd /skyline-apiserver && pip3 install -r requirements.txt && python3 setup.py install"
 	$(Q)cp ${ROOTDIR}/skyline-apiserver/etc/gunicorn.py ${ROOTDIR}/etc/skyline/gunicorn.py
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/skyline/skyline-apiserver.service ./lib/systemd/system
@@ -43,7 +43,7 @@ heavyfs_install::
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) pip3 uninstall -y skyline-console
 	$(Q)chroot $(ROOTDIR) pip3 cache remove skyline-console
-	$(Q)for i in {1..10} ; do timeout 30 git clone -b v3.0.0-rc4 --depth 1 https://github.com/bigstack-oss/skyline-console.git $(ROOTDIR)/skyline-console && break ; done
+	$(Q)for i in {1..10} ; do timeout 30 git clone --depth 1 https://github.com/bigstack-oss/skyline-console.git $(ROOTDIR)/skyline-console && break ; done
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(Q)nvm use $(SKYLINE_NODE_VERSION) $(QEND) && make -C $(ROOTDIR)/skyline-console package

--- a/core/ui/Makefile
+++ b/core/ui/Makefile
@@ -20,11 +20,12 @@ UI_SPEC_FILE := $(UI_RPMBUILD_DIR)/SPECS/cube-cos-ui.spec
 UI_RPM_BUILD := $(UI_RPMBUILD_DIR)/RPMS/x86_64/cube-cos-ui-$(UI_VERSION)-1.el9.$(UI_BUILD_NUMBER).x86_64.rpm
 
 # prepare the ui source code, being pulled from GitHub using the default branch
+# For RC: git clone -b v3.0.0-rc4
 $(UI_GIT_DIR):
 	$(Q)mkdir $(UI_GIT_DIR)
 	$(call RUN_CMD_TIMED, \
 		for i in {1..10} ; do \
-		timeout 30 git clone -b v3.0.0-rc4 --depth 1 https://github.com/bigstack-oss/cube-cos-ui.git $(UI_GIT_DIR) && break ; \
+		timeout 30 git clone --depth 1 https://github.com/bigstack-oss/cube-cos-ui.git $(UI_GIT_DIR) && break ; \
 		done,\
 		"  CLONE   github.com/bigstack-oss/cube-cos-ui.git")
 


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Fix cube-cos-api and Ceph Dashboard fighting on the same Keycloak SSO session
  - Separate cookie name "token" from different backends
- Bump version to v3.1.0
- Set code owners to the backend team

#### Which issue(s) this PR fixes

- Fix https://github.com/bigstack-oss/cube-cos-api/issues/214

#### Special notes for your reviewer

- This PR needs https://github.com/bigstack-oss/hex/pull/33

#### Additional documentation
