### PR TITLE
Build opensearch-dashboard by ourself to solve security issue

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -12,6 +12,7 @@ SUBDIRS += appctl
 SUBDIRS += telegraf
 SUBDIRS += yq
 SUBDIRS += prometheus
+SUBDIRS += elk
 SUBDIRS += nvidia
 SUBDIRS += etcd
 SUBDIRS += terraform

--- a/core/elk/Makefile
+++ b/core/elk/Makefile
@@ -2,6 +2,130 @@
 
 include ../../build.mk
 
+PKG_NAME     := opensearch-dashboards
+PKG_VER      := 3.4.0
+PKG_REL      := 1.patched
+ARCH         := x86_64
+ORIGIN_RPM   := $(PKG_NAME)-$(PKG_VER)-linux-x64.rpm
+DOWNLOAD_URL := https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/$(PKG_VER)/$(ORIGIN_RPM)
+NODE_VERSION := 20
+TARGET_RPM   := $(PKG_NAME)-$(PKG_VER)-$(PKG_REL).$(ARCH).rpm
+
+# Directories
+RPMBUILD_DIR := rpmbuild
+BUILD_ROOT   := $(RPMBUILD_DIR)/BUILDROOT
+SOURCE_DIR   := $(RPMBUILD_DIR)/SOURCES
+SPECS_DIR    := $(RPMBUILD_DIR)/SPECS
+RPMS_DIR     := $(RPMBUILD_DIR)/RPMS
+
+# Plugin Path
+PLUGIN_PATH  := usr/share/opensearch-dashboards/plugins/reportsDashboards
+
+# --- STAMP FILES (To track state) ---
+STAMP_DIR      := $(RPMBUILD_DIR)/.stamps
+STAMP_DOWNLOAD := $(STAMP_DIR)/download
+STAMP_EXTRACT  := $(STAMP_DIR)/extract
+STAMP_PATCH    := $(STAMP_DIR)/patch
+
+$(STAMP_DIR):
+	$(Q)mkdir -p $(RPMBUILD_DIR)/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+	$(Q)mkdir -p $(BUILD_ROOT)
+	$(Q)mkdir -p $(STAMP_DIR)
+
+$(STAMP_DOWNLOAD): | $(STAMP_DIR)
+	$(call RUN_CMD_TIMED, \
+		wget -c $(DOWNLOAD_URL) -O $(SOURCE_DIR)/original.rpm, \
+		"  DWL     $(ORIGIN_RPM)")
+	$(Q)touch $@
+
+$(STAMP_EXTRACT): $(STAMP_DOWNLOAD)
+	$(call RUN_CMD_TIMED, \
+		rm -rf $(BUILD_ROOT) && mkdir -p $(BUILD_ROOT) && \
+		cd $(BUILD_ROOT) && \
+		rpm2cpio ../SOURCES/original.rpm | cpio -idm --quiet, \
+		"  EXT     $(ORIGIN_RPM)")
+	$(Q)touch $@
+
+$(STAMP_PATCH): $(STAMP_EXTRACT)
+	$(Q)# enable nvm
+	$(Q)sed -i 's/^#//g' $$BASH_ENV
+	$(call RUN_CMD_TIMED, \
+		cd $(BUILD_ROOT)/$(PLUGIN_PATH) && \
+		nvm install $(NODE_VERSION) && \
+		nvm use $(NODE_VERSION) && \
+		npm install -g yarn && \
+		yarn add jspdf@4.0.0 && \
+		yarn install --no-frozen-lockfile && \
+		yarn install --production --no-frozen-lockfile --ignore-scripts && \
+		rm -rf node_modules/.cache, \
+		"  PATCH   jspdf@4.0.0")
+	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
+	$(Q)touch $@
+
+# --- OFFICIAL-STYLE SPEC FILE ---
+define SPEC_FILE_CONTENT
+Name: $(PKG_NAME)
+Version: $(PKG_VER)
+Release: $(PKG_REL)
+Summary: Patched OpenSearch Dashboards
+License: Apache-2.0
+AutoReqProv: no
+
+%description
+Patched version of OpenSearch Dashboards with jspdf fix.
+
+# 1. PRE-INSTALL: Create User/Group
+%pre
+getent group opensearch-dashboards >/dev/null || groupadd -r opensearch-dashboards
+getent passwd opensearch-dashboards >/dev/null || \
+    useradd -r -g opensearch-dashboards -d /usr/share/opensearch-dashboards \
+    -s /sbin/nologin -c "opensearch-dashboards user" opensearch-dashboards
+exit 0
+
+# 2. POST-INSTALL: Reload Systemd
+%post
+systemctl daemon-reload
+if [ $$1 -eq 1 ]; then
+    systemctl preset opensearch-dashboards.service >/dev/null 2>&1 || :
+fi
+
+# 3. PRE-UNINSTALL: Stop service
+%preun
+if [ $$1 -eq 0 ]; then
+    systemctl --no-reload disable --now opensearch-dashboards.service >/dev/null 2>&1 || :
+fi
+
+%files
+%defattr(-,root,root,-)
+# App Files (Owned by User)
+%attr(-,opensearch-dashboards,opensearch-dashboards) /usr/share/opensearch-dashboards
+
+# Config Files (Marked so upgrades don't delete user changes)
+%config(noreplace) /etc/opensearch-dashboards/opensearch_dashboards.yml
+%attr(0755,opensearch-dashboards,opensearch-dashboards) /var/lib/opensearch-dashboards
+%attr(0755,opensearch-dashboards,opensearch-dashboards) /var/log/opensearch-dashboards
+
+# System Files (Owned by Root)
+/usr/lib/systemd/system/opensearch-dashboards.service
+/etc/opensearch-dashboards
+/usr/share/opensearch-dashboards/bin/opensearch-dashboards
+/usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin
+
+/*
+endef
+export SPEC_FILE_CONTENT
+# --- END SPEC ---
+
+$(TARGET_RPM): $(STAMP_PATCH)
+	$(Q)echo "$$SPEC_FILE_CONTENT" > $(SPECS_DIR)/$(PKG_NAME).spec
+	$(call RUN_CMD_TIMED, \
+		rpmbuild -bb \
+		--define "_topdir $(CURDIR)/$(RPMBUILD_DIR)" \
+		--define "buildroot $(CURDIR)/$(BUILD_ROOT)" \
+		$(SPECS_DIR)/$(PKG_NAME).spec, \
+		"  PACK    $(TARGET_RPM)")
+	$(Q)mv $(RPMS_DIR)/$(ARCH)/$(PKG_NAME)-$(PKG_VER)-$(PKG_REL).$(ARCH).rpm .
+
 dev-deploy:
 	$(call RUN_CMD_TIMED, cd $(SRCDIR)/logstash && tar -cf - pipelines.yml patterns.txt eventdb conf.d | pigz -9 > logstash.tgz,"  GEN     logstash.tgz")
 	$(call RUN_CMD_TIMED, cd $(SRCDIR)/logstash && scp logstash.tgz root@$(HOST):/etc/logstash,"  UPLOAD  logstash.tgz")
@@ -9,6 +133,7 @@ dev-deploy:
 	$(Q)ssh root@$(HOST) tar -I pigz -xf /etc/logstash/logstash.tgz -C /etc/logstash
 	$(call RUN_CMD, ssh root@$(HOST) hex_config bootstrap logstash,"  RECFG   logstash")
 
-BUILDCLEAN += $(SRCDIR)/logstash/logstash.tgz
+BUILD += $(TARGET_RPM)
+BUILDCLEAN += $(TARGET_RPM) $(RPMBUILD_DIR) $(SRCDIR)/logstash/logstash.tgz
 
 include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/core/elk/elk.mk
+++ b/core/elk/elk.mk
@@ -28,13 +28,19 @@ BEATS_VER := 9.2.3
 ROOTFS_DNF_DL_FROM += https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-$(BEATS_VER)-x86_64.rpm
 ROOTFS_DNF_DL_FROM += https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-$(BEATS_VER)-x86_64.rpm
 
-ROOTFS_DNF_DL_FROM += https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/$(OSEARCH_VER)/opensearch-dashboards-$(OSEARCH_VER)-linux-x64.rpm
+# ROOTFS_DNF_DL_FROM += https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/$(OSEARCH_VER)/opensearch-dashboards-$(OSEARCH_VER)-linux-x64.rpm
 ROOTFS_DNF_DL_FROM += https://artifacts.opensearch.org/releases/bundle/opensearch/$(OSEARCH_VER)/opensearch-$(OSEARCH_VER)-linux-x64.rpm
 ROOTFS_PIP_NC += curator-$(OSEARCH)
 
 LOGSTASH_TGZ := logstash-$(LOGSTASH_VER)-linux-x86_64.tar.gz
 $(ARCS_DIR)/$(LOGSTASH_TGZ):
 	$(Q)wget https://artifacts.elastic.co/downloads/logstash/$(LOGSTASH_TGZ) -O $@
+
+DASHBOARD_RPM := $(TOP_BLDDIR)/core/elk/opensearch-dashboards-3.4.0-1.patched.x86_64.rpm
+rootfs_install::
+    $(Q)cp -f $(DASHBOARD_RPM) $(ROOTDIR)/tmp/
+    $(Q)chroot $(ROOTDIR) dnf install -y --nogpgcheck /tmp/$(notdir $(DASHBOARD_RPM))
+    $(Q)rm -f $(ROOTDIR)/tmp/$(notdir $(DASHBOARD_RPM))
 
 rootfs_install:: $(ARCS_DIR)/$(LOGSTASH_TGZ)
 	$(Q)tar xf $< -C $(ROOTDIR)/usr/share/


### PR DESCRIPTION
#### What type of PR is this?

Build
Feat

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

* Rebuild the opensearch-dashboard to update jspdf to v4.0.0 to solve the security issue

#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cubecos-private/issues/60

#### Special notes for your reviewer

> Check metadata and dry run
```
[root@centos9-jail centos9-jail]# rpm -qip core/elk/opensearch-dashboards-3.4.0-1.patched.x86_64.rpm
Name        : opensearch-dashboards
Version     : 3.4.0
Release     : 1.patched
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 1562510191
License     : Apache-2.0
Signature   : (none)
Source RPM  : opensearch-dashboards-3.4.0-1.patched.src.rpm
Build Date  : Thu Jan  8 20:14:06 2026
Build Host  : centos9-jail
Summary     : Patched OpenSearch Dashboards
Description :
Patched version of OpenSearch Dashboards.
[root@centos9-jail centos9-jail]# rpm -ivh --test core/elk/opensearch-dashboards-3.4.0-1.patched.x86_64.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
        file /usr/lib from install of opensearch-dashboards-3.4.0-1.patched.x86_64 conflicts with file from package filesystem-3.16-5.el9.x86_64
[root@centos9-jail centos9-jail]# 
```

> install test
```
[root@centos9-jail centos9-jail]# rpm -Uvh --force core/elk/opensearch-dashboards-3.4.0-1.patched.x86_64.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:opensearch-dashboards-3.4.0-1.pat################################# [ 50%]
Cleaning up / removing...
   2:opensearch-dashboards-3.4.0-1.pat################################# [100%]
/usr/lib/tmpfiles.d/opensearch-dashboards.conf:1: Line references path below legacy directory /var/run/, updating /var/run/opensearch-dashboards → /run/opensearch-dashboards; please update the tmpfiles.d/ drop-in file accordingly.
```

> runtime test
```
[root@centos9-jail centos9-jail]# sudo systemctl status opensearch-dashboards
● opensearch-dashboards.service - "OpenSearch Dashboards"
     Loaded: loaded (/usr/lib/systemd/system/opensearch-dashboards.service; disabled; preset: disabled)
     Active: active (running) since Thu 2026-01-08 20:58:32 CST; 9s ago
   Main PID: 10403 (node)
        CPU: 9.943s
     CGroup: /system.slice/docker-f527e8ffdd2286f4d5feb44912e6f5ee312fa76d7a43b269b44d6105e4da84db.scope/system.slice/opensearch-dashboards.service
             └─10403 /usr/share/opensearch-dashboards/node/bin/node /usr/share/opensearch-dashboards/src/cli/dist

Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: [agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTime>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: [agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTime>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: [agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTime>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: [agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTime>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: [agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTime>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: {"type":"log","@timestamp":"2026-01-08T12:58:39Z","tags":["info","dynamic-config-service"],"pid":10403,"message>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: {"type":"log","@timestamp":"2026-01-08T12:58:39Z","tags":["info","dynamic-config-service"],"pid":10403,"message>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: {"type":"log","@timestamp":"2026-01-08T12:58:39Z","tags":["info","savedobjects-service"],"pid":10403,"message":>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: {"type":"log","@timestamp":"2026-01-08T12:58:39Z","tags":["error","opensearch","data"],"pid":10403,"message":"[>
Jan 08 20:58:39 centos9-jail opensearch-dashboards[10403]: {"type":"log","@timestamp":"2026-01-08T12:58:39Z","tags":["error","savedobjects-service"],"pid":10403,"message">
[root@centos9-jail centos9-jail]# curl -XGET http://localhost:5601/api/status
OpenSearch Dashboards server is not ready yet
[root@centos9-jail centos9-jail]# 
```

> static check

```
[root@centos9-jail centos9-jail]# cat /usr/share/opensearch-dashboards/plugins/reportsDashboards/yarn.lock  | grep jspdf
jspdf@4.0.0:
  resolved "https://registry.yarnpkg.com/jspdf/-/jspdf-4.0.0.tgz#3731c0a1a7d8afe28c681891236f8ad4a662d893"
[root@centos9-jail centos9-jail]# grype dir:/usr/share/opensearch-dashboards/plugins/reportsDashboards
 ✔ Indexed file system                                                                                        /usr/share/opensearch-dashboards/plugins/reportsDashboards 
 ✔ Cataloged contents                                                                                   f9b220edea5d6485b4acac248f4ca1573f38bffae42452cdb1ad5c5707920105 
   ├── ✔ Packages                        [596 packages]  
   ├── ✔ Executables                     [0 executables]  
   ├── ✔ File metadata                   [4 locations]  
   └── ✔ File digests                    [4 files]  
 ✔ Scanned for vulnerabilities     [1 vulnerability matches]  
   ├── by severity: 0 critical, 1 high, 0 medium, 0 low, 0 negligible
   └── by status:   1 fixed, 0 not-fixed, 0 ignored [0000]  WARN no explicit name and version provided for directory source, deriving artifact ID from the given path (whic
NAME  INSTALLED  FIXED IN  TYPE  VULNERABILITY        SEVERITY  EPSS         RISK  
qs    6.10.4     6.14.1    npm   GHSA-6rw7-vpxm-498p  High      0.2% (36th)  0.1
[root@centos9-jail centos9-jail]# 
```
#### Additional documentation

```docs

```
