### PR TITLE
fix(hex_cli): remove the Quiet() for the `ceph restful create-key` and `ceph restful list-keys`

### DIFF
--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2220,7 +2220,7 @@ ceph_restful_username_list()
 ceph_restful_key_create()
 {
     local username=$1
-    Quiet -n $CEPH restful create-key $username
+    $CEPH restful create-key $username
 }
 
 ceph_restful_key_delete()
@@ -2231,7 +2231,7 @@ ceph_restful_key_delete()
 
 ceph_restful_key_list()
 {
-    Quiet -n $CEPH restful list-keys
+    $CEPH restful list-keys
 }
 
 ceph_mgr_module_enable()


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

Remove the Quiet() for the
- ceph restful create-key
- ceph restful list-keys

Actually, the core function of ceph is not broken, but not sure why we placed the `Quiet()` in front of both CLI then cause the Stdout can't be printed. 

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/490

<br/>

#### Test result

Before:

```sh
cc1:restful> key_create
Input username: bigstack
cc1:restful> key_list
cc1:restful>
```

<br/>

After:

```sh
cc1:restful> key_create test-user-3
7d18636b-38b1-43d8-beb6-da2bfeb7af6a
cc1:restful> key_list
{
    "bigstack": "a8508576-4118-4587-aaf5-2e7f4dfac447",
    "test-user": "c37d06b5-ca1c-448c-9d45-1f3dff81e62b",
    "test-user-2": "7228baa1-aee7-4971-b519-e060c6f76dbe",
    "test-user-3": "7d18636b-38b1-43d8-beb6-da2bfeb7af6a"
}
```
