### PR TITLE
feat(alert): allow arbitrary file names to be set as alert response exec shell names

### DIFF
--- a/core/modules/cli_alert_resp.cpp
+++ b/core/modules/cli_alert_resp.cpp
@@ -690,20 +690,14 @@ NotifySettingMain(int argc, const char** argv)
 
                 // list files not directory
                 std::string cmd = "ls -p " + dir + " | grep -v /";
-                int execFileIndex;
-                std::string execFile;
-                if (CliMatchCmdHelper(argc, argv, 6, cmd, &execFileIndex, &execFile) != 0) {
+                int execNameIndex;
+                std::string execName;
+                if (CliMatchCmdHelper(argc, argv, 6, cmd, &execNameIndex, &execName) != 0) {
                     CliPrintf("no such file");
                     return CLI_UNEXPECTED_ERROR;
                 }
 
-                std::string fullPath = dir + "/" + execFile;
-                std::string execName = execFile;
-                std::size_t dotPosition = execName.find_first_of('.');
-                if (dotPosition != std::string::npos) {
-                    // remove the file extension, e.g., aaa.bbb => aaa
-                    execName.erase(dotPosition);
-                }
+                std::string fullPath = dir + "/" + execName;
                 HexSystemF(0, "cp -f %s /var/alert_resp/exec_%s.%s", fullPath.c_str(), execName.c_str(), execType.c_str());
                 if (execFileDirectoryIndex == FILE_DIRECTORY_USB) {
                     HexSpawnNoSig(UnInterruptibleHdr, (int)true, 0, HEX_CFG, "umount_usb", NULL);
@@ -815,19 +809,12 @@ NotifySettingMain(int argc, const char** argv)
 
                 std::string execName = "";
                 std::string execType = "";
-                std::size_t dotPositionOne = execFile.find_first_of('.');
-                if (dotPositionOne != std::string::npos) {
-                    execName = execFile.substr(0, dotPositionOne);
+                std::size_t dotPosition = execFile.find_last_of('.');
+                if (dotPosition != std::string::npos) {
+                    execName = execFile.substr(0, dotPosition);
 
-                    std::size_t dotPositionTwo = execFile.find_last_of('.');
-                    if (dotPositionTwo != std::string::npos) {
-                        if (dotPositionOne != dotPositionTwo) {
-                            return CLI_UNEXPECTED_ERROR;
-                        }
-
-                        if ((dotPositionTwo + 1) < execFile.length()) {
-                            execType = execFile.substr(dotPositionTwo + 1);
-                        }
+                    if ((dotPosition + 1) < execFile.length()) {
+                        execType = execFile.substr(dotPosition + 1);
                     }
                 } else {
                     execName = execFile;

--- a/core/sdk_sh/modules/sdk_alert.sh
+++ b/core/sdk_sh/modules/sdk_alert.sh
@@ -529,20 +529,19 @@ alert_put_setting_receiver_slack()
 alert_add_update_setting_receiver_exec_shell()
 {
     # the shell should be under /var/response
-    # the file name should be $1.shell
-    # $1: name
+    # $1: file name
 
     # process inputs
     local name=${1:-""}
     if [[ "$name" == "" ]] ; then
         return 1
     fi
-    if [ ! -f "/var/response/${name}.shell" ] ; then
+    if [ ! -f "/var/response/${name}" ] ; then
         return 1
     fi
 
     # prepare the environment
-    cp -f "/var/response/$name.shell" "$ALERT_RESP_DIR/exec_$name.shell"
+    cp -f "/var/response/$name" "$ALERT_RESP_DIR/exec_$name.shell"
     chmod +x "$ALERT_RESP_DIR/exec_$name.shell"
     local input_dir=$(MakeTempDir)
 
@@ -574,7 +573,6 @@ alert_add_update_setting_receiver_exec_shell()
 alert_put_setting_receiver_exec_shell()
 {
     # the shell should be under /var/response
-    # the file name should be [name].shell
     # input format: {
     #   name: "",
     # }
@@ -582,11 +580,10 @@ alert_put_setting_receiver_exec_shell()
     # process inputs
     local input=${1:-""}
     local name="$(echo $input | jq -r '.name')"
-    name="${name%%.*}"
     if [[ "$name" == "" ]] ; then
         return 1
     fi
-    if [ ! -f "/var/response/${name}.shell" ] ; then
+    if [ ! -f "/var/response/${name}" ] ; then
         return 1
     fi
 

--- a/core/sdk_sh/modules/sdk_gcp.sh
+++ b/core/sdk_sh/modules/sdk_gcp.sh
@@ -8993,7 +8993,7 @@ gcp_auto_scaler_create()
     local gcloud=$run_dir/google-cloud-sdk/bin/gcloud
 
     echo "Generating GCP auto scaling script ..."
-    cat << EOF > /var/response/gcp_auto_$name.shell
+    cat << EOF > /var/response/gcp_auto_$name
 #! /bin/bash
 
 cat << KFEOF > $run_dir/$name.key


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Allow arbitrary file names to be set as alert response exec shell names

#### Which issue(s) this PR fixes

- Related to #172 

#### Special notes for your reviewer

#### Additional documentation
