### PR TITLE
fix(app frameworks): fix the image typo in the extpack's rancher md5 check

### DIFF
--- a/core/extpacks/Makefile
+++ b/core/extpacks/Makefile
@@ -49,7 +49,7 @@ $(RANCHER): $(NAS)
 
 .PHONY: $(RANCHER).md5
 $(RANCHER).md5: $(RANCHER)
-	$(Q)diff $@ $(NAS)/app-image/yoga/rancher-cluster-image-rke2-v1.32.4.raw.md5 2>/dev/null || ( cp -f $(NAS)/app-image/yoga/rancher-cluster-image-rke2-v1.32.4.raw.raw $< && md5sum $< | awk '{print $$1}' > $@ )
+	$(Q)diff $@ $(NAS)/app-image/yoga/rancher-cluster-image-rke2-v1.32.4.raw.md5 2>/dev/null || ( cp -f $(NAS)/app-image/yoga/rancher-cluster-image-rke2-v1.32.4.raw $< && md5sum $< | awk '{print $$1}' > $@ )
 
 .PHONY: ext
 ext: $(PROJ_EXT) $(PROJ_PORTAL_EXT)


### PR DESCRIPTION
#### What type of PR is this?

Fix
<br/>

#### What this PR does / why we need it

For the extpacks process,

1). fix the image typo in the extpack's rancher md5 check

2). the corresponding image is already uploaded to the NAS(/volume1/docker/minio/downloads/app-image/yoga)

<img width="975" height="349" alt="Screenshot 2025-12-22 at 12 43 24 PM" src="https://github.com/user-attachments/assets/24a32259-d853-43cc-a028-4bd1302688b1" />

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/132
