### PR TITLE
refactor(make): let upstreams maintain their NodeJS version through .nvmrc

### DIFF
--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -1,7 +1,7 @@
 # Cube SDK
 
 include ../../build.mk
-API_RPM := $(TOP_BLDDIR)/core/api/api.rpm
+API_RPM := api.rpm
 
 ifneq ($(RC),)
 $(API_RPM):
@@ -14,7 +14,7 @@ include build_number
 
 # api binary
 API_GIT_DIR := ./git
-API_RPMBUILD_DIR := $(TOP_BLDDIR)/core/api/rpmbuild
+API_RPMBUILD_DIR := rpmbuild
 API_TARBALL := $(API_RPMBUILD_DIR)/SOURCES/cube-cos-api-$(API_VERSION).tar.gz
 API_SPEC_FILE := $(API_RPMBUILD_DIR)/SPECS/cube-cos-api.spec
 API_RPM_BUILD := $(API_RPMBUILD_DIR)/RPMS/x86_64/cube-cos-api-$(API_VERSION)-1.el9.$(API_BUILD_NUMBER).x86_64.rpm
@@ -60,7 +60,7 @@ $(API_SPEC_FILE): $(API_RPMBUILD_DIR) $(API_GIT_DIR)
 # build the api rpm package
 $(API_RPM_BUILD): $(API_TARBALL) $(API_SPEC_FILE)
 	$(call RUN_CMD_TIMED, \
-		rpmbuild -bb --nodeps --define "_topdir $(API_RPMBUILD_DIR)" --define "version $(API_VERSION)" --define "build_number $(API_BUILD_NUMBER)" $(API_SPEC_FILE),\
+		rpmbuild -bb --nodeps --define "_topdir $(CURDIR)/$(API_RPMBUILD_DIR)" --define "version $(API_VERSION)" --define "build_number $(API_BUILD_NUMBER)" $(API_SPEC_FILE),\
 		"  BUILD   cube-cos-api-$(API_VERSION)-1.el9.$(API_BUILD_NUMBER).x86_64.rpm")
 
 # move the built rpm back to the local directory

--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -39,13 +39,19 @@ $(LOGIN_GIT_DIR):
 		timeout 30 git clone --depth 1 https://github.com/bigstack-oss/cube-cos-ui.git $(LOGIN_GIT_DIR) && break ; \
 		done,\
 		"  CLONE   github.com/bigstack-oss/cube-cos-ui.git")
+	$(Q)# enable nvm
+	$(Q)sed -i 's/^#//g' $$BASH_ENV
+	$(Q)cd $(LOGIN_GIT_DIR) && nvm install $(QEND)
+	$(Q)cd $(LOGIN_GIT_DIR) && nvm use $(QEND) && npm install -g pnpm@latest-10 $(QEND)
+	$(Q)# disable nvm
+	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
 
 version: $(LOGIN_GIT_DIR)
 	$(Q)echo -n "LOGIN_VERSION := " > version
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(Q)cd $(LOGIN_GIT_DIR) && \
-		nvm use $(UI_NODE_VERSION) $(QEND) && \
+		nvm use $(QEND) && \
 		node -p "require('./packages/cube-frontend-keycloak-login/package.json').version" >> ../version
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
@@ -84,7 +90,8 @@ $(LOGIN_RPM_BUILD): $(LOGIN_TARBALL) $(LOGIN_SPEC_FILE)
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(call RUN_CMD_SILENT, \
-		nvm use $(UI_NODE_VERSION) $(QEND) && \
+		cd $(LOGIN_GIT_DIR) && \
+		nvm use $(QEND) && \
 		rpmbuild -bb --nodeps --define "_topdir $(LOGIN_RPMBUILD_DIR)" --define "version $(LOGIN_VERSION)" --define "build_number $(LOGIN_BUILD_NUMBER)" --define "keycloak_version $(KEYCLOAK_VERSION)" $(LOGIN_SPEC_FILE), \
 		"  BUILD   cube-cos-login-$(LOGIN_VERSION)-1.el9.$(LOGIN_BUILD_NUMBER).x86_64.rpm")
 	$(Q)# disable nvm

--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -11,7 +11,7 @@ $(CHART):
 	$(Q)helm pull codecentric/keycloak --version $(CHART_VERSION)
 
 # login rpm
-LOGIN_RPM := $(TOP_BLDDIR)/core/keycloak/login.rpm
+LOGIN_RPM := login.rpm
 KEYCLOAK_DIR := /opt/keycloak/
 
 ifneq ($(RC),)
@@ -25,7 +25,7 @@ include build_number
 include keycloak_version
 
 LOGIN_GIT_DIR := ./git
-LOGIN_RPMBUILD_DIR := $(TOP_BLDDIR)/core/keycloak/rpmbuild
+LOGIN_RPMBUILD_DIR := rpmbuild
 LOGIN_TARBALL := $(LOGIN_RPMBUILD_DIR)/SOURCES/cube-cos-login-$(LOGIN_VERSION).tar.gz
 LOGIN_SPEC_FILE := $(LOGIN_RPMBUILD_DIR)/SPECS/cube-cos-login.spec
 LOGIN_RPM_BUILD := $(LOGIN_RPMBUILD_DIR)/RPMS/x86_64/cube-cos-login-$(LOGIN_VERSION)-1.el9.$(LOGIN_BUILD_NUMBER).x86_64.rpm
@@ -92,7 +92,8 @@ $(LOGIN_RPM_BUILD): $(LOGIN_TARBALL) $(LOGIN_SPEC_FILE)
 	$(call RUN_CMD_SILENT, \
 		cd $(LOGIN_GIT_DIR) && \
 		nvm use $(QEND) && \
-		rpmbuild -bb --nodeps --define "_topdir $(LOGIN_RPMBUILD_DIR)" --define "version $(LOGIN_VERSION)" --define "build_number $(LOGIN_BUILD_NUMBER)" --define "keycloak_version $(KEYCLOAK_VERSION)" $(LOGIN_SPEC_FILE), \
+		cd - && \
+		rpmbuild -bb --nodeps --define "_topdir $(CURDIR)/$(LOGIN_RPMBUILD_DIR)" --define "version $(LOGIN_VERSION)" --define "build_number $(LOGIN_BUILD_NUMBER)" --define "keycloak_version $(KEYCLOAK_VERSION)" $(LOGIN_SPEC_FILE), \
 		"  BUILD   cube-cos-login-$(LOGIN_VERSION)-1.el9.$(LOGIN_BUILD_NUMBER).x86_64.rpm")
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV

--- a/core/skyline/skyline.mk
+++ b/core/skyline/skyline.mk
@@ -46,7 +46,9 @@ rootfs_install::
 	$(Q)for i in {1..10} ; do timeout 30 git clone --depth 1 https://github.com/bigstack-oss/skyline-console.git $(ROOTDIR)/skyline-console && break ; done
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
-	$(Q)nvm use $(SKYLINE_NODE_VERSION) $(QEND) && make -C $(ROOTDIR)/skyline-console package
+	$(Q)cd $(ROOTDIR)/skyline-console && nvm install $(QEND)
+	$(Q)cd $(ROOTDIR)/skyline-console && nvm use $(QEND) && npm install -g yarn $(QEND)
+	$(Q)cd $(ROOTDIR)/skyline-console && nvm use $(QEND) && make package
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
 	$(Q)chroot $(ROOTDIR) sh -c "cd /skyline-console && pip3 install dist/skyline_console-*.whl"
@@ -59,7 +61,9 @@ heavyfs_install::
 	$(Q)for i in {1..10} ; do timeout 30 git clone -b v3.0.0-rc4 --depth 1 https://github.com/bigstack-oss/skyline-console.git $(ROOTDIR)/skyline-console && break ; done
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
-	$(Q)nvm use $(SKYLINE_NODE_VERSION) $(QEND) && make -C $(ROOTDIR)/skyline-console package
+	$(Q)cd $(ROOTDIR)/skyline-console && nvm install $(QEND)
+	$(Q)cd $(ROOTDIR)/skyline-console && nvm use $(QEND) && npm install -g yarn $(QEND)
+	$(Q)cd $(ROOTDIR)/skyline-console && nvm use $(QEND) && make package
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
 	$(Q)chroot $(ROOTDIR) sh -c "cd /skyline-console && pip3 install dist/skyline_console-*.whl"

--- a/core/ui/Makefile
+++ b/core/ui/Makefile
@@ -28,13 +28,19 @@ $(UI_GIT_DIR):
 		timeout 30 git clone --depth 1 https://github.com/bigstack-oss/cube-cos-ui.git $(UI_GIT_DIR) && break ; \
 		done,\
 		"  CLONE   github.com/bigstack-oss/cube-cos-ui.git")
+	$(Q)# enable nvm
+	$(Q)sed -i 's/^#//g' $$BASH_ENV
+	$(Q)cd $(UI_GIT_DIR) && nvm install $(QEND)
+	$(Q)cd $(UI_GIT_DIR) && nvm use $(QEND) && npm install -g pnpm@latest-10 $(QEND)
+	$(Q)# disable nvm
+	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
 
 version: $(UI_GIT_DIR)
 	$(Q)echo -n "UI_VERSION := " > version
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(Q)cd $(UI_GIT_DIR) && \
-		nvm use $(UI_NODE_VERSION) $(QEND) && \
+		nvm use $(QEND) && \
 		node -p "require('./packages/cube-frontend-web-app/package.json').version" >> ../version
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
@@ -68,7 +74,8 @@ $(UI_RPM_BUILD): $(UI_TARBALL) $(UI_SPEC_FILE)
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(call RUN_CMD_TIMED, \
-		nvm use $(UI_NODE_VERSION) $(QEND) && \
+		cd $(UI_GIT_DIR) && \
+		nvm use $(QEND) && \
 		rpmbuild -bb --nodeps --define "_topdir $(UI_RPMBUILD_DIR)" --define "version $(UI_VERSION)" --define "build_number $(UI_BUILD_NUMBER)" $(UI_SPEC_FILE), \
 		"  BUILD   cube-cos-ui-$(UI_VERSION)-1.el9.$(UI_BUILD_NUMBER).x86_64.rpm")
 	$(Q)# disable nvm

--- a/core/ui/Makefile
+++ b/core/ui/Makefile
@@ -1,7 +1,7 @@
 # Cube SDK
 
 include ../../build.mk
-UI_RPM := $(TOP_BLDDIR)/core/ui/ui.rpm
+UI_RPM := ui.rpm
 
 ifneq ($(RC),)
 $(UI_RPM):
@@ -14,7 +14,7 @@ include build_number
 
 # ui artifacts
 UI_GIT_DIR := ./git
-UI_RPMBUILD_DIR := $(TOP_BLDDIR)/core/ui/rpmbuild
+UI_RPMBUILD_DIR := rpmbuild
 UI_TARBALL := $(UI_RPMBUILD_DIR)/SOURCES/cube-cos-ui-$(UI_VERSION).tar.gz
 UI_SPEC_FILE := $(UI_RPMBUILD_DIR)/SPECS/cube-cos-ui.spec
 UI_RPM_BUILD := $(UI_RPMBUILD_DIR)/RPMS/x86_64/cube-cos-ui-$(UI_VERSION)-1.el9.$(UI_BUILD_NUMBER).x86_64.rpm
@@ -76,7 +76,8 @@ $(UI_RPM_BUILD): $(UI_TARBALL) $(UI_SPEC_FILE)
 	$(call RUN_CMD_TIMED, \
 		cd $(UI_GIT_DIR) && \
 		nvm use $(QEND) && \
-		rpmbuild -bb --nodeps --define "_topdir $(UI_RPMBUILD_DIR)" --define "version $(UI_VERSION)" --define "build_number $(UI_BUILD_NUMBER)" $(UI_SPEC_FILE), \
+		cd - && \
+		rpmbuild -bb --nodeps --define "_topdir $(CURDIR)/$(UI_RPMBUILD_DIR)" --define "version $(UI_VERSION)" --define "build_number $(UI_BUILD_NUMBER)" $(UI_SPEC_FILE), \
 		"  BUILD   cube-cos-ui-$(UI_VERSION)-1.el9.$(UI_BUILD_NUMBER).x86_64.rpm")
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV

--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -6,8 +6,6 @@ FROM quay.io/centos/centos:stream9 AS tier1
 ENV LANG=C.UTF-8
 ENV HEX_VER=hex2.0
 ENV GOLANG_VER=1.24.0
-ENV UI_NODE_VER=22.14.0
-ENV SKYLINE_NODE_VER=12.22.12
 ENV HEX_ARCH=x86_64
 ENV DEVOPS_ENV=__JAIL__
 ENV TZ=Asia/Taipei
@@ -147,11 +145,6 @@ RUN touch "${BASH_ENV}"
 RUN echo '. "${BASH_ENV}"' >> /root/.bashrc
 # download and install nvm
 RUN wget -qO- --no-check-certificate https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | PROFILE="${BASH_ENV}" bash
-# install node, npm, yarn, and pnpm
-RUN /bin/bash -c "nvm install $UI_NODE_VER"
-RUN /bin/bash -c "nvm install $SKYLINE_NODE_VER"
-RUN /bin/bash -c "nvm use $UI_NODE_VER && npm install -g pnpm@latest-10"
-RUN /bin/bash -c "nvm use $SKYLINE_NODE_VER && npm install -g yarn"
 # disable nvm to stop it from slowing down bash
 RUN sed -i 's/^/#/g' $BASH_ENV
 # install wheel

--- a/project.mk
+++ b/project.mk
@@ -19,8 +19,6 @@ CORE_POLICYDIR := $(COREDIR)/policies
 
 # cubecos shared build envs
 GOLANG_VERSION := 1.24.0
-UI_NODE_VERSION := 22.14.0
-SKYLINE_NODE_VERSION := 12.22.12
 PROJ_NFS_SERVER := 10.32.0.200
 PROJ_NFS_CUBECOS_PATH := /volume1/bigstack/cube-images
 PROJ_NFS_OPENSTACK_PATH := /volume1/docker/minio/downloads


### PR DESCRIPTION
#### What type of PR is this?

- refactor

#### What this PR does / why we need it

- Update license type option prime to enterprise
- Let upstreams maintain their NodeJS version through .nvmrc
- Set relative paths for RPM targets

#### Which issue(s) this PR fixes

- Close #174 

#### Special notes for your reviewer

- This PR needs https://github.com/bigstack-oss/hex/pull/34

#### Additional documentation
