### PR TITLE
Fix designate configuration

### DIFF
--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -485,7 +485,7 @@ UpdateCfg(std::string domain, std::string region, std::string password,
         ml2Cfg["ml2"]["type_drivers"] = "local,flat,vlan,geneve";
         ml2Cfg["ml2"]["tenant_network_types"] = "geneve";
         ml2Cfg["ml2"]["mechanism_drivers"] = "ovn,baremetal";
-        ml2Cfg["ml2"]["extension_drivers"] = "port_security,dns_domain_ports,qos";
+        ml2Cfg["ml2"]["extension_drivers"] = "port_security,dns_domain_ports,qos,subnet_dns_publish_fixed_ip";
         ml2Cfg["ml2"]["overlay_ip_version"] = "4";
         ml2Cfg["ml2"]["path_mtu"] = std::to_string(overlayMtu);
         ml2Cfg["ml2_type_flat"]["flat_networks"] = "provider" + ep;

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -427,6 +427,13 @@ os_neutron_network_update()
     local value=$4
     local nid=$(os_get_network_id_by_tenant_and_name $tenant $network)
     neutron net-update $nid --$type $value 2>/dev/null
+
+    if [ "$type" == "dns-domain" ]; then
+        local subnet_ids=$(openstack subnet list --network $nid -f value -c ID)
+        for subnet_id in $subnet_ids; do
+            openstack subnet set --dns-publish-fixed-ip $subnet_id
+        done
+    fi
 }
 
 os_neutron_network_show()


### PR DESCRIPTION
#### What type of PR is this?

bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

1. Enable the `subnet_dns_publish_fixed_ip` in neutron for designate.
2. Automatically publish the dns record to all subnets under the network when setup `dns-domian` for it.

##### Test

* setup dns-domain through hex.
```
[cube311 ~]# su - admin
Last login: Wed Dec 24 19:54:23 CST 2025 on pts/5
iWelcome to Cube Appliance
aLicense (type: trial) is valid for 5 days
Enter "help" for a list of available commands
cube311> iaas

cube311:iaas> network

cube311:network> network_set
Select domain:
1: Default
Enter index: 1
Select tenant:
1: PROJ002
2: PROJ001
3: raven-test
4: app-framework
5: Tutorial-Project
6: admin
7: demo
Enter index: 2
Select network:
1: NFV-test-private
2: private-k8s
3: private
Enter index: 1
Select type:
1: name
2: description
3: qos-policy
4: no-qos-policy
5: dns-domain
6: no-dns-domain
Enter index: 5
Input value: arashi.li.local.
Updated network: 41621392-0626-4195-84e3-dfae02e6e227
```

* create zone
```
[cube311 ~]# openstack zone create --email arashi.li@bigstack.co arashi.li.local.
+----------------+--------------------------------------+
| Field          | Value                                |
+----------------+--------------------------------------+
| action         | CREATE                               |
| attributes     |                                      |
| created_at     | 2025-12-27T07:02:03.000000           |
| description    | None                                 |
| email          | arashi.li@bigstack.co                |
| id             | ad85e430-a726-411d-b408-9ffcb245c020 |
| masters        |                                      |
| name           | arashi.li.local.                     |
| pool_id        | 794ccc2c-d751-44fe-b57f-8894c9f5c842 |
| project_id     | a23fe2d9fa61473bb778c90cf8459e21     |
| serial         | 1766818923                           |
| status         | PENDING                              |
| transferred_at | None                                 |
| ttl            | 3600                                 |
| type           | PRIMARY                              |
| updated_at     | None                                 |
| version        | 1                                    |
+----------------+--------------------------------------+
```

* create two VMs for verification
```
[cube311 ~]# openstack server create --flavor basic.small --image Ubuntu2404 --network 41621392-0626-4195-84e3-dfae02e6e227 dns-test-vm
+-------------------------------------+----------------------------------------------------+
| Field                               | Value                                              |
+-------------------------------------+----------------------------------------------------+
| OS-DCF:diskConfig                   | MANUAL                                             |
| OS-EXT-AZ:availability_zone         |                                                    |
| OS-EXT-SRV-ATTR:host                | None                                               |
| OS-EXT-SRV-ATTR:hypervisor_hostname | None                                               |
| OS-EXT-SRV-ATTR:instance_name       |                                                    |
| OS-EXT-STS:power_state              | NOSTATE                                            |
| OS-EXT-STS:task_state               | scheduling                                         |
| OS-EXT-STS:vm_state                 | building                                           |
| OS-SRV-USG:launched_at              | None                                               |
| OS-SRV-USG:terminated_at            | None                                               |
| accessIPv4                          |                                                    |
| accessIPv6                          |                                                    |
| addresses                           |                                                    |
| adminPass                           | XbBK4uPiM6ZX                                       |
| config_drive                        |                                                    |
| created                             | 2025-12-27T07:05:55Z                               |
| flavor                              | basic.small (3ab517e3-efe1-4e56-a8e5-f01e0ab8678f) |
| hostId                              |                                                    |
| id                                  | 54d08e5a-bdbb-4dc2-a80d-75ccd679fa3c               |
| image                               | Ubuntu2404 (baa95589-bb0f-4808-a9e4-a63ef62bd50d)  |
| key_name                            | None                                               |
| name                                | dns-test-vm                                        |
| progress                            | 0                                                  |
| project_id                          | a23fe2d9fa61473bb778c90cf8459e21                   |
| properties                          |                                                    |
| security_groups                     | name='default'                                     |
| status                              | BUILD                                              |
| updated                             | 2025-12-27T07:05:55Z                               |
| user_id                             | f47f0223604842ff8b28c7191fdae395                   |
| volumes_attached                    |                                                    |
+-------------------------------------+----------------------------------------------------+

[cube311 ~]# openstack server create --flavor basic.small --image Ubuntu2404 --network 41621392-0626-4195-84e3-dfae02e6e227 dns-test-vm-2
+-------------------------------------+----------------------------------------------------+
| Field                               | Value                                              |
+-------------------------------------+----------------------------------------------------+
| OS-DCF:diskConfig                   | MANUAL                                             |
| OS-EXT-AZ:availability_zone         |                                                    |
| OS-EXT-SRV-ATTR:host                | None                                               |
| OS-EXT-SRV-ATTR:hypervisor_hostname | None                                               |
| OS-EXT-SRV-ATTR:instance_name       |                                                    |
| OS-EXT-STS:power_state              | NOSTATE                                            |
| OS-EXT-STS:task_state               | scheduling                                         |
| OS-EXT-STS:vm_state                 | building                                           |
| OS-SRV-USG:launched_at              | None                                               |
| OS-SRV-USG:terminated_at            | None                                               |
| accessIPv4                          |                                                    |
| accessIPv6                          |                                                    |
| addresses                           |                                                    |
| adminPass                           | EmfDPp9TSqMm                                       |
| config_drive                        |                                                    |
| created                             | 2025-12-27T07:07:36Z                               |
| flavor                              | basic.small (3ab517e3-efe1-4e56-a8e5-f01e0ab8678f) |
| hostId                              |                                                    |
| id                                  | ac62f81f-17f5-40b9-b71b-bdefb11941e1               |
| image                               | Ubuntu2404 (baa95589-bb0f-4808-a9e4-a63ef62bd50d)  |
| key_name                            | None                                               |
| name                                | dns-test-vm-2                                      |
| progress                            | 0                                                  |
| project_id                          | a23fe2d9fa61473bb778c90cf8459e21                   |
| properties                          |                                                    |
| security_groups                     | name='default'                                     |
| status                              | BUILD                                              |
| updated                             | 2025-12-27T07:07:36Z                               |
| user_id                             | f47f0223604842ff8b28c7191fdae395                   |
| volumes_attached                    |                                                    |
+-------------------------------------+----------------------------------------------------+
```

* check dns record
```
[cube311 ~]# openstack recordset list arashi.li.local.
+--------------------------------------+--------------------------------+------+-------------------------------------------------------------------------+--------+--------+
| id                                   | name                           | type | records                                                                 | status | action |
+--------------------------------------+--------------------------------+------+-------------------------------------------------------------------------+--------+--------+
| 26ee81fa-fcf3-486e-aadc-8d810ca807c2 | arashi.li.local.               | SOA  | cube313.cube.org. arashi.li.bigstack.co. 1766819259 3562 600 86400 3600 | ACTIVE | NONE   |
| 5a989396-d87f-405f-bbb8-bd6bde61aae1 | arashi.li.local.               | NS   | cube313.cube.org.                                                       | ACTIVE | NONE   |
|                                      |                                |      | cube311.cube.org.                                                       |        |        |
|                                      |                                |      | cube312.cube.org.                                                       |        |        |
| b72af36d-aaf0-4001-b652-11f82d29f642 | dns-test-vm.arashi.li.local.   | A    | 192.168.2.79                                                            | ACTIVE | NONE   |
| 14cfd434-aee7-4d80-801f-c74d416ee86a | dns-test-vm-2.arashi.li.local. | A    | 192.168.2.60                                                            | ACTIVE | NONE   |
+--------------------------------------+--------------------------------+------+-------------------------------------------------------------------------+--------+--------+
``` 

* check from other VM at the same network
```
ubuntu@dns-test-vm-2:~$ dig @10.32.31.10 dns-test-vm.arashi.li.local

; <<>> DiG 9.18.30-0ubuntu0.24.04.2-Ubuntu <<>> @10.32.31.10 dns-test-vm.arashi.li.local
; (1 server found)
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 20382
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 14b6719cf6d5fc5d01000000694f8c9a601a5c8d9f18f7e8 (good)
;; QUESTION SECTION:
;dns-test-vm.arashi.li.local.	IN	A

;; ANSWER SECTION:
dns-test-vm.arashi.li.local. 3600 IN	A	192.168.2.79

;; Query time: 3 msec
;; SERVER: 10.32.31.10#53(10.32.31.10) (UDP)
;; WHEN: Sat Dec 27 07:36:58 UTC 2025
;; MSG SIZE  rcvd: 100
```

#### Which issue(s) this PR fixes

Fixes #532 

#### Special notes for your reviewer



#### Additional documentation


