### PR TITLE
chore: pull upstream fix on unix socket error

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -11,7 +11,7 @@ fi
 
 export HOSTNAME=$(ssh localhost hostname 2>/dev/null)
 query="insert system,category=BSP,key=BSP00001I,service=bootstrap,host=$HOSTNAME"
-# Bring up influxdb as early as early as possible to log bootstrap activities
+# Bring up influxdb as early as possible to log bootstrap activities
 cubectl node exec -r control -pn "systemctl show -p SubState influxdb | grep -q -i running || systemctl restart influxdb"
 
 BootstrapAndClusterstart()

--- a/core/modules/config_pacemaker.cpp
+++ b/core/modules/config_pacemaker.cpp
@@ -212,7 +212,7 @@ Commit(bool modified, int dryLevel)
 
     WriteLogRotateConf(log_conf);
 
-    // vip could be misssing when corosync doesn't form quorum between system reboots
+    // vip could be missing when corosync doesn't form quorum between system reboots
     HexUtilSystemF(0, 0, HEX_SDK " health_vip_check || " HEX_SDK " health_vip_repair");
 
     return true;

--- a/core/nginx/nginx.conf.in
+++ b/core/nginx/nginx.conf.in
@@ -61,7 +61,7 @@ http {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
     upstream skyline {
-        server 127.0.0.1:9998 fail_timeout=0;
+        server unix:/var/lib/skyline/skyline.sock fail_timeout=0;
     }
 
     upstream cube-cos-api {

--- a/core/sdk_sh/modules.pre/sdk_remote.sh
+++ b/core/sdk_sh/modules.pre/sdk_remote.sh
@@ -30,7 +30,7 @@ remote_systemd_restart()
 }
 
 remote_run()
-{   
+{
     local flag=
     local host=$1
     shift 1

--- a/core/skyline/skyline.mk
+++ b/core/skyline/skyline.mk
@@ -3,6 +3,7 @@
 
 SKYLINE_CONF_DIR := /etc/skyline
 SKYLINE_POLICY_DIR := $(SKYLINE_CONF_DIR)/policy
+SKYLINE_APP_DIR := /var/lib/skyline
 SKYLINE_LOG_DIR := /var/log/skyline
 
 # refer to skyline-apiserver/requirements.txt, need to be installed before openstack deps
@@ -10,11 +11,11 @@ ROOTFS_PIP_NC += gunicorn
 
 # skyline user/group/directory
 rootfs_install::
-	$(Q)chroot $(ROOTDIR) mkdir -p $(SKYLINE_CONF_DIR) $(SKYLINE_POLICY_DIR) $(SKYLINE_LOG_DIR)
+	$(Q)chroot $(ROOTDIR) mkdir -p $(SKYLINE_CONF_DIR) $(SKYLINE_POLICY_DIR) $(SKYLINE_APP_DIR) $(SKYLINE_LOG_DIR)
 
 # for RC builds
 heavyfs_install::
-	$(Q)chroot $(ROOTDIR) mkdir -p $(SKYLINE_CONF_DIR) $(SKYLINE_POLICY_DIR) $(SKYLINE_LOG_DIR)
+	$(Q)chroot $(ROOTDIR) mkdir -p $(SKYLINE_CONF_DIR) $(SKYLINE_POLICY_DIR) $(SKYLINE_APP_DIR) $(SKYLINE_LOG_DIR)
 
 # note: ROOTFS_PIP_DL_FROM is not used since we clone source from master branch instead of targeted openstack branch (stable/yoga)
 # skyline-apiserver installation


### PR DESCRIPTION
#### What type of PR is this?

- chore

#### What this PR does / why we need it

- Pull the upstream fix on unix socket opening error
- Fix some typos

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

- This PR needs https://github.com/bigstack-oss/skyline-apiserver/pull/3

#### Additional documentation

> Operation not supported" errors: Recent Linux kernel versions (e.g., 6.1.124 and newer) have explicitly restricted SO_REUSEPORT to AF_INET and AF_INET6 sockets. Attempting to set SO_REUSEPORT on an AF_UNIX socket will result in an OSError: [Errno 95] Operation not supported (EOPNOTSUPP). Gunicorn, like other applications, will encounter this error if reuse_port is set to True for Unix socket bindings.

Fixed by https://github.com/openstack/skyline-apiserver/commit/65673a38f330dd79eb7bcbfd97a8f0910bf15156

Upstream bug report https://bugs.launchpad.net/skyline-apiserver/+bug/2111808
