### PR TITLE
fix(k3s): adjust the process flow for generating the ceph rgw credential

### DIFF
--- a/core/cubectl/app/config/config_k3s.go
+++ b/core/cubectl/app/config/config_k3s.go
@@ -274,6 +274,16 @@ func initDependencyClients() error {
 		return err
 	}
 
+	identityCli, err = openstack.NewIdentityCli()
+	if err != nil {
+		return err
+	}
+
+	err = syncStorageAccess()
+	if err != nil {
+		return err
+	}
+
 	s3Cli, err = aws.NewS3Client(
 		aws.Region(aws.RegionAuto),
 		aws.EnableStaticCreds(true),
@@ -283,11 +293,6 @@ func initDependencyClients() error {
 		aws.S3Url(ceph.GetRadosGatewayUrl()),
 		aws.InsecureSkipVerify(true),
 	)
-	if err != nil {
-		return err
-	}
-
-	identityCli, err = openstack.NewIdentityCli()
 	if err != nil {
 		return err
 	}

--- a/core/cubectl/app/config/config_k3s_user.go
+++ b/core/cubectl/app/config/config_k3s_user.go
@@ -402,14 +402,20 @@ func syncStorageAccess() error {
 		aws.S3DefaultAccessKey,
 		aws.S3DefaultSecretKey,
 	)
-	if err == nil {
-		return nil
+	if err != nil {
+		_, is409 := err.(gophercloud.ErrDefault409)
+		if !is409 {
+			return err
+		}
 	}
-	_, is409 := err.(gophercloud.ErrDefault409)
-	if !is409 {
+
+	cred, err := openstack.GetEc2CredentialByUserId(identityCli, userId)
+	if err != nil {
 		return err
 	}
 
+	aws.S3DefaultAccessKey = cred.AccessKey
+	aws.S3DefaultSecretKey = cred.SecretKey
 	return nil
 }
 

--- a/core/cubectl/app/util/aws/aws.go
+++ b/core/cubectl/app/util/aws/aws.go
@@ -9,7 +9,9 @@ import (
 
 const (
 	RegionAuto = "auto"
+)
 
+var (
 	S3DefaultAccessKey = "admin"
 	S3DefaultSecretKey = "admin"
 )

--- a/core/cubectl/app/util/openstack/openstack.go
+++ b/core/cubectl/app/util/openstack/openstack.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -188,6 +189,51 @@ func CreateEc2Credential(identityCli *gophercloud.ServiceClient, userId, project
 	).Extract()
 	if err != nil {
 		return nil, err
+	}
+
+	return &Credential{
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	}, nil
+}
+
+func GetEc2CredentialByUserId(identityCli *gophercloud.ServiceClient, userId string) (*Credential, error) {
+	pages, err := credentials.List(
+		identityCli,
+		credentials.ListOpts{
+			UserID: userId,
+			Type:   "ec2",
+		},
+	).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	creds, err := credentials.ExtractCredentials(pages)
+	if err != nil {
+		return nil, err
+	}
+	if len(creds) == 0 {
+		return nil, fmt.Errorf(
+			"ec2 credential for user %s not found",
+			userId,
+		)
+	}
+
+	blob := creds[0].Blob
+	keys := map[string]string{}
+	err = json.Unmarshal([]byte(blob), &keys)
+	if err != nil {
+		return nil, err
+	}
+
+	accessKey, found := keys["access"]
+	if !found {
+		return nil, fmt.Errorf("access key not found for %s", blob)
+	}
+	secretKey, found := keys["secret"]
+	if !found {
+		return nil, fmt.Errorf("secret key not found for %s", blob)
 	}
 
 	return &Credential{


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

1). Adjust the process flow for generating the ceph rgw credential

2). It seems like the openstack ec2 credential module got changed between COS 2.4.4 and COS 3.0.0. we can't specify the accessKey and secretKey during credential creation anymore.

```sh
[cube451 /opt]# ./cubectl config k3s user-create test-user-2 --namespaces test-ns-1
URL to download Kube config: http://10.32.45.10:8888/k3s/test-user-2/config?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=admin%2F20251201%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20251201T185706Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=b85f0724f17df803f37c7e6071da94aa1c830c5a2fff744b78e1aeaffd472256
Caution: The URL will be expired in 7 days. Please download it as soon as possible

[cube451 /opt]# ./cubectl config k3s user-delete test-user-2
User test-user-2 deleted successfully
```

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/420
