### PR TITLE
fix(cinder): failed to filter out duplicated storage names

### DIFF
--- a/core/sdk_sh/modules/sdk_cinder.sh
+++ b/core/sdk_sh/modules/sdk_cinder.sh
@@ -1561,7 +1561,7 @@ cinder_apply_storage_creation()
 
     local backend_index="0"
     local blank_backend_index=""
-    for backend_index in "$(seq 0 "$backend_count_minus_one")" ; do
+    for backend_index in $(seq 0 "$backend_count_minus_one") ; do
         if _hex_function exec_output exec_error \
             yq -r ".backends[${backend_index}].name" \
             "$ext_storage_policy_file" \
@@ -1573,7 +1573,7 @@ cinder_apply_storage_creation()
 
     local storage_found="false"
     backend_index="0"
-    for backend_index in "$(seq 0 "$backend_count_minus_one")" ; do
+    for backend_index in $(seq 0 "$backend_count_minus_one") ; do
         _hex_function exec_output exec_error yq -r ".backends[${backend_index}].name" "$ext_storage_policy_file"
         if [[ "$?" == "0" && "$exec_output" == "$storage_name" ]] ; then
             storage_found="true"


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Fix the bash syntax error which stopped us from filtering out the duplicated storage names
  - The error would cause duplicated items of key `backends` in `/etc/policies/external_storage/external_storage1_0.yml`.
  - Cinder is fine with duplicated backends of `enabled_backends` in `/etc/cinder/cinder.conf`. However, Glance would complain the duplicated backends of `enabled_backends` in `/etc/glance/glance-api.conf`.

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/2
- Related to #142 
- Related to https://github.com/bigstack-oss/cubecos-private/issues/3

#### Special notes for your reviewer

#### Additional documentation
