### PR TITLE
fix(mongodb): upgrade mongodb from 7.0.25 to 7.0.28 to fix the CVE-2025-14847

### DIFF
--- a/core/mongodb/mongodb.mk
+++ b/core/mongodb/mongodb.mk
@@ -4,7 +4,7 @@
 MONGODB_BINARY := /usr/bin/mongod
 MONGODB_LOG_DIR := /var/log/mongodb
 
-MONGODB_PKG := mongodb-org-server-7.0.25-1.el9.x86_64.rpm
+MONGODB_PKG := mongodb-org-server-7.0.28-1.el9.x86_64.rpm
 MONGOSH_PKG := mongodb-mongosh-shared-openssl3-2.2.15.x86_64.rpm
 
 ROOTFS_DNF_DL_FROM += https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/RPMS/$(MONGODB_PKG)


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

- Upgrade mongodb to from 7.0.25 to 7.0.28 to fix the CVE-2025-14847

- It's a critical issue which reported by CVE community https://www.mongodb.com/company/blog/news/mongodb-server-security-update-december-2025 (guessing DefectDoJo might haven't synced the newest data source?)
