### PR TITLE
fix(glance): skip empty store backend name

### DIFF
--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -23,4 +23,4 @@ rootfs_install::
 #	$(Q)cp -f $(COREDIR)/cinder/db_schema_stein.tgz $(CINDER_CONFDIR)
 	$(Q)cp -f $(CINDER_CONFDIR)/cinder.conf $(CINDER_CONFDIR)/cinder.conf.org
 	$(Q)touch $(CINDER_CONFDIR)/cinder.conf.def
-	$(Q)chroot $(ROOTDIR) systemctl disable qemu-guest-agent multipathd iscsi-onboot iscsi
+	$(Q)chroot $(ROOTDIR) systemctl disable multipathd iscsi

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -21,5 +21,6 @@ rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/cinder/openstack-cinder-volume.service ./lib/systemd/system
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/cinder/openstack-cinder-backup.service ./lib/systemd/system
 #	$(Q)cp -f $(COREDIR)/cinder/db_schema_stein.tgz $(CINDER_CONFDIR)
-	$(Q)cp -f $(CINDER_CONFDIR)/cinder.conf $(CINDER_CONFDIR)/cinder.conf.bak
-	# $(Q)chroot $(ROOTDIR) systemctl disable qemu-guest-agent multipathd iscsi-onboot iscsi
+	$(Q)cp -f $(CINDER_CONFDIR)/cinder.conf $(CINDER_CONFDIR)/cinder.conf.org
+	$(Q)touch $(CINDER_CONFDIR)/cinder.conf.def
+	$(Q)chroot $(ROOTDIR) systemctl disable qemu-guest-agent multipathd iscsi-onboot iscsi

--- a/core/cube_sdk_library/src/config_file/config_file.cpp
+++ b/core/cube_sdk_library/src/config_file/config_file.cpp
@@ -11,6 +11,11 @@ void SetupConfig(
 {
     for (std::vector<std::string>::const_iterator it = sections.begin(); it != sections.end(); it++) {
         std::string section = *it;
+        // if the section is already defined, skip the creation
+        if (config.count(section) > 0) {
+            continue;
+        }
+
         config.emplace(section, ConfigList {});
     }
 }

--- a/core/glance/glance.mk
+++ b/core/glance/glance.mk
@@ -9,4 +9,5 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p /var/lib/glance/image-cache
 	$(Q)chroot $(ROOTDIR) chown -R glance:glance /var/lib/glance
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/glance/cirros-0.4.0-x86_64-disk.qcow2 ./etc/glance
-	$(Q)cp -f $(ROOTDIR)/etc/glance/glance-api.conf $(ROOTDIR)/etc/glance/glance-api.conf.bak
+	$(Q)cp -f $(ROOTDIR)/etc/glance/glance-api.conf $(ROOTDIR)/etc/glance/glance-api.conf.org
+	$(Q)chroot $(ROOTDIR) touch $(ROOTDIR)/etc/glance/glance-api.conf.def

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -811,6 +811,10 @@ Commit(bool modified, int dryLevel)
     std::stringstream enabledHostLine;
     enabledHostLine << BUILTIN_STORAGE_HOST << "@" << BUILTIN_STORAGE_BACKEND;
     for (std::vector<ConfigString>::const_iterator it = s_storageBackends.begin(); it != s_storageBackends.end(); it++) {
+        if (it->newValue().length() == 0) {
+            continue;
+        }
+
         enabledHostLine << "," << it->newValue() << "@" << it->newValue();
     }
     HexUtilSystemF(

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -281,6 +281,20 @@ SetupRbdPools()
 }
 
 /**
+ * Load default configs.
+ */
+static bool
+LoadDefaultConfig(Configs& config)
+{
+    if (!LoadConfig(CONF DEF_EXT, SB_SEC_RFMT, '=', config)) {
+        HexLogError("Failed to load the default cinder config file %s", CONF DEF_EXT);
+        return false;
+    }
+
+    return true;
+}
+
+/**
  * Initiate the structure of the config.
  */
 static void
@@ -764,6 +778,7 @@ Commit(bool modified, int dryLevel)
     if (s_bConfigChanged) {
         std::string domain = s_cubeDomain.newValue();
 
+        LoadDefaultConfig(mainConfig);
         InitConfig(mainConfig);
         SetDefaults(mainConfig, s_eCubeRole);
         SetEndpoint(mainConfig, ctrlIp);

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -238,6 +238,20 @@ SetupGlanceExportSyncCronJob(const int rp)
 }
 
 /**
+ * Load default configs.
+ */
+static bool
+LoadDefaultConfig(Configs& config)
+{
+    if (!LoadConfig(GA_CONF DEF_EXT, SB_SEC_RFMT, '=', config)) {
+        HexLogError("Failed to load the default glance api config file %s", GA_CONF DEF_EXT);
+        return false;
+    }
+
+    return true;
+}
+
+/**
  * Initiate the structure of the config.
  */
 static void
@@ -589,6 +603,7 @@ Commit(bool modified, int dryLevel)
 
     // configure the services
     if (s_bConfigChanged) {
+        LoadDefaultConfig(config);
         InitConfig(config);
         SetDefaults(config);
         SetEndpoint(config, myIp);

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -430,16 +430,19 @@ SetCinderStores(
     const std::string glancePass)
 {
     for (std::vector<std::string>::const_iterator it = cinderStores.begin(); it != cinderStores.end(); it++) {
-        if (!(*it).empty()) {
-            std::string volumeType = *it;
-            config.emplace(volumeType, ConfigList {});
-            config[volumeType]["store_description"] = "\"Cinder volume type " + volumeType + "\"";
-            config[volumeType]["cinder_store_auth_address"] = "http://" + sharedId + ":5000";
-            config[volumeType]["cinder_store_user_name"] = "glance";
-            config[volumeType]["cinder_store_password"] = glancePass;
-            config[volumeType]["cinder_store_project_name"] = "service";
-            config[volumeType]["cinder_volume_type"] = volumeType;
+        // filter out the empty strings
+        if ((*it).empty()) {
+            continue;
         }
+
+        std::string volumeType = *it;
+        config.emplace(volumeType, ConfigList {});
+        config[volumeType]["store_description"] = "\"Cinder volume type " + volumeType + "\"";
+        config[volumeType]["cinder_store_auth_address"] = "http://" + sharedId + ":5000";
+        config[volumeType]["cinder_store_user_name"] = "glance";
+        config[volumeType]["cinder_store_password"] = glancePass;
+        config[volumeType]["cinder_store_project_name"] = "service";
+        config[volumeType]["cinder_volume_type"] = volumeType;
     }
 }
 
@@ -448,15 +451,19 @@ SetCinderStores(
  */
 static void
 SetStores(Configs& config,
-          const std::vector<std::string>& cinderStores,
-          const std::string defaultVolumeType)
+    const std::vector<std::string>& cinderStores,
+    const std::string defaultVolumeType)
 {
     // enabled store
     std::stringstream stores;
     stores << "http:http" << "," << BUILTIN_STORE << ":rbd";
     for (std::vector<std::string>::const_iterator it = cinderStores.begin(); it != cinderStores.end(); it++) {
-        if (!(*it).empty())
-            stores << "," << *it << ":cinder";
+        // filter out the empty strings
+        if ((*it).empty()) {
+            continue;
+        }
+
+        stores << "," << *it << ":cinder";
     }
     config["DEFAULT"]["enabled_backends"] = stores.str();
 
@@ -594,13 +601,13 @@ Commit(bool modified, int dryLevel)
         SetCubeStore(config);
 
         std::vector<std::string> cinderStores;
-        std::transform(
-            s_storageBackends.begin(),
-            s_storageBackends.end(),
-            std::back_inserter(cinderStores),
-            [](const ConfigString& store) -> std::string {
-                return store;
-            });
+        for (std::vector<ConfigString>::const_iterator it = s_storageBackends.begin(); it != s_storageBackends.end(); it++) {
+            // filter out the empty strings
+            if ((*it).empty()) {
+                continue;
+            }
+            cinderStores.push_back(*it);
+        }
         SetCinderStores(config, cinderStores, sharedId, glancePass);
         SetStores(config, cinderStores, s_volumeTypeDefault);
 

--- a/core/modules/include/constant.h
+++ b/core/modules/include/constant.h
@@ -7,6 +7,7 @@
  * We define some global constants here.
  */
 
+#define DEF_EXT ".def"
 #define BUILTIN_VOLUME_TYPE "CubeStorage"
 
 #endif /* endif CUBE_CONSTANT_H */

--- a/core/mongodb/mongodb.mk
+++ b/core/mongodb/mongodb.mk
@@ -15,5 +15,5 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) chown mongod:mongod $(MONGODB_BINARY) $(MONGODB_LOG_DIR)
 	$(Q)chroot $(ROOTDIR) rm -rf ./lib/systemd/system/mongod.service
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/mongodb/mongodb.service ./lib/systemd/system
-	$(Q)chroot $(ROOTDIR) mv /etc/mongod.conf /etc/mongod.conf.bak
+	$(Q)chroot $(ROOTDIR) mv /etc/mongod.conf /etc/mongod.conf.org
 	$(Q)$(INSTALL_DATA) -f $(ROOTDIR) $(COREDIR)/mongodb/mongod.conf.in ./etc/mongod.conf.in


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Skip empty Cinder volume backend name and Glance store backend name
- Load default configs of Cinder and Glance for the support team
  - Provide a point of entry to manipulate configs on the fly of CubeCOS

#### Which issue(s) this PR fixes

- Related to #142 
- Related to https://github.com/bigstack-oss/cubecos-private/issues/2
- Related to https://github.com/bigstack-oss/cubecos-private/issues/3
- Related to #374

#### Special notes for your reviewer

#### Additional documentation
