### PR TITLE
refactor(glance): increase glance's image size cap from 1 TiB to 2 TiB

### DIFF
--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1083,7 +1083,9 @@ MountCephfsStore()
         HexSystemF(0, "mkdir -p %s/k8s", CEPHFS_STORE_DIR);
         HexSystemF(0, "mkdir -p %s/nfs", CEPHFS_STORE_DIR);
         HexSystemF(0, "mkdir -p %s/nova/instances", CEPHFS_STORE_DIR);
+        HexSystemF(0, "mkdir -p %s/glance_tmp_transition", CEPHFS_STORE_DIR);
         HexSetFileMode("/mnt/cephfs/glance", "root", "root", 0777);
+        HexSetFileMode("/mnt/cephfs/glance_tmp_transition", "root", "root", 0777);
         HexSetFileMode("/mnt/cephfs/nfs", "root", "root", 0777);
         HexSetFileMode("/mnt/cephfs/nova", "nova", "nova", 0755);
         HexSetFileMode("/mnt/cephfs/nova/instances", "nova", "nova", 0755);

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -33,6 +33,7 @@ static const char USERPASS[] = "0ZsvkS1bHXYsywTx";
 static const char DBPASS[] = "g6CEJCNFT6ufPY22";
 
 static const char EXPORT_SYNC[] = "/etc/cron.d/glance_export_sync";
+static const char TwoTiB[] = "2199023255552";
 
 #define BUILTIN_STORE "cube"
 
@@ -308,6 +309,7 @@ SetDefaults(Configs& config)
     config["DEFAULT"]["show_image_direct_url"] = "true";
     config["DEFAULT"]["show_multiple_locations"] = "true";
     config["DEFAULT"]["workers"] = std::to_string(GetControlWorkers(IsConverged(s_eCubeRole), IsEdge(s_eCubeRole)));
+    config["DEFAULT"]["image_size_cap"] = TwoTiB;
 
     config["oslo_concurrency"]["lock_path"] = "/var/lib/glance/locks";
 

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -310,6 +310,7 @@ SetDefaults(Configs& config)
     config["DEFAULT"]["show_multiple_locations"] = "true";
     config["DEFAULT"]["workers"] = std::to_string(GetControlWorkers(IsConverged(s_eCubeRole), IsEdge(s_eCubeRole)));
     config["DEFAULT"]["image_size_cap"] = TwoTiB;
+    config["DEFAULT"]["node_staging_uri"] = "file:///mnt/cephfs/glance_tmp_transition";
 
     config["oslo_concurrency"]["lock_path"] = "/var/lib/glance/locks";
 


### PR DESCRIPTION
#### What type of PR is this?

Refactor

<br/>

#### What this PR does / why we need it

Increase glance's image size cap from 1 TiB to 2 TiB to support exporting a 1TB volume to external storage

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/486

