### PR TITLE
Remove the `replace-header` of cookie in cube-cos-api and ceph-dashboard's HAProxy conf

### DIFF
--- a/core/modules/config_haproxy.cpp
+++ b/core/modules/config_haproxy.cpp
@@ -145,9 +145,6 @@ WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
     fprintf(fout, "  mode http\n");
     fprintf(fout, "  option forwardfor\n");
     fprintf(fout, "  option http-server-close\n");
-    fprintf(fout, "  http-request replace-header Cookie (^|;)token=[^;]+;+(.*) \\1\\2\n");
-    fprintf(fout, "  http-request replace-header Cookie (^|;)ceph_token=([^;]+)(.*) \\1token=\\2\\3\n");
-    fprintf(fout, "  http-response replace-header Set-Cookie token=(.*) ceph_token=\\1\n");
     if (ha) {
         fprintf(fout, "  server localhost %s:7443 check ssl verify none\n", sharedId.c_str());
     } else {
@@ -173,9 +170,6 @@ WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
     fprintf(fout, "  option forwardfor\n");
     fprintf(fout, "  option http-server-close\n");
     fprintf(fout, "  redirect scheme https if !{ ssl_fc }\n");
-    fprintf(fout, "  http-request replace-header Cookie (^|;)token=[^;]+;+(.*) \\1\\2\n");
-    fprintf(fout, "  http-request replace-header Cookie (^|;)cos_token=([^;]+)(.*) \\1token=\\2\\3\n");
-    fprintf(fout, "  http-response replace-header Set-Cookie token=(.*) cos_token=\\1\n");
     fprintf(fout, "  server localhost %s:8082 check\n", myip.c_str());
     fprintf(fout, "  \n");
 


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

As discussed in the scrum, we realized

- sometimes, not sure why the replace-header won't work as expected so cause api received the `cos_token` which is not able to be verified by api, but sometimes maybe good

- finally, we modified this in the cube-cos-api's SP object directly which makes the overall status more stable and easier 🙇 


<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cube-cos-api/issues/214

