### PR TITLE
fix(cinder): restore the built-in model's multipath settings if it exists on user-input model's deletion

### DIFF
--- a/core/cinder/builtin_models/multipath/dell_emc-sc-storagecenter_fc-SCFCDriver.conf
+++ b/core/cinder/builtin_models/multipath/dell_emc-sc-storagecenter_fc-SCFCDriver.conf
@@ -1,0 +1,8 @@
+devices {
+    device {
+        vendor "COMPELNT"
+        product "Compellent Vol"
+        user_friendly_names no
+        flush_on_last_del yes
+    }
+}

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -28,7 +28,8 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p /usr/share/cube/cos/cinder
 	$(Q)chroot $(ROOTDIR) mkdir -p /usr/share/cube/cos/cinder/builtin_models
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/cinder/builtin_models/dell_emc-sc-storagecenter_fc-SCFCDriver.yaml ./usr/share/cube/cos/cinder/builtin_models
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/multipath/conf.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/cinder/builtin_models/multipath/dell_emc-sc-storagecenter_fc-SCFCDriver.conf ./etc/multipath/conf.d
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cinder
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cinder/models
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cinder/storage_extra_configs_ownership
-	$(Q)chroot $(ROOTDIR) mkdir -p /etc/multipath/conf.d

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -27,7 +27,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) systemctl disable multipathd iscsi
 	$(Q)chroot $(ROOTDIR) mkdir -p /usr/share/cube/cos/cinder
 	$(Q)chroot $(ROOTDIR) mkdir -p /usr/share/cube/cos/cinder/builtin_models
-	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/cinder/builtin_models/dell_emc-sc-storagecenter_fc-SCFCDriver.yaml ./usr/share/cube/cos/cinder/builtin_models/dell_emc-sc-storagecenter_fc-SCFCDriver.yaml
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/cinder/builtin_models/dell_emc-sc-storagecenter_fc-SCFCDriver.yaml ./usr/share/cube/cos/cinder/builtin_models
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cinder
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cinder/models
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cinder/storage_extra_configs_ownership

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -311,7 +311,8 @@ SetDefaults(Configs& config)
 
     config["oslo_concurrency"]["lock_path"] = "/var/lib/glance/locks";
 
-    config["oslo_reports"]["log_dir"] = "/var/log/glance";
+    // should be oslo_reports.log_dir, however, the current version does not support it
+    config["DEFAULT"]["log_dir"] = "/var/log/glance";
 
     config["paste_deploy"]["flavor"] = "keystone";
     config["paste_deploy"]["config_file"] = "/etc/glance/glance-api-paste.ini";

--- a/core/sdk_sh/modules/sdk_cinder.sh
+++ b/core/sdk_sh/modules/sdk_cinder.sh
@@ -1022,6 +1022,9 @@ cinder_delete_model()
     #   message: "",
     # }
 
+    local exec_output=""
+    local exec_error=""
+
     local input="${1:-""}"
     if ! is_valid_json "$input" ; then
         # The input is not a valid JSON string.
@@ -1054,6 +1057,36 @@ cinder_delete_model()
     local multipath_conf_file_path="/etc/multipath/conf.d/${model_file_name}.conf"
     if [ -f "$multipath_conf_file_path" ] ; then
         rm -f "$multipath_conf_file_path"
+    fi
+
+    # restore the built-in model's multipath settings if it exists
+    local builtin_model_file_path="${CINDER_BUILTIN_MODEL_DIRECTORY}/${model_file_name}.yaml"
+    if [ -f "$builtin_model_file_path" ] ; then
+        _hex_function exec_output exec_error yq -p=yaml -o=json "$builtin_model_file_path"
+        if [[ "$?" != "0" ]] ; then
+            jq -c -n \
+                '{message: "failed to restore the built-in model multipath settings"}' \
+                >&2
+            return 2
+        fi
+
+        local multipath="$(json_get_value "$exec_output" ".multipath")"
+        local multipath_conf=""
+        multipath_conf="$(cinder_marshal_multipath_conf "$multipath")"
+        if [[ "$?" != "0" ]] ; then
+            jq -c -n \
+                '{message: "failed to restore the built-in model multipath settings"}' \
+                >&2
+            return 2
+        fi
+
+        _hex_function_ret cinder_write_multipath_conf "$model_file_name" "$multipath_conf"
+        if [[ "$?" != "0" ]] ; then
+            jq -c -n \
+                '{message: "failed to restore the built-in model multipath settings"}' \
+                >&2
+            return 2
+        fi
     fi
 
     # apply multipathd changes


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Set the correct built-in model file path
- Reactivate the logging for Glance
- Restore the built-in model's multipath settings if it exists on user-input model's deletion

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/2

#### Special notes for your reviewer

#### Additional documentation
