### PR TITLE
Fix the unexpected rancher pod pending during version upgrade in 1cc and 1ec

### DIFF
--- a/core/cubectl/app/config/config_rancher.go
+++ b/core/cubectl/app/config/config_rancher.go
@@ -698,6 +698,8 @@ func commitRancher() error {
 				); err != nil {
 					return errors.Wrap(err, outErr)
 				}
+
+				skipOrResyncRancherReplicaSet()
 				zap.L().Info("Rancher release upgraded")
 
 				return nil
@@ -739,6 +741,17 @@ func commitRancher() error {
 	}
 
 	return nil
+}
+
+func skipOrResyncRancherReplicaSet() {
+	if cubeSettings.IsHA() {
+		return
+	}
+
+	out, outErr, err := util.ExecCmd("/usr/local/bin/k3s", "kubectl", "delete", "rs", "-l", "app=rancher", "-n", rancherNamespace)
+	if err != nil {
+		zap.S().Errorf("Failed to delete rancher replica sets for force rolling(%v, %s, %s)", err, outErr, out)
+	}
 }
 
 func resetRancher() error {


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

Fix the unexpected rancher pod pending during version upgrade in 1cc and 1ec

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/176

<br/>

#### Test result

1). Find a 1cc or 1ec env

```bash
[dell180 /opt/rancher]# k get nodes
NAME      STATUS   ROLES                       AGE   VERSION
dell180   Ready    control-plane,etcd,master   47d   v1.26.6+k3s1
```

<br/>

2). Make sure the current version is the older version like 2.7.9

```bash
[dell180 /opt/rancher]# k get pods rancher-8447757555-kbmqr -o yaml -n cattle-system | grep image
    image: rancher/rancher:v2.7.9
    imagePullPolicy: IfNotPresent
    image: docker.io/rancher/rancher:v2.7.9
    imageID: docker.io/rancher/rancher@sha256:926c5f1c21191cfa8f05441b33237d82ad58e50b1833ba2b60efbacddd6320ea
```

<br/>

3). Simulate the rancher upgrade procedure by the fixed binary of `cubectl` -> `cubectl config commit rancher --stacktrace --force` (to `v2.11.2`)

```bash
[dell180 /opt/rancher]# cubectl config commit rancher --stacktrace --force
{"level":"warn","timestamp":"2025-06-30T18:59:05+08:00","caller":"config/config_rancher.go:684","msg":"error: failed to create secret secrets \"tls-ca\" already exists\n: exit status 1"}
{"level":"info","timestamp":"2025-06-30T18:59:06+08:00","caller":"config/config_rancher.go:703","msg":"Rancher release upgraded"}
...
...
...
```

<br/>

4). Make sure no any pending rancher pods in the k3s anymore

```bash
[dell180 /opt/rancher]# k get pods -l app=rancher -n cattle-system
NAME                      READY   STATUS    RESTARTS   AGE
rancher-f88bb5c48-sgxd9   1/1     Running   0          115s
```

<br/>

5). Make sure the current rancher pod is at newest version we want (`v2.11.2`)

```bash
[dell180 /opt/rancher]# k get pods rancher-f88bb5c48-sgxd9 -o yaml -n cattle-system | grep image
    image: rancher/rancher:v2.11.2
    imagePullPolicy: IfNotPresent
    image: docker.io/rancher/rancher:v2.11.2
    imageID: docker.io/rancher/rancher@sha256:3e8d186f0ff2b23211c0b0ede0aaaf373719d93c9c606b81aa08c2d2bebbebc4
```
