### PR TITLE
Allow more memory usage for k3s

### DIFF
--- a/core/cubectl/app/config/config_k3s_last.go
+++ b/core/cubectl/app/config/config_k3s_last.go
@@ -63,7 +63,7 @@ func genK3sResourceConf(kube, system ReservedResource) k3sServiceConf {
 		KubeLetArg: []string{
 			fmt.Sprintf("kube-reserved=cpu=%d,memory=%dMi,ephemeral-storage=%dGi", kube.CPU, kube.Memory, kube.EphemeralStorage),
 			fmt.Sprintf("system-reserved=cpu=%d,memory=%dMi", system.CPU, system.Memory),
-			"eviction-hard=memory.available<15%,nodefs.available<10%",
+			"eviction-hard=memory.available<5%,nodefs.available<10%",
 		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

Feat

<br/>

#### What this PR does / why we need it

Allow more memory usage for k3s by decreasing the eviction-hard=memory.available from `<15%` to `<5%`

<br/>

Reason: according to the feedback from support team, the eviction-hard=memory.available<15% might be too restricted in the edge mode to cause the false alarm, so we decide to allow more memory space for K3S

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/171
