### PR TITLE
fix(cinder): escape the colon in volume type for cinder_get_volume_type_properties

### DIFF
--- a/core/appfw/charts/docker-registry/Makefile
+++ b/core/appfw/charts/docker-registry/Makefile
@@ -8,7 +8,7 @@ CHART=docker-registry-$(VERSION).tgz
 IMGS += registry:2.7.1
 
 $(CHART):
-	$(Q)helm repo add twuni https://helm.twun.io $(QEND)
+	$(Q)helm repo add twuni https://twuni.github.io/docker-registry.helm $(QEND)
 	$(Q)helm fetch twuni/docker-registry --version $(VERSION)
 
 BUILD += $(CHART)

--- a/core/sdk_sh/modules/sdk_cinder.sh
+++ b/core/sdk_sh/modules/sdk_cinder.sh
@@ -1876,7 +1876,7 @@ cinder_get_volume_type_properties()
             continue
         fi
 
-        current_property_value="$(json_get_value "$current_properties" ".${current_property_key}")"
+        current_property_value="$(json_get_value "$current_properties" ".[\"${current_property_key}\"]")"
 
         if _hex_function exec_output exec_error \
             jq -c \


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Update docker-registry helm chart repo url
- Escape the colon in volume type for `hex_sdk cinder_get_volume_type_properties`
  - This caused the output of `hex_sdk cinder_get_storage` to be incorrect

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
