### PR TITLE
fix(keycloak): failed to pull the keycloak image

### DIFF
--- a/core/api/api.mk
+++ b/core/api/api.mk
@@ -1,11 +1,18 @@
 # Cube SDK
 # CubeCOS API installation
 
-# api log
+# api directories
 API_LOG_DIR := /var/log/cube-cos-api
+API_CONF_DIR := /etc/cube/api
 
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p $(API_LOG_DIR)
+	$(Q)chroot $(ROOTDIR) mkdir -p $(API_CONF_DIR)
+
+# for RC builds
+heavyfs_install::
+	$(Q)chroot $(ROOTDIR) mkdir -p $(API_LOG_DIR)
+	$(Q)chroot $(ROOTDIR) mkdir -p $(API_CONF_DIR)
 
 # api installation
 API_RPM = $(TOP_BLDDIR)/core/api/api.rpm

--- a/core/keycloak/chart-values.yaml
+++ b/core/keycloak/chart-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: localhost:5080/bigstack/keycloak
-  tag: 17.1.0
+  tag: 17.2.0
 
 replicas: 1
 

--- a/core/keycloak/keycloak.mk
+++ b/core/keycloak/keycloak.mk
@@ -1,9 +1,12 @@
 # Cube SDK
 # keycloak installation
 
+# keycloak directories
 KEYCLOAK_DIR := /opt/keycloak/
+KEYCLOAK_CONF_DIR := /etc/keycloak
 
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KEYCLOAK_DIR)
+	$(Q)chroot $(ROOTDIR) mkdir -p $(KEYCLOAK_CONF_DIR)
 	$(Q)cp -f $(COREDIR)/keycloak/chart-values.yaml $(ROOTDIR)/$(KEYCLOAK_DIR)
 	$(Q)cp -f $(TOP_BLDDIR)/core/keycloak/keycloak-*.tgz $(ROOTDIR)/$(KEYCLOAK_DIR)

--- a/core/ui/ui.mk
+++ b/core/ui/ui.mk
@@ -1,10 +1,14 @@
 # Cube SDK
 # CubeCOS UI installation
 
-# ui log
+# ui directories
 UI_LOG_DIR := /var/log/cube-cos-ui
 
 rootfs_install::
+	$(Q)chroot $(ROOTDIR) mkdir -p $(UI_LOG_DIR)
+
+# for RC builds
+heavyfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p $(UI_LOG_DIR)
 
 # ui installation


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Bump Keycloak image tag from 17.1.0 to 17.2.0 as the change made in the upstream `cube-cos-ui`
- Create config directories in the build jail to increase CubeCOS runtime stability

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
