### PR TITLE
feat(ceph): add cli > storage > set_force_use_mpath_devices to switch on or off using multipath devices for ceph if external storages exist

### DIFF
--- a/core/modules/cli_ceph.cpp
+++ b/core/modules/cli_ceph.cpp
@@ -408,6 +408,56 @@ CephAutoScaleMain(int argc, const char** argv)
 }
 
 static int
+CephSetForceUseMpathDevicesMain(int argc, const char** argv)
+{
+    if (argc > 2) {
+        return CLI_INVALID_ARGS;
+    }
+
+    int index;
+    std::string value;
+
+    if (CliMatchCmdHelper(
+            argc,
+            argv,
+            1,
+            "echo 'true\nfalse'",
+            &index,
+            &value,
+            "Set to force to use multipath devices for Ceph: ")
+        != CLI_SUCCESS) {
+        CliPrintf("Unknown option");
+        return CLI_INVALID_ARGS;
+    }
+
+    if (value == "true") {
+        const ExecSyncResult sr = ExecBashSync(
+            0,
+            false,
+            false,
+            {},
+            HEX_SDK " storage_set_force_use_mpath_devices_for_ceph"
+        );
+        if (sr.exitCode != 0) {
+            return CLI_FAILURE;
+        }
+    } else {
+        const ExecSyncResult ur = ExecBashSync(
+            0,
+            false,
+            false,
+            {},
+            HEX_SDK " storage_unset_force_use_mpath_devices_for_ceph"
+        );
+        if (ur.exitCode != 0) {
+            return CLI_FAILURE;
+        }
+    }
+
+    return CLI_SUCCESS;
+}
+
+static int
 CephListAvailDisksMain(int argc, const char** argv)
 {
     if (argc > 1) {
@@ -1364,6 +1414,14 @@ CLI_MODE_COMMAND("storage", "status", CephStatusMain, NULL,
 CLI_MODE_COMMAND("storage", "set_autoscale", CephAutoScaleMain, NULL,
     "Turn on/off pool autoscaling.",
     "set_pool_autoscale [on|off]");
+
+CLI_MODE_COMMAND(
+    "storage",
+    "set_force_use_mpath_devices",
+    CephSetForceUseMpathDevicesMain,
+    NULL,
+    "Set to allow multipath devices be added to Ceph even if external storage is set under iaas > volume_backend.",
+    "set_force_use_mpath_devices [true|false]");
 
 CLI_MODE_COMMAND("storage", "list_avail", CephListAvailDisksMain, NULL,
     "List all available disks recognized by this node.",

--- a/core/sdk_sh/modules/sdk_storage.sh
+++ b/core/sdk_sh/modules/sdk_storage.sh
@@ -176,7 +176,8 @@ storage_are_mpath_devices_allowed_for_ceph()
         return 0
     fi
 
-    if _hex_function_ret $HEX_SDK cinder_is_storage_set ; then
+    # check if external storages are set on controls from the control node holding the vip
+    if _hex_function_ret remote_run "$(shared_id)" "${HEX_SDK} cinder_is_storage_set" ; then
         return 1
     fi
 

--- a/core/sdk_sh/modules/sdk_storage.sh
+++ b/core/sdk_sh/modules/sdk_storage.sh
@@ -152,6 +152,24 @@ storage_update_partition_label_links()
     done
 }
 
+storage_set_force_use_mpath_devices_for_ceph()
+{
+    if [ -f "$STORAGE_FORCE_TO_USE_MPATH_DEVICES" ] ; then
+        return 0
+    fi
+
+    touch "$STORAGE_FORCE_TO_USE_MPATH_DEVICES"
+}
+
+storage_unset_force_use_mpath_devices_for_ceph()
+{
+    if [ ! -f "$STORAGE_FORCE_TO_USE_MPATH_DEVICES" ] ; then
+        return 0
+    fi
+
+    rm -f "$STORAGE_FORCE_TO_USE_MPATH_DEVICES"
+}
+
 storage_are_mpath_devices_allowed_for_ceph()
 {
     if [ -f "$STORAGE_FORCE_TO_USE_MPATH_DEVICES" ] ; then


### PR DESCRIPTION
#### What type of PR is this?

- feature
- fix

#### What this PR does / why we need it

- Add `CLI > storage > set_force_use_mpath_devices` to switch on or off using multipath devices for ceph if external storages exist
- Check if external storage is set on vip control node instead of the local node

#### Which issue(s) this PR fixes

- Related to #513 

#### Special notes for your reviewer

#### Additional documentation

Usage of the newly added CLI is put in https://github.com/bigstack-oss/bigstack-document/issues/168
