### PR TITLE
Use CephFS as the data storage for docker registry

### DIFF
--- a/core/cubectl/app/config/config_docker.go
+++ b/core/cubectl/app/config/config_docker.go
@@ -23,7 +23,7 @@ const (
 	dockerConfigFile      = "/etc/docker/daemon.json"
 	dockerDataDir         = "/opt/docker/"
 	dockerRegistryArchive = dockerDataDir + "/registry@2.tar"
-	dockerRegistryVolume  = dockerDataDir + "/registry"
+	dockerRegistryVolume  = "/mnt/cephfs/docker/registry"
 	dockerRegistryPort    = 5080
 )
 
@@ -204,12 +204,6 @@ var cmdDockerImportRegistry = &cobra.Command{
 			return errors.Wrap(err, outErr)
 		}
 		zap.L().Info("Registry volume extracted")
-
-		zap.L().Info("Syncing registry volume to every control nodes")
-		if _, outErr, err := util.ExecCmd("cubectl", "node", "rsync", dockerRegistryVolume, "--role", "control"); err != nil {
-			return errors.Wrap(err, outErr)
-		}
-		zap.L().Info("Registry volume synced")
 
 		if _, outErr, err := util.ExecCmd("cubectl", "node", "exec",
 			"--role", "control", "--parallel",

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1083,6 +1083,7 @@ MountCephfsStore()
         HexSystemF(0, "mkdir -p %s/k8s", CEPHFS_STORE_DIR);
         HexSystemF(0, "mkdir -p %s/nfs", CEPHFS_STORE_DIR);
         HexSystemF(0, "mkdir -p %s/nova/instances", CEPHFS_STORE_DIR);
+        HexSystemF(0, "mkdir -p %s/docker/registry", CEPHFS_STORE_DIR);
         HexSetFileMode("/mnt/cephfs/glance", "root", "root", 0777);
         HexSetFileMode("/mnt/cephfs/nfs", "root", "root", 0777);
         HexSetFileMode("/mnt/cephfs/nova", "nova", "nova", 0755);

--- a/core/modules/config_docker.cpp
+++ b/core/modules/config_docker.cpp
@@ -20,5 +20,6 @@ Commit(bool modified, int dryLevel)
 
 CONFIG_MODULE(docker, 0, 0, 0, 0, Commit);
 CONFIG_REQUIRES(docker, cluster);
+CONFIG_REQUIRES(docker, ceph);
 
 //CONFIG_MIGRATE(docker, "/var/lib/docker");

--- a/core/sdk_sh/modules.pre/sdk_01-var-static.sh
+++ b/core/sdk_sh/modules.pre/sdk_01-var-static.sh
@@ -41,6 +41,7 @@ CEPHFS_GLANCE_DIR=/mnt/cephfs/glance
 CEPHFS_NOVA_DIR=/mnt/cephfs/nova
 CEPHFS_K8S_DIR=/mnt/cephfs/k8s
 CEPHFS_UPDATE_DIR=/mnt/cephfs/update
+CEPHFS_DOCKER_DIR=/mnt/cephfs/docker/registry
 ADMIN_KEYRING=/etc/ceph/ceph.client.admin.keyring
 CEPHFS_CLIENT_AUTHKEY=/etc/ceph/admin.key
 CEPH_OSD_MAP=/var/lib/ceph/osd/dev_osd.map


### PR DESCRIPTION
#### What type of PR is this?

Refactor

<br/>

#### What this PR does / why we need it

- Use CephFS as the data storage for docker registry for avoiding stuffed the system disk(/opt)

- Change the dockerRegistryVolume to `/mnt/cephfs/docker/registry`

- Add hex_config dependency for docker by `CONFIG_REQUIRES(docker, ceph);`

- Remove the `cubectl node rsync dockerRegistryVolume` because all image data are shared by CephFS

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/170

