### PR TITLE
fix(keycloak): use the correct status flag

### DIFF
--- a/core/grafana/grafana.mk
+++ b/core/grafana/grafana.mk
@@ -2,7 +2,7 @@
 # grafana installation
 
 # ROOTFS_DNF += grafana
-ROOTFS_DNF_DL_FROM += https://dl.grafana.com/enterprise/release/grafana-enterprise-10.1.10-1.x86_64.rpm
+ROOTFS_DNF_DL_FROM += https://dl.grafana.com/enterprise/release/grafana-enterprise-10.3.12-1.x86_64.rpm
 
 rootfs_install::
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/resolv.conf

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -90,7 +90,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) dnf versionlock add $(LOCKED_DNF)
 
 # qemu-kvm-17:9.1.0-29.el9 is not compatible with 17:9.1.0-20 (v3.0.0)
-QEMU_VER := 17:9.1.0-25.el9
+QEMU_VER := 17:9.1.0-26.el9
 QEMU_LOCKED_RPMS := qemu-kvm-$(QEMU_VER)
 QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-gpu-pci-$(QEMU_VER)
 QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-gpu-$(QEMU_VER)

--- a/core/main/Makefile
+++ b/core/main/Makefile
@@ -71,9 +71,30 @@ include $(SRCDIR)/cube-post.mk
 
 PROJ_SBOM := $(PROJ_NAME)_$(PROJ_VERSION)_$(PROJ_BUILD_LABEL).sbom
 $(PROJ_BASE_ROOTFS): $(TOP_BLDDIR)/core/heavyfs/heavy_rootfs $(PROJ_BOOTSTRAP) $(PROGRAMS) $(shell for m in $(ROOT_COMPONENTS); do find $(COREDIR)/$$m -type f; done)
-	$(call RUN_CMD_TIMED,rm -rf $@,"  RM      $$(basename $@)")
-	$(call RUN_CMD_TIMED,cp -rpf $< $@,"  COPY    $$(basename $<)")
-	$(call RUN_CMD_TIMED, mkdir -p $(PROJ_SHIPDIR) ; trivy fs --skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/docker" --skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/rancher" --format cyclonedx $(PROJ_BASE_ROOTFS) -o $(PROJ_SHIPDIR)/$(PROJ_SBOM), "  GEN     $(PROJ_SBOM)")
+	$(call RUN_CMD_TIMED, rm -rf $@,"  RM      $$(basename $@)")
+	$(call RUN_CMD_TIMED, cp -rpf $< $@,"  COPY    $$(basename $<)")
+	$(call RUN_CMD_TIMED, mkdir -p $(PROJ_SHIPDIR); trivy fs \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/dev" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/proc" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/sys" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/run" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/run" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/tmp" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/tmp" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/cache" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/log" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/lock" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/spool" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/mnt" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/media" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/docker" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/rancher" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/var/lib/kubelet" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/srv" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/home" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/root" \
+	--format cyclonedx $(PROJ_BASE_ROOTFS) \
+	-o $(PROJ_SHIPDIR)/$(PROJ_SBOM), "  GEN     $(PROJ_SBOM)")
 
 PKGCLEAN += $(CURDIR)/*.before rootfs *initramfs $(PROJ_SHIPDIR)/$(PROJ_SBOM)
 

--- a/core/main/Makefile
+++ b/core/main/Makefile
@@ -93,6 +93,7 @@ $(PROJ_BASE_ROOTFS): $(TOP_BLDDIR)/core/heavyfs/heavy_rootfs $(PROJ_BOOTSTRAP) $
 	--skip-dirs "$(PROJ_BASE_ROOTFS)/srv" \
 	--skip-dirs "$(PROJ_BASE_ROOTFS)/home" \
 	--skip-dirs "$(PROJ_BASE_ROOTFS)/root" \
+	--skip-dirs "$(PROJ_BASE_ROOTFS)/etc" \
 	--format cyclonedx $(PROJ_BASE_ROOTFS) \
 	-o $(PROJ_SHIPDIR)/$(PROJ_SBOM), "  GEN     $(PROJ_SBOM)")
 

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -412,6 +412,7 @@ Commit(bool modified, int dryLevel)
         }
     }
 
+    bool isKeycloakUpdated = false;
     if ((s_bApplianceModified || !checkKeycloak())
         && isUpdateKeycloakPossible(s_ha, s_hostname, s_ctrlHosts)) {
         // update keycloak and roll out pods
@@ -423,6 +424,7 @@ Commit(bool modified, int dryLevel)
             return true;
         }
         HexLogInfo("updated keycloak");
+        isKeycloakUpdated = true;
 
         // check the roll out status of pods
         if (!K3sWatchRollOut(APP, APP_NAMESPACE, "3m")) {
@@ -432,7 +434,7 @@ Commit(bool modified, int dryLevel)
         }
     }
 
-    if (s_bApplianceModified) {
+    if (isKeycloakUpdated) {
         // check if the Keycloak endpoint is reachable
         std::string sharedId = G(SHARED_ID);
         if (!checkKeycloakEndpoint(sharedId)) {

--- a/core/mongodb/mongodb.mk
+++ b/core/mongodb/mongodb.mk
@@ -4,7 +4,7 @@
 MONGODB_BINARY := /usr/bin/mongod
 MONGODB_LOG_DIR := /var/log/mongodb
 
-MONGODB_PKG := mongodb-org-server-7.0.12-1.el9.x86_64.rpm
+MONGODB_PKG := mongodb-org-server-7.0.25-1.el9.x86_64.rpm
 MONGOSH_PKG := mongodb-mongosh-shared-openssl3-2.2.15.x86_64.rpm
 
 ROOTFS_DNF_DL_FROM += https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/RPMS/$(MONGODB_PKG)

--- a/core/sdk_sh/modules/sdk_network.sh
+++ b/core/sdk_sh/modules/sdk_network.sh
@@ -277,13 +277,22 @@ network_device_link()
     done
 }
 
-network_ipt_serviceint()
+_init_network_chain()
 {
-    local policy=${1:-ACCEPT}
-    local chain=SERVICE-INT
+    local chain="${1:-""}"
 
-    iptables $table -n --list $chain >/dev/null 2>&1 || iptables -N $chain
+    if [ -z "$chain" ] ; then
+        return 0
+    fi
+
+    iptables -n --list $chain >/dev/null 2>&1 || iptables -N $chain
     iptables -F $chain
+}
+
+_set_ipt_service_int()
+{
+    local chain=SERVICE-INT
+    _init_network_chain "$chain"
 
     # we should allow all local traffics
     iptables -A $chain -i lo -j ACCEPT
@@ -307,7 +316,26 @@ network_ipt_serviceint()
 
     iptables -A $chain -p tcp --match multiport --dports 5900:5999 -j DROP # drop all direct vnc access, except for internal nodes
     iptables -A $chain -p tcp --dport 3306 -j DROP # drop Database Open Access (database-open-access 3306)
+    iptables -A $chain -p icmp --icmp-type timestamp-request -j DROP # drop ICMP timestamp requests
+
     iptables -nv -L INPUT 2>/dev/null | grep -q $chain || iptables -A INPUT -j $chain
+}
+
+_set_ipt_service_out()
+{
+    local chain=SERVICE-OUT
+    _init_network_chain "$chain"
+
+    # drop ICMP timestamp replies
+    iptables -A "$chain" -p icmp --icmp-type timestamp-reply -j DROP
+
+    iptables -nv -L OUTPUT 2>/dev/null | grep -q $chain || iptables -A OUTPUT -j $chain
+}
+
+network_ipt_serviceint()
+{
+    _set_ipt_service_int
+    _set_ipt_service_out
 }
 
 network_ipt_restore()


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Use the correct status flag to let the first time setup go through
- Omit more directories in SBOM generations
- Bump qemu-kvm version to 17:9.1.0-26.el9
- Bump MongoDB to 7.0.25-1
- Bump Grafana to 10.3.12
- Drop ICMP timestamp requests and replies

#### Which issue(s) this PR fixes

- Related to #456
- Close https://github.com/bigstack-oss/cubecos-private/issues/52
- Fix https://github.com/bigstack-oss/cubecos-private/issues/15
- Fix https://github.com/bigstack-oss/cubecos-private/issues/8
- Fix https://github.com/bigstack-oss/cubecos-private/issues/10

#### Special notes for your reviewer

#### Additional documentation
