### PR TITLE
fix(nova): allow volume-backed instance snapshots to be used to create vms

### DIFF
--- a/core/nova/yoga_patch/compute/api.py
+++ b/core/nova/yoga_patch/compute/api.py
@@ -742,7 +742,8 @@ class API:
 
         # Target disk is a volume. Don't check flavor disk size because it
         # doesn't make sense, and check min_disk against the volume size.
-        if root_bdm is not None and root_bdm.is_volume:
+        # Also, skip checking instance snapshots without base images.
+        if root_bdm is not None and root_bdm.is_volume and root_bdm.source_type != 'snapshot':
             # There are 2 possibilities here:
             #
             # 1. The target volume already exists but bdm.volume_size is not


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Allow instance snapshots created from volume-backed instances to be used to create new VMs

#### Which issue(s) this PR fixes

- Related #429

#### Special notes for your reviewer

#### Additional documentation
