### PR TITLE
fix(hex_sdk): check file existence and adjust the wrong input parameter in alert_put_setting_receiver_exec_shell for alert_add_update_setting_receiver_exec_shell

### DIFF
--- a/core/sdk_sh/modules/sdk_alert.sh
+++ b/core/sdk_sh/modules/sdk_alert.sh
@@ -537,6 +537,9 @@ alert_add_update_setting_receiver_exec_shell()
     if [[ "$name" == "" ]] ; then
         return 1
     fi
+    if [ ! -f "/var/response/${name}.shell" ] ; then
+        return 1
+    fi
 
     # prepare the environment
     cp -f "/var/response/$name.shell" "$ALERT_RESP_DIR/exec_$name.shell"
@@ -583,8 +586,11 @@ alert_put_setting_receiver_exec_shell()
     if [[ "$name" == "" ]] ; then
         return 1
     fi
+    if [ ! -f "/var/response/${name}.shell" ] ; then
+        return 1
+    fi
 
-    alert_add_update_setting_receiver_exec_shell "$name.shell"
+    alert_add_update_setting_receiver_exec_shell "$name"
     local ret=$?
     return $ret
 }


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Check file existence in `hex_sdk alert_put_setting_receiver_exec_shell` and `hex_sdk alert_add_update_setting_receiver_exec_shell`
- Fix the wrong input parameter in `alert_put_setting_receiver_exec_shell` for `alert_add_update_setting_receiver_exec_shell`

#### Which issue(s) this PR fixes

- Related to #172 

#### Special notes for your reviewer

#### Additional documentation
