### PR TITLE
feat(ceph): force to use the form /dev/mapper/[wwid] as mapped device name in case naming changes between reboots

### DIFF
--- a/core/ceph/ceph.mk
+++ b/core/ceph/ceph.mk
@@ -25,6 +25,10 @@ CEPH_PATCHDIR := $(COREDIR)/ceph/$(OPENSTACK_RELEASE)_patch
 CEPH_REPO = $(shell cp $(COREDIR)/ceph/ceph.repo $(ROOTDIR)/etc/yum.repos.d/ ; echo "ceph")
 
 rootfs_install::
+	$(Q)chroot $(ROOTDIR) mv /etc/multipath.conf /etc/multipath.conf.orig
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/ceph/multipath.conf ./etc/
+
+rootfs_install::
 	$(Q)chroot $(ROOTDIR) systemctl mask lvm2-monitor
 	$(Q)chroot $(ROOTDIR) systemctl disable ceph-crash libstoragemgmt
 	#$(Q)mv -f $(ROOTDIR)/etc/ceph/radosgw-sync.conf $(ROOTDIR)/etc/ceph/radosgw-sync.conf.example

--- a/core/ceph/multipath.conf
+++ b/core/ceph/multipath.conf
@@ -1,0 +1,20 @@
+# device-mapper-multipath configuration file
+
+# For a complete list of the default configuration values, run either:
+# # multipath -t
+# or
+# # multipathd show config
+
+# For a list of configuration options with descriptions, see the
+# multipath.conf man page.
+
+# set user_friendly_names to no to ensure we have /dev/mapper/[WWID] form
+# in case /dev/mapper/mpatha referring to different volumes between reboots
+
+defaults {
+    user_friendly_names no
+    find_multipaths on
+}
+
+blacklist {
+}


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Force to use the form `/dev/mapper/[wwid]` as mapped device name in case naming changes between reboots

#### Which issue(s) this PR fixes

- Related to #513 

#### Special notes for your reviewer

#### Additional documentation
