### PR TITLE
Upgrade the terraform rancher module to 7.0.0

### DIFF
--- a/core/cubectl/app/config/config_rancher.go
+++ b/core/cubectl/app/config/config_rancher.go
@@ -713,6 +713,11 @@ func commitRancher() error {
 			zap.S().Warn(errors.WithStack(err))
 		}
 
+		_, outErr, err := util.ExecCmd("/usr/local/bin/terraform", fmt.Sprintf("-chdir=%s", terraformWorkDir), "init", "-upgrade")
+		if err != nil {
+			zap.S().Warn(errors.Wrap(err, outErr))
+		}
+
 		// Create token and eanble keycloak auth
 		if err := terraformExec("apply", "rancher", "cube_controller="+cubeSettings.GetControllerIp()); err != nil {
 			zap.S().Warn(errors.WithStack(err))

--- a/core/terraform/src/rancher/main.tf
+++ b/core/terraform/src/rancher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.24.0"
+      version = "7.0.0"
     }
   }
 }
@@ -20,7 +20,6 @@ resource "rancher2_bootstrap" "admin" {
 
   initial_password = "default-admin"
   password = "default-admin"
-  telemetry = false
 }
 
 provider "rancher2" {
@@ -51,18 +50,10 @@ resource "rancher2_auth_config_keycloak" "keycloak" {
   ]
 }
 
-# resource "rancher2_global_role_binding" "admin" {
-#   provider = rancher2.admin
-
-#   #name = "admin"
-#   global_role_id = "restricted-admin"
-#   group_principal_id = "keycloak_user://admin"
-# }
-
 resource "rancher2_global_role_binding" "cube_admins" {
   provider = rancher2.admin
 
-  global_role_id = "restricted-admin"
+  global_role_id = "admin"
   group_principal_id = "keycloak_group://cube-admins"
 }
 
@@ -72,58 +63,3 @@ resource "rancher2_global_role_binding" "cube_users" {
   global_role_id = "user"
   group_principal_id = "keycloak_group://cube-users"
 }
-
-# resource "rancher2_node_driver" "cube" {
-#   provider = rancher2.admin
-
-#   name = "cube"
-#   url = "http://${var.cube_controller}:8080/static/nodedrivers/docker-machine-driver-cube"
-#   active = true
-#   builtin = false
-#   description = "Cube node driver"
-
-#   timeouts {
-#     create = "5s"
-#     delete = "5s"
-#   }
-# }
-
-# data "rancher2_node_driver" "openstack" {
-#     provider = rancher2.admin
-
-#     name = "openstack"
-# }
-
-
-
-# data "rancher2_node_driver" "amazonec2" {
-#     provider = rancher2.admin
-
-#     name = "amazonec2"
-# }
-
-# resource "rancher2_node_driver" "openstack" {
-#     provider = rancher2.admin
-#     #id = data.rancher2_node_driver.openstack.id
-
-#     name = "openstack"
-#     #id = "openstack"
-#     active = true
-#     builtin = true
-#     url = "local://"
-# }
-
-# resource "rancher2_node_driver" "others" {
-#     provider = rancher2.admin
-
-#     for_each = toset( ["azure", "digitalocean"] )
-#     name     = each.key
-#     #id       = each.key
-#     active = false
-#     builtin = true
-#     url = "local://"
-# }
-
-# output "token" {
-#     value = rancher2_bootstrap.admin.token
-# }


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

To align the official set up from https://github.com/rancher/terraform-provider-rancher2/issues/1492 by

- Upgrade the terraform rancher module to 7.0.0 to support the rancher server(v2.11.2) operation

- Check and do terraform rancher module upgrade for all the cases (first time commit and upgrade).

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/131

<br/>

#### Test

1). Find a CubeCOS dev env (for example: 1cc poweredge and 3c_3p_5s)

<br/>

2). Replace the original `/usr/local/bin/cubectl` with the adjusted version

<br/>

3). Do `cubectl config commit rancher --stacktrace --force` to simulate the upgrade case

```bash
[cc1 ~]# cubectl config commit rancher --stacktrace --force
{"level":"warn","timestamp":"2025-07-02T13:40:18+08:00","caller":"config/config_rancher.go:684","msg":"error: failed to create secret secrets \"tls-ca\" already exists\n: exit status 1"}
{"level":"info","timestamp":"2025-07-02T13:40:23+08:00","caller":"config/config_rancher.go:703","msg":"Rancher release upgraded"}
{"level":"info","timestamp":"2025-07-02T13:40:56+08:00","caller":"config/common.go:134","msg":"Terraform applied","command":"apply","module":"rancher"}
{"level":"info","timestamp":"2025-07-02T13:41:03+08:00","caller":"config/common.go:134","msg":"Terraform applied","command":"apply","module":"keycloak_rancher"}
{"level":"info","timestamp":"2025-07-02T13:41:04+08:00","caller":"config/config_rancher.go:237","msg":"Rancher driver configured","id":"aliyunkubernetescontainerservice","action":"deactivate"}
{"level":"info","timestamp":"2025-07-02T13:41:04+08:00","caller":"config/config_rancher.go:237","msg":"Rancher driver configured","id":"amazonelasticcontainerservice","action":"deactivate"}
{"level":"info","timestamp":"2025-07-02T13:41:04+08:00","caller":"config/config_rancher.go:237","msg":"Rancher driver configured","id":"azurekubernetesservice","action":"deactivate"}
{"level":"info","timestamp":"2025-07-02T13:41:04+08:00","caller":"config/config_rancher.go:237","msg":"Rancher driver configured","id":"baiducloudcontainerengine","action":"deactivate"}
{"level":"info","timestamp":"2025-07-02T13:41:04+08:00","caller":"config/config_rancher.go:237","msg":"Rancher driver configured","id":"googlekubernetesengine","action":"deactivate"}
```

<br/>

4). After execution, make sure the `/root/.rancher/cli2.json` appears

```bash
[cc1 /var/lib/terraform/rancher]# ll /root/.rancher/cli2.json
-rw------- 1 root root 1563 Jul  2 12:42 /root/.rancher/cli2.json
```

<br/>

5). Continue to install the app framework again

```bash
[cc1 /var/lib/terraform/rancher]# hex_cli -c app framework_install public public 10.32.17.200
installing app-framework...
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [openstack] *********************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************
ok: [localhost]

TASK [Gather information about management network] ***********************************************************************************************************************************
ok: [localhost]

TASK [Gather information about management subnet] ************************************************************************************************************************************
ok: [localhost]

TASK [Show management subnet CIDR] ***************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "10.32.0.0/16"
}

TASK [openstack.cloud.project] *******************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.quota] *********************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.identity_user] *************************************************************************************************************************************************
[WARNING]: Module did not set no_log for update_password
ok: [localhost]

TASK [openstack.cloud.role_assignment] ***********************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.role_assignment] ***********************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.network] *******************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.subnet] ********************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.network] *******************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.subnet] ********************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.subnet] ********************************************************************************************************************************************************
skipping: [localhost]

TASK [openstack.cloud.router] ********************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.router] ********************************************************************************************************************************************************
skipping: [localhost]

TASK [openstack.cloud.security_group] ************************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.security_group_rule] *******************************************************************************************************************************************
ok: [localhost]

TASK [openstack.cloud.security_group_rule] *******************************************************************************************************************************************
ok: [localhost] => (item=22)
ok: [localhost] => (item=80)
ok: [localhost] => (item=443)
ok: [localhost] => (item=2376)
ok: [localhost] => (item=6443)

TASK [openstack.cloud.security_group_rule] *******************************************************************************************************************************************
ok: [localhost] => (item=tcp)
ok: [localhost] => (item=udp)

PLAY RECAP ***************************************************************************************************************************************************************************
localhost                  : ok=18   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0

Installing app-framework cluster
Waiting for cluster to be active. State: provisioning. Time elapsed: 30 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 60 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 90 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 120 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 150 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 180 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 210 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 240 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 270 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 300 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 330 secs
Waiting for cluster to be active. State: provisioning. Time elapsed: 360 secs
Waiting for cluster to be active. State: waiting. Time elapsed: 390 secs
Cluster is active. Deploying essential workloads
NAME: openstack-ccm
LAST DEPLOYED: Wed Jul  2 12:52:09 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NAME: cinder-csi
LAST DEPLOYED: Wed Jul  2 12:52:11 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Use the following storageClass csi-cinder-sc-retain and csi-cinder-sc-delete only for RWO volumes.
service/ingress-lb created
Release "docker-registry" does not exist. Installing it now.
NAME: docker-registry
LAST DEPLOYED: Wed Jul  2 12:52:15 2025
...
...
...
```

<br/>

6). Make sure the app-framework is installed successfully

![Screenshot 2025-07-02 at 1 53 10 PM](https://github.com/user-attachments/assets/fc3fef68-1bee-420f-a7eb-64ac104091ff)
