### PR TITLE
bigstack/shell image add a troubleshooting tool by apk add busybox-extras

### DIFF
--- a/core/k3s/build/buildah-image.sh
+++ b/core/k3s/build/buildah-image.sh
@@ -10,7 +10,7 @@ fi
 ctr=$(buildah from alpine:latest)
 
 buildah run $ctr apk update
-buildah run $ctr apk add --no-cache bash curl jq openssh-client sshpass
+buildah run $ctr apk add --no-cache bash curl jq openssh-client sshpass busybox-extras
 buildah run $ctr mkdir -p /var/alert_resp
 
 buildah config --entrypoint '["/bin/sh","-c","trap : TERM INT; sleep infinity & wait"]' $ctr


### PR DESCRIPTION
#### What type of PR is this?

Feat

<br/>

#### What this PR does / why we need it

For bigstack/shell OCI image, I would like to add a troubleshooting tool `telnet` by apk add busybox-extras.

Reasons:

- In the app-framework 2.0, we'll have a feature to check the port access between COS MGMT net and app-framework.

- Would like to reuse the bigstack/shell:latest for port access check, rather than have another similar image and build flow.

- The `telnet` will be more useful to check different service protocols.
