### PR TITLE
feat(cinder): add storage operations to cli > iaas > volume_backend

### DIFF
--- a/core/cube_sdk_library/src/Makefile
+++ b/core/cube_sdk_library/src/Makefile
@@ -18,6 +18,7 @@ LIB_SRCS += openstack.cpp
 LIB_SRCS += terraform.cpp
 LIB_SRCS += upgrade.cpp
 LIB_SRCS += url.cpp
+LIB_SRCS += yaml.cpp
 
 COMPILE_FOR_SHARED_LIB = 1
 

--- a/core/cube_sdk_library/src/yaml.cpp
+++ b/core/cube_sdk_library/src/yaml.cpp
@@ -20,3 +20,20 @@ YamlFileToJson(
 
     return r.stdoutOutput;
 }
+
+bool YamlFromJson(std::string& output, const std::string& input)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "/usr/bin/echo '" + input + "' | /usr/local/bin/yq -p=json -o=yaml");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}

--- a/core/cube_sdk_library/src/yaml.cpp
+++ b/core/cube_sdk_library/src/yaml.cpp
@@ -1,0 +1,22 @@
+// CUBE SDK
+
+#include "yaml.hpp"
+
+const std::string
+YamlFileToJson(
+    std::string& error,
+    const std::string& yamlFilePath)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "/usr/local/bin/yq -p=yaml -o=json \"" + yamlFilePath + "\"");
+    if (r.exitCode != 0) {
+        error = r.stderrOutput;
+        return "";
+    }
+
+    return r.stdoutOutput;
+}

--- a/core/cube_sdk_library/src/yaml.hpp
+++ b/core/cube_sdk_library/src/yaml.hpp
@@ -1,0 +1,21 @@
+// CUBE SDK
+
+#ifndef CUBE_YAML_H
+#define CUBE_YAML_H
+
+#include <hex/exec.hpp>
+#include <string>
+
+/**
+ * Parse the YAML file into a JSON string.
+ *
+ * @param error
+ * @param yamlFilePath
+ * @return JSON string
+ */
+const std::string
+YamlFileToJson(
+    std::string& error,
+    const std::string& yamlFilePath);
+
+#endif /* endif CUBE_YAML_H */

--- a/core/cube_sdk_library/src/yaml.hpp
+++ b/core/cube_sdk_library/src/yaml.hpp
@@ -18,4 +18,13 @@ YamlFileToJson(
     std::string& error,
     const std::string& yamlFilePath);
 
+/**
+ * Parse the JSON string into an YAML string.
+ *
+ * @param output
+ * @param input
+ * @return parsing is successful or not
+ */
+bool YamlFromJson(std::string& output, const std::string& input);
+
 #endif /* endif CUBE_YAML_H */

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -332,32 +332,6 @@ prepareModelFile(
     return f;
 }
 
-/**
- * Parse the model file into a JSON string.
- *
- * @param error
- * @param modelFilePath
- * @return model
- */
-static const std::string
-parseModel(
-    std::string& error,
-    const std::string& modelFilePath)
-{
-    const ExecSyncResult r = ExecBashSync(
-        0,
-        true,
-        true,
-        {},
-        "/usr/local/bin/yq -p=yaml -o=json \"" + modelFilePath + "\"");
-    if (r.exitCode != 0) {
-        error = r.stderrOutput;
-        return "";
-    }
-
-    return r.stdoutOutput;
-}
-
 static bool
 setModel(
     std::string& output,
@@ -469,7 +443,7 @@ SetModelMain(int argc, const char** argv)
     if (sourceType == "local") {
         std::string error;
 
-        model = parseModel(
+        model = YamlFileToJson(
             error,
             std::filesystem::path(localDirectory) / std::filesystem::path(modelFilePath));
         if (!error.empty()) {
@@ -487,7 +461,7 @@ SetModelMain(int argc, const char** argv)
             return CLI_FAILURE;
         }
 
-        model = parseModel(error, f.fileName);
+        model = YamlFileToJson(error, f.fileName);
         if (!error.empty()) {
             std::cerr << "Error: " << error << std::endl;
             DeleteTempFile(f);
@@ -609,7 +583,7 @@ getActiveMultipathSetting(std::string& output)
         true,
         true,
         {},
-        "echo '" + r.stdoutOutput + "' | /usr/local/bin/yq -p=json -o=yaml");
+        "/usr/bin/echo '" + r.stdoutOutput + "' | /usr/local/bin/yq -p=json -o=yaml");
     if (yr.exitCode != 0) {
         output = yr.stderrOutput;
         return false;

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -703,3 +703,107 @@ CLI_MODE_COMMAND(
     NULL,
     "Get storages of external storage.",
     "get_storages");
+
+/**
+ * Get a storage by name.
+ *
+ * @param output
+ * @param name
+ * @return hex_sdk interface output
+ */
+static bool
+getStorage(std::string& output, const std::string& name)
+{
+    // structure the payload
+    json11::Json payload = json11::Json::object {
+        { "name", name },
+    };
+
+    // call the hex_sdk interface
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_get_storage '" + payload.dump() + "'");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}
+
+/**
+ * Parse the storage JSON into YAML.
+ *
+ * @param output
+ * @param storage
+ * @return storage in YAML
+ */
+static bool
+parseStorage(std::string& output, const std::string& storage)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "/usr/bin/echo '" + storage + "' | /usr/local/bin/yq -p=json -o=yaml");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}
+
+static int
+GetStorageMain(int argc, const char** argv)
+{
+    /**
+     * [0] get_storage
+     * [1] <name>
+     */
+    if (argc > 2) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string name;
+
+    // [1] <name>
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            1,
+            "Enter the name: ",
+            &name)) {
+        std::cerr << "Field name is required" << std::endl;
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string storage;
+    if (!getStorage(storage, name)) {
+        std::cerr << "Error: " << storage << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::string storageOutput;
+    if (!parseStorage(storageOutput, storage)) {
+        std::cerr << "Error: " << storageOutput << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << storageOutput << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "get_storage",
+    GetStorageMain,
+    NULL,
+    "Get a storage by name.",
+    "get_storage <name>");

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -448,7 +448,7 @@ SetModelMain(int argc, const char** argv)
                 argc,
                 argv,
                 2,
-                "find " + localDirectory + "/ -type f -print0 | xargs -0 -n 1 basename",
+                "/usr/bin/find " + localDirectory + "/ -type f -print0 | xargs -0 -n 1 basename",
                 &index,
                 &modelFilePath,
                 message.c_str())
@@ -643,3 +643,63 @@ CLI_MODE_COMMAND(
     NULL,
     "Get the active multipath settings.",
     "get_active_multipath_setting");
+
+/**
+ * Get storages.
+ *
+ * @param output
+ * @return storages in YAML
+ */
+static bool
+getStorages(std::string& output)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_get_storages");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    const ExecSyncResult yr = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        "/usr/bin/echo '" + r.stdoutOutput + "' | /usr/local/bin/yq -p=json -o=yaml");
+    if (yr.exitCode != 0) {
+        output = yr.stderrOutput;
+        return false;
+    }
+
+    output = yr.stdoutOutput;
+    return true;
+}
+
+static int
+GetStoragesMain(int argc, const char** argv)
+{
+    if (argc > 1) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string output;
+    if (!getStorages(output)) {
+        std::cerr << "Error: " << output << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << output << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "get_storages",
+    GetStoragesMain,
+    NULL,
+    "Get storages of external storage.",
+    "get_storages");

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -758,6 +758,79 @@ CLI_MODE_COMMAND(
     "get_storage <name>");
 
 /**
+ * Delete a storage by name.
+ *
+ * @param output
+ * @param name
+ * @return is successful or not
+ */
+static bool
+deleteStorage(std::string& output, const std::string& name)
+{
+    // structure the payload
+    json11::Json payload = json11::Json::object {
+        { "name", name },
+    };
+
+    // call the hex_sdk interface
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_delete_storage '" + payload.dump() + "'");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}
+
+static int
+DeleteStorageMain(int argc, const char** argv)
+{
+    /**
+     * [0] delete_storage
+     * [1] <name>
+     */
+    if (argc > 2) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string name;
+
+    // [1] <name>
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            1,
+            "Enter the name: ",
+            &name)) {
+        std::cerr << "Field name is required" << std::endl;
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string output;
+    if (!deleteStorage(output, name)) {
+        std::cerr << getMessage(output) << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << getMessage(output) << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "delete_storage",
+    DeleteStorageMain,
+    NULL,
+    "Delete a storage by name.",
+    "delete_storage <name>");
+
+/**
  * Test a storage by name.
  *
  * @param output

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -839,3 +839,66 @@ CLI_MODE_COMMAND(
     "It would first check if the Cinder service for the storage is up. "
     "Then, it would create a test volume with size 1 GiB on the storage and delete it afterwards.",
     "test_storage <name>");
+
+/**
+ * Get the name of the default storage.
+ *
+ * @param defaultStorage
+ * @return successful or not
+ */
+static bool
+getDefaultStorage(std::string& defaultStorage)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_get_default_storage");
+    if (r.exitCode != 0) {
+        defaultStorage = "";
+        return false;
+    }
+
+    // parse the name
+    std::string jsonError;
+    const json11::Json response = json11::Json::parse(r.stdoutOutput, jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("%s", jsonError.c_str());
+        defaultStorage = "";
+        return false;
+    }
+
+    if (!response["name"].is_string()) {
+        HexLogError("failed to parse the field name out of %s", r.stdoutOutput.c_str());
+        defaultStorage = "";
+        return false;
+    }
+
+    defaultStorage = response["name"].string_value();
+    return true;
+}
+
+static int
+GetDefaultStorageMain(int argc, const char** argv)
+{
+    if (argc > 1) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string defaultStorage;
+    if (!getDefaultStorage(defaultStorage)) {
+        return CLI_FAILURE;
+    }
+
+    std::cout << "Default storage: " << defaultStorage << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "get_default_storage",
+    GetDefaultStorageMain,
+    NULL,
+    "Get the default storage.",
+    "get_default_storage");

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -902,3 +902,69 @@ CLI_MODE_COMMAND(
     NULL,
     "Get the default storage.",
     "get_default_storage");
+
+static bool
+setDefaultStorage(std::string& output, const std::string& name)
+{
+    // structure the payload
+    json11::Json payload = json11::Json::object {
+        { "name", name },
+    };
+
+    // call the hex_sdk interface
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_set_default_storage '" + payload.dump() + "'");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}
+
+static int
+SetDefaultStorageMain(int argc, const char** argv)
+{
+    /**
+     * [0] set_default_storage
+     * [1] <name>
+     */
+    if (argc > 2) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string name;
+
+    // [1] <name>
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            1,
+            "Enter the name: ",
+            &name)) {
+        std::cerr << "Field name is required" << std::endl;
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string output;
+    if (!setDefaultStorage(output, name)) {
+        std::cerr << getMessage(output) << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << getMessage(output) << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "set_default_storage",
+    SetDefaultStorageMain,
+    NULL,
+    "Set the default storage.",
+    "set_default_storage <name>");

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -758,6 +758,147 @@ CLI_MODE_COMMAND(
     "get_storage <name>");
 
 /**
+ * Set a storage using a storage JSON.
+ *
+ * @param output
+ * @param storage
+ * @return is successful or not
+ */
+static bool
+setStorage(std::string& output, const std::string& storage)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_put_storage '" + storage + "'");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}
+
+static int
+SetStorageMain(int argc, const char** argv)
+{
+    /**
+     * [0] set_model
+     * [1] <local | console>
+     * [2] <local_storage_file_name | storage_content>
+     */
+    if (argc > 3) {
+        return CLI_INVALID_ARGS;
+    }
+
+    const std::string localDirectory = "/var/update";
+
+    // collect inputs
+    int index;
+    std::string sourceType;
+    std::string storageFilePath;
+    std::string storageContent;
+
+    CliList sourceTypes;
+    sourceTypes.push_back("local");
+    sourceTypes.push_back("console");
+
+    // [1] <local | console>
+    if (CliMatchListHelper(
+            argc,
+            argv,
+            1,
+            sourceTypes,
+            &index,
+            &sourceType,
+            "Select input method: ")
+        != 0) {
+        std::cerr << "Input method is missing or invalid" << std::endl;
+        return CLI_INVALID_ARGS;
+    }
+
+    if (sourceType == "local") {
+        // [2] <local_storage_file_name>
+        const std::string message = "Please prepare the storage file under "
+            + localDirectory
+            + " . Select the input file: ";
+        std::cout << "" << localDirectory << std::endl;
+        if (CliMatchCmdHelper(
+                argc,
+                argv,
+                2,
+                "/usr/bin/find " + localDirectory + "/ -type f -print0 | xargs -0 -n 1 basename",
+                &index,
+                &storageFilePath,
+                message.c_str())
+            != 0) {
+            std::cerr << "File " << storageFilePath << " not found" << std::endl;
+            return CLI_INVALID_ARGS;
+        }
+    } else {
+        // [2] <storage_content>
+        if (!CliReadMultipleLines("Please enter the content of the storage: ", storageContent)) {
+            std::cerr << "Invalid file content" << std::endl;
+            return CLI_INVALID_ARGS;
+        }
+    }
+
+    // parse the storage
+    std::string storage;
+    if (sourceType == "local") {
+        std::string error;
+
+        storage = YamlFileToJson(
+            error,
+            std::filesystem::path(localDirectory) / std::filesystem::path(storageFilePath));
+        if (!error.empty()) {
+            std::cerr << "Error: " << error << std::endl;
+            return CLI_FAILURE;
+        }
+    } else if (sourceType == "console") {
+        // prepare the model file
+        std::string error;
+
+        TempFile f = prepareModelFile(error, storageContent);
+        if (!error.empty()) {
+            std::cerr << "Error: " << error << std::endl;
+            DeleteTempFile(f);
+            return CLI_FAILURE;
+        }
+
+        storage = YamlFileToJson(error, f.fileName);
+        if (!error.empty()) {
+            std::cerr << "Error: " << error << std::endl;
+            DeleteTempFile(f);
+            return CLI_FAILURE;
+        }
+
+        DeleteTempFile(f);
+    }
+
+    // set the model
+    std::string output;
+    if (!setStorage(output, storage)) {
+        std::cerr << "Error: " << getMessage(output) << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << getMessage(output) << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "set_storage",
+    SetStorageMain,
+    NULL,
+    "Set a storage.",
+    "set_storage <local | console> <local_storage_file_name | storage_content>");
+
+/**
  * Delete a storage by name.
  *
  * @param output

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -709,31 +709,6 @@ getStorage(std::string& output, const std::string& name)
     return true;
 }
 
-/**
- * Parse the storage JSON into YAML.
- *
- * @param output
- * @param storage
- * @return storage in YAML
- */
-static bool
-parseStorage(std::string& output, const std::string& storage)
-{
-    const ExecSyncResult r = ExecBashSync(
-        0,
-        true,
-        true,
-        {},
-        "/usr/bin/echo '" + storage + "' | /usr/local/bin/yq -p=json -o=yaml");
-    if (r.exitCode != 0) {
-        output = r.stderrOutput;
-        return false;
-    }
-
-    output = r.stdoutOutput;
-    return true;
-}
-
 static int
 GetStorageMain(int argc, const char** argv)
 {
@@ -765,7 +740,7 @@ GetStorageMain(int argc, const char** argv)
     }
 
     std::string storageOutput;
-    if (!parseStorage(storageOutput, storage)) {
+    if (!YamlFromJson(storageOutput, storage)) {
         std::cerr << "Error: " << storageOutput << std::endl;
         return CLI_FAILURE;
     }

--- a/core/modules/cli_iaas_volume_backend.cpp
+++ b/core/modules/cli_iaas_volume_backend.cpp
@@ -756,3 +756,86 @@ CLI_MODE_COMMAND(
     NULL,
     "Get a storage by name.",
     "get_storage <name>");
+
+/**
+ * Test a storage by name.
+ *
+ * @param output
+ * @param name
+ * @return is storage working or not
+ */
+static bool
+testStorage(std::string& output, const std::string& name)
+{
+    // structure the payload
+    json11::Json payload = json11::Json::object {
+        { "name", name },
+    };
+
+    // call the hex_sdk interface
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        true,
+        {},
+        HEX_SDK " cinder_test_storage '" + payload.dump() + "'");
+    if (r.exitCode != 0) {
+        output = r.stderrOutput;
+        return false;
+    }
+
+    output = r.stdoutOutput;
+    return true;
+}
+
+static int
+TestStorageMain(int argc, const char** argv)
+{
+    /**
+     * [0] test_storage
+     * [1] <name>
+     */
+    if (argc > 2) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string name;
+
+    // [1] <name>
+    if (!CliReadInputStr(
+            argc,
+            argv,
+            1,
+            "Enter the name: ",
+            &name)) {
+        std::cerr << "Field name is required" << std::endl;
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string testResult;
+    bool isSuccessful = testStorage(testResult, name);
+
+    std::string output;
+    if (!YamlFromJson(output, testResult)) {
+        std::cerr << "Error: " << output << std::endl;
+        return CLI_FAILURE;
+    }
+
+    if (!isSuccessful) {
+        std::cerr << output << std::endl;
+        return CLI_FAILURE;
+    }
+
+    std::cout << output << std::endl;
+    return CLI_SUCCESS;
+}
+
+CLI_MODE_COMMAND(
+    CLI_COMMAND_IAAS_STORAGE,
+    "test_storage",
+    TestStorageMain,
+    NULL,
+    "Test a storage by name. "
+    "It would first check if the Cinder service for the storage is up. "
+    "Then, it would create a test volume with size 1 GiB on the storage and delete it afterwards.",
+    "test_storage <name>");

--- a/core/modules/cli_iaas_volume_backend.hpp
+++ b/core/modules/cli_iaas_volume_backend.hpp
@@ -13,6 +13,7 @@
 #include <hex/process.h>
 #include <hex/strict.h>
 #include <openstack.hpp>
+#include <yaml.hpp>
 
 #include <iostream>
 


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Add CLI > iaas > volume_backend > get_storages
- Add CLI > iaas > volume_backend > get_storage
- Add CLI > iaas > volume_backend > set_storage
- Add CLI > iaas > volume_backend > delete_storage
- Add CLI > iaas > volume_backend > test_storage
- Add CLI > iaas > volume_backend > get_default_storage
- Add CLI > iaas > volume_backend > set_default_storage

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/cubecos-private/issues/2
- Close #142 
- Close https://github.com/bigstack-oss/cubecos-private/issues/3

#### Special notes for your reviewer

#### Additional documentation

Usages:

```bash
hex_cli -v -c iaas volume_backend get_storages
hex_cli -v -c iaas volume_backend get_storage <name>
hex_cli -v -c iaas volume_backend set_storage <local | console> <local_storage_file_name | storage_content>
hex_cli -v -c iaas volume_backend delete_storage <name>
hex_cli -v -c iaas volume_backend test_storage <name>
hex_cli -v -c iaas volume_backend get_default_storage
hex_cli -v -c iaas volume_backend set_default_storage <name>
```
