### PR TITLE
feat(keycloak): add a setting health check for keycloak admin password not synced

### DIFF
--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -1070,3 +1070,41 @@ UpdateKeycloakAdminPasswordMain(int argc, char** argv)
 }
 
 CONFIG_COMMAND_WITH_SETTINGS(update_keycloak_admin_password, UpdateKeycloakAdminPasswordMain, UpdateKeycloakAdminPasswordUsage);
+
+/**
+ * Check if we could use the stored Keycloak admin password to log in Keycloak.
+ */
+static bool
+checkKeycloakAdminPassword(const std::string& endpointIp)
+{
+    std::string currentAdminPass;
+    if (isKeycloakUserPasswordInK8sSecret()) {
+        currentAdminPass = getKeycloakAdminPasswordFromK8sSecret();
+    } else {
+        currentAdminPass = "admin";
+    }
+
+    const std::string token = getKeycloakAdminAccessToken(endpointIp, currentAdminPass);
+
+    if (token.empty()) {
+        HexLogError("failed to log in keycloak using the current admin password");
+        return false;
+    }
+
+    return true;
+}
+
+static void
+CheckKeycloakAdminPasswordUsage()
+{
+    fprintf(stderr, "Usage: %s check_keycloak_admin_password <password>\n", HexLogProgramName());
+}
+
+static int
+CheckKeycloakAdminPasswordMain(int argc, char** argv)
+{
+    std::string sharedId = G(SHARED_ID);
+    return checkKeycloakAdminPassword(sharedId) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+CONFIG_COMMAND_WITH_SETTINGS(check_keycloak_admin_password, CheckKeycloakAdminPasswordMain, CheckKeycloakAdminPasswordUsage);

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -31,9 +31,10 @@ eval "ERR_DESC_$SRV[1]='service unready'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="settings"
-eval "ERR_DESC_$SR[1]='misconfigured alerts'"
-eval "ERR_DESC_$SR[2]='misconfigured net_hostname'"
-eval "ERR_DESC_$SR[3]='misconfigured tunings'"
+eval "ERR_DESC_$SRV[1]='misconfigured alerts'"
+eval "ERR_DESC_$SRV[2]='misconfigured net_hostname'"
+eval "ERR_DESC_$SRV[3]='misconfigured tunings'"
+eval "ERR_DESC_$SRV[4]='wrong keycloak admin password'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="license"

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -312,6 +312,11 @@ health_settings_check()
         esac
     done
 
+    if ! $HEX_CFG check_keycloak_admin_password ; then
+        ERR_MSG+="wrong keycloak admin password\n"
+        ERR_CODE=4
+    fi
+
     _health_fail_log
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

- Add a setting health check for keycloak admin password not synced
  - In case users change the keycloak admin password through UI, which would cause system level administrative tasks fail, like Terraform

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/4

#### Special notes for your reviewer

#### Additional documentation
