### PR TITLE
fix(watcher): fix the incorrect statistic unit for instance_ram_usage from GiB to MiB

### DIFF
--- a/core/watcher/yoga_patch/watcher/decision_engine/datasources/monasca.py
+++ b/core/watcher/yoga_patch/watcher/decision_engine/datasources/monasca.py
@@ -124,14 +124,14 @@ class MonascaHelper(base.DataSourceBase):
         statistics = self.query_retry(
             f=self.monasca.metrics.list_statistics, **kwargs)
 
-        cpu_usage = None
+        usage = None
         for stat in statistics:
             avg_col_idx = stat['columns'].index(aggregate)
             values = [r[avg_col_idx] for r in stat['statistics']]
             value = float(sum(values)) / len(values)
-            cpu_usage = value
+            usage = value
 
-        return cpu_usage
+        return usage
 
     def statistic_series(self, resource=None, resource_type=None,
                          meter_name=None, start_time=None, end_time=None,

--- a/core/watcher/yoga_patch/watcher/decision_engine/strategy/strategies/workload_balance.py
+++ b/core/watcher/yoga_patch/watcher/decision_engine/strategy/strategies/workload_balance.py
@@ -203,16 +203,20 @@ class WorkloadBalance(base.WorkloadStabilizationBaseStrategy):
                     free_res['memory'] >= required_mem and
                     free_res['disk'] >= required_disk):
                 if self._meter == 'instance_cpu_usage':
+                    metric = 'cpu'
                     usage = src_instance_workload + workload
                     usage_percent = usage / host.vcpus * 100
                     limit = self.threshold / 100 * host.vcpus
                     if usage < limit:
                         destination_hosts.append(instance_data)
-                LOG.info(f"Host {host.hostname} evaluated as destination for {instance_to_migrate.uuid}. Host usage for cpu would be {usage_percent}. The threshold is: {self.threshold}. selected: {usage < limit}")
-                if (self._meter == 'instance_ram_usage' and
-                    ((src_instance_workload + workload) <
-                     self.threshold / 100 * host.memory)):
-                    destination_hosts.append(instance_data)
+                if self._meter == 'instance_ram_usage':
+                    metric = 'memory'
+                    usage = src_instance_workload + workload
+                    usage_percent = usage / host.memory * 100
+                    limit = self.threshold / 100 * host.memory
+                    if usage < limit:
+                        destination_hosts.append(instance_data)
+                LOG.info(f"Host {host.hostname} evaluated as destination for {instance_to_migrate.uuid}. Host usage for {metric} would be {usage_percent}. The threshold is: {self.threshold}. selected: {usage < limit}")
 
         return destination_hosts
 
@@ -253,10 +257,9 @@ class WorkloadBalance(base.WorkloadStabilizationBaseStrategy):
                               instance.uuid, self._meter)
                     continue
                 if self._meter == 'instance_cpu_usage':
-                    workload_cache[instance.uuid] = (util *
-                                                     instance.vcpus / 100)
+                    workload_cache[instance.uuid] = (util * instance.vcpus / 100)
                 else:
-                    workload_cache[instance.uuid] = util
+                    workload_cache[instance.uuid] = (util * 1024.0)
                 node_workload += workload_cache[instance.uuid]
                 LOG.debug("VM (%s): %s %f", instance.uuid, self._meter,
                           util)


### PR DESCRIPTION
#### What type of PR is this?

Fix
Refactor

<br/>

#### What this PR does / why we need it

The instance memory metric which we feed to the Watcher is GiB(mem.used_gb), but Watcher's hardcoded logic is MiB, this will cause the actual migration won't be happened forever.

But, unfortunately, COS's Monasca doesn't provides the `mem.used_mb`, so we can only multiply the GiB with 1024 to align the hardcoded equation of Watcher

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cube-cos-api/issues/555

