### PR TITLE
feat: Rolling upgrade definition: no VMs go into error states #155

### DIFF
--- a/core/extpacks/Makefile
+++ b/core/extpacks/Makefile
@@ -15,7 +15,7 @@ NAS := $(TOP_BLDDIR)/nas
 
 AMPHORA := $(TOP_BLDDIR)/../amphora-x64-haproxy_yoga.qcow2
 MANILA  := $(TOP_BLDDIR)/../manila-service-image_yoga.qcow2
-RANCHER := $(TOP_BLDDIR)/../rancher-cluster-image_22.04.vmdk
+RANCHER := $(TOP_BLDDIR)/../rancher-cluster-image_22.04.raw
 EXTPACK := $(AMPHORA) $(MANILA) $(RANCHER)
 EXTPACK_MD5 := $(shell for E in $(EXTPACK); do echo $${E}.md5 ; done)
 
@@ -45,11 +45,11 @@ $(MANILA).md5: $(MANILA)
 	$(Q)diff $@ $(NAS)/app-image/yoga/manila-service-image_yoga.qcow2.md5 2>/dev/null || ( cp -f $(NAS)/app-image/yoga/manila-service-image_yoga.qcow2 $< && md5sum $< | awk '{print $$1}' > $@ )
 
 $(RANCHER): $(NAS)
-	$(Q)cp $</app-image/yoga/rancher-cluster-image_22.04.vmdk $@
+	$(Q)cp $</app-image/yoga/rancher-cluster-image_22.04.raw $@
 
 .PHONY: $(RANCHER).md5
 $(RANCHER).md5: $(RANCHER)
-	$(Q)diff $@ $(NAS)/app-image/yoga/rancher-cluster-image_22.04.vmdk.md5 2>/dev/null || ( cp -f $(NAS)/app-image/yoga/rancher-cluster-image_22.04.vmdk $< && md5sum $< | awk '{print $$1}' > $@ )
+	$(Q)diff $@ $(NAS)/app-image/yoga/rancher-cluster-image_22.04.raw.md5 2>/dev/null || ( cp -f $(NAS)/app-image/yoga/rancher-cluster-image_22.04.raw $< && md5sum $< | awk '{print $$1}' > $@ )
 
 .PHONY: ext
 ext: $(PROJ_EXT) $(PROJ_PORTAL_EXT)

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -1,4 +1,4 @@
-
+#!/bin/sh
 export BOOTSTRAP_CUBE_MARKER=/run/cube_commit_done
 export BOOTSTRAP_CUBE_MODE=/etc/appliance/state/boot_mode
 source /usr/sbin/hex_tuning /etc/settings.txt
@@ -9,17 +9,28 @@ else
     export MASTER_CONTROL=$(echo $T_cubesys_control_hosts | cut -d"," -f1)
 fi
 
+export HOSTNAME=$(ssh localhost hostname 2>/dev/null)
+query="insert system,category=BSP,key=BSP00001I,service=bootstrap,host=$HOSTNAME"
+# Bring up influxdb as early as early as possible to log bootstrap activities
+cubectl node exec -r control -pn "systemctl show -p SubState influxdb | grep -q -i running || systemctl restart influxdb"
+
 BootstrapAndClusterstart()
 {
     if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
-        echo -n "Bootstrapping CubeCOS" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+        msg="Bootstrapping CubeCOS"
+        echo -n "$msg" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+        hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
         echo -n "                                                            " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
         bash -c "hex_config -p bootstrap standalone-done | tee -a $(hex_sdk GetKernelConsoleDevices)"
         if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
-            echo -n "Bootstrap failed (Please fix it and contunue manually)" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            msg="Bootstrap failed (manual fix required)"
+            echo -n "$msg" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            hex_sdk influx_event "${query},severity=\"W\" message=\"$msg\""
         else
             echo -n "                                                            " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
-            echo -n "Starting cluster" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            msg="Starting cluster"
+            echo -n "$msg" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
             bash -c "hex_sdk -v cube_cluster_start | tee -a $(hex_sdk GetKernelConsoleDevices)"
             cubectl node exec -pn "rm -f /tmp/health_*error.count"
         fi
@@ -33,6 +44,7 @@ RollingEvacuateAndReboot()
     local cluster_info=/store/ppu/cluster-info.json
     local upgrading=false
     local last_n=$(cat $cluster_info 2>/dev/null | jq -r .[].hostname | tail -1)
+    local query="insert system,category=RUG,key=RUG00001I,service=rolling_upgrade,host=$HOSTNAME,metadata\"rolling upgrade to $(hex_cli -c firmware list | grep -i active | cut -d' ' -f2)\""
     if [ -e "$cluster_info" -a "x$inst_type" = "xPPU" ] ; then
         for N in $(cat $cluster_info | jq -r .[].hostname) ; do
             # Cube dashboard topN misses partial info after rolling upgrades
@@ -51,13 +63,19 @@ RollingEvacuateAndReboot()
                     upgrading=true
                     if [ "x$n_role" = "xcontrol-converged" -o "x$n_role" = "xedge-core" -o "x$n_role" = "xcompute" ] ; then
                         hex_cli -c cluster check_repair
-                        echo -n "Auto rolling ppu upgrade: evacuating VMs on $N          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                        msg="Auto rolling ppu upgrade: evacuating VMs on $N"
+                        echo -n "$msg          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                        hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
                         if ! hex_sdk remote_run $MASTER_CONTROL "hex_sdk os_pre_failure_host_evacuation_sequential $N" upgrade ; then
-                            echo -n "Auto rolling ppu upgrade aborted since some VMs on $N failed to evacuate (Please fix it and contunue manually)          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                            msg="Auto rolling ppu upgrade aborted due to evacuation failures on $N (manual fix required)"
+                            echo -n "$msg          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                            hex_sdk influx_event "${query},severity=\"W\" message=\"$msg\""
                             break
                         fi
                     fi
-                    echo -n "Auto rolling ppu upgrade: rebooting $N                                        " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    msg="Auto rolling ppu upgrade: rebooting $N"
+                    echo -n "$msg                                        " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
                     hex_sdk remote_run $n_ip "echo YES | hex_cli -c reboot"
                     break
                 fi
@@ -68,9 +86,13 @@ RollingEvacuateAndReboot()
     fi
     if [ "x$upgrading" = "xfalse" ]; then
         if hex_sdk cube_cluster_ready ; then
-            echo -n "  cluster checking and repairing                                        " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            msg="cluster checking and repairing"
+            echo -n "  $msg                                        " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
             hex_cli -c cluster check_repair
-            echo -n "  cluster checked and repaired                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            msg="cluster checked and repaired"
+            echo -n "  $msg                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
             need_be_active_servers="$(cat /mnt/cephfs/nova/instances/active_running 2>/dev/null)"
             if [ "x$need_be_active_servers" != "x" ] ; then
                 for i in $need_be_active_servers ; do
@@ -79,12 +101,16 @@ RollingEvacuateAndReboot()
                     else
                         hex_sdk os_nova_instance_reset $i
                         hex_sdk os_nova_instance_hardreboot $i
-                        echo -n "  reset and booted non-active server: $i                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                        msg="reset and booted non-active server: $i"
+                        echo -n "  $msg                                          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                        hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
                     fi
                 done
             fi
         else
-            echo -n "  cluster check and repair skipped because not all nodes are bootstrapped and synced                                           " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            msg="cluster check and repair skipped as not all nodes are bootstrapped and synced"
+            echo -n "  $msg                                           " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+            hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
         fi
     fi
 }
@@ -92,25 +118,29 @@ RollingEvacuateAndReboot()
 [ -e $BOOTSTRAP_CUBE_MODE ] || touch $BOOTSTRAP_CUBE_MODE
 export CLUSTER_SIZE=$(cubectl node list | wc -l)
 
-if [ -e /etc/appliance/state/configured ] ; then
+if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; then
     echo -n "                                                                    " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
     if grep -q manual $BOOTSTRAP_CUBE_MODE ; then
-        echo -n "Please bootstrap CubeCOS manually" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+        msg="Auto bootstrap is disabled (manual boot required)"
+        echo -n "$msg" $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+        hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
     else
         if [ "x$MASTER_CONTROL" = "x$T_net_hostname" ] ; then
-            if [ $(timeout 60 hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -lt $(($CLUSTER_SIZE - 1)) ] ; then
+            if [ $(hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -eq 0 -o $CLUSTER_SIZE -eq 0 ] ; then
                 echo "YES" | hex_cli -c cluster stop
             fi
             BootstrapAndClusterstart
             RollingEvacuateAndReboot
-        elif [ "x$T_cubesys_role" = "xcontrol" -o "x$T_cubesys_role" = "xcontrol-converged" -o "x$T_cubesys_role" = "xedge-core" -o "x$T_cubesys_role" = "xmoderator" -o $CLUSTER_SIZE -eq 0 ] ; then
-            if [ $(timeout 60 hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -lt $(($CLUSTER_SIZE - 1)) ] ; then
+        elif [ "x$T_cubesys_role" = "xcontrol" -o "x$T_cubesys_role" = "xcontrol-converged" -o "x$T_cubesys_role" = "xedge-core" -o "x$T_cubesys_role" = "xmoderator" ] ; then
+            if [ $(hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -eq 0 -o $CLUSTER_SIZE -eq 0 ] ; then
                 echo "YES" | hex_cli -c cluster stop
             fi
             (
                 cnt=0
                 while ! hex_sdk remote_run ${MASTER_CONTROL:-NOMASTER} stat $BOOTSTRAP_CUBE_MARKER >/dev/null 2>&1 ; do
-                    echo -n "Waiting for master control to finish bootstrap_cube [$cnt min]          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    msg="Waiting for master control to finish bootstrapping [$cnt min]"
+                    echo -n "$msg          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    hex_sdk influx_event "${query} code=0,status=\"$msg\""
                     ((cnt++))
                     sleep 60
                 done
@@ -123,7 +153,9 @@ if [ -e /etc/appliance/state/configured ] ; then
             (
                 cnt=0
                 while ! cubectl node exec -r control stat $BOOTSTRAP_CUBE_MARKER >/dev/null 2>1 ; do
-                    echo -n "Waiting for control(s) to finish bootstrap_cube [$cnt min]          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    msg="Waiting for control(s) to finish bootstrapping [$cnt min]"
+                    echo -n "$msg          " $'\r' | tee -a $(hex_sdk GetKernelConsoleDevices)
+                    hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
                     ((cnt++))
                     sleep 60
                 done

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -4,6 +4,7 @@
 hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_01-var-static.sh
 hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_02-var-runtime.sh
 hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_cmd.sh
+hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_influx.sh
 hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_is.sh
 hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_license.sh
 hex_shell_MODULES_PRE += $(PROJ_SHMODDIR)/modules.pre/sdk_remote.sh

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -23,11 +23,28 @@ _hex_exec()
     local cmd="${1:-BADCMD}"
     shift 1
     local runtime=/run/$cmd
+    local pid=$$
+    local usr=$(ps -o user= -p $pid | xargs)
+    local pcmd=$(ps -o comm= $PPID | xargs)
+    local pusr=$(ps -o user= -p $PPID | xargs)
+    local gpid=$(ps -o ppid= -p $PPID | xargs)
+    local gcmd=$(ps -o comm= $gpid | xargs)
+    local gusr=$(ps -o user= -p $gpid | xargs)
+
+    [ "x$(type -t influx_event)" = "xfunction" ] || source /usr/lib/hex_sdk/modules.pre/sdk_influx.sh
+    if echo $pcmd | grep -i ssh ; then
+        pip=$(ss -tunpa | grep $PPID | awk '{print $6}')
+        [ "x$pip" = "x" ] || pcmd+="($pip)"
+        gip=$(ss -tunpa | grep $gpid | awk '{print $6}')
+        [ "x$gip" = "x" ] || gcmd+="($gip)"
+    fi
+    influx_event "insert audit,node=$HOSTNAME,gusr=$gusr,gcmd=$gcmd,gpid=$gpid,pusr=$pusr,pcmd=$pcmd,ppid=$PPID,usr=$usr,pid=$pid cmd=\"$cmd\""
+
     if echo "$cmd" | grep -q "health_.*_check$" ; then
+        local srv=$(echo $cmd | sed -e "s/^health_//" -e "s/_check$//")
         if [ -e $HEX_STATE_DIR/${cmd}_disabled ] ; then
-            local srv=$(echo $cmd | sed -e "s/^health_//" -e "s/_check$//")
-            query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"disabled\""
-            $INFLUX -database events -execute "${query},detail=\"$cmd\""
+            query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"check disabled\""
+            influx_event "${query},detail=\"$cmd\""
         else
             if [ "x$1" = "x-l" -o "x$1" = "x-last" -o "x${HEX_HEALTH_LAST:=0}" != "x0" ] ; then
                 shift 1
@@ -42,17 +59,27 @@ _hex_exec()
             fi
         fi
     elif echo "$cmd" | grep -q "health_.*_repair$" ; then
-        if $HEX_SDK is_repairing ; then
+        local srv=$(echo $cmd | sed -e "s/^health_//" -e "s/^_health_//" -e "s/_auto_repair$//" -e "s/_repair$//")
+        [ "x$MANNER" != "xforce" ] || cubectl node exec -pn rm -f /run/cube_cluster_repairing
+        local repair_json="$(VERBOSE=1 is_repairing)"
+        if [ "x$repair_json" != "x" ] ; then
+            local node=$(echo $repair_json | jq -r .node)
+            local service=$(echo $repair_json | jq -r .service)
+            local elaps=$(echo $repair_json | jq -r .elaps)
+            query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixing skipped due to $service($elaps) by $node\""
+            influx_event "${query},detail=\"$cmd\""
             return 1
         else
             trap _hex_exec_abort INT EXIT
             $cmd "$@" &
             echo $! > $runtime
             ln -sf $runtime $CLUSTER_REPAIRING
-            local srv=$(echo $cmd | sed -e "s/^health_//" -e "s/_repair$//")
             query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixing\""
-            $INFLUX -database events -execute "${query},detail=\"$cmd\""
-            wait $(cat $runtime) && rm -f $runtime $CLUSTER_REPAIRING
+            influx_event "${query},detail=\"$cmd PID$(cat $runtime)\""
+            wait $(cat $runtime)
+            query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixed\""
+            influx_event "${query},detail=\"$cmd PID$(cat $runtime)\""
+            rm -f $runtime $CLUSTER_REPAIRING
         fi
     else
         $cmd "$@"
@@ -869,10 +896,20 @@ cube_cluster_ppu()
 
 cluster_check()
 {
-    HEX_HEALTH_LAST=1 hex_cli -c cluster check
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if is_remote_running $node influxdb ; then
+            VERBOSE=1 remote_run $node "HEX_HEALTH_LAST=1 hex_cli -c cluster check"
+            break
+        fi
+    done
 }
 
 cluster_check_repair()
 {
-    HEX_HEALTH_LAST=1 hex_cli -c cluster check_repair
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if is_remote_running $node influxdb ; then
+            VERBOSE=1 remote_run $node "HEX_HEALTH_LAST=1 hex_cli -c cluster check_repair"
+            break
+        fi
+    done
 }

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -826,8 +826,7 @@ ClusterReadyMain(int argc, const char** argv)
     HexSpawn(0, HEX_SDK, "host_local_run", "hex_cli", "-c", "cluster check_repair", ZEROCHAR_PTR);
 
     CliPrintf("[7/7] Global Information Tracker");
-    HexUtilSystemF(0, 0, HEX_SDK " host_local_run " HEX_SDK " git_server_init");
-    HexUtilSystemF(0, 0, HEX_SDK " host_local_run cubectl node exec -p " HEX_SDK " git_client_init");
+    HexUtilSystemF(0, 0, "nohup " HEX_SDK " host_local_run " HEX_SDK " git_init &");
 
     CliPrintf("Done");
 

--- a/core/modules/config_masakari.cpp
+++ b/core/modules/config_masakari.cpp
@@ -49,8 +49,6 @@ static const char DBPASS[] = "GRmeqOmBcyus5cW0";
 
 static const char OSCMD[] = "/usr/bin/openstack";
 
-static const char INSTANCE_HA_HELPER[] = "/etc/cron.d/instance_ha_helper";
-
 static Configs cfg;
 static Configs monCfg;
 
@@ -435,26 +433,6 @@ CommitCheck(bool modified, int dryLevel)
 }
 
 static bool
-WriteCronInstanceHaHelper()
-{
-    FILE *fout = fopen(INSTANCE_HA_HELPER, "w");
-    if (!fout) {
-        HexLogError("Unable to write cron job: %s", INSTANCE_HA_HELPER);
-        return false;
-    }
-
-    fprintf(fout, "* * * * * root " HEX_SDK " os_instance_ha_helper\n");
-    fclose(fout);
-
-    if(HexSetFileMode(INSTANCE_HA_HELPER, "root", "root", 0644) != 0) {
-        HexLogError("Unable to set file %s mode/permission", INSTANCE_HA_HELPER);
-        return false;
-    }
-
-    return true;
-}
-
-static bool
 Commit(bool modified, int dryLevel)
 {
     // todo: remove this if support dry run
@@ -509,9 +487,6 @@ Commit(bool modified, int dryLevel)
     MasakariService(s_enabled);
 
     WriteLogRotateConf(log_conf);
-
-    if (IsControl(s_eCubeRole))
-        WriteCronInstanceHaHelper();
 
     return true;
 }

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -870,7 +870,7 @@ CommitLast(bool modified, int dryLevel)
 
     // restart neutron-server since ovn-northd is now managed by pacemaker
     if (enabled && isHaMaster) {
-        SystemdCommitService(enabled , SRV_NAME, true);
+        SystemdCommitService(enabled, SRV_NAME, false);
     }
 
     if (access(SFLOW_ENABLED, F_OK) == 0) {

--- a/core/modules/config_pacemaker.cpp
+++ b/core/modules/config_pacemaker.cpp
@@ -79,6 +79,9 @@ SetupCluster(const bool enabled, const bool ha, std::string sharedId, const std:
 
         HexUtilSystemF(0, 0, "pcs resource create vip ocf:heartbeat:IPaddr2 "
                              "ip=\"%s\" op monitor interval=\"30s\"", sharedId.c_str());
+        HexUtilSystemF(0, 0, "pcs resource create vaw systemd:vaw op monitor interval=\"30s\"");
+        HexUtilSystemF(0, 0, "pcs constraint colocation add vip with vaw score=INFINITY");
+        HexUtilSystemF(0, 0, "pcs constraint order vip then vaw");
         HexUtilSystemF(0, 0, "pcs resource create haproxy systemd:haproxy-ha op monitor interval=\"1s\"");
         HexUtilSystemF(0, 0, "pcs constraint colocation add vip with haproxy score=INFINITY");
         HexUtilSystemF(0, 0, "pcs constraint order vip then haproxy");
@@ -208,6 +211,9 @@ Commit(bool modified, int dryLevel)
     }
 
     WriteLogRotateConf(log_conf);
+
+    // vip could be misssing when corosync doesn't form quorum between system reboots
+    HexUtilSystemF(0, 0, HEX_SDK " health_vip_check || " HEX_SDK " health_vip_repair");
 
     return true;
 }

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -3,8 +3,10 @@
 
 # Unknown system variable 'innodb_version' since MariaDB 10.10
 # ROOTFS_DNF += mariadb-server mariadb-server-galera rsync
-MARIADB_VER := 10.5.27-1.el9
-MARIADB_URL := https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages
+MARIADB_VER := 10.5.27-1.el9_5
+# rpmfind.net is often not responsive
+# MARIADB_URL := https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages
+MARIADB_URL := ftp://ftp.icm.edu.pl/vol/rzm5/linux-rocky/9.6/devel/x86_64/os/Packages/m
 MARIADB_LOCKED_RPMS := mariadb-$(MARIADB_VER) mariadb-backup-$(MARIADB_VER) mariadb-common-$(MARIADB_VER) mariadb-errmsg-$(MARIADB_VER)
 MARIADB_LOCKED_RPMS += mariadb-gssapi-server-$(MARIADB_VER) mariadb-server-$(MARIADB_VER) mariadb-server-galera-$(MARIADB_VER) mariadb-server-utils-$(MARIADB_VER)
 LOCKED_DNF += $(MARIADB_LOCKED_RPMS)

--- a/core/pacemaker/pacemaker.mk
+++ b/core/pacemaker/pacemaker.mk
@@ -10,3 +10,5 @@ ROOTFS_DNF += $(PACEMAKER_DNF) pcs fence-agents-all libqb
 
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) systemctl disable rpcbind nfs-convert || true
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/pacemaker/vaw.service ./lib/systemd/system
+	$(Q)$(INSTALL_SCRIPT) -f $(ROOTDIR) $(COREDIR)/pacemaker/vaw ./usr/sbin/vaw

--- a/core/pacemaker/vaw
+++ b/core/pacemaker/vaw
@@ -1,0 +1,7 @@
+#/bin/bash
+
+source /etc/admin-openrc.sh
+while true; do
+    hex_sdk health_vip_check
+    hex_sdk os_instance_ha_helper
+done

--- a/core/pacemaker/vaw.service
+++ b/core/pacemaker/vaw.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=vip xxx wiper that cleans up dirty side-effects when vip changes
+DefaultDependencies=no
+After=systemd-hexctl-user.service
+
+[Service]
+ExecStart=bash -c "/usr/sbin/vaw 0<&- &> /var/log/vaw.log"
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/core/sdk_sh/modules.pre/sdk_02-var-runtime.sh
+++ b/core/sdk_sh/modules.pre/sdk_02-var-runtime.sh
@@ -22,5 +22,5 @@ CUBE_NODE_COMPUTE_HOSTNAMES=($(echo $CUBE_NODE_COMPUTE_JSON | jq -r .[].hostname
 CUBE_NODE_STORAGE_HOSTNAMES=($(echo $CUBE_NODE_STORAGE_JSON | jq -r .[].hostname))
 
 if [ -f /etc/appliance/state/configured ] ; then
-    INFLUX="timeout $SRVSTO /usr/bin/influx -host $(shared_id)"
+    INFLUX="timeout 3 /usr/bin/influx -host $(shared_id)"
 fi

--- a/core/sdk_sh/modules.pre/sdk_influx.sh
+++ b/core/sdk_sh/modules.pre/sdk_influx.sh
@@ -1,0 +1,110 @@
+# CUBE SDK
+
+# PROG must be set before sourcing this file
+if [ -z "$PROG" ] ; then
+    echo "Error: PROG not set" >&2
+    exit 1
+fi
+
+_influx()
+{
+    local db=$1
+    shift
+    local flag="-database $db"
+
+    if echo "$@" | grep -q -i insert ; then
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            timeout 3 /usr/bin/influx $flag -host $node -execute "$@" >/dev/null 2>&1 &
+        done
+        wait $! || true
+    else
+        if [ "x$FORMAT" = "xjson" ] ; then
+            flag+=" -format json -pretty"
+        fi
+        if [ "x$VERBOSE" = "x1" ] ; then
+            flag+=" -precision rfc3339"
+        fi
+
+        if ! $INFLUX $flag -execute "$@" 2>/dev/null ; then
+            for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+                ! timeout 3 /usr/bin/influx $flag -host $node -execute "$@" 2>/dev/null || break
+            done
+        fi
+    fi
+}
+
+influx_event()
+{
+    _influx events "$@"
+}
+
+influx_event_health()
+{
+    local component=$1
+    local limit=${2:-10}
+    local tagfield="component,code,description,node,log"
+
+    [ "x$VERBOSE" != "x1" ] || tagfield="*"
+
+    if [ "x$1" = "x" ] ; then
+        for component in $($HEX_SDK toggle_health_check | cut -d":" -f1) ; do
+            influx_event "select $tagfield from health where component='$component' order by desc limit $limit"
+        done
+    else
+        influx_event "select $tagfield from health where component='$component' order by desc limit $limit"
+    fi
+
+}
+
+
+influx_event_system()
+{
+    local re='^[0-9]+$'
+    local limit=10
+    local category=
+    if [ $# -eq 1 ] ; then
+        if [[ $1 =~ $re ]] ; then
+            limit=$1
+        else
+            local category=$1
+        fi
+    elif [ $# -gt 1 ] ; then
+        category=$1
+        limit=$2
+    fi
+    local tagfield="host,node,category,service,severity,message,metadata"
+
+    [ "x$VERBOSE" != "x1" ] || tagfield="*"
+
+    if [ "x$category" = "x" ] ; then
+        influx_event "select * from system order by desc limit $limit"
+    else
+        influx_event "select $tagfield from system where category='$category' order by desc limit $limit"
+    fi
+}
+
+influx_event_audit()
+{
+    local re='^[0-9]+$'
+    local limit=10
+    local pcmd=
+    if [ $# -eq 1 ] ; then
+        if [[ $1 =~ $re ]] ; then
+            limit=$1
+        else
+            local pcmd=$1
+        fi
+    elif [ $# -gt 1 ] ; then
+        pcmd=$1
+        limit=$2
+    fi
+    local tagfield="node,gcmd,pcmd,cmd"
+
+    [ "x$VERBOSE" != "x1" ] || tagfield="node,gusr,gcmd,gpid,pusr,pcmd,ppid,usr,cmd,pid"
+
+    if [ "x$pcmd" = "x" ] ; then
+        influx_event "select $tagfield from audit order by desc limit $limit"
+    else
+        influx_event "select $tagfield from audit where pcmd='$pcmd' order by desc limit $limit"
+    fi
+}

--- a/core/sdk_sh/modules.pre/sdk_remote.sh
+++ b/core/sdk_sh/modules.pre/sdk_remote.sh
@@ -30,8 +30,14 @@ remote_systemd_restart()
 }
 
 remote_run()
-{
+{   
+    local flag=
     local host=$1
     shift 1
-    ssh root@$host $@ 2>/dev/null
+    if [ "$VERBOSE" == "1" ] ; then
+        if test -t 0 ; then
+            flag="-t"
+        fi
+    fi
+    ssh $flag root@$host $@ 2>/dev/null
 }

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -67,9 +67,11 @@ eval "ERR_DESC_$SRV[3]='state unsync'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="vip"
-eval "ERR_DESC_$SRV[1]='active control IP down'"
-eval "ERR_DESC_$SRV[2]='inactive control IP active'"
+eval "ERR_DESC_$SRV[1]='active control misses VIP'"
+eval "ERR_DESC_$SRV[2]='inactive control has VIP'"
 eval "ERR_DESC_$SRV[3]='stale VIP in arp table'"
+eval "ERR_DESC_$SRV[4]='vip changed'"
+eval "ERR_DESC_$SRV[5]='vip missing'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="haproxy_ha"
@@ -165,6 +167,7 @@ eval "ERR_DESC_$SRV[5]='agent down'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="neutron"
+eval "ERR_DESC_$SRV[1]=':( due to vip change'"
 eval "ERR_DESC_$SRV[2]='api timeout'"
 eval "ERR_DESC_$SRV[3]='metadata not all up'"
 eval "ERR_DESC_$SRV[4]='vpn not all up'"

--- a/core/sdk_sh/modules/sdk_git.sh
+++ b/core/sdk_sh/modules/sdk_git.sh
@@ -66,7 +66,7 @@ _git_server_init()
             if [ -e "/.gitignore" ] ; then
                 Quiet -n git add -A
                 Quiet -n git commit -m "$(hex_cli -c firmware list | grep ACTIVE | awk '{print $2}')" -a
-                Quiet -n git push --set-upstream $project $branch
+                Quiet -n git push --set-upstream $project $branch && touch /etc/appliance/state/git_server_init
             else
                 Error "failed to generate /.gitignore"
             fi
@@ -133,4 +133,12 @@ git_push()
     local msg="${@:-n/a}"
     ( $GIT commit -m "$msg" -a && $GIT push -q && cubectl node exec "$GIT stash ; $GIT pull" ) >/dev/null || Error "nothing is pushed"
     Quiet -n $GIT -P log -3
+}
+
+git_init()
+{
+    git_server_init
+    if [ -e /etc/appliance/state/git_server_init ] ; then
+        host_local_run cubectl node exec -p "hex_sdk git_client_init"
+    fi
 }

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -141,7 +141,7 @@ gpu_device_status()
     printf "+%14s+%36s\n" | tr " " "-"
     printf "\n"
 
-    health_cyborg_report
+    hex_sdk -v -f none health_cyborg_report
 
     printf "\n"
 }

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -9,7 +9,7 @@ fi
 source ${SDK_DIR}/modules/errcodes
 # _check is invoked by lmi which lacks persmissions to run
 # ssh commands like is_remote_running. Wrap it with /usr/sbin/hex_config sdk_run
-ERR_CODE=0                      # health_check error code
+ERR_CODE=${ERR_CODE:-0}         # health_check error code
 ERR_MSG=                        # health_check error message
 ERR_LOG=                        # health_check log file
 ERR_LOGSIZE=100                 # health_check log size (number of lines)
@@ -80,7 +80,6 @@ _health_fail_log()
     local srv=$(caller 0 | cut -d" " -f2 | sed -e "s/^health_//" -e "s/_check$//")
 
     [ "$VERBOSE" != "1" ] || echo -e "$ERR_MSG"
-    [ `cubectl node exec -pn "[ -e $CUBE_DONE ] && echo 0" | wc -l` -eq ${#CUBE_NODE_LIST_HOSTNAMES[@]} ] || return $ERR_CODE
 
     local maxerr=6
     if [ -f /etc/alert.level ] ; then
@@ -118,15 +117,19 @@ _health_fail_log()
         echo -e "$ERR_MSG" $'\n' >> /var/log/health_${srv}_error.log
         echo $count > /tmp/health_${srv}_error.count
         if [ $count -lt $maxerr ] ; then
-            local auto_repair_func="_health_${srv}_auto_repair"
-            if Quiet type $auto_repair_func 2>/dev/null ; then
-                query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixing\""
-                if ! $INFLUX -database events -execute "${query},detail=\"auto repair ($count/$maxerr)\"" ; then
-                    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-                        timeout $SRVSTO /usr/bin/influx -host $node -database events -execute "${query},detail=\"auto repair ($count/$maxerr)\""
-                    done
+            if [ `cubectl node exec -pn "[ -e $CUBE_DONE ] && echo 0" | wc -l` -eq ${#CUBE_NODE_LIST_HOSTNAMES[@]} ] ; then
+                local auto_repair_func="_health_${srv}_auto_repair"
+                if Quiet type $auto_repair_func 2>/dev/null ; then
+                    query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixing\""
+                    $auto_repair_func &
+                    echo $! > $runtime
+                    influx_event "${query},detail=\"$auto_repair_func PID$(cat $runtime) ($count/$maxerr)\""
+                    ln -sf $runtime $CLUSTER_REPAIRING
+                    wait $(cat $runtime)
+                    query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixed\""
+                    influx_event "${query},detail=\"$auto_repair_func PID$(cat $runtime) ($count/$maxerr)\""
+                    rm -f $runtime $CLUSTER_REPAIRING
                 fi
-                $auto_repair_func
             fi
         fi
     fi
@@ -146,26 +149,26 @@ EOF
         if [ "x$keys" = "x" ] ; then
             Quiet -n $OPENSTACK ec2 credentials create --user admin --project admin
             keys="$($OPENSTACK ec2 credentials list --user admin -c Access -c Secret -f value | head -n 1)"
-            keys=$keys $HEX_SDK os_s3_bucket_create admin log >/dev/null 2>&1
+            keys=$keys timeout $SRVSTO $HEX_SDK os_s3_bucket_create admin log >/dev/null 2>&1
         fi
         # Only when there're valid keys would we be able to save logs
         if [ "x$keys" != "x" ] ; then
             timeout $SRVSTO cubectl node exec -p "if [ -f \"$ERR_LOG\" ] ; then tail -n $ERR_LOGSIZE $ERR_LOG ; else $ERR_LOG ; fi" > /tmp/$log
             if [ -e /tmp/${log:-NOSUCHLOG} ] ; then
-                keys=$keys $HEX_SDK os_s3_object_put admin /tmp/$log $log_pth >/dev/null 2>&1 || keys=$keys $HEX_SDK os_s3_bucket_create admin log
+                keys=$keys timeout $SRVSTO $HEX_SDK os_s3_object_put admin /tmp/$log $log_pth >/dev/null 2>&1 || keys=$keys timeout $SRVSTO $HEX_SDK os_s3_bucket_create admin log
                 log_url="s3://$log_pth"
                 rm -f /tmp/$log
             else
                 # In case collecting logs from remote fails, look for local log
                 if [ -e $ERR_LOG ] ; then
                     tail -n $ERR_LOGSIZE $ERR_LOG > /tmp/$log
-                    keys=$keys $HEX_SDK os_s3_object_put admin $ERR_LOG $log_pth >/dev/null 2>&1 || keys=$keys $HEX_SDK os_s3_bucket_create admin log
+                    keys=$keys timeout $SRVSTO $HEX_SDK os_s3_object_put admin $ERR_LOG $log_pth >/dev/null 2>&1 || keys=$keys timeout $SRVSTO $HEX_SDK os_s3_bucket_create admin log
                     log_url="s3://$log_pth"
                 fi
             fi
         fi
     fi
-    $INFLUX -database events -execute "${query},log=\"${log_url}\",detail=\"${err_msg_oneline}\""
+    influx_event "${query},log=\"${log_url}\",detail=\"${err_msg_oneline}\""
 
     return $ERR_CODE
 }
@@ -632,30 +635,37 @@ health_vip_check()
 {
     local active_host=$($HEX_CFG status_pacemaker | awk '/IPaddr2/{print $5}')
     DESCRIPTION="non-HA"
+    ERR_LOG="pcs status"
 
     if [ -n "$active_host" ] ; then
         for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-            local ipcidr=$(remote_run $node ip addr list | awk '/ secondary /{print $2}')
+            local ipcidr=$(ssh -o ConnectTimeout=3 root@$node 2>/dev/null ip addr list | awk '/ secondary /{print $2}')
             local ipaddr=$(echo $ipcidr | cut -d"/" -f1)
             if [ "$node" == "$active_host" ] ; then
                 DESCRIPTION="$ipcidr@$active_host"
-                if [ -z "$ipcidr" ] ; then
-                    ERR_CODE=1
-                    ERR_MSG+="$ipcidr should be active on $node\n"
-                    ERR_LOG="pcs status"
+                ERR_MSG=$DESCRIPTION
+                old_vip=$(FORMAT=json VERBOSE=1 influx_event_health vip | jq -r .results[].series[].values[][4] | grep "[0-9].*@" | head -1)
+                if [  "x$ipcidr" != "x" -a "x$old_vip" != "x" -a "$old_vip" != "$DESCRIPTION" -a "$HOSTNAME" == "$active_host" ] ; then
+                    # in case of instanceha, repair has to happen while not all nodes are bootstrapped
+                    rm -f /tmp/health_neutron_error.count
+                    ERR_CODE=1 _health_neutron_auto_repair
+                    ERR_CODE=4
                 elif [ $(cubectl node exec -np "arping -c 1 -w 1 $ipaddr >/dev/null && arp -n $ipaddr" | grep "^${ipaddr}" | awk '{print $1, $3}' | sort -u | wc -l) -gt 1 ] ; then
                     ERR_CODE=3
-                    ERR_MSG+="stale VIP in arp table\n"
                     ERR_LOG="cubectl node exec -p arp -e -n $ipaddr"
+                elif [ -z "$ipcidr" ] ; then
+                    ERR_CODE=1
                 fi
             else
                 if [ -n "$ipcidr" ] ; then
                     ERR_CODE=2
-                    ERR_MSG+="$ipcidr shouldn't be active on $node\n"
-                    ERR_LOG="pcs status"
                 fi
             fi
         done
+    else
+        if [ ${#CUBE_NODE_CONTROL_HOSTNAMES[@]} -ge 3 ] ; then
+            ERR_CODE=5
+        fi
     fi
 
     _health_fail_log
@@ -663,18 +673,21 @@ health_vip_check()
 
 _health_vip_auto_repair()
 {
-    if [ "$ERR_CODE" == "3" ] ; then
+    if [ $ERR_CODE -eq 3 ] ; then # fixing arp table first
         Quiet -n cubectl node exec -np "arp -d $ipaddr ; arping -c 1 -w 1 $ipaddr"
+    elif [ $ERR_CODE -eq 5 ] ; then
+        unlink /run/cube_cluster_repairing # fixing vip has high priority
+        cubectl node exec -r control -p systemctl restart corosync
     fi
 }
 
 health_vip_repair()
 {
     local active_host=$($HEX_CFG status_pacemaker | awk '/IPaddr2/{print $5}')
-    if [ -n "$active_host" ] ; then
+    if cubectl node list -r control -j | jq -r .[].hostname | grep -q "^${active_host}$" ; then
         for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-            local ipaddr=$(remote_run $node ip addr list | awk '/ secondary /{print $2}')
-            local ifname=$(remote_run $node ip addr list | awk '/ secondary /{print $NF}')
+            local ipaddr=$(ssh -o ConnectTimeout=3 root@$node 2>/dev/null ip addr list | awk '/ secondary /{print $2}')
+            local ifname=$(ssh -o ConnectTimeout=3 root@$node 2>/dev/null ip addr list | awk '/ secondary /{print $NF}')
             if [ "$node" == "$active_host" ] ; then
                 if [ -z "$ipaddr" ] ; then
                     pcs resource disable vip
@@ -687,6 +700,28 @@ health_vip_repair()
                 fi
             fi
         done
+    else
+        if [ ${#CUBE_NODE_CONTROL_HOSTNAMES[@]} -ge 3 ] ; then
+            cubectl node exec -r control -p systemctl restart corosync
+            pcs resource disable vip
+            pcs resource enable vip
+            for i in {1..20} ; do
+                if pcs resource status vip | grep -q -i started ; then
+                    break
+                else
+                    sleep 10
+                fi
+            done
+
+            pcs resource status vip | grep -q -i started || health_hacluster_repair
+            for i in {1..20} ; do
+                if pcs resource status vip | grep -q -i started ; then
+                    break
+                else
+                    sleep 10
+                fi
+            done
+        fi
     fi
 }
 
@@ -1619,8 +1654,11 @@ health_neutron_check()
     local control_up=$(echo "$service_stats" | grep ovn-controller | grep -i True | wc -l )
     local control_down=$(echo "$service_stats" | grep ovn-controller | grep -i False | wc -l )
 
+    ERR_MSG+="$service_stats\n"
     ERR_LOG="journalctl -n $ERR_LOGSIZE -u neutron-server"
-    if [ -z "$service_stats" ] ; then
+    if echo $(VERBOSE=1 influx_event_health vip) | grep -q "vip changed" ; then
+        ERR_CODE=1
+    elif [ -z "$service_stats" ] ; then
         ERR_CODE=2
     elif [ "$metadata_up" == "0" -o "$metadata_down" != "0" ] ; then
         ERR_CODE=3
@@ -1628,6 +1666,8 @@ health_neutron_check()
         ERR_CODE=4
     elif [ "$control_up" == "0" -o "$control_down" != "0" ] ; then
         ERR_CODE=5
+    else
+        ERR_MSG=
     fi
 
     if [ $ERR_CODE -eq 0 ] ; then
@@ -1644,15 +1684,24 @@ health_neutron_check()
         fi
     fi
 
-    ERR_MSG+="$service_stats\n"
     _health_fail_log
 }
 
 _health_neutron_auto_repair()
 {
-    if [ "$ERR_CODE" != "0" ] ; then
+    if [ $ERR_CODE -ne 0 ] ; then
         $OPENSTACK port list -f value -c ID -c Name | grep "diag[-]" | cut -d " " -f1 | xargs -i $OPENSTACK port delete {}
-        if [ $ERR_CODE -eq 6 ] ; then
+        if [ $ERR_CODE -eq 1 ] ; then
+            # $OPENSTACK network agent list -f json -c ID -c Alive | jq -r ".[] | select(.Alive == false).ID" | xargs -i $OPENSTACK network agent delete {}
+            cubectl node exec -r control -pn systemctl restart neutron-server
+            timeout $SRVTO cubectl node exec -r compute -pn "systemctl restart neutron-ovn-metadata-agent"
+            timeout $SRVTO cubectl node exec -r compute -pn "systemctl restart neutron-ovn-vpn-agent"
+
+            # Fail over Ceph dashboard which doesn't work automatically with new active ceph-mgr
+            # SDK auto repair cannot help because when inst-ha takes place, not all nodes complete bootstrap
+            $CEPH mgr module disable dashboard
+            $CEPH mgr module enable dashboard
+        elif [ $ERR_CODE -eq 6 ] ; then
             Quiet -n cubectl node exec -r control -pn -- $HEX_SDK os_neutron_worker_scale
         else
             $HEX_SDK ovn_neutron_db_sync
@@ -3019,32 +3068,11 @@ health_node_report()
     printf "+%12s+%7s+%7s+%7s+%7s+%7s+\n" | tr " " "-"
 }
 
-health_db_select()
-{
-    local component=$1
-    local limit=${2:-10}
-    local tagfield="component,code,description,node,log"
-    local flag=
-
-    if [ "$FORMAT" = "json" ] ; then
-        flag="-format json -pretty"
-    fi
-    [ "$VERBOSE" != "1" ] || tagfield+=",detail"
-
-    if [ "x$1" = "x" ] ; then
-        for component in $($HEX_SDK toggle_health_check | cut -d":" -f1) ; do
-            $INFLUX $flag -database events -execute "select $tagfield from health where component='$component' order by desc limit $limit"
-        done
-    else
-        $INFLUX $flag -database events -execute "select $tagfield from health where component='$component' order by desc limit $limit"
-    fi
-}
-
 health_log_dump()
 {
     local component=$1
     local n_from_last=${2:-1}
-    local s3_log=$(health_db_select ${component:-NOSUCHCOMPONENT} 2>/dev/null | grep s3 | sed -n ${n_from_last}p | grep -o "s3://log/.*")
+    local s3_log=$(influx_event_health ${component:-NOSUCHCOMPONENT} 2>/dev/null | grep s3 | sed -n ${n_from_last}p | grep -o "s3://log/.*")
 
     if [ "x$s3_log" != "x" ] ; then
         $HEX_SDK os_s3_object_get admin $s3_log /tmp/$s3_log
@@ -3057,15 +3085,14 @@ health_log_detail()
 {
     local component=$1
     local n_from_last=${2:-1}
-    local flag="-format json"
 
     [ $n_from_last -ge 1 ] || Error "invalid index $n_from_last"
-    local timestamp=$(VERBOSE=1 FORMAT= health_db_select $component $n_from_last | tail -1 | awk '{print $1}')
+    local timestamp=$(VERBOSE=1 FORMAT= influx_event_health $component $n_from_last | tail -1 | awk '{print $1}')
     if [ "$FORMAT" = "json" ] ; then
-        $INFLUX $flag -database events -execute "select time,detail from health where (component='$component' and time=$timestamp)"
+        influx_event "select time,detail from health where (component='$component' and time=$timestamp)"
     else
         echo -n "$(date -d @${timestamp:0:10}) - "
-        $INFLUX $flag -database events -execute "select time,detail from health where (component='$component' and time=$timestamp)" | jq -r .results[].series[].values[][] | tr ";" "\n"
+        influx_event "select time,detail from health where (component='$component' and time=$timestamp)" | jq -r .results[].series[].values[][] | tr ";" "\n"
     fi
 }
 

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -281,127 +281,47 @@ os_instance_ha_helper()
 {
     # Do not intervene bootstrap processes
     [ -e /run/cube_commit_done ] >/dev/null 2>&1 || return 0
-    # Proceed only when instance_ha is enabled
-    [ $($OPENSTACK segment list -f value -c name | wc -l) -ne 0 ] || return 0
-    # Do nothing if another node is taking actions
-    local helping=/mnt/cephfs/nova/instance_ha.helping
-    local cmp_lst=$($OPENSTACK compute service list -f json)
-    local down_host=$(echo $cmp_lst | jq -r '.[] | select (.Binary == "nova-compute" and .Status == "disabled" and .State == "down").Host' | sort -u)
-    if [ -e $helping ] ; then
-        # Remove stale lock if it exceeds 60 min
-        duration=$(echo $(( ($(date +%s) - $(stat $helping -c %Y)) / 60 )))
-        [ ${duration:-60} -lt 60 ] || rm -f $helping
-        [ "x$down_host" != "x$(cat $helping)" ] || rm -f $helping
-        return 0
-    fi
 
-    hostname > $helping # mutex lock
+    # Proceed only when instance_ha is enabled
+    $OPENSTACK segment list -f value -c is_enabled | grep -q -i true || return 0
 
     # Fail over Ceph dashboard which doesn't work automatically with new active ceph-mgr
     # SDK auto repair cannot help because when inst-ha takes place, not all nodes complete bootstrap
     local active=$($CEPH mgr stat -f json | jq -r .active_name)
     if ! timeout $SRVSTO curl -I -k https://${active}:7442/ceph/ 2>/dev/null | grep -q "200 OK" ; then
         $CEPH mgr module disable dashboard
-        echo "ceph mgr module disable dashboard" >> $helping
         $CEPH mgr module enable dashboard
-        echo "ceph mgr module enable dashboard" >> $helping
     fi
     mountpoint -- $CEPHFS_STORE_DIR  | grep -q "is a mountpoint" || timeout $SRVTO cubectl node exec -pn "$HEX_SDK ceph_mount_cephfs"
 
-    local vip=/mnt/cephfs/nova/cluster.vip
-    if [ ! -e $vip ] ; then
-        timeout $SRVSTO $HEX_SDK -f json health_vip_report | jq -r .description > $vip
-    else
-        old_vip=$(cat $vip)
-        new_vip=$(timeout $SRVSTO $HEX_SDK -f json health_vip_report | jq -r .description)
-        if [ "x$old_vip" != "x$new_vip" ] ; then
-            echo "old_vip=$old_vip" >> $helping
-            echo "new_vip=$new_vip" >> $helping
-            $OPENSTACK network agent list -f json -c ID -c Alive | jq -r ".[] | select(.Alive == false).ID" | xargs -i $OPENSTACK network agent delete {}
-            echo "removed non active network agent" >> $helping
-            timeout $SRVTO cubectl node exec -r control -pn systemctl restart neutron-server
-            echo "cubectl node exec -r control -pn systemctl restart neutron-server" >> $helping
-            timeout $SRVTO cubectl node exec -r compute -pn "$OPENSTACK network agent list --host \$HOSTNAME | grep -q 'OVN Metadata .* :-)' || systemctl restart neutron-ovn-metadata-agent"
-            echo "cubectl node exec -r compute -pn systemctl restart neutron-ovn-metadata-agent" >> $helping
-            timeout $SRVTO cubectl node exec -r compute -pn "$OPENSTACK network agent list --host \$HOSTNAME | grep -q 'VPN .* :-)' || systemctl restart neutron-ovn-vpn-agent"
-            echo "cubectl node exec -r compute -pn systemctl restart neutron-ovn-vpn-agent" >> $helping
-            echo $new_vip > $vip
-        else
-            local NET_LST=$($OPENSTACK network agent list -f json)
-            for node in $(echo $NET_LST | jq -r '.[] | select (.Alive == false and .State == true and ."Agent Type" == "VPN Agent").Host' | sort -u) ; do
-                if [ "x$node" != "x$down_host" ] ; then
-                    timeout $SRVSTO $HEX_SDK remote_run $node systemctl restart neutron-ovn-vpn-agent
-                    echo "$HEX_SDK remote_run $node systemctl restart neutron-ovn-vpn-agent" >> $helping
-                fi
-            done
-            for node in $(echo $NET_LST | jq -r '.[] | select (.Alive == false and .State == true and ."Agent Type" == "OVN Metadata agent").Host' | sort -u) ; do
-                if [ "x$node" != "x$down_host" ] ; then
-                    timeout $SRVSTO $HEX_SDK remote_run $node systemctl restart neutron-ovn-metadata-agent
-                    echo "$HEX_SDK remote_run $node systemctl restart neutron-ovn-metadata-agent" >> $helping
-                fi
-            done
-        fi
-    fi
-
-    # Revive nova compute if it is enabled but service is down
-    for node in $(echo $cmp_lst | jq -r '.[] | select (.Binary == "nova-compute" and .Status == "enabled" and .State == "down").Host' | sort -u) ; do
-        timeout $SRVTO $HEX_SDK remote_run $node systemctl restart openstack-nova-compute
-        echo "$HEX_SDK remote_run $node systemctl restart openstack-nova-compute" >> $helping
-    done
-
-    local notify_log=/mnt/cephfs/nova/notification.log
     local new_notify=$($OPENSTACK notification list -f value | grep COMPUTE_HOST | head -1)
-    if [ ! -e $notify_log ] ; then
-        echo $new_notify > $notify_log
-    else
-        if echo $new_notify | grep -q "finished COMPUTE_HOST" ; then
-            echo $new_notify > $notify_log
-        elif echo $new_notify | grep -q -e "new COMPUTE_HOST" -e "running COMPUTE_HOST" ; then
-            :
-        else
-            local old_notify="$(head -1 $notify_log)"
-            if [ "x$new_notify" = "x$old_notify" ] ; then
-                fix_cnt="$(tail -1 $notify_log | cut -d":" -f1)"
-                case $fix_cnt in
-                    0|1|2|3|4|5|6|7|8|9)
-                        ((fix_cnt++))
-                        echo "${fix_cnt}:$HOSTNAME" >> $notify_log
-                        ;;
-                    *)
-                        ;;
-                esac
+    local old_notify=$(VERBOSE=1 FORMAT=json influx_event_health instanceha 1 | jq -r .results[].series[].values[][4])
+    local notify_id=$(echo $new_notify | cut -d" " -f1)
+    local query="insert health,component=instanceha,node=$HOSTNAME,code=0 description=\"checking\""
+    [ "x$old_notify" = "x$new_notify" ] || influx_event "${query},log=\"$($OPENSTACK notification show ${notify_id:-NOID} -f json)\",detail=\"$new_notify\""
+    if echo $new_notify | grep -q -e "failed COMPUTE_HOST" ; then
+        query="insert health,component=instanceha,node=$HOSTNAME,code=1 description=\"fixing\""
+        local srv_lst=$($OPENSTACK server list --long --all-projects -f json)
+        for ID in $(echo $srv_lst | jq -r .[].ID) ; do
+            local cur_status=$(echo $srv_lst | jq -r ".[] | select(.ID == \"${ID}\").\"Status\"")
+            local cur_host=$(echo $srv_lst | jq -r ".[] | select(.ID == \"${ID}\").Host")
+            if [ "x$cur_host" = "x$down_host" ] ; then
+                if [ "x$cur_status" = "xERROR" ] ; then
+                    timeout $SRVSTO $HEX_SDK os_nova_instance_reset $ID
+                    influx_event "${query},detail=\"os_nova_instance_reset $ID\""
+                fi
+                influx_event "${query},detail=\"nova evacuate $ID\""
+                timeout $SRVTO nova evacuate $ID
             else
-                echo $new_notify > $notify_log
-                fix_cnt=1
-                echo "${fix_cnt}:$HOSTNAME" >> $notify_log
+                if [ "x$cur_status" = "xERROR" -o "x$cur_status" = "xREBUILD" ] ; then
+                    influx_event "${query},detail=\"os_nova_instance_reset $ID\""
+                    timeout $SRVSTO $HEX_SDK os_nova_instance_reset $ID
+                    influx_event "${query},detail=\"os_nova_instance_hardreboot $ID\""
+                    timeout $SRVSTO $HEX_SDK os_nova_instance_hardreboot $ID
+                fi
             fi
-            if [ $fix_cnt -lt 10 ] ; then
-                notify_id=$(echo $new_notify | cut -d" " -f1)
-                local notify_detail=$($OPENSTACK notification show $notify_id -f json)
-                local srv_lst=$($OPENSTACK server list --long --all-projects -f json)
-                for ID in $(echo $srv_lst | jq -r .[].ID) ; do
-                    local cur_status=$(echo $srv_lst | jq -r ".[] | select(.ID == \"${ID}\").\"Status\"")
-                    local cur_host=$(echo $srv_lst | jq -r ".[] | select(.ID == \"${ID}\").Host")
-                    if [ "x$cur_host" = "x$down_host" ] ; then
-                        if [ "x$cur_status" = "xERROR" ] ; then
-                            timeout $SRVSTO $HEX_SDK os_nova_instance_reset $ID
-                            echo "$HEX_SDK os_nova_instance_reset $ID" >> $helping
-                        fi
-                        timeout $SRVTO nova evacuate $ID
-                        echo "nova evacuate $ID" >> $helping
-                    else
-                        if [ "x$cur_status" = "xERROR" -o "x$cur_status" = "xREBUILD" ] ; then
-                            timeout $SRVSTO $HEX_SDK os_nova_instance_reset $ID
-                            echo "$HEX_SDK os_nova_instance_reset $ID" >> $helping
-                            timeout $SRVSTO $HEX_SDK os_nova_instance_hardreboot $ID
-                            echo "$HEX_SDK os_nova_instance_hardreboot $ID" >> $helping
-                        fi
-                    fi
-                done
-            fi
-        fi
+        done
     fi
-    rm -f $helping              # mutex unlock
 }
 
 os_get_network_id_by_tenant_and_name()
@@ -2672,13 +2592,13 @@ os_device_profile_create()
 
     OLDIFS="$IFS"
     IFS=$'\n'
-    for d in $($OPENSTACK accelerator device list -f value -c vendor -c std_board_info | sort | uniq) ; do
+    for d in $(timeout $SRVTO openstack accelerator device list -f value -c vendor -c std_board_info | sort | uniq) ; do
         if echo $d | grep -q "^10de " ; then
             pid=$(echo $d | awk '{ s = "" ; for (i = 2 ; i <= NF ; i++) s = s $i " " ; print s }' | jq -r .product_id | tr '[:lower:]' '[:upper:]')
-            uuid=$($OPENSTACK accelerator device list -f value -c uuid -c vendor -c std_board_info | grep $d | head -1 | awk '{print $1}')
-            model=$($OPENSTACK accelerator device show -f json $uuid | jq -r .model)
+            uuid=$(timeout $SRVTO openstack accelerator device list -f value -c uuid -c vendor -c std_board_info | grep $d | head -1 | awk '{print $1}')
+            model=$(timeout $SRVTO openstack accelerator device show -f json $uuid | jq -r .model)
             name=$(echo $model | awk -F'[' '{print $2}' | awk -F']' '{print $1}' | tr '[:upper:]' '[:lower:]' | tr ' ' '_')
-            if ! $OPENSTACK accelerator device profile list -f value -c name | grep -q "${name}_${units}" ; then
+            if ! timeout $SRVTO openstack accelerator device profile list -f value -c name | grep -q "${name}_${units}" ; then
                 echo "Creating device profile for $model (resource unit: $units)"
                 profile="["
                 for i in $(seq $units) ; do
@@ -2689,7 +2609,7 @@ os_device_profile_create()
                 done
                 profile="${profile}]"
 
-                $OPENSTACK accelerator device profile create ${name}_${units} "$profile"
+                timeout $SRVTO openstack accelerator device profile create ${name}_${units} "$profile"
             fi
         fi
     done


### PR DESCRIPTION
- feat: hex_sdk audit logs #163
- fix: CLI GPU management function not found #178
- new: update rancher-cluster-image_22.04.vmdk to rancher-cluster-image_22.04.raw
- new: log bootstrap activities into events system BSP
- new: log rolling-upgrade activities into events system RUG
- new: log all hex_sdk operations into influx_event_audit
- new: log health check/repair actual command into detail tags
- fix: make robust influx operations
- new: deprecate legacy instance-ha helper cron job
- new: pcs resource vaw to catch and handle vip change in seconds
- new: retire rpmfind.net that is often unavailable
- new: improved health_vip_check/repair logic

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
