### PR TITLE
feat(cinder): finish cli > iaas > volume > manage_existing_from_nfs

### DIFF
--- a/core/cube_sdk_library/src/openstack.cpp
+++ b/core/cube_sdk_library/src/openstack.cpp
@@ -352,3 +352,31 @@ GetVolumeTypeById(const std::string& volumeId)
 
     return volumeDetail["type"].string_value();
 }
+
+const bool
+SetVolumeImageProperties(
+    const std::string& volumeId,
+    const std::map<std::string, std::string>& metadata)
+{
+    if (metadata.empty()) {
+        return true;
+    }
+
+    // construct the flags
+    std::stringstream flags;
+    for (const std::pair<const std::string, std::string>& m : metadata) {
+        flags << "--image-property " << m.first << "=" << m.second << " ";
+    }
+
+    // set the metadata
+    const ExecSyncResult r = OpenstackExec("volume set " + flags.str() + volumeId);
+    if (r.exitCode != 0) {
+        HexLogError(
+            "failed to set the metadata %s on volume %s",
+            flags.str().c_str(),
+            volumeId.c_str());
+        return false;
+    }
+
+    return true;
+}

--- a/core/cube_sdk_library/src/openstack.hpp
+++ b/core/cube_sdk_library/src/openstack.hpp
@@ -136,4 +136,16 @@ IsQuotaVolumesEnough(
 const std::string
 GetVolumeTypeById(const std::string& volumeId);
 
+/**
+ * Set image properties onto a volume.
+ *
+ * @param volumeId
+ * @param metadata
+ * @return successful or not
+ */
+const bool
+SetVolumeImageProperties(
+    const std::string& volumeId,
+    const std::map<std::string, std::string>& metadata);
+
 #endif /* endif CUBE_OPENSTACK_H */

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -455,6 +455,47 @@ getVolumeVirtualSize(const std::string& filePath)
 }
 
 /**
+ * Get the virt-v2v XML and decide if the volume supports UEFI.
+ *
+ * @param workingDirectory
+ * @return is UEFI supported
+ */
+const bool
+doesVolumeSupportUefi(const std::filesystem::path& workingDirectory)
+{
+    // get the XML
+    std::string fsError;
+    const std::vector<std::string> files = GetFilesUnderDirectory(fsError, workingDirectory.string());
+    if (!fsError.empty()) {
+        HexLogError("%s", fsError.c_str());
+        return false;
+    }
+
+    std::string filePath;
+    for (const std::string& f : files) {
+        if (f.find(".xml") == std::string::npos) {
+            continue;
+        }
+
+        filePath = f;
+        break;
+    }
+    if (filePath.empty()) {
+        return false;
+    }
+
+    // parse the XML
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        false,
+        false,
+        {},
+        "grep -i \"os firmware\" \"" + filePath + "\" 2>/dev/null | grep -q -i efi");
+
+    return (r.exitCode == 0);
+}
+
+/**
  * Add admin_cli to the project for having sufficient permissions
  * to add the volume to the project.
  *
@@ -708,8 +749,13 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
      * [5]=<project>
      * [6]=<YES|NO> perform virt-v2v conversion or not,
      * also implies the volume is bootable or not
+     * [7]=<os_distro>
+     * [8]=<os_version>
+     *
+     * Volume image properties are set if and only if
+     * performing virt-v2v conversion is yes.
      */
-    if (argc > 7) {
+    if (argc > 9) {
         return CLI_INVALID_ARGS;
     }
 
@@ -724,6 +770,8 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
     std::string domain;
     std::string project;
     bool performVolumeConversion;
+    std::string osDistro;
+    std::string osVersion;
 
     // [1]=<source_nfs_storage_backend>
     if (CliMatchListHelper(
@@ -828,6 +876,38 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         &performVolumeConversionAnswer);
     performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
 
+    // [7]=<os_distro>
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            7,
+            "Specify OS distro name (big impacts to performance if it's windows): ",
+            &osDistro)) {
+        CliPrint("OS distro name is required");
+        return CLI_INVALID_ARGS;
+    }
+    if (osDistro.empty()) {
+        osDistro = "linux";
+    } else {
+        // set OS distro to lowercase
+        std::transform(
+            osDistro.begin(),
+            osDistro.end(),
+            osDistro.begin(),
+            [](unsigned char c) { return std::tolower(c); });
+    }
+
+    // [8]=<os_version>
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            8,
+            "Specify OS version number: ",
+            &osVersion)) {
+        CliPrint("OS version number is required");
+        return CLI_INVALID_ARGS;
+    }
+
     // check if we still have enough quota in the project to manage the volume
     const long long volumeSizeInBytes = getVolumeVirtualSize(fileExtraInfo.filePath);
 
@@ -913,10 +993,26 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
             return CLI_FAILURE;
         }
 
-        filePath = convertedVolumePath.string();
-        std::cout << "updated file path: " << filePath << std::endl;
+        filePath = fileExtraInfo.exportPath + RemovePrefix(convertedVolumePath.string(), fileExtraInfo.target);
 
-        // TODO: parse the metadata
+        // parse the metadata
+        volumeMetadata["hw_machine_type"] = "q35";
+        volumeMetadata["hw_disk_bus"] = "scsi";
+        volumeMetadata["hw_scsi_model"] = "virtio-scsi";
+        volumeMetadata["hw_video_model"] = "vga";
+        volumeMetadata["hw_input_bus"] = "virtio";
+        volumeMetadata["hw_qemu_guest_agent"] = "yes";
+        volumeMetadata["os_require_quiesce"] = "yes";
+        volumeMetadata["os_type"] = (osDistro == "windows" ? "windows" : "linux");
+        volumeMetadata["os_distro"] = osDistro;
+        volumeMetadata["os_admin_user"] = osDistro;
+        volumeMetadata["os_vers"] = osVersion;
+        if (doesVolumeSupportUefi(workingDirectory)) {
+            volumeMetadata["hw_firmware_type"] = "uefi";
+            volumeMetadata["os_secure_boot"] = "optional";
+        } else {
+            volumeMetadata["hw_firmware_type"] = "bios";
+        }
     }
 
     // set access to the project
@@ -972,7 +1068,7 @@ CLI_MODE_COMMAND(
     "Perform needed conversions and set metadata if requested.",
     "manage_existing_from_nfs <source_nfs_storage_backend> "
     "<file_path> <volume_name> <domain> <project> "
-    "<perform virt-v2v conversion or not>");
+    "<perform virt-v2v conversion or not> <os_distro> <os_version>");
 
 /**
  * Get volume types.

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -875,11 +875,9 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
      *
      * We only need to convert volumes not in the raw format.
      */
+    std::map<std::string, std::string> volumeMetadata;
     if (performVolumeConversion && !isVolumeInRaw(fileExtraInfo.filePath)) {
         // create the working directory
-        std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
-        std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
-        std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
         std::filesystem::path workingDirectory = createWorkingDirectoryForVolumeConversion(
             fileExtraInfo.target,
             std::filesystem::path(fileExtraInfo.filePath).filename().string());
@@ -918,16 +916,17 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         filePath = convertedVolumePath.string();
         std::cout << "updated file path: " << filePath << std::endl;
 
-        // parse the metadata
+        // TODO: parse the metadata
     }
-    return CLI_SUCCESS;
 
+    // set access to the project
     if (!addAdminCliToProject(domain, project)) {
         HexLogError("failed to add admin_cli to the project to manage volumes");
         CliPrint("Not sufficient permissions to manage volumes in the project");
         return CLI_FAILURE;
     }
 
+    // manage the existing volume
     const std::string volumeId = manageExistingVolume(
         sourceNfsStorageBackend,
         filePath,
@@ -951,8 +950,15 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         return CLI_FAILURE;
     }
 
-    std::cout << "volume id: " << volumeId << std::endl;
-    // TODO: set volume metadata
+    // set the volume metadata
+    if (!SetVolumeImageProperties(volumeId, volumeMetadata)) {
+        HexLogError(
+            "failed to set the metadata onto volume %s",
+            volumeId.c_str());
+        CliPrintf("Failed to set the metadata onto volume %s",
+            volumeId.c_str());
+        return CLI_FAILURE;
+    }
 
     return CLI_SUCCESS;
 }

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -661,6 +661,37 @@ convertVolume(const std::string& filePath, const std::string& workingDirectory)
     return false;
 }
 
+/**
+ * Get the converted volume file full path.
+ *
+ * @param workingDirectory the full path of the working directory
+ * @param sourceFile the full path of the source volume file
+ * @return the full path of the converted volume file,
+ * if failed, path.empty() = true
+ */
+static const std::filesystem::path
+getConvertedVolumePath(
+    const std::filesystem::path& workingDirectory,
+    const std::filesystem::path& sourceFile)
+{
+    const std::string fileNameFeature = sourceFile.stem().string();
+
+    std::string fsError;
+    const std::vector<std::string> files = GetFilesUnderDirectory(
+        fsError,
+        workingDirectory.string());
+    for (const std::string& f : files) {
+        const std::string basename = std::filesystem::path(f).filename().string();
+        if (basename.rfind(fileNameFeature + "-", 0) != 0) {
+            continue;
+        }
+
+        return workingDirectory / basename;
+    }
+
+    return std::filesystem::path();
+}
+
 struct fileInfo : public mountPoint {
     std::string filePath;
 };
@@ -873,6 +904,19 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         }
 
         // update the filePath with the converted volume path
+        const std::filesystem::path convertedVolumePath = getConvertedVolumePath(workingDirectory, fileExtraInfo.filePath);
+        if (convertedVolumePath.empty()) {
+            HexLogError(
+                "failed to get the converted volume file path, working directory: %s",
+                workingDirectory.c_str());
+            CliPrintf(
+                "Failed to get the converted volume file path, working directory: %s",
+                workingDirectory.c_str());
+            return CLI_FAILURE;
+        }
+
+        filePath = convertedVolumePath.string();
+        std::cout << "updated file path: " << filePath << std::endl;
 
         // parse the metadata
     }

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -547,6 +547,120 @@ manageExistingVolume(
     return Trim(volumeId);
 }
 
+/**
+ * Create a working directory for the volume conversion.
+ *
+ * @param baseDirectory the local mount point (target) of the NFS share
+ * @param fileName the volume file name
+ * @return the working directory path, if failed, path.empty() = true
+ */
+static const std::filesystem::path
+createWorkingDirectoryForVolumeConversion(
+    const std::string& baseDirectory,
+    const std::string& fileName)
+{
+    // replace all dots (.) to dashes (-)
+    std::string tentativeDirectoryName = fileName;
+    std::replace(
+        tentativeDirectoryName.begin(),
+        tentativeDirectoryName.end(),
+        '.',
+        '-');
+
+    std::filesystem::path directoryPath = std::filesystem::path(baseDirectory)
+        / std::filesystem::path(tentativeDirectoryName);
+    if (mkdir(directoryPath.c_str(), 0755) != 0) {
+        return std::filesystem::path();
+    }
+
+    return directoryPath;
+}
+
+/**
+ * Perform the conversion and stream the outputs to stdout and stderr.
+ *
+ * @param filePath the local full path of the volume file
+ * @param workingDirectory the full path of the working directory
+ * @return successful or not
+ */
+static const bool
+convertVolume(const std::string& filePath, const std::string& workingDirectory)
+{
+    Cmd c;
+    c.path = "/usr/bin/virt-v2v";
+    c.args = {
+        "-i", "disk", filePath,
+        "-o", "local",
+        "-of", "raw",
+        "-os", workingDirectory,
+        "--parallel", "4"
+    };
+    c.captureStdout = true;
+    c.captureStderr = true;
+
+    const Process p = Exec(c, false);
+    if (p.pid == -1) {
+        // failed to create the process
+        return false;
+    }
+
+    int status;
+    bool processFinished = false;
+    char buffer[4096];
+    ssize_t bytesRead = 0;
+    while (!processFinished) {
+        // read from stdout
+        bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
+        if (bytesRead > 0) {
+            // stream to stdout
+            std::cout.write(buffer, bytesRead);
+        }
+
+        // read from stderr
+        bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
+        if (bytesRead > 0) {
+            // stream to stderr
+            std::cerr.write(buffer, bytesRead);
+        }
+
+        pid_t waitpidResult = waitpid(p.pid, &status, WNOHANG);
+        if (waitpidResult == p.pid) {
+            processFinished = true;
+        }
+
+        if (!processFinished) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+
+    // read any remaining data
+    bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
+    if (bytesRead > 0) {
+        // stream to stdout
+        std::cout.write(buffer, bytesRead);
+    }
+    // close the read-end
+    close(p.stdoutPipeReadEnd);
+
+    bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
+    if (bytesRead > 0) {
+        // stream to stderr
+        std::cerr.write(buffer, bytesRead);
+    }
+    // close the read-ends
+    close(p.stderrPipeReadEnd);
+
+    // wait for process to fully terminate
+    waitpid(p.pid, &status, 0);
+
+    if (WIFEXITED(status)) {
+        return (WEXITSTATUS(status) == 0);
+    }
+
+    // abnormal termination
+    return false;
+}
+
 struct fileInfo : public mountPoint {
     std::string filePath;
 };
@@ -683,14 +797,17 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
         &performVolumeConversionAnswer);
     performVolumeConversion = isAnswered && performVolumeConversionAnswer == "YES";
 
-    std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
-    std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
-    std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
-
     // check if we still have enough quota in the project to manage the volume
     const long long volumeSizeInBytes = getVolumeVirtualSize(fileExtraInfo.filePath);
 
     if (!IsQuotaGigabytesEnough(domain, project, volumeSizeInBytes)) {
+        HexLogError(
+            "project %s under domain %s does not have enough quota on resource %s, "
+            "needed space for the volume is %lld",
+            project.c_str(),
+            domain.c_str(),
+            "gigabytes",
+            volumeSizeInBytes);
         CliPrintf(
             "Project %s under domain %s does not have enough quota on resource %s, "
             "needed space for the volume is %lld",
@@ -702,6 +819,13 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
     }
 
     if (!IsQuotaVolumesEnough(domain, project)) {
+        HexLogError(
+            "project %s under domain %s does not have enough quota on resource %s, "
+            "needed space for the volume is %lld",
+            project.c_str(),
+            domain.c_str(),
+            "volumes",
+            volumeSizeInBytes);
         CliPrintf(
             "Project %s under domain %s does not have enough quota on resource %s, "
             "needed space for the volume is %lld",
@@ -721,10 +845,38 @@ ManageExistingVolumeFromNfsMain(int argc, const char** argv)
      * We only need to convert volumes not in the raw format.
      */
     if (performVolumeConversion && !isVolumeInRaw(fileExtraInfo.filePath)) {
-        // perform the conversion
+        // create the working directory
+        std::cout << "fileInfo export: " << fileExtraInfo.exportPath << std::endl;
+        std::cout << "fileInfo target: " << fileExtraInfo.target << std::endl;
+        std::cout << "fileInfo path: " << fileExtraInfo.filePath << std::endl;
+        std::filesystem::path workingDirectory = createWorkingDirectoryForVolumeConversion(
+            fileExtraInfo.target,
+            std::filesystem::path(fileExtraInfo.filePath).filename().string());
+        if (workingDirectory.empty()) {
+            HexLogError(
+                "failed to create the working directory %s",
+                workingDirectory.c_str());
+            CliPrintf(
+                "Failed to create the working directory %s",
+                workingDirectory.c_str());
+            return CLI_FAILURE;
+        }
+
+        // perform the conversion and stream the outputs
+        if (!convertVolume(fileExtraInfo.filePath, workingDirectory.string())) {
+            HexLogError(
+                "failed to perform the volume conversion from %s to %s",
+                fileExtraInfo.filePath.c_str(),
+                workingDirectory.c_str());
+            CliPrintf("Failed to perform the volume conversion");
+            return CLI_FAILURE;
+        }
+
+        // update the filePath with the converted volume path
 
         // parse the metadata
     }
+    return CLI_SUCCESS;
 
     if (!addAdminCliToProject(domain, project)) {
         HexLogError("failed to add admin_cli to the project to manage volumes");

--- a/core/modules/cli_iaas_volume.hpp
+++ b/core/modules/cli_iaas_volume.hpp
@@ -16,6 +16,7 @@
 
 #include <filesystem>
 #include <iostream>
+#include <sys/stat.h>
 
 #define CLI_COMMAND_IAAS_VOLUME "volume"
 


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Finish CLI > iaas > volume > manage_existing_from_nfs
  - Add volume conversion via virt-v2v
  - Parse volume metadata and set volume image properties

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/2
- Related to #142 
- Related to https://github.com/bigstack-oss/cubecos-private/issues/3
- Related to #486 
- Related to #412
- Related to https://github.com/bigstack-oss/hex/pull/83

#### Special notes for your reviewer

#### Additional documentation

Usage of `CLI > iaas > volume > manage_existing_from_nfs`

```bash
hex_cli -v -c iaas volume manage_existing_from_nfs <source_nfs_storage_backend> <file_path> <volume_name> <domain> <project> <perform virt-v2v conversion or not> <os_distro> <os_version>

# e.g., hex_cli -v -c iaas volume manage_existing_from_nfs nfs <ip>:<file_path_on_share> ubuntu2404-volume-from-nfs default admin YES ubuntu 24.04
```

Usage of `cinder manage`

```bash
cinder --os-project-domain-name default --os-project-name admin manage --bootable --name ubuntu2404-volume-from-nfs --volume-type nfs nfs@nfs#nfs <ip>:<file_path_on_share>
```
