### PR TITLE
feat(cinder): add cli > iaas > volume_backend > get_active_multipath_setting

### DIFF
--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -651,17 +651,27 @@ convertVolume(const std::string& filePath, const std::string& workingDirectory)
     ssize_t bytesRead = 0;
     while (!processFinished) {
         // read from stdout
-        bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
-        if (bytesRead > 0) {
-            // stream to stdout
-            std::cout.write(buffer, bytesRead);
+        while (true) {
+            // drain the pipe
+            bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
+            if (bytesRead > 0) {
+                // stream to stdout
+                std::cout.write(buffer, bytesRead);
+            } else {
+                break;
+            }
         }
 
         // read from stderr
-        bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
-        if (bytesRead > 0) {
-            // stream to stderr
-            std::cerr.write(buffer, bytesRead);
+        while (true) {
+            // drain the pipe
+            bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
+            if (bytesRead > 0) {
+                // stream to stderr
+                std::cerr.write(buffer, bytesRead);
+            } else {
+                break;
+            }
         }
 
         pid_t waitpidResult = waitpid(p.pid, &status, WNOHANG);
@@ -675,18 +685,28 @@ convertVolume(const std::string& filePath, const std::string& workingDirectory)
     }
 
     // read any remaining data
-    bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
-    if (bytesRead > 0) {
-        // stream to stdout
-        std::cout.write(buffer, bytesRead);
+    while (true) {
+        // drain the pipe
+        bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
+        if (bytesRead > 0) {
+            // stream to stdout
+            std::cout.write(buffer, bytesRead);
+        } else {
+            break;
+        }
     }
     // close the read-end
     close(p.stdoutPipeReadEnd);
 
-    bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
-    if (bytesRead > 0) {
-        // stream to stderr
-        std::cerr.write(buffer, bytesRead);
+    while (true) {
+        // drain the pipe
+        bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
+        if (bytesRead > 0) {
+            // stream to stderr
+            std::cerr.write(buffer, bytesRead);
+        } else {
+            break;
+        }
     }
     // close the read-ends
     close(p.stderrPipeReadEnd);

--- a/core/modules/cli_iaas_volume.cpp
+++ b/core/modules/cli_iaas_volume.cpp
@@ -349,7 +349,7 @@ isVolumeInRaw(const std::string& filePath)
         true,
         true,
         {},
-        "qemu-img info \"" + filePath + "\"");
+        "/usr/bin/qemu-img info \"" + filePath + "\"");
     if (r.exitCode != 0) {
         HexLogError(
             "failed to use qemu-img to probe the info of the volume, error: %s",
@@ -391,7 +391,7 @@ getVolumeVirtualSize(const std::string& filePath)
         true,
         true,
         {},
-        "qemu-img info \"" + filePath + "\"");
+        "/usr/bin/qemu-img info \"" + filePath + "\"");
     if (r.exitCode != 0) {
         HexLogError(
             "failed to use qemu-img to probe the info of the volume, error: %s",
@@ -490,7 +490,7 @@ doesVolumeSupportUefi(const std::filesystem::path& workingDirectory)
         false,
         false,
         {},
-        "grep -i \"os firmware\" \"" + filePath + "\" 2>/dev/null | grep -q -i efi");
+        "/usr/bin/grep -i \"os firmware\" \"" + filePath + "\" 2>/dev/null | grep -q -i efi");
 
     return (r.exitCode == 0);
 }
@@ -1251,7 +1251,7 @@ MoveVolumeToBackendMain(int argc, const char** argv)
         true,
         true,
         ParseOpenstackCliAuth(),
-        "cinder retype --migration-policy on-demand \""
+        "/usr/local/bin/cinder retype --migration-policy on-demand \""
             + volumeId + "\" \"" + destinationVolumeType + "\"");
     if (r.exitCode != 0) {
         HexLogError("%s", r.stderrOutput.c_str());

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -117,7 +117,7 @@ listModels()
         true,
         true,
         {},
-        "echo '" + r.stdoutOutput + "' | yq -p=json -o=yaml");
+        "/usr/bin/echo '" + r.stdoutOutput + "' | /usr/local/bin/yq -p=json -o=yaml");
     if (yr.exitCode != 0) {
         std::cerr << "Error: " << yr.stderrOutput << std::endl;
         return false;
@@ -250,7 +250,7 @@ listModel(const std::string& driver)
         true,
         true,
         {},
-        "echo '" + r.stdoutOutput + "' | yq -p=json -o=yaml");
+        "/usr/bin/echo '" + r.stdoutOutput + "' | /usr/local/bin/yq -p=json -o=yaml");
     if (yr.exitCode != 0) {
         std::cerr << "Error: " << yr.stderrOutput << std::endl;
         return false;
@@ -349,7 +349,7 @@ parseModel(
         true,
         true,
         {},
-        "yq -p=yaml -o=json \"" + modelFilePath + "\"");
+        "/usr/local/bin/yq -p=yaml -o=json \"" + modelFilePath + "\"");
     if (r.exitCode != 0) {
         error = r.stderrOutput;
         return "";
@@ -392,7 +392,7 @@ getMessage(const std::string& output)
         true,
         true,
         {},
-        "echo '" + output + "' | jq -r \".message\"");
+        "/usr/bin/echo '" + output + "' | /usr/bin/jq -r \".message\"");
     if (r.exitCode != 0) {
         return r.stderrOutput;
     }
@@ -610,7 +610,7 @@ getActiveMultipathSetting(std::string& output)
         true,
         true,
         {},
-        "yq -p=json -o=yaml " + f.fileName);
+        "/usr/local/bin/yq -p=json -o=yaml " + f.fileName);
     DeleteTempFile(f);
 
     if (yr.exitCode != 0) {

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -593,13 +593,12 @@ CLI_MODE_COMMAND(
 static bool
 getActiveMultipathSetting(std::string& output)
 {
-    TempFile f = CreateTempFile();
     const ExecSyncResult r = ExecBashSync(
         0,
         true,
         true,
         {},
-        HEX_SDK " cinder_get_active_multipath_setting > " + f.fileName);
+        HEX_SDK " cinder_get_active_multipath_setting");
     if (r.exitCode != 0) {
         output = r.stderrOutput;
         return false;
@@ -610,9 +609,7 @@ getActiveMultipathSetting(std::string& output)
         true,
         true,
         {},
-        "/usr/local/bin/yq -p=json -o=yaml " + f.fileName);
-    DeleteTempFile(f);
-
+        "echo '" + r.stdoutOutput + "' | /usr/local/bin/yq -p=json -o=yaml");
     if (yr.exitCode != 0) {
         output = yr.stderrOutput;
         return false;

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -583,3 +583,66 @@ CLI_MODE_COMMAND(
     NULL,
     "Delete an external storage model.",
     "delete_model <driver>");
+
+/**
+ * Get the active multipath settings in the kernel.
+ *
+ * @param output
+ * @return active multipath settings in YAML
+ */
+static bool
+getActiveMultipathSetting(std::string& output)
+{
+    TempFile f = CreateTempFile();
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_get_active_multipath_setting > " + f.fileName);
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    const ExecSyncResult yr = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "yq -p=json -o=yaml " + f.fileName);
+    DeleteTempFile(f);
+
+    if (yr.exitCode != 0) {
+        output = yr.stderrOutput;
+        return false;
+    }
+
+    output = yr.stdoutOutput;
+    return true;
+}
+
+static int
+GetActiveMultipathSettingMain(int argc, const char** argv)
+{
+    if (argc > 1) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string output;
+    if (!getActiveMultipathSetting(output)) {
+        std::cerr << "Error: " << output << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << output << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "get_active_multipath_setting",
+    GetActiveMultipathSettingMain,
+    NULL,
+    "Get the active multipath settings.",
+    "get_active_multipath_setting");


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Add CLI > iaas > volume_backend > get_active_multipath_setting
- Exclude zero size devices during the installation process

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/2
- Related to #142 
- Related to https://github.com/bigstack-oss/cubecos-private/issues/3

#### Special notes for your reviewer

#### Additional documentation

Usages

```bash
hex_cli -v -c iaas volume_backend get_active_multipath_setting
```
