### PR TITLE
feat(cinder): add cli > iaas > volume > move and prepare arguments for cli > iaas > volume > manage_existing_from_nfs

### DIFF
--- a/core/cube_sdk_library/src/constant.hpp
+++ b/core/cube_sdk_library/src/constant.hpp
@@ -11,6 +11,7 @@
 
 #define OPENSTACK_CLI "/usr/bin/openstack"
 
+#define BUILTIN_VOLUME_BACKEND_POOL "cube@ceph#ceph"
 #define BUILTIN_VOLUME_TYPE "CubeStorage"
 #define CINDER_BACKEND_DIR "/etc/cinder/backends"
 

--- a/core/cube_sdk_library/src/filesystem.cpp
+++ b/core/cube_sdk_library/src/filesystem.cpp
@@ -2,6 +2,38 @@
 
 #include "filesystem.hpp"
 
+const std::vector<std::string>
+GetFilesUnderDirectory(
+    std::string& error,
+    const std::string& path)
+{
+    std::vector<std::string> result;
+    // check if the path exists and is a directory
+    if (!std::filesystem::exists(path) || !std::filesystem::is_directory(path)) {
+        std::stringstream errorOutput;
+        errorOutput << "path " << path << " does not exist or is not a directory";
+        error = errorOutput.str();
+        return {};
+    }
+
+    try {
+        // tterate over all entries in the directory
+        for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(path)) {
+            // check if the entry is a regular file
+            if (entry.is_regular_file()) {
+                // get the full path
+                result.push_back(entry.path().string());
+            }
+        }
+    } catch (const std::filesystem::filesystem_error& e) {
+        std::stringstream errorOutput;
+        errorOutput << "filesystem error: " << e.what();
+        error = errorOutput.str();
+    }
+
+    return result;
+}
+
 bool HasFileMatchGlob(
     std::string& error,
     const std::string& directory,
@@ -32,7 +64,7 @@ bool HasFileMatchGlob(
         }
     } catch (const std::filesystem::filesystem_error& e) {
         std::stringstream errorOutput;
-        errorOutput << "Filesystem error: " << e.what();
+        errorOutput << "filesystem error: " << e.what();
         error = errorOutput.str();
         return false;
     }

--- a/core/cube_sdk_library/src/filesystem.cpp
+++ b/core/cube_sdk_library/src/filesystem.cpp
@@ -17,7 +17,7 @@ GetFilesUnderDirectory(
     }
 
     try {
-        // tterate over all entries in the directory
+        // iterate over all entries in the directory
         for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(path)) {
             // check if the entry is a regular file
             if (entry.is_regular_file()) {

--- a/core/cube_sdk_library/src/filesystem.hpp
+++ b/core/cube_sdk_library/src/filesystem.hpp
@@ -12,6 +12,18 @@
 #include <unistd.h>
 
 /**
+ * Get all files under a directory.
+ *
+ * @param error error messages
+ * @param path path of a directory
+ * @return a list of files in full path
+ */
+const std::vector<std::string>
+GetFilesUnderDirectory(
+    std::string& error,
+    const std::string& path);
+
+/**
  * Check if any file under a directory matches the glob pattern.
  *
  * @param error The error message if the function return false.

--- a/core/cube_sdk_library/src/openstack.cpp
+++ b/core/cube_sdk_library/src/openstack.cpp
@@ -25,7 +25,7 @@ Trim(const std::string& str)
  * TODO: move this to string.hpp after the refactor branch is rebased.
  */
 const std::string
-removePrefix(const std::string& line, const std::string& prefix)
+RemovePrefix(const std::string& line, const std::string& prefix)
 {
     // check if the line starts with the prefix, the prefix must be found at position 0
     if (line.rfind(prefix, 0) == 0) {
@@ -128,7 +128,7 @@ ParseOpenstackCliAuth()
     std::string line;
     std::vector<std::string> configLines;
     while (std::getline(ss, line)) {
-        configLines.push_back(removePrefix(Trim(line), "export "));
+        configLines.push_back(RemovePrefix(Trim(line), "export "));
     }
 
     return ParseEnv(configLines);

--- a/core/cube_sdk_library/src/openstack.cpp
+++ b/core/cube_sdk_library/src/openstack.cpp
@@ -329,3 +329,26 @@ IsQuotaVolumesEnough(
 
     return (q.used < q.limit);
 }
+
+const std::string
+GetVolumeTypeById(const std::string& volumeId)
+{
+    const ExecSyncResult r = OpenstackExec("volume show \"" + volumeId + "\" -f json");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return "";
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json volumeDetail = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        return "";
+    }
+    if (!volumeDetail["type"].is_string()) {
+        return "";
+    }
+
+    return volumeDetail["type"].string_value();
+}

--- a/core/cube_sdk_library/src/openstack.cpp
+++ b/core/cube_sdk_library/src/openstack.cpp
@@ -161,3 +161,171 @@ OpenstackExec(const std::string& command)
     HexLogInfo("executed openstack cli: %s", command.c_str());
     return r;
 }
+
+const std::string
+GetProjectId(const std::string& domain, const std::string& project)
+{
+    const ExecSyncResult r = OpenstackExec(
+        "project show --domain \"" + domain
+        + "\" \"" + project + "\" -f json");
+    if (r.exitCode != 0) {
+        return "";
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json projectDetail = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        return "";
+    }
+    if (!projectDetail["id"].is_string()) {
+        return "";
+    }
+
+    return projectDetail["id"].string_value();
+}
+
+const QuotaWithUsage
+GetQuotaWithUsage(
+    std::string& error,
+    const std::string& domain,
+    const std::string& project,
+    const QuotaResourceType& resourceType,
+    const std::string& resource)
+{
+    const std::string projectId = GetProjectId(domain, project);
+    if (projectId.empty()) {
+        error = "failed to get the project id";
+        return {};
+    }
+
+    std::string resourceTypeFlag;
+    switch (resourceType) {
+    case QuotaResourceType::all:
+        resourceTypeFlag = "--all";
+        break;
+    case QuotaResourceType::compute:
+        resourceTypeFlag = "--compute";
+        break;
+    case QuotaResourceType::volume:
+        resourceTypeFlag = "--volume";
+        break;
+    case QuotaResourceType::network:
+        resourceTypeFlag = "--network";
+        break;
+    default:
+        error = "the resource type is not supported";
+        return {};
+    }
+
+    const ExecSyncResult r = OpenstackExec(
+        "quota show " + resourceTypeFlag + " --usage \"" + projectId
+        + "\" -f json");
+    if (r.exitCode != 0) {
+        error = "failed to get the quota details";
+        return {};
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json quotaList = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        error = jsonError;
+        return {};
+    }
+
+    int limit = 0;
+    int used = 0;
+    int reserved = 0;
+    const json11::Json::array& quotas = quotaList.array_items();
+    for (const json11::Json& q : quotas) {
+        if (!q["Resource"].is_string()) {
+            continue;
+        }
+
+        if (q["Resource"].string_value() != resource) {
+            continue;
+        }
+
+        if (!q["Limit"].is_number()) {
+            error = "failed to parse the limit of resource " + resource;
+            return {};
+        }
+        limit = q["Limit"].number_value();
+
+        if (!q["In Use"].is_number()) {
+            error = "failed to parse the in use of resource " + resource;
+            return {};
+        }
+        used = q["In Use"].number_value();
+
+        if (!q["Reserved"].is_number()) {
+            error = "failed to parse the reserved of resource " + resource;
+            return {};
+        }
+        reserved = q["Reserved"].number_value();
+
+        break;
+    }
+
+    return {
+        .limit = limit,
+        .used = used,
+        .reserved = reserved,
+    };
+}
+
+const bool
+IsQuotaGigabytesEnough(
+    const std::string& domain,
+    const std::string& project,
+    const long long& needSpaceInBytes)
+{
+    std::string error;
+    const QuotaWithUsage q = GetQuotaWithUsage(
+        error,
+        domain,
+        project,
+        QuotaResourceType::volume,
+        "gigabytes");
+
+    if (!error.empty()) {
+        HexLogError("%s", error.c_str());
+        return false;
+    }
+
+    if (q.limit == -1) {
+        // we have no limit here
+        return true;
+    }
+
+    long long freeSize = q.limit - q.used;
+    return (needSpaceInBytes <= (freeSize << 10 << 10 << 10));
+}
+
+const bool
+IsQuotaVolumesEnough(
+    const std::string& domain,
+    const std::string& project)
+{
+    std::string error;
+    const QuotaWithUsage q = GetQuotaWithUsage(
+        error,
+        domain,
+        project,
+        QuotaResourceType::volume,
+        "volumes");
+
+    if (!error.empty()) {
+        HexLogError("%s", error.c_str());
+        return false;
+    }
+
+    if (q.limit == -1) {
+        // we have no limit here
+        return true;
+    }
+
+    return (q.used < q.limit);
+}

--- a/core/cube_sdk_library/src/openstack.cpp
+++ b/core/cube_sdk_library/src/openstack.cpp
@@ -114,7 +114,7 @@ ParseIni(const std::string& config)
 }
 
 const std::map<std::string, std::string>
-parseOpenstackCliAuth()
+ParseOpenstackCliAuth()
 {
     // read the openrc file
     std::string fsError;
@@ -142,7 +142,7 @@ OpenstackExec(const std::string& command)
     std::string openstackCommand = std::string(OPENSTACK_CLI) + std::string(" ") + command;
 
     // set openstack admin rc for openstack cli auth
-    const std::map<std::string, std::string> openstackCliAuth = parseOpenstackCliAuth();
+    const std::map<std::string, std::string> openstackCliAuth = ParseOpenstackCliAuth();
 
     const ExecSyncResult r = ExecBashSync(
         0,

--- a/core/cube_sdk_library/src/openstack.hpp
+++ b/core/cube_sdk_library/src/openstack.hpp
@@ -127,4 +127,13 @@ IsQuotaVolumesEnough(
     const std::string& domain,
     const std::string& project);
 
+/**
+ * Get the volume type by ID.
+ *
+ * @param volumeId
+ * @return volume type
+ */
+const std::string
+GetVolumeTypeById(const std::string& volumeId);
+
 #endif /* endif CUBE_OPENSTACK_H */

--- a/core/cube_sdk_library/src/openstack.hpp
+++ b/core/cube_sdk_library/src/openstack.hpp
@@ -3,6 +3,7 @@
 #ifndef CUBE_OPENSTACK_H
 #define CUBE_OPENSTACK_H
 
+#include "third_party/json11.hpp"
 #include <constant.hpp>
 #include <filesystem.hpp>
 #include <hex/exec.hpp>
@@ -58,5 +59,72 @@ ParseOpenstackCliAuth();
  */
 const ExecSyncResult
 OpenstackExec(const std::string& command);
+
+/**
+ * Get the project ID by the domain and the project name.
+ *
+ * @param domain
+ * @param project
+ * @return project ID, if failed, blank
+ */
+const std::string
+GetProjectId(const std::string& domain, const std::string& project);
+
+struct QuotaWithUsage {
+    int limit;
+    int used;
+    int reserved;
+};
+
+enum QuotaResourceType {
+    all,
+    compute,
+    volume,
+    network,
+};
+
+/**
+ * Get the quota with usage.
+ *
+ * @param error error messages
+ * @param domain
+ * @param project
+ * @param resourceType
+ * @param resource
+ * @return quota with usage
+ */
+const QuotaWithUsage
+GetQuotaWithUsage(
+    std::string& error,
+    const std::string& domain,
+    const std::string& project,
+    const QuotaResourceType& resourceType,
+    const std::string& resource);
+
+/**
+ * Check if the quota gigabytes of the project enough to contain the volume.
+ *
+ * @param domain
+ * @param project
+ * @param needSpaceInBytes
+ * @return is quota enough or not
+ */
+const bool
+IsQuotaGigabytesEnough(
+    const std::string& domain,
+    const std::string& project,
+    const long long& needSpaceInBytes);
+
+/**
+ * Check if the quota volumes of the project is still available.
+ *
+ * @param domain
+ * @param project
+ * @return is quota enough or not
+ */
+const bool
+IsQuotaVolumesEnough(
+    const std::string& domain,
+    const std::string& project);
 
 #endif /* endif CUBE_OPENSTACK_H */

--- a/core/cube_sdk_library/src/openstack.hpp
+++ b/core/cube_sdk_library/src/openstack.hpp
@@ -40,6 +40,12 @@ const std::vector<IniSection>
 ParseIni(const std::string& config);
 
 /**
+ * Parse OpenStack admin-openrc into the env format.
+ */
+const std::map<std::string, std::string>
+ParseOpenstackCliAuth();
+
+/**
  * Execute OpenStack CLI.
  */
 const ExecSyncResult

--- a/core/cube_sdk_library/src/openstack.hpp
+++ b/core/cube_sdk_library/src/openstack.hpp
@@ -20,6 +20,14 @@ const std::string
 Trim(const std::string& str);
 
 /**
+ * Remove the matching prefix.
+ *
+ * TODO: move this to string.hpp after the refactor branch is rebased.
+ */
+const std::string
+RemovePrefix(const std::string& line, const std::string& prefix);
+
+/**
  * Parse an env file.
  */
 const std::map<std::string, std::string>

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -126,6 +126,12 @@ CLI_MODE_COMMAND(
     "Show volume quota for a tenant.",
     "quota_show [<domain>] [<tenant>]");
 
+/**
+ * Get names of NFS storage backends.
+ * The backends must be configured, enabled, and up.
+ *
+ * @return names of NFS storage backends
+ */
 static const std::vector<std::string>
 getNfsStorageBackends()
 {
@@ -175,6 +181,12 @@ getNfsStorageBackends()
     return result;
 }
 
+/**
+ * Find the mount point on the file system from the NFS host export.
+ *
+ * @param nfsExport export path of the NFS share
+ * @return mount point
+ */
 static const std::string
 findNfsMountPointFromExport(const std::string& nfsExport)
 {
@@ -211,6 +223,12 @@ struct mountPoint {
     std::string target;
 };
 
+/**
+ * Get NFS mount point infos of an NFS storage backend.
+ *
+ * @param name NFS storage backend name
+ * @return mount point infos of the NFS storage backend
+ */
 static const std::vector<mountPoint>
 getNfsMountPoints(const std::string name)
 {
@@ -285,32 +303,6 @@ getNfsMountPoints(const std::string name)
     return mountPoints;
 }
 
-static const std::vector<std::string>
-getFilesUnderDirectory(const std::string& path)
-{
-    std::vector<std::string> result;
-    // check if the path exists and is a directory
-    if (!std::filesystem::exists(path) || !std::filesystem::is_directory(path)) {
-        HexLogError(" path %s does not exist or is not a directory", path.c_str());
-        return {};
-    }
-
-    try {
-        // tterate over all entries in the directory
-        for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(path)) {
-            // check if the entry is a regular file
-            if (entry.is_regular_file()) {
-                // get the full path
-                result.push_back(entry.path().string());
-            }
-        }
-    } catch (const std::filesystem::filesystem_error& e) {
-        HexLogError("filesystem error: %s", e.what());
-    }
-
-    return result;
-}
-
 struct fileInfo : public mountPoint {
     std::string filePath;
 };
@@ -359,7 +351,11 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     std::vector<fileInfo> fileInfos;
     CliList files;
     for (const mountPoint& p : nfsMountPoints) {
-        const CliList fl = getFilesUnderDirectory(p.target);
+        std::string fsError;
+        const CliList fl = GetFilesUnderDirectory(fsError, p.target);
+        if (!fsError.empty()) {
+            HexLogError("%s", fsError.c_str());
+        }
 
         for (const std::string& f : fl) {
             fileInfo fi;

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -369,10 +369,10 @@ struct fileInfo : public mountPoint {
 };
 
 static int
-MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
+ManageExistingVolumeFromNfsMain(int argc, const char** argv)
 {
     /**
-     * [0]="migrate_large_volume_from_nfs"
+     * [0]="manage_existing_from_nfs"
      * [1]=<source_nfs_storage_backend>
      * [2]=<file_path>
      * [3]=<volume_name>
@@ -506,11 +506,12 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
 
 CLI_MODE_COMMAND(
     CLI_COMMAND_IAAS_VOLUME,
-    "migrate_large_volume_from_nfs",
-    MigrateLargeVolumeFromNfsMain,
+    "manage_existing_from_nfs",
+    ManageExistingVolumeFromNfsMain,
     NULL,
-    "Migrate a large volume from a configured NFS volume backend.",
-    "migrate_large_volume_from_nfs <source_nfs_storage_backend> "
+    "Manage an existing volume from a configured NFS volume backend. "
+    "Perform needed conversions and set metadata if requested.",
+    "manage_existing_from_nfs <source_nfs_storage_backend> "
     "<file_path> <volume_name> <domain> <project> "
     "<perform virt-v2v conversion or not>");
 

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -303,6 +303,56 @@ getNfsMountPoints(const std::string name)
     return mountPoints;
 }
 
+/**
+ * Check if the file is already managed by Cinder.
+ *
+ * @param filePath full path of the file
+ * @param volumeType
+ * @return true or false
+ */
+static bool
+isFileAlreadyManagedByCinder(
+    const std::string& filePath,
+    const std::string& volumeType)
+{
+    const std::filesystem::path p(filePath);
+    const std::string basename = p.filename().string();
+    if (basename.empty()) {
+        return false;
+    }
+
+    // check if the file name starts with "volume-"
+    const std::string managedVolumeNamePrefix = "volume-";
+    std::string volumeId;
+    if (basename.rfind(managedVolumeNamePrefix, 0) == 0) {
+        volumeId = basename.substr(managedVolumeNamePrefix.length());
+    }
+    if (volumeId.empty()) {
+        return false;
+    }
+
+    // check with OpenStack
+    const ExecSyncResult r = OpenstackExec("volume show " + volumeId + " -f json");
+    if (r.exitCode != 0) {
+        return false;
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json volumeDetail = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        return false;
+    }
+    if (!volumeDetail["type"].is_string()) {
+        return false;
+    }
+    if (volumeDetail["type"].string_value() != volumeType) {
+        return false;
+    }
+
+    return true;
+}
+
 struct fileInfo : public mountPoint {
     std::string filePath;
 };
@@ -358,6 +408,16 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         }
 
         for (const std::string& f : fl) {
+            /**
+             * We would skip volumes already managed by Cinder.
+             * Since we enforced host name = volume backend name
+             * = volume backend pool name = type name, we would use
+             * the backend name as the volume type.
+             */
+            if (isFileAlreadyManagedByCinder(f, sourceNfsStorageBackend)) {
+                continue;
+            }
+
             fileInfo fi;
             fi.exportPath = p.exportPath;
             fi.target = p.target;

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -312,7 +312,7 @@ getNfsMountPoints(const std::string name)
 static const std::string
 getVolumeTypeById(const std::string& volumeId)
 {
-    const ExecSyncResult r = OpenstackExec("volume show " + volumeId + " -f json");
+    const ExecSyncResult r = OpenstackExec("volume show \"" + volumeId + "\" -f json");
     if (r.exitCode != 0) {
         HexLogError("%s", r.stderrOutput.c_str());
         return "";
@@ -564,9 +564,9 @@ static const std::vector<volumeInfo>
 getVolumes(const std::string& domain, const std::string& project)
 {
     const ExecSyncResult r = OpenstackExec(
-        "volume list --project " + project
-        + " --project-domain " + domain
-        + " -f json");
+        "volume list --project \"" + project
+        + "\" --project-domain \"" + domain
+        + "\" -f json");
     if (r.exitCode != 0) {
         HexLogError("%s", r.stderrOutput.c_str());
         return {};
@@ -696,8 +696,8 @@ MoveVolumeToBackendMain(int argc, const char** argv)
         true,
         true,
         ParseOpenstackCliAuth(),
-        "cinder retype --migration-policy on-demand "
-            + volumeId + " " + destinationVolumeType);
+        "cinder retype --migration-policy on-demand \""
+            + volumeId + "\" \"" + destinationVolumeType + "\"");
     if (r.exitCode != 0) {
         HexLogError("%s", r.stderrOutput.c_str());
         std::cout << "Output: " << std::endl

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -304,35 +304,6 @@ getNfsMountPoints(const std::string name)
 }
 
 /**
- * Get the volume type by ID.
- *
- * @param volumeId
- * @return volume type
- */
-static const std::string
-getVolumeTypeById(const std::string& volumeId)
-{
-    const ExecSyncResult r = OpenstackExec("volume show \"" + volumeId + "\" -f json");
-    if (r.exitCode != 0) {
-        HexLogError("%s", r.stderrOutput.c_str());
-        return "";
-    }
-
-    // parse the output
-    std::string jsonError;
-    const json11::Json volumeDetail = json11::Json::parse(r.stdoutOutput, jsonError);
-    if (!jsonError.empty()) {
-        HexLogError("%s", jsonError.c_str());
-        return "";
-    }
-    if (!volumeDetail["type"].is_string()) {
-        return "";
-    }
-
-    return volumeDetail["type"].string_value();
-}
-
-/**
  * Check if the file is already managed by Cinder.
  *
  * @param filePath full path of the file
@@ -361,7 +332,7 @@ isFileAlreadyManagedByCinder(
     }
 
     // check with OpenStack
-    return (getVolumeTypeById(volumeId) == volumeType);
+    return (GetVolumeTypeById(volumeId) == volumeType);
 }
 
 /**
@@ -943,7 +914,7 @@ MoveVolumeToBackendMain(int argc, const char** argv)
     }
 
     // [4] destination_volume_type
-    const std::string volumeSrouceType = getVolumeTypeById(volumeId);
+    const std::string volumeSrouceType = GetVolumeTypeById(volumeId);
     const std::vector<std::string> volumeTypes = getVolumeTypes();
     CliList typeList;
     // filter out undesired types

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -365,6 +365,48 @@ isFileAlreadyManagedByCinder(
 }
 
 /**
+ * Check if the volume is already in raw format.
+ *
+ * @param filePath the local full path of the file
+ * @return is in raw format or not
+ */
+static const bool
+isVolumeInRaw(const std::string& filePath)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "qemu-img info \"" + filePath + "\"");
+    if (r.exitCode != 0) {
+        HexLogError(
+            "failed to use qemu-img to probe the info of the volume, error: %s",
+            r.stderrOutput.c_str());
+        return false;
+    }
+
+    // parse the file format
+    std::stringstream volumeInfo(r.stdoutOutput);
+    std::string line;
+    const std::string fileFormatLineTitle = "file format: ";
+    // read the output line by line
+    while (std::getline(volumeInfo, line)) {
+        if (line.find(fileFormatLineTitle) == std::string::npos) {
+            continue;
+        }
+
+        break;
+    }
+    if (line.empty()) {
+        HexLogError("failed to parse the file format from\n%s", r.stdoutOutput.c_str());
+        return false;
+    }
+
+    return (RemovePrefix(line, fileFormatLineTitle) == "raw");
+}
+
+/**
  * Add admin_cli to the project for having sufficient permissions
  * to add the volume to the project.
  *
@@ -440,6 +482,10 @@ manageExistingVolume(
 
         break;
     }
+    if (line.empty()) {
+        HexLogError("failed to parse the volume id from\n%s", r.stdoutOutput.c_str());
+        return "";
+    }
 
     const std::vector<std::string> lineData = hex_string_util::split(line, '|');
     std::string volumeId;
@@ -474,6 +520,7 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
+    // gather the arguments
     std::string cmd = "";
     int index;
 
@@ -485,6 +532,7 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
     std::string project;
     bool performVolumeConversion;
 
+    // [1]=<source_nfs_storage_backend>
     if (CliMatchListHelper(
             argc,
             argv,
@@ -498,6 +546,7 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
+    // [2]=<file_path>
     const std::vector<mountPoint> nfsMountPoints = getNfsMountPoints(sourceNfsStorageBackend);
     std::vector<fileInfo> fileInfos;
     CliList files;
@@ -551,6 +600,7 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         fileExtraInfo = fileInfos[index];
     }
 
+    // [3]=<volume_name>
     if (!CliReadInputStr(
             argc,
             argv,
@@ -561,18 +611,21 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
+    // [4]=<domain>
     cmd = HEX_SDK " os_list_domain_basic | awk '{print tolower($0)}'";
     if (CliMatchCmdHelper(argc, argv, 4, cmd, &index, &domain, "Select domain: ") != CLI_SUCCESS) {
         CliPrintf("Invalid domain");
         return CLI_INVALID_ARGS;
     }
 
+    // [5]=<project>
     cmd = HEX_SDK " os_list_project_by_domain_basic " + domain;
     if (CliMatchCmdHelper(argc, argv, 5, cmd, &index, &project, "Select project: ") != CLI_SUCCESS) {
         CliPrintf("Invalid project");
         return CLI_INVALID_ARGS;
     }
 
+    // [6]=<YES|NO> perform virt-v2v conversion or not
     std::string performVolumeConversionAnswer;
     bool isAnswered = CliReadInputStr(
         argc,
@@ -585,6 +638,18 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
     std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
     std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
     std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
+
+    /**
+     * Perform the conversion.
+     * Only virt-v2v is used since we are highly likely
+     * only migrating large volumes from other hypervisors.
+     */
+    if (isVolumeInRaw(fileExtraInfo.filePath)) {
+        std::cout << "file is in raw" << std::endl;
+    } else {
+        std::cout << "file is not in raw" << std::endl;
+    }
+    return CLI_SUCCESS;
 
     // TODO: perform the conversion and metadata parsing
 

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -304,13 +304,42 @@ getNfsMountPoints(const std::string name)
 }
 
 /**
+ * Get the volume type by ID.
+ *
+ * @param volumeId
+ * @return volume type
+ */
+static const std::string
+getVolumeTypeById(const std::string& volumeId)
+{
+    const ExecSyncResult r = OpenstackExec("volume show " + volumeId + " -f json");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return "";
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json volumeDetail = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        return "";
+    }
+    if (!volumeDetail["type"].is_string()) {
+        return "";
+    }
+
+    return volumeDetail["type"].string_value();
+}
+
+/**
  * Check if the file is already managed by Cinder.
  *
  * @param filePath full path of the file
  * @param volumeType
  * @return true or false
  */
-static bool
+static const bool
 isFileAlreadyManagedByCinder(
     const std::string& filePath,
     const std::string& volumeType)
@@ -332,60 +361,7 @@ isFileAlreadyManagedByCinder(
     }
 
     // check with OpenStack
-    const ExecSyncResult r = OpenstackExec("volume show " + volumeId + " -f json");
-    if (r.exitCode != 0) {
-        HexLogError("%s", r.stderrOutput.c_str());
-        return false;
-    }
-
-    // parse the output
-    std::string jsonError;
-    const json11::Json volumeDetail = json11::Json::parse(r.stdoutOutput, jsonError);
-    if (!jsonError.empty()) {
-        HexLogError("%s", jsonError.c_str());
-        return false;
-    }
-    if (!volumeDetail["type"].is_string()) {
-        return false;
-    }
-    if (volumeDetail["type"].string_value() != volumeType) {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * Get volume types.
- *
- * @return a list of volume types, not filtered
- */
-static const std::vector<std::string>
-getVolumeTypes()
-{
-    const ExecSyncResult r = OpenstackExec("volume type list -f json");
-    if (r.exitCode != 0) {
-        HexLogError("%s", r.stderrOutput.c_str());
-        return {};
-    }
-
-    // parse the output
-    std::string jsonError;
-    const json11::Json volumeTypeList = json11::Json::parse(r.stdoutOutput, jsonError);
-    if (!jsonError.empty()) {
-        HexLogError("%s", jsonError.c_str());
-        return {};
-    }
-    const json11::Json::array& volumeTypes = volumeTypeList.array_items();
-    std::vector<std::string> result;
-    for (const json11::Json& t : volumeTypes) {
-        if (!t["Name"].is_string()) {
-            continue;
-        }
-        result.push_back(t["Name"].string_value());
-    }
-
-    return result;
+    return (getVolumeTypeById(volumeId) == volumeType);
 }
 
 struct fileInfo : public mountPoint {
@@ -402,10 +378,9 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
      * [3]=<volume_name>
      * [4]=<domain>
      * [5]=<project>
-     * [6]=<destination_volume_type>
-     * [7]=<YES|NO> perform virt-v2v conversion or not
+     * [6]=<YES|NO> perform virt-v2v conversion or not
      */
-    if (argc > 8) {
+    if (argc > 7) {
         return CLI_INVALID_ARGS;
     }
 
@@ -418,7 +393,6 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     std::string volumeName;
     std::string domain;
     std::string project;
-    std::string destinationVolumeType;
     bool performVolumeConversion;
 
     if (CliMatchListHelper(
@@ -509,6 +483,182 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
+    std::string performVolumeConversionAnswer;
+    bool isAnswered = CliReadInputStr(
+        argc,
+        argv,
+        6,
+        "Enter 'YES' to perform virt-v2v conversion on the volume: ",
+        &performVolumeConversionAnswer);
+    performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
+
+    std::cout << "backend: " << sourceNfsStorageBackend << std::endl;
+    std::cout << "filePath: " << filePath << std::endl;
+    std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
+    std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
+    std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
+    std::cout << "volume name: " << volumeName << std::endl;
+    std::cout << "domain: " << domain << std::endl;
+    std::cout << "project: " << project << std::endl;
+    std::cout << "perform volume conversion: " << (performVolumeConversion ? "yes" : "no") << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_VOLUME,
+    "migrate_large_volume_from_nfs",
+    MigrateLargeVolumeFromNfsMain,
+    NULL,
+    "Migrate a large volume from a configured NFS volume backend.",
+    "migrate_large_volume_from_nfs <source_nfs_storage_backend> "
+    "<file_path> <volume_name> <domain> <project> "
+    "<perform virt-v2v conversion or not>");
+
+/**
+ * Get volume types.
+ *
+ * @return a list of volume types, not filtered
+ */
+static const std::vector<std::string>
+getVolumeTypes()
+{
+    const ExecSyncResult r = OpenstackExec("volume type list -f json");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return {};
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json volumeTypeList = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        return {};
+    }
+    const json11::Json::array& volumeTypes = volumeTypeList.array_items();
+    std::vector<std::string> result;
+    for (const json11::Json& t : volumeTypes) {
+        if (!t["Name"].is_string()) {
+            continue;
+        }
+        result.push_back(t["Name"].string_value());
+    }
+
+    return result;
+}
+
+struct volumeInfo {
+    std::string id;
+    std::string name;
+};
+
+/**
+ * Get the list of volumes under a project under a domain.
+ *
+ * @param domain
+ * @param project
+ * @return a list of volumes with id and name
+ */
+static const std::vector<volumeInfo>
+getVolumes(const std::string& domain, const std::string& project)
+{
+    const ExecSyncResult r = OpenstackExec(
+        "volume list --project " + project
+        + " --project-domain " + domain
+        + " -f json");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return {};
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json volumeList = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        return {};
+    }
+    const json11::Json::array& volumes = volumeList.array_items();
+    std::vector<volumeInfo> result;
+    for (const json11::Json& v : volumes) {
+        if (!v["ID"].is_string()) {
+            continue;
+        }
+
+        volumeInfo i = {
+            .id = v["ID"].string_value(),
+        };
+
+        if (v["Name"].is_string()) {
+            i.name = v["Name"].string_value();
+        }
+
+        result.push_back(i);
+    }
+
+    return result;
+}
+
+static int
+MoveVolumeToBackendMain(int argc, const char** argv)
+{
+    /**
+     * [0]="move"
+     * [1]=<domain>
+     * [2]=<project>
+     * [3]=<volume_id>
+     * [4]=<destination_volume_type>
+     */
+    if (argc > 5) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string cmd = "";
+    int index;
+
+    std::string domain;
+    std::string project;
+    std::string volumeId;
+    std::string destinationVolumeType;
+
+    // [1] domain
+    cmd = HEX_SDK " os_list_domain_basic | awk '{print tolower($0)}'";
+    if (CliMatchCmdHelper(argc, argv, 1, cmd, &index, &domain, "Select domain: ") != CLI_SUCCESS) {
+        CliPrintf("Invalid domain");
+        return CLI_INVALID_ARGS;
+    }
+
+    // [2] project
+    cmd = HEX_SDK " os_list_project_by_domain_basic " + domain;
+    if (CliMatchCmdHelper(argc, argv, 2, cmd, &index, &project, "Select project: ") != CLI_SUCCESS) {
+        CliPrintf("Invalid project");
+        return CLI_INVALID_ARGS;
+    }
+
+    // [3] volume_id
+    const std::vector<volumeInfo> volumes = getVolumes(domain, project);
+    CliList volumeList;
+    CliList volumeDescList;
+    for (const volumeInfo& v : volumes) {
+        volumeList.push_back(v.id);
+        volumeDescList.push_back(v.id + " " + v.name);
+    }
+    if (CliMatchListDescHelper(
+            argc,
+            argv,
+            3,
+            volumeList,
+            volumeDescList,
+            &index,
+            &volumeId,
+            "Select the volume ID: ")
+        != CLI_SUCCESS) {
+        CliPrintf("Invalid volume ID");
+        return CLI_INVALID_ARGS;
+    }
+
+    // [4] destination_volume_type
+    const std::string volumeSrouceType = getVolumeTypeById(volumeId);
     const std::vector<std::string> volumeTypes = getVolumeTypes();
     CliList typeList;
     // filter out undesired types
@@ -516,7 +666,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         if (t == "__DEFAULT__") {
             continue;
         }
-        if (t == sourceNfsStorageBackend) {
+        if (t == volumeSrouceType) {
             /**
              * Setting the destination volume type the same
              * as the source volume type is meaningless.
@@ -530,7 +680,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     if (CliMatchListHelper(
             argc,
             argv,
-            6,
+            4,
             typeList,
             &index,
             &destinationVolumeType,
@@ -540,34 +690,31 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
-    std::string performVolumeConversionAnswer;
-    bool isAnswered = CliReadInputStr(
-        argc,
-        argv,
-        7,
-        "Enter 'YES' to perform virt-v2v conversion on the volume: ",
-        &performVolumeConversionAnswer);
-    performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        ParseOpenstackCliAuth(),
+        "cinder retype --migration-policy on-demand "
+            + volumeId + " " + destinationVolumeType);
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        std::cout << "Output: " << std::endl
+                  << r.stdoutOutput << std::endl;
+        std::cout << "Error: " << std::endl
+                  << r.stderrOutput << std::endl;
+        return CLI_FAILURE;
+    }
 
-    std::cout << "backend: " << sourceNfsStorageBackend << std::endl;
-    std::cout << "filePath: " << filePath << std::endl;
-    std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
-    std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
-    std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
-    std::cout << "volume name: " << volumeName << std::endl;
-    std::cout << "domain: " << domain << std::endl;
-    std::cout << "project: " << project << std::endl;
-    std::cout << "destination volume type: " << destinationVolumeType << std::endl;
-    std::cout << "perform volume conversion: " << (performVolumeConversion ? "yes" : "no") << std::endl;
+    std::cout << "Output: " << std::endl
+              << r.stdoutOutput << std::endl;
     return CLI_SUCCESS;
 }
 
 CLI_MODE_COMMAND(
     CLI_COMMAND_IAAS_VOLUME,
-    "migrate_large_volume_from_nfs",
-    MigrateLargeVolumeFromNfsMain,
+    "move",
+    MoveVolumeToBackendMain,
     NULL,
-    "Migrate a large volume from a configured NFS volume backend.",
-    "migrate_large_volume_from_nfs <source_nfs_storage_backend> "
-    "<file_path> <volume_name> <domain> <project> <destination_volume_type> "
-    "<perform virt-v2v conversion or not>");
+    "Move a volume to a volume backend.",
+    "move <domain> <project> <volume_id> <destination_volume_type>");

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -687,6 +687,31 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
     std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
     std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
 
+    // check if we still have enough quota in the project to manage the volume
+    const long long volumeSizeInBytes = getVolumeVirtualSize(fileExtraInfo.filePath);
+
+    if (!IsQuotaGigabytesEnough(domain, project, volumeSizeInBytes)) {
+        CliPrintf(
+            "Project %s under domain %s does not have enough quota on resource %s, "
+            "needed space for the volume is %lld",
+            project.c_str(),
+            domain.c_str(),
+            "gigabytes",
+            volumeSizeInBytes);
+        return CLI_FAILURE;
+    }
+
+    if (!IsQuotaVolumesEnough(domain, project)) {
+        CliPrintf(
+            "Project %s under domain %s does not have enough quota on resource %s, "
+            "needed space for the volume is %lld",
+            project.c_str(),
+            domain.c_str(),
+            "volumes",
+            volumeSizeInBytes);
+        return CLI_FAILURE;
+    }
+
     /**
      * Perform the conversion.
      *
@@ -696,32 +721,9 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
      * We only need to convert volumes not in the raw format.
      */
     if (performVolumeConversion && !isVolumeInRaw(fileExtraInfo.filePath)) {
-        // check if we still have enough quota in the project to manage the volume
-        const long long volumeSizeInBytes = getVolumeVirtualSize(fileExtraInfo.filePath);
+        // perform the conversion
 
-        if (!IsQuotaGigabytesEnough(domain, project, volumeSizeInBytes)) {
-            CliPrintf(
-                "Project %s under domain %s does not have enough quota on resource %s, "
-                "needed space for the volume is %lld",
-                project.c_str(),
-                domain.c_str(),
-                "gigabytes",
-                volumeSizeInBytes);
-            return CLI_FAILURE;
-        }
-
-        if (!IsQuotaVolumesEnough(domain, project)) {
-            CliPrintf(
-                "Project %s under domain %s does not have enough quota on resource %s, "
-                "needed space for the volume is %lld",
-                project.c_str(),
-                domain.c_str(),
-                "volumes",
-                volumeSizeInBytes);
-            return CLI_FAILURE;
-        }
-
-        // TODO: perform the conversion and metadata parsing
+        // parse the metadata
     }
 
     if (!addAdminCliToProject(domain, project)) {

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -407,6 +407,83 @@ isVolumeInRaw(const std::string& filePath)
 }
 
 /**
+ * Get the virtual size of the volume.
+ *
+ * @param filePath the local full path of the file
+ * @return is in raw format or not
+ */
+static const long long
+getVolumeVirtualSize(const std::string& filePath)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "qemu-img info \"" + filePath + "\"");
+    if (r.exitCode != 0) {
+        HexLogError(
+            "failed to use qemu-img to probe the info of the volume, error: %s",
+            r.stderrOutput.c_str());
+        return 0;
+    }
+
+    // parse the virtual size
+    std::stringstream volumeInfo(r.stdoutOutput);
+    std::string line;
+    const std::string virtualSizeLineTitle = "virtual size: ";
+    // read the output line by line
+    while (std::getline(volumeInfo, line)) {
+        if (line.find(virtualSizeLineTitle) == std::string::npos) {
+            continue;
+        }
+
+        break;
+    }
+    if (line.empty()) {
+        HexLogError("failed to parse the virtual size from\n%s", r.stdoutOutput.c_str());
+        return 0;
+    }
+
+    const std::size_t startPosition = line.find('(');
+    if (startPosition == std::string::npos) {
+        HexLogError("failed to parse the virtual size from\n%s", r.stdoutOutput.c_str());
+        return 0;
+    }
+    const std::size_t endPosition = line.find(')');
+    if (endPosition == std::string::npos) {
+        HexLogError("failed to parse the virtual size from\n%s", r.stdoutOutput.c_str());
+        return 0;
+    }
+    if (startPosition >= endPosition) {
+        HexLogError("failed to parse the virtual size from\n%s", r.stdoutOutput.c_str());
+        return 0;
+    }
+
+    const std::string data = line.substr(startPosition + 1, endPosition - startPosition - 1);
+    const std::size_t bytesPosition = data.find("bytes");
+    if (bytesPosition == std::string::npos) {
+        HexLogError("failed to parse the virtual size from\n%s", r.stdoutOutput.c_str());
+        return 0;
+    }
+
+    const std::string byteNumberString = Trim(data.substr(0, bytesPosition));
+    long long byteNumber = 0;
+    try {
+        std::size_t pos;
+        byteNumber = std::stoll(byteNumberString, &pos);
+    } catch (const std::exception& e) {
+        // failed to convert the output string to a long long
+        HexLogError(
+            "failed to parse the virtual size from %s, error: %s",
+            byteNumberString.c_str(),
+            e.what());
+        return 0;
+    }
+    return byteNumber;
+}
+
+/**
  * Add admin_cli to the project for having sufficient permissions
  * to add the volume to the project.
  *
@@ -641,19 +718,40 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
 
     /**
      * Perform the conversion.
+     *
      * Only virt-v2v is used since we are highly likely
      * only migrating large volumes from other hypervisors.
+     *
+     * We only need to convert volumes not in the raw format.
      */
-    if (isVolumeInRaw(fileExtraInfo.filePath)) {
-        std::cout << "file is in raw" << std::endl;
-    } else {
-        std::cout << "file is not in raw" << std::endl;
+    if (performVolumeConversion && !isVolumeInRaw(fileExtraInfo.filePath)) {
+        // check if we still have enough quota in the project to manage the volume
+        const long long volumeSizeInBytes = getVolumeVirtualSize(fileExtraInfo.filePath);
+
+        if (!IsQuotaGigabytesEnough(domain, project, volumeSizeInBytes)) {
+            CliPrintf(
+                "Project %s under domain %s does not have enough quota on resource %s, "
+                "needed space for the volume is %lld",
+                project.c_str(),
+                domain.c_str(),
+                "gigabytes",
+                volumeSizeInBytes);
+            return CLI_FAILURE;
+        }
+
+        if (!IsQuotaVolumesEnough(domain, project)) {
+            CliPrintf(
+                "Project %s under domain %s does not have enough quota on resource %s, "
+                "needed space for the volume is %lld",
+                project.c_str(),
+                domain.c_str(),
+                "volumes",
+                volumeSizeInBytes);
+            return CLI_FAILURE;
+        }
+
+        // TODO: perform the conversion and metadata parsing
     }
-    return CLI_SUCCESS;
-
-    // TODO: perform the conversion and metadata parsing
-
-    // TODO: raise the project quotas
 
     if (!addAdminCliToProject(domain, project)) {
         HexLogError("failed to add admin_cli to the project to manage volumes");

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -363,7 +363,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     /**
      * [0]="migrate_large_volume_from_nfs"
      * [1]=<source_nfs_storage_backend>
-     * [2]=<file_name>
+     * [2]=<file_path>
      * [3]=<volume_name>
      * [4]=<domain>
      * [5]=<project>
@@ -450,6 +450,16 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         fileExtraInfo = fileInfos[index];
     }
 
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            3,
+            "Specify volume name: ",
+            &volumeName)) {
+        CliPrint("Volume name is required");
+        return CLI_INVALID_ARGS;
+    }
+
     cmd = HEX_SDK " os_list_domain_basic | awk '{print tolower($0)}'";
     if (CliMatchCmdHelper(argc, argv, 4, cmd, &index, &domain, "Select domain: ") != CLI_SUCCESS) {
         CliPrintf("Invalid domain");
@@ -467,6 +477,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
     std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
     std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
+    std::cout << "volume name: " << volumeName << std::endl;
     std::cout << "domain: " << domain << std::endl;
     std::cout << "project: " << project << std::endl;
     return CLI_SUCCESS;

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -541,7 +541,12 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     }
 
     std::string performVolumeConversionAnswer;
-    bool isAnswered = CliReadLine("Enter 'YES' to perform virt-v2v conversion on the volume: ", performVolumeConversionAnswer);
+    bool isAnswered = CliReadInputStr(
+        argc,
+        argv,
+        7,
+        "Enter 'YES' to perform virt-v2v conversion on the volume: ",
+        &performVolumeConversionAnswer);
     performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
 
     std::cout << "backend: " << sourceNfsStorageBackend << std::endl;

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -403,8 +403,9 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
      * [4]=<domain>
      * [5]=<project>
      * [6]=<destination_volume_type>
+     * [7]=<YES|NO> perform virt-v2v conversion or not
      */
-    if (argc > 7) {
+    if (argc > 8) {
         return CLI_INVALID_ARGS;
     }
 
@@ -418,6 +419,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     std::string domain;
     std::string project;
     std::string destinationVolumeType;
+    bool performVolumeConversion;
 
     if (CliMatchListHelper(
             argc,
@@ -538,6 +540,10 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
+    std::string performVolumeConversionAnswer;
+    bool isAnswered = CliReadLine("Enter 'YES' to perform virt-v2v conversion on the volume: ", performVolumeConversionAnswer);
+    performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
+
     std::cout << "backend: " << sourceNfsStorageBackend << std::endl;
     std::cout << "filePath: " << filePath << std::endl;
     std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
@@ -547,6 +553,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     std::cout << "domain: " << domain << std::endl;
     std::cout << "project: " << project << std::endl;
     std::cout << "destination volume type: " << destinationVolumeType << std::endl;
+    std::cout << "perform volume conversion: " << (performVolumeConversion ? "yes" : "no") << std::endl;
     return CLI_SUCCESS;
 }
 
@@ -557,4 +564,5 @@ CLI_MODE_COMMAND(
     NULL,
     "Migrate a large volume from a configured NFS volume backend.",
     "migrate_large_volume_from_nfs <source_nfs_storage_backend> "
-    "<file_path> <volume_name> <domain> <project> <destination_volume_type>");
+    "<file_path> <volume_name> <domain> <project> <destination_volume_type> "
+    "<perform virt-v2v conversion or not>");

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -334,6 +334,7 @@ isFileAlreadyManagedByCinder(
     // check with OpenStack
     const ExecSyncResult r = OpenstackExec("volume show " + volumeId + " -f json");
     if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
         return false;
     }
 
@@ -341,6 +342,7 @@ isFileAlreadyManagedByCinder(
     std::string jsonError;
     const json11::Json volumeDetail = json11::Json::parse(r.stdoutOutput, jsonError);
     if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
         return false;
     }
     if (!volumeDetail["type"].is_string()) {
@@ -351,6 +353,39 @@ isFileAlreadyManagedByCinder(
     }
 
     return true;
+}
+
+/**
+ * Get volume types.
+ *
+ * @return a list of volume types, not filtered
+ */
+static const std::vector<std::string>
+getVolumeTypes()
+{
+    const ExecSyncResult r = OpenstackExec("volume type list -f json");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return {};
+    }
+
+    // parse the output
+    std::string jsonError;
+    const json11::Json volumeTypeList = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        return {};
+    }
+    const json11::Json::array& volumeTypes = volumeTypeList.array_items();
+    std::vector<std::string> result;
+    for (const json11::Json& t : volumeTypes) {
+        if (!t["Name"].is_string()) {
+            continue;
+        }
+        result.push_back(t["Name"].string_value());
+    }
+
+    return result;
 }
 
 struct fileInfo : public mountPoint {
@@ -472,6 +507,37 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
     }
 
+    const std::vector<std::string> volumeTypes = getVolumeTypes();
+    CliList typeList;
+    // filter out undesired types
+    for (const std::string& t : volumeTypes) {
+        if (t == "__DEFAULT__") {
+            continue;
+        }
+        if (t == sourceNfsStorageBackend) {
+            /**
+             * Setting the destination volume type the same
+             * as the source volume type is meaningless.
+             */
+            continue;
+        }
+
+        typeList.push_back(t);
+    }
+
+    if (CliMatchListHelper(
+            argc,
+            argv,
+            6,
+            typeList,
+            &index,
+            &destinationVolumeType,
+            "Select the destination volume type: ")
+        != CLI_SUCCESS) {
+        CliPrintf("Invalid volume type");
+        return CLI_INVALID_ARGS;
+    }
+
     std::cout << "backend: " << sourceNfsStorageBackend << std::endl;
     std::cout << "filePath: " << filePath << std::endl;
     std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
@@ -480,6 +546,7 @@ MigrateLargeVolumeFromNfsMain(int argc, const char** argv)
     std::cout << "volume name: " << volumeName << std::endl;
     std::cout << "domain: " << domain << std::endl;
     std::cout << "project: " << project << std::endl;
+    std::cout << "destination volume type: " << destinationVolumeType << std::endl;
     return CLI_SUCCESS;
 }
 

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -364,6 +364,95 @@ isFileAlreadyManagedByCinder(
     return (getVolumeTypeById(volumeId) == volumeType);
 }
 
+/**
+ * Add admin_cli to the project for having sufficient permissions
+ * to add the volume to the project.
+ *
+ * @param domain
+ * @param project
+ * @return successful or not
+ */
+static const bool
+addAdminCliToProject(const std::string& domain, const std::string& project)
+{
+    const ExecSyncResult r = OpenstackExec(
+        "role add --user admin_cli --project \"" + project
+        + "\" --project-domain \"" + domain + "\" admin");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Take an existing volume under control of Cinder.
+ *
+ * @param volumeType
+ * @param filePath the full path of the file on the NFS share, e.g., <ip>:<file_full_path>
+ * @param volumeName the display name for the incoming volume
+ * @param domain
+ * @param project
+ * @param isBootable
+ * @return volume ID, if blank, the manage failed
+ */
+static const std::string
+manageExistingVolume(
+    const std::string& volumeType,
+    const std::string& filePath,
+    const std::string& volumeName,
+    const std::string& domain,
+    const std::string& project,
+    const bool& isBootable)
+{
+    std::string volumeBackendPool;
+    if (volumeType == BUILTIN_VOLUME_TYPE) {
+        volumeBackendPool = BUILTIN_VOLUME_BACKEND_POOL;
+    } else {
+        volumeBackendPool = volumeType + "@" + volumeType + "#" + volumeType;
+    }
+
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        ParseOpenstackCliAuth(),
+        "cinder --os-project-domain-name \"" + domain
+            + "\" --os-project-name \"" + project
+            + "\" manage " + (isBootable ? "--bootable" : "")
+            + " --name \"" + volumeName
+            + "\" --volume-type \"" + volumeType
+            + "\" \"" + volumeBackendPool + "\" \"" + filePath + "\"");
+    if (r.exitCode != 0) {
+        HexLogError("%s", r.stderrOutput.c_str());
+        return "";
+    }
+
+    // parse the id
+    std::stringstream volumeDetail(r.stdoutOutput);
+    std::string line;
+    // read the output line by line
+    while (std::getline(volumeDetail, line)) {
+        if (line.find("| id") == std::string::npos) {
+            continue;
+        }
+
+        break;
+    }
+
+    const std::vector<std::string> lineData = hex_string_util::split(line, '|');
+    std::string volumeId;
+    try {
+        volumeId = lineData.at(2);
+    } catch (const std::out_of_range& e) {
+        HexLogError("failed to parse the volume id from\n%s", r.stdoutOutput.c_str());
+        return "";
+    }
+
+    return Trim(volumeId);
+}
+
 struct fileInfo : public mountPoint {
     std::string filePath;
 };
@@ -378,7 +467,8 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
      * [3]=<volume_name>
      * [4]=<domain>
      * [5]=<project>
-     * [6]=<YES|NO> perform virt-v2v conversion or not
+     * [6]=<YES|NO> perform virt-v2v conversion or not,
+     * also implies the volume is bootable or not
      */
     if (argc > 7) {
         return CLI_INVALID_ARGS;
@@ -492,15 +582,46 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         &performVolumeConversionAnswer);
     performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
 
-    std::cout << "backend: " << sourceNfsStorageBackend << std::endl;
-    std::cout << "filePath: " << filePath << std::endl;
     std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
     std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
     std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
-    std::cout << "volume name: " << volumeName << std::endl;
-    std::cout << "domain: " << domain << std::endl;
-    std::cout << "project: " << project << std::endl;
-    std::cout << "perform volume conversion: " << (performVolumeConversion ? "yes" : "no") << std::endl;
+
+    // TODO: perform the conversion and metadata parsing
+
+    // TODO: raise the project quotas
+
+    if (!addAdminCliToProject(domain, project)) {
+        HexLogError("failed to add admin_cli to the project to manage volumes");
+        CliPrint("Not sufficient permissions to manage volumes in the project");
+        return CLI_FAILURE;
+    }
+
+    const std::string volumeId = manageExistingVolume(
+        sourceNfsStorageBackend,
+        filePath,
+        volumeName,
+        domain,
+        project,
+        performVolumeConversion);
+    if (volumeId.empty()) {
+        HexLogError(
+            "failed to manage the existing volume on nfs, "
+            "source nfs storage backend: %s, file path: %s, "
+            "volume name: %s, domain: %s, project: %s, "
+            "perform volume conversion: %s",
+            sourceNfsStorageBackend.c_str(),
+            filePath.c_str(),
+            volumeName.c_str(),
+            domain.c_str(),
+            project.c_str(),
+            (performVolumeConversion ? "YES" : "NO"));
+        CliPrint("Failed to manage the existing volume on NFS");
+        return CLI_FAILURE;
+    }
+
+    std::cout << "volume id: " << volumeId << std::endl;
+    // TODO: set volume metadata
+
     return CLI_SUCCESS;
 }
 

--- a/core/modules/cli_iaas_volume.hpp
+++ b/core/modules/cli_iaas_volume.hpp
@@ -7,6 +7,7 @@
 #include "include/policy_ext_storage.h"
 
 #include <cube/cubesys.h>
+#include <filesystem.hpp>
 #include <hex/cli_module.h>
 #include <hex/cli_util.h>
 #include <hex/process.h>

--- a/core/modules/cli_iaas_volume.hpp
+++ b/core/modules/cli_iaas_volume.hpp
@@ -12,6 +12,7 @@
 #include <hex/cli_util.h>
 #include <hex/process.h>
 #include <hex/strict.h>
+#include <hex/string_util.h>
 
 #include <filesystem>
 #include <iostream>

--- a/core/modules/cli_iaas_volume_meta.cpp
+++ b/core/modules/cli_iaas_volume_meta.cpp
@@ -64,7 +64,7 @@ ApplyMain(int argc, const char** argv)
 
     HexSpawn(0, HEX_CFG, "volume_meta_apply",
         user.c_str(), proj.c_str(),
-        "cube@ceph#ceph", "CubeStorage", filename.c_str(), NULL);
+        BUILTIN_VOLUME_BACKEND_POOL, BUILTIN_VOLUME_TYPE, filename.c_str(), NULL);
 
     return CLI_SUCCESS;
 }

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -827,7 +827,6 @@ os_image_import()
             local limit=$(echo $gigabytes_json | jq -r ".Limit")
             local used=$(echo $gigabytes_json | jq -r ".\"In Use\"")
             local free=$(($limit - $used))
-            local vol_name=$(mktemp -u volume-${name}-XXXX)
             if [ $free -le $((img_siz / 1024 / 1024 / 1024)) ] ; then
                 cmd rm -f $mf_importing
                 Error "${proj_name:-admin} quota's free volume space $free(GB) is less then needed $((img_siz / 1024 / 1024 / 1024))(GB)"


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Add CLI > iaas > volume > move to move a volume between backends
- Rename CLI > iaas > volume > migrate_large_volume_from_nfs to CLI > iaas > volume > manage_existing_from_nfs
- Finish the argument list for CLI > iaas > volume > manage_existing_from_nfs
- Let CLI > iaas > volume > manage_existing_from_nfs take an existing volume under the control of Cinder

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/2
- Related to #142 
- Related to https://github.com/bigstack-oss/cubecos-private/issues/3
- Related to #486 
- Related to #412

#### Special notes for your reviewer

#### Additional documentation

Usage of `CLI > iaas > volume > move`

```bash
hex_cli -v -c iaas volume move <domain> <project> <volume_id> <dest_volume_type>
```
