### PR TITLE
fix(rolling): mariadbd failed to be repaired #155

### DIFF
--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -90,7 +90,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) dnf versionlock add $(LOCKED_DNF)
 
 # qemu-kvm-17:9.1.0-29.el9 is not compatible with 17:9.1.0-20 (v3.0.0)
-QEMU_VER := 17:9.1.0-24.el9
+QEMU_VER := 17:9.1.0-25.el9
 QEMU_LOCKED_RPMS := qemu-kvm-$(QEMU_VER)
 QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-gpu-pci-$(QEMU_VER)
 QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-gpu-$(QEMU_VER)

--- a/core/main/Makefile
+++ b/core/main/Makefile
@@ -73,7 +73,7 @@ PROJ_SBOM := $(PROJ_NAME)_$(PROJ_VERSION)_$(PROJ_BUILD_LABEL).sbom
 $(PROJ_BASE_ROOTFS): $(TOP_BLDDIR)/core/heavyfs/heavy_rootfs $(PROJ_BOOTSTRAP) $(PROGRAMS) $(shell for m in $(ROOT_COMPONENTS); do find $(COREDIR)/$$m -type f; done)
 	$(call RUN_CMD_TIMED,rm -rf $@,"  RM      $$(basename $@)")
 	$(call RUN_CMD_TIMED,cp -rpf $< $@,"  COPY    $$(basename $<)")
-	$(call RUN_CMD_TIMED, mkdir -p $(PROJ_SHIPDIR) ; trivy fs --format cyclonedx $(PROJ_BASE_ROOTFS) -o $(PROJ_SHIPDIR)/$(PROJ_SBOM), "  GEN     $(PROJ_SBOM)")
+	$(call RUN_CMD_TIMED, mkdir -p $(PROJ_SHIPDIR) ; trivy fs --skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/docker" --skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/rancher" --format cyclonedx $(PROJ_BASE_ROOTFS) -o $(PROJ_SHIPDIR)/$(PROJ_SBOM), "  GEN     $(PROJ_SBOM)")
 
 PKGCLEAN += $(CURDIR)/*.before rootfs *initramfs $(PROJ_SHIPDIR)/$(PROJ_SBOM)
 

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -76,24 +76,6 @@ RollingEvacuateAndReboot()
                             break
                         fi
                     fi
-                    if [ "x$(hex_sdk -f json health_vip_report | jq -r .description | cut -d '@' -f2)" = "x$N" ] ; then
-                        msg="Moving VIP away from $N"
-                        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
-                        hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
-                        pcs resource cleanup
-                        pcs resource move vip
-                        for i in {1..10} ; do
-                            new_vip=$(hex_sdk -f json health_vip_report | jq -r .description | cut -d '@' -f2)
-                            if cubectl node list -j | jq -r .[].hostname | grep "^${new_vip:-NOVIP}$" && [ "x$new_vip" != "x$N" ] ; then
-                                msg="Moved VIP away from $N"
-                                echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
-                                hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
-                                break
-                            else
-                                sleep 10
-                            fi
-                        done
-                    fi
                     msg="Rebooting $N"
                     echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
                     hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -282,6 +282,9 @@ cube_cluster_start()
         [ ! -e /etc/glance/cirros-0.4.0-x86_64-disk.qcow2 ] || $HEX_SDK os_image_import /etc/glance cirros-0.4.0-x86_64-disk.qcow2 Cirros
         [ ! -e /etc/glance/alpine-tools.qcow2 ] || $HEX_SDK os_image_import /etc/glance alpine-tools.qcow2 Alpine
     fi
+    for i in $($OPENSTACK image list -f value | grep "Cirros queued" | cut -d " " -f1) ; do
+        [ $cnt -le 1 ] || $OPENSTACK image delete $i
+    done
     local cnt=0
     for i in $($OPENSTACK image list -f value | grep "Cirros active" | cut -d " " -f1) ; do
         ((cnt++))

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -823,8 +823,9 @@ ClusterReadyMain(int argc, const char** argv)
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run hex_sdk cmd " HEX_CFG " cube_password_init");
 
     CliPrintf("[6/6] Cluster check and repair");
-    HexSpawn(0, HEX_SDK, "host_local_run", "rm -f /tmp/health_*_error.count", ZEROCHAR_PTR);
     HexSpawn(0, HEX_SDK, "host_local_run", "hex_cli", "-c", "cluster check_repair", ZEROCHAR_PTR);
+    HexSpawn(0, HEX_SDK, "host_local_run", "hex_sdk", "-m force",  "health_neutron_repair", ZEROCHAR_PTR);
+    HexSpawn(0, HEX_SDK, "host_local_run", "rm -f /tmp/health_*_error.count", ZEROCHAR_PTR);
 
     CliPrintf("Done");
 

--- a/core/sdk_sh/modules.post/sdk_99wrapper.sh
+++ b/core/sdk_sh/modules.post/sdk_99wrapper.sh
@@ -14,6 +14,7 @@ appliance_shutdown()
         timeout 10 umount $CEPHFS_STORE_DIR
         Quiet -n $HEX_SDK ceph_osd_compact
         if is_control_node ; then
+            systemctl stop mariadb
             systemctl stop nfs-ganesha
             Quiet -n $CEPH mds fail $HOSTNAME
         fi
@@ -29,6 +30,7 @@ appliance_reboot()
         timeout 10 umount $CEPHFS_STORE_DIR
         Quiet -n $HEX_SDK ceph_osd_compact
         if is_control_node ; then
+            systemctl stop mariadb
             systemctl stop nfs-ganesha
             Quiet -n $CEPH mds fail $HOSTNAME
         fi
@@ -46,6 +48,7 @@ firmware_swap_active()
         timeout 10 umount $CEPHFS_STORE_DIR
         Quiet -n $HEX_SDK ceph_osd_compact
         if is_control_node ; then
+            systemctl stop mariadb
             systemctl stop nfs-ganesha
             Quiet -n $CEPH mds fail $HOSTNAME
         fi
@@ -61,6 +64,7 @@ firmware_backup()
         timeout 10 umount $CEPHFS_STORE_DIR
         Quiet -n $HEX_SDK ceph_osd_compact
         if is_control_node ; then
+            systemctl stop mariadb
             systemctl stop nfs-ganesha
             Quiet -n $CEPH mds fail $HOSTNAME
         fi

--- a/core/sdk_sh/modules.pre/sdk_is.sh
+++ b/core/sdk_sh/modules.pre/sdk_is.sh
@@ -183,12 +183,15 @@ is_sshable()
 
 is_node_rolling_upgrade()
 {
+    local ret=1
     if cmd -v "cat /run/cube_bootstrap.log" | grep -q -e 'Rebooting' -e 'Starting auto rolling upgrade' ; then
-        $HEX_SDK cube_cluster_ready || return 0
-    elif [ $(cmd -v "hex_cli -c firmware list | grep -i active" | cut -d"|" -f3 | sort -u | sed "/^$/d" | wc -l) -gt 1 ] ; then
-        return 0
+        $HEX_SDK cube_cluster_ready || ret=0
     fi
-    return 1
+    if [ $(cmd -v "hex_cli -c firmware list | grep -i active" | cut -d"|" -f3 | sort -u | sed "/^$/d" | wc -l) -gt 1 ] ; then
+        ret=0
+    fi
+
+    return $ret
 }
 
 is_vip_active()

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -70,6 +70,7 @@ SRV="mysql"
 eval "ERR_DESC_$SRV[1]='disconnected'"
 eval "ERR_DESC_$SRV[2]='not all online'"
 eval "ERR_DESC_$SRV[3]='state unsync'"
+eval "ERR_DESC_$SRV[4]='not all active'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="vip"

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -1953,8 +1953,9 @@ ceph_osd_get_id()
         local id0=$(cat $CEPH_OSD_MAP | grep $dev | awk '{print $2}')
         if [ -n "$id0" ] ; then
             if grep "$dev" $CEPH_OSD_MAP | grep -q "$uuid" ; then
+                # while quorum is not formed (ex: powercycling), any further ceph operation is unnecessary
                 # ceph-volume raw list could be wrong
-                if [ "x$($CEPH osd find $id0 | jq -r .crush_location.host)" = "x$HOSTNAME" ] ; then
+                if ! $CEPH -s >/dev/null 2>&1 || [ "x$($CEPH osd find $id0 | jq -r .crush_location.host)" = "x$HOSTNAME" ] ; then
                     echo -n $id0
                     return 0
                 fi

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -681,6 +681,7 @@ health_mysql_check()
     local status=$($MYSQL -u root -e "show global status like 'wsrep_cluster_status'" | grep wsrep_cluster_status | awk '{print $2}')
     local online=$($MYSQL -u root -e "show global status like 'wsrep_cluster_size'" | grep wsrep_cluster_size | awk '{print $2}')
     local state=$($MYSQL -u root -e "show global status like 'wsrep_local_state_comment'" | grep wsrep_local_state_comment | awk '{print $2}')
+    local active_total=$(cmd -v systemctl is-active mariadb | grep "|0|active$" | wc -l)
     if [ $node_total -eq 1 ] ; then
         if [ "$status" != "Disconnected" ] ; then
             ERR_CODE=1
@@ -696,6 +697,9 @@ health_mysql_check()
             ERR_CODE=3
             ERR_MSG+="mysql cluster doesn't sync-ed\n"
             ERR_LOG="$MYSQL -u root -e \"show global status like 'wsrep_local_state_comment'\""
+        elif [ $"$node_total" != "$active_total" ] ; then
+            ERR_CODE=4
+            ERR_MSG+="$active_total/$node_total mariadb active\n"
         fi
     fi
 
@@ -704,35 +708,44 @@ health_mysql_check()
 
 _health_mysql_repair()
 {
-    cmd -cor "hex_sdk remote_systemd_stop \$HOSTNAME mariadb"
+    local ts=$(date +%Y%m%d-%H%M%S)
+    local master=$CUBE_NODE_CONTROL_HOSTNAMES
+
+    cmd -cor "hex_sdk remote_systemd_stop \$HOSTNAME mariadb ; killall -9 mariadbd ; rm -f /var/lib/mysql/mysql.sock"
     if cmd -cv cat /var/lib/mysql/grastate.dat | grep -q "safe_to_bootstrap: 1" ; then
         local node=$(cmd -cv "grep -q 'safe_to_bootstrap: 1' /var/lib/mysql/grastate.dat" | grep '|0|' | cut -d"|" -f1 | tail -1)
         remote_run $node galera_new_cluster
-        cmd -co "hex_sdk remote_systemd_start \$HOSTNAME mariadb || ( killall -9 mariadbd ; systemctl restart mariadb )"
     else
-        local num_control=${#CUBE_NODE_CONTROL_HOSTNAMES[@]}
+        cmd -c "cp -rp /var/lib/mysql /var/lib/mysql-\${HOSTNAME}-${ts}"
         local cnt=0
-        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        for node in $(for n in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do echo $n ; done | tac) ; do
             ((cnt++))
-            echo "num_control: $((num_control - 1))"
-            if [ $(cmd -v "systemctl is-active mariadb" | grep failed | wc -l) -ge $((num_control - 1)) -a $cnt -eq 1 ] ; then
-                galera_new_cluster
+            if [ $cnt -eq 1 ] ; then # last control node
+                remote_run $node "sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/' /var/lib/mysql/grastate.dat"
+                remote_run $node galera_new_cluster
             else
-                remote_systemd_start $node mariadb || remote_run $node "killall -9 mariadbd ; systemctl restart mariadb"
+                remote_run $node "rm -rf /var/lib/mysql/*"
             fi
         done
     fi
+
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        remote_systemd_start $node mariadb || remote_run $node "timeout $SRVSTO systemctl stop mariadb ; killall -9 mariadbd ; rm -rf /var/lib/mysql/* ; systemctl start mariadb"
+    done
 }
 
 health_mysql_repair()
 {
-    # multiple attempts to fix is needed, especially after rolling-upgrade
-    for i in 1 2 3 ; do
-        _health_mysql_repair
-        if health_mysql_check ; then
-            break
-        fi
-    done
+    cmd -c "timeout $SRVTO systemctl restart mariadb"
+    if ! health_mysql_check ; then
+        # multiple attempts to fix is needed, especially after rolling-upgrade
+        for i in 1 2 3 ; do
+            _health_mysql_repair
+            if health_mysql_check ; then
+                break
+            fi
+        done
+    fi
 }
 
 health_vip_report()
@@ -2934,7 +2947,7 @@ health_logstash_report()
 health_logstash_check()
 {
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if cubectl node list -r control | grep "^${ctrl}," | grep -q moderator ; then
+        if remote_run $node $HEX_SDK is_moderator_node >/dev/null 2>&1 ; then
             continue
         fi
         if ! is_remote_running $node logstash ; then
@@ -2950,7 +2963,7 @@ health_logstash_check()
 health_logstash_repair()
 {
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if cubectl node list -r control | grep "^${ctrl}," | grep -q moderator ; then
+        if remote_run $node $HEX_SDK is_moderator_node >/dev/null 2>&1 ; then
             continue
         fi
         if ! is_remote_running $node logstash ; then

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -8,10 +8,6 @@ fi
 
 migrate_prepare()
 {
-    if is_control_node ; then
-        # During rolling upgrade, maria times out to start on control 2 and 3
-        touch /etc/appliance/state/mysql_new_cluster
-    fi
     touch /run/cube_migration
 }
 

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1315,6 +1315,7 @@ _os_pre_failure_host_evacuation()
     if [ "$1" == "upgrade" ] ; then
         # os_evac_upgrade_prepare
         $HEX_CLI -c cluster check_repair MsgQueue >/tmp/upgrade_rabbitmq.log 2>&1
+        $HEX_SDK -m force health_mysql_repair
 
         if $HEX_SDK health_rabbitmq_check ; then
             # clear stale api for nova, neutron, and cinder


### PR DESCRIPTION
- fix(hex_sdk):  health_logstash_check to use is_moderator_node
- sec(SBOM): trivy scan to exclude /var/lib/docker and /var/lib/rancher
- fix(build): bump up qemu-kvm version to 17:9.1.0-25.el9
- fix(bootstrap): skip unnessary ceph operations when quorum is not ready

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
