### PR TITLE
fix(terraform): skip sum check for self build rancher provider

### DIFF
--- a/core/terraform/override.tfrc
+++ b/core/terraform/override.tfrc
@@ -1,0 +1,6 @@
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/rancher/rancher2" = "/var/lib/terraform/.terraform/providers/registry.terraform.io/rancher/rancher2/7.0.0/linux_amd64"
+  }
+  direct {}
+}

--- a/core/terraform/scripts/terraform-action.sh
+++ b/core/terraform/scripts/terraform-action.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export TF_CLI_CONFIG_FILE=/etc/cube/cos/terraform/configs/override.tfrc
+
 pushd /tmp >/dev/null 2>&1
 timeout -k 1s 60s /usr/local/bin/terraform -chdir=/var/lib/terraform "$@"
 [ $? -eq 0 ] || exit 1

--- a/core/terraform/terraform.mk
+++ b/core/terraform/terraform.mk
@@ -6,4 +6,5 @@ rootfs_install::
 	$(Q)cp -rf $(TOP_BLDDIR)/core/terraform/terraform/ $(ROOTDIR)/var/lib/
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/terraform
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/terraform/values
+	$(Q)cp -f $(COREDIR)/terraform/override.tfrc $(ROOTDIR)/etc/cube/cos/terraform/configs/
 	$(Q)cp -f $(COREDIR)/terraform/values/* $(ROOTDIR)/etc/cube/cos/terraform/values/


### PR DESCRIPTION
#### What type of PR is this?

Fix

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

* We built the rancher provider by ourself, so the checksum step will failed when `terraform apply`, need to skip the check for terraform.

#### Which issue(s) this PR fixes

Fixes # https://github.com/bigstack-oss/cubecos-private/issues/57

#### Special notes for your reviewer

> Tested module by running `hex_config -vvve commit bootstrap terraform` manually, and without any error.

<img width="626" height="293" alt="image" src="https://github.com/user-attachments/assets/d1bded11-cbb8-4de4-bf11-fa1f75bc213c" />


#### Additional documentation

```docs

```
