### PR TITLE
feat(gpu): upgrade nvidia vgpu manage driver to v580.105.06 to support rtx pro 6000 blackwell server edition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 core/nvidia/NVIDIA-Linux-x86_64-535.129.03-grid.run filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-535.129.03-vgpu-kvm.run filter=lfs diff=lfs merge=lfs -text
+core/nvidia/NVIDIA-Linux-x86_64-575.57.08.run filter=lfs diff=lfs merge=lfs -text
 core/pkg/x86_64/oss/ssh-keydgen filter=lfs diff=lfs merge=lfs -text
 core/appctl/images/tars/postgresql-11.11.0-debian-10-r31.tar filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
+core/appctl/images/tars/postgresql-11.11.0-debian-10-r31.tar filter=lfs diff=lfs merge=lfs -text
+core/glance/cirros-0.4.0-x86_64-disk.qcow2 filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-535.129.03-grid.run filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-535.129.03-vgpu-kvm.run filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-575.57.08.run filter=lfs diff=lfs merge=lfs -text
 core/pkg/x86_64/oss/ssh-keydgen filter=lfs diff=lfs merge=lfs -text
-core/appctl/images/tars/postgresql-11.11.0-debian-10-r31.tar filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@ core/glance/cirros-0.4.0-x86_64-disk.qcow2 filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-535.129.03-grid.run filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-535.129.03-vgpu-kvm.run filter=lfs diff=lfs merge=lfs -text
 core/nvidia/NVIDIA-Linux-x86_64-575.57.08.run filter=lfs diff=lfs merge=lfs -text
+core/nvidia/NVIDIA-Linux-x86_64-580.105.06-vgpu-kvm-aie.run filter=lfs diff=lfs merge=lfs -text
 core/pkg/x86_64/oss/ssh-keydgen filter=lfs diff=lfs merge=lfs -text

--- a/core/fixpacks/.gitattributes
+++ b/core/fixpacks/.gitattributes
@@ -1,2 +1,0 @@
-advantech_ahg/rootfs/root/server_imanager_v0.14.bin filter=lfs diff=lfs merge=lfs -text
-logrotate_fix/rootfs/usr/sbin/hex_config filter=lfs diff=lfs merge=lfs -text

--- a/core/glance/.gitattributes
+++ b/core/glance/.gitattributes
@@ -1,1 +1,0 @@
-cirros-0.4.0-x86_64-disk.qcow2 filter=lfs diff=lfs merge=lfs -text

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -188,13 +188,12 @@ rootfs_install::
 	$(Q)echo "install usb_storage /bin/true" >> $(ROOTDIR)/etc/modprobe.d/usb.conf
 
 # note: install skyline pkgs first since it doesn't follow yoga constraint
+HEAVY_COMPONENTS += nvidia
 HEAVY_COMPONENTS += yq api ui skyline nginx
 HEAVY_COMPONENTS += mysql mongodb ntp rabbitmq memcache etcd ceph pacemaker haproxy grafana
 HEAVY_COMPONENTS += influxdb prometheus kapacitor elk telegraf kafka keystone glance nova ironic neutron cinder swift
 HEAVY_COMPONENTS += heat horizon octavia barbican manila designate masakari monasca watcher cyborg
 HEAVY_COMPONENTS += terraform docker k3s keycloak rancher appfw appctl
-# FIXME: uncomment nvia when the new driver is available
-# HEAVY_COMPONENTS += nvidia
 
 include $(shell for m in $(HEAVY_COMPONENTS); do ls $(COREDIR)/$$m/$$m.mk; done)
 $(shell for r in $(LOCKED_DNF); do echo $$r >> $(LOCKED_RPMS); done)

--- a/core/nvidia/.gitattributes
+++ b/core/nvidia/.gitattributes
@@ -1,3 +1,0 @@
-NVIDIA-Linux-x86_64-450.80-vgpu-kvm.run filter=lfs diff=lfs merge=lfs -text
-NVIDIA-Linux-x86_64-470.63-vgpu-kvm.run filter=lfs diff=lfs merge=lfs -text
-NVIDIA-Linux-x86_64-470.63.01-grid.run filter=lfs diff=lfs merge=lfs -text

--- a/core/nvidia/NVIDIA-Linux-x86_64-575.57.08.run
+++ b/core/nvidia/NVIDIA-Linux-x86_64-575.57.08.run
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa701dac180a7b20a6e578cccd901ded8d44e57d60580f08f9d28dd1fffc6f2
+size 389558524

--- a/core/nvidia/NVIDIA-Linux-x86_64-580.105.06-vgpu-kvm-aie.run
+++ b/core/nvidia/NVIDIA-Linux-x86_64-580.105.06-vgpu-kvm-aie.run
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b19574e69be7e80756f54bd1130be873ed25707c43f44fa67453df787b711e0
+size 100835785

--- a/core/nvidia/nvidia.mk
+++ b/core/nvidia/nvidia.mk
@@ -3,20 +3,23 @@
 
 ROOTFS_DNF += make kernel-devel elfutils-libelf-devel
 
-NVIDIA_DRIVER := NVIDIA-Linux-x86_64-575.57.08.run
+NVIDIA_DRIVER := NVIDIA-Linux-x86_64-580.105.06-vgpu-kvm-aie.run
 
 rootfs_install::
 	$(Q)cp -f $(COREDIR)/nvidia/$(NVIDIA_DRIVER) $(ROOTDIR)/root/
 	$(Q)mount -t sysfs sys $(ROOTDIR)/sys || true
 	$(Q)mount -o bind /dev $(ROOTDIR)/dev || true
-	$(Q)chroot $(ROOTDIR) sh /root/$(NVIDIA_DRIVER) --kernel-name=$(KERNEL_VERS) -s || true
+	$(Q)chroot $(ROOTDIR) sh /root/$(NVIDIA_DRIVER) \
+		--kernel-name=$(KERNEL_VERS) \
+		--kernel-module-type=open \
+		-s || true
 	$(Q)umount -l $(ROOTDIR)/sys || true
 	$(Q)umount -l $(ROOTDIR)/dev || true
-	$(Q)chroot $(ROOTDIR) ls $(KERNEL_MODULE_DIR)/kernel/drivers/video/{nvidia,nvidia-vgpu-vfio}.ko || true
+	$(Q)chroot $(ROOTDIR) ls $(KERNEL_MODULE_DIR)/kernel/drivers/video/{nvidia,nvidia-vgpu-vfio}.ko
 	$(Q)rm -f $(ROOTDIR)/root/$(NVIDIA_DRIVER)
 	$(Q)rm -f $(ROOTDIR)/var/log/nvidia*.log
-	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpu-mgr || true
-	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpud || true
+	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpu-mgr
+	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpud
 
 # disable nouveau driver: nouveau is a free and open-source graphics device driver for Nvidia video cards
 rootfs_install::

--- a/core/nvidia/nvidia.mk
+++ b/core/nvidia/nvidia.mk
@@ -3,7 +3,7 @@
 
 ROOTFS_DNF += make kernel-devel elfutils-libelf-devel
 
-NVIDIA_DRIVER := NVIDIA-Linux-x86_64-535.129.03-vgpu-kvm.run
+NVIDIA_DRIVER := NVIDIA-Linux-x86_64-575.57.08.run
 
 rootfs_install::
 	$(Q)cp -f $(COREDIR)/nvidia/$(NVIDIA_DRIVER) $(ROOTDIR)/root/
@@ -12,11 +12,11 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) sh /root/$(NVIDIA_DRIVER) --kernel-name=$(KERNEL_VERS) -s || true
 	$(Q)umount -l $(ROOTDIR)/sys || true
 	$(Q)umount -l $(ROOTDIR)/dev || true
-	$(Q)chroot $(ROOTDIR) ls $(KERNEL_MODULE_DIR)/kernel/drivers/video/{nvidia,nvidia-vgpu-vfio}.ko
+	$(Q)chroot $(ROOTDIR) ls $(KERNEL_MODULE_DIR)/kernel/drivers/video/{nvidia,nvidia-vgpu-vfio}.ko || true
 	$(Q)rm -f $(ROOTDIR)/root/$(NVIDIA_DRIVER)
 	$(Q)rm -f $(ROOTDIR)/var/log/nvidia*.log
-	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpu-mgr
-	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpud
+	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpu-mgr || true
+	$(Q)chroot $(ROOTDIR) systemctl disable nvidia-vgpud || true
 
 # disable nouveau driver: nouveau is a free and open-source graphics device driver for Nvidia video cards
 rootfs_install::


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Upgrade Nvidia vGPU manage driver to v580.105.06 to support RTX PRO 6000 Blackwell Server Edition

#### Which issue(s) this PR fixes

- Related to #312

#### Special notes for your reviewer

#### Additional documentation
