### PR TITLE
feat(make): push checksum computations of terminal artifacts to background and nohup them

### DIFF
--- a/core/extpacks/Makefile
+++ b/core/extpacks/Makefile
@@ -64,8 +64,8 @@ ext_build: $(EXTPACK_MD5)
 	$(Q)mkdir -p $(SHIP_DIR)
 	$(call RUN_CMD_TIMED,$(SHELL) $(HEX_SCRIPTSDIR)/makeextpack $(SHIP_DIR)/$(PROJ_EXT_LONGNAME) $(EXTPACK),"  GEN     $(PROJ_EXT_LONGNAME)")
 	$(Q)ln -sf $(SHIP_DIR)/$(PROJ_EXT_LONGNAME) $(PROJ_EXT)
-	$(Q)md5sum < $(PROJ_EXT) > $(SHIP_DIR)/$(PROJ_EXT_LONGNAME).md5
-	$(Q)sha256sum < $(PROJ_EXT) > $(SHIP_DIR)/$(PROJ_EXT_LONGNAME).sha256
+	$(Q)nohup md5sum < $(PROJ_EXT) > $(SHIP_DIR)/$(PROJ_EXT_LONGNAME).md5 &
+	$(Q)nohup sha256sum < $(PROJ_EXT) > $(SHIP_DIR)/$(PROJ_EXT_LONGNAME).sha256 &
 	$(Q)umount $(NAS) || true
 	$(Q)rmdir $(NAS) || true
 
@@ -77,8 +77,8 @@ portal_ext_build: $(NAS)
 	$(Q)mkdir -p $(SHIP_DIR)
 	$(call RUN_CMD_TIMED,$(SHELL) $(HEX_SCRIPTSDIR)/makeextpack $(SHIP_DIR)/$(PROJ_PORTAL_EXT_LONGNAME) $(PORTALPACK),"  GEN     $(PROJ_PORTAL_EXT_LONGNAME)")
 	$(Q)ln -sf $(SHIP_DIR)/$(PROJ_PORTAL_EXT_LONGNAME) $(PROJ_PORTAL_EXT)
-	$(Q)md5sum < $(PROJ_PORTAL_EXT) > $(SHIP_DIR)/$(PROJ_PORTAL_EXT_LONGNAME).md5
-	$(Q)sha256sum < $(PROJ_PORTAL_EXT) > $(SHIP_DIR)/$(PROJ_PORTAL_EXT_LONGNAME).sha256
+	$(Q)nohup md5sum < $(PROJ_PORTAL_EXT) > $(SHIP_DIR)/$(PROJ_PORTAL_EXT_LONGNAME).md5 &
+	$(Q)nohup sha256sum < $(PROJ_PORTAL_EXT) > $(SHIP_DIR)/$(PROJ_PORTAL_EXT_LONGNAME).sha256 &
 	$(Q)umount $(NAS) || true
 	$(Q)rmdir $(NAS) || true
 


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Push checksum computations of terminal artifacts to background and nohup them to speed up the build process

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/triangle/issues/30

#### Special notes for your reviewer

#### Additional documentation
