### PR TITLE
fix(cinder): get volume backend pools when backends have similar names 

### DIFF
--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -50,6 +50,7 @@ hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_node.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_ntp.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_opensearch.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_os.sh
+hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_os/os_cinder.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_ovn.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_preset.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_rabbitmq.sh

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -6,6 +6,9 @@ if [ -z "$PROG" ] ; then
     exit 1
 fi
 
+# source dependencies
+source "${SDK_DIR}/modules/os_cinder.sh"
+
 COOKIE_FILE=/tmp/cookie.txt
 LOGIN_PAGE=/tmp/login.html
 EP_SNAPSHOT=/var/appliance-db/os_endpoint.snapshot
@@ -66,19 +69,6 @@ os_get_horizon_sessionid()
     #verify the presence of sessionid
     sessionid=`cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//'`
     echo -n $sessionid
-}
-
-os_list_volume_backend_by_pool()
-{
-    local pool=${1:-$BUILTIN_BACKPOOL}
-    local vtype=${2:-CubeStorage}
-    local backend_name=$($OPENSTACK volume type show $vtype -f json -c properties | jq -r .properties.volume_backend_name 2>/dev/null)
-
-    if [ "x$pool" = "x$BUILTIN_BACKPOOL" ] ; then
-        $OPENSTACK volume backend pool list -f value -c Name | grep ${backend_name:-cube@ceph#ceph}
-    else
-        $OPENSTACK volume backend pool list -f value -c Name | grep ${backend_name:-cube@ceph#ceph} | cut -d "@" -f1
-    fi
 }
 
 os_list_domain_basic()
@@ -869,7 +859,7 @@ os_image_import()
     $OPENSTACK role add --user admin_cli --project ${proj_name:-admin} admin
     echo "[$(date +"%T")] Importing image $name ..."
     if [ "x$pool" = "xglance-images" -o "x$volume_type" != "xCubeStorage" ] ; then
-        local backend=$(os_list_volume_backend_by_pool glance-images $volume_type)
+        local backend=$(os_cinder_get_volume_backend_host_by_volume_type "$volume_type" | jq -r ".[0]")
         local img_id=$(uuidgen)
         glance --os-project-domain-name ${domain:-default} --os-project-name admin image-create --disk-format raw --container-format bare --visibility ${visibility:-public} --store ${backend:-cube} --file $img_name $properties --name $name --progress --id $img_id
         if [ "x$pool" != "xglance-images" -a "x$volume_type" != "xCubeStorage" ] ; then
@@ -881,7 +871,7 @@ os_image_import()
             $OPENSTACK image set --project ${proj_name:-admin} $img_id >/dev/null 2>&1
         fi
     else
-        local backend=$(os_list_volume_backend_by_pool $pool $volume_type)
+        local backend=$(os_cinder_get_volume_backend_pool_by_volume_type "$volume_type" | jq -r ".[0]")
         local vol_name=$(mktemp -u volume-${name}-XXXX)
         rbd --id cinder import "$img_name" "${BUILTIN_BACKPOOL}/$vol_name"
         local vol_id=$(cinder --os-project-domain-name ${domain:-default} --os-project-name ${proj_name:-admin} manage --bootable --name "$name" --volume-type $volume_type ${backend:-cube@ceph#ceph} "$vol_name" | grep " id" | cut -d"|" -f3)

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -755,28 +755,37 @@ _os_image_distro_ver()
     echo "${distro}:${ver}"
 }
 
-# params:
-# $1: file dir (required)
-# $2: file name  (required)
-# $3: image name (required)
 os_image_import()
 {
+    # params:
+    # $1: file dir (required)
+    # $2: file name  (required)
+    # $3: image name (required)
+    # $4: flags
+    # $5: pool: glance-images: from Bigstack, cinder-volumes: from another hypervisor
+    # $6: volume_type: destination
+    # $7: _distro: OS distro
+    # $8: properties: image properties
     local dir=$1
     local file=$2
-    local IMG="$dir/$file"
     local name=$3
     local flags=${4:---os-project-domain-name default --os-project-name admin --visibility public}
     local pool=${5:-glance-images}
+    local volume_type=${6:-CubeStorage}
+    local _distro=${7:-linux}
+    local properties=${8:---property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_machine_type=q35 --property hw_video_model=vga}
+
+    # prevent duplicated importing
     local mf_importing="/run/${FUNCNAME[0]}_${file}_${name}_${pool}"
     if  cmd -v ls $mf_importing | grep -q "|0|" ; then
         Error "Image is being imported. If this is not the case, remove $mf_importing on all nodes"
     else
         touch $mf_importing
     fi
-    local volume_type=${6:-CubeStorage}
-    local _distro=${7:-linux}
+
+    # process inputs
     local distro=$(echo $_distro | tr "[A-Z]" "[a-z]")
-    local properties=${8:---property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_machine_type=q35 --property hw_video_model=vga}
+
     properties+=" --property hw_qemu_guest_agent=yes --property os_require_quiesce=yes"
     properties+=" --property hw_input_bus=virtio"
     properties+=" --property os_distro=$distro"
@@ -794,6 +803,8 @@ os_image_import()
     local visibility=$(echo $flags | grep -o "[-][-]visibility .*" | cut -d" " -f2)
     local domain=$(echo $flags | grep -o "[-][-]os-project-domain-name .*" | cut -d" " -f2)
 
+    # convert the image file
+    local IMG="$dir/$file"
     if [[ $(qemu-img info "$IMG" | grep "file format") =~ raw ]] ; then
         local img_name=$IMG
     else
@@ -856,29 +867,39 @@ os_image_import()
         local img_name=$img_raw
     fi
 
+    # import the image
     $OPENSTACK role add --user admin_cli --project ${proj_name:-admin} admin
     echo "[$(date +"%T")] Importing image $name ..."
-    if [ "x$pool" = "xglance-images" -o "x$volume_type" != "xCubeStorage" ] ; then
-        local backend=$(os_cinder_get_volume_backend_host_by_volume_type "$volume_type" | jq -r ".[0]")
-        local img_id=$(uuidgen)
+    local backend=""
+    local img_id=""
+    if [ "x$pool" = "xglance-images" ] ; then
+        backend=$(os_cinder_get_volume_backend_host_by_volume_type "$volume_type" | jq -r ".[0]")
+        img_id=$(uuidgen)
         glance --os-project-domain-name ${domain:-default} --os-project-name admin image-create --disk-format raw --container-format bare --visibility ${visibility:-public} --store ${backend:-cube} --file $img_name $properties --name $name --progress --id $img_id
-        if [ "x$pool" != "xglance-images" -a "x$volume_type" != "xCubeStorage" ] ; then
-            local cinder_id=$($OPENSTACK image show $img_id -f json | jq -r ".properties.direct_url" | sed -e "s;^cinder://${volume_type}/;;")
-            local vol_id=$($OPENSTACK volume create --type $volume_type --source $cinder_id --bootable $name -f value -c id)
+        $OPENSTACK image set --project ${proj_name:-admin} $img_id >/dev/null 2>&1
+    else
+        local vol_name=""
+        local vol_id=""
+        local cinder_id=""
+        if [ "x$volume_type" = "xCubeStorage" ] ; then
+            backend=$(os_cinder_get_volume_backend_pool_by_volume_type "$volume_type" | jq -r ".[0]")
+            vol_name=$(mktemp -u volume-${name}-XXXX)
+            rbd --id cinder import "$img_name" "${BUILTIN_BACKPOOL}/$vol_name"
+            vol_id=$(cinder --os-project-domain-name ${domain:-default} --os-project-name ${proj_name:-admin} manage --bootable --name "$name" --volume-type $volume_type ${backend:-cube@ceph#ceph} "$vol_name" | grep " id" | cut -d"|" -f3)
+            $OPENSTACK volume set $(echo $properties | sed "s/--property/--image-property/g") ${vol_id:-NOSUCHVOLID}
+        else
+            backend=$(os_cinder_get_volume_backend_host_by_volume_type "$volume_type" | jq -r ".[0]")
+            img_id=$(uuidgen)
+            glance --os-project-domain-name ${domain:-default} --os-project-name admin image-create --disk-format raw --container-format bare --visibility ${visibility:-public} --store ${backend:-cube} --file $img_name $properties --name $name --progress --id $img_id
+            cinder_id=$($OPENSTACK image show $img_id -f json | jq -r ".properties.direct_url" | sed -e "s;^cinder://${volume_type}/;;")
+            vol_id=$($OPENSTACK volume create --type $volume_type --source $cinder_id --bootable $name -f value -c id)
             $OPENSTACK volume set $(echo $properties | sed "s/--property/--image-property/g") ${vol_id:-NOSUCHVOLID}
             [ "x$($OPENSTACK volume show $cinder_id -f value -c status)" != "xavailable" ] || $OPENSTACK image delete $img_id
-        else
-            $OPENSTACK image set --project ${proj_name:-admin} $img_id >/dev/null 2>&1
         fi
-    else
-        local backend=$(os_cinder_get_volume_backend_pool_by_volume_type "$volume_type" | jq -r ".[0]")
-        local vol_name=$(mktemp -u volume-${name}-XXXX)
-        rbd --id cinder import "$img_name" "${BUILTIN_BACKPOOL}/$vol_name"
-        local vol_id=$(cinder --os-project-domain-name ${domain:-default} --os-project-name ${proj_name:-admin} manage --bootable --name "$name" --volume-type $volume_type ${backend:-cube@ceph#ceph} "$vol_name" | grep " id" | cut -d"|" -f3)
-        $OPENSTACK volume set $(echo $properties | sed "s/--property/--image-property/g") ${vol_id:-NOSUCHVOLID}
     fi
     echo "[$(date +"%T")] Finished creating image $name"
 
+    # clean up
     [ -z "$img_raw" ] || rm -f "$img_raw"
     cmd rm -f $mf_importing
 }

--- a/core/sdk_sh/modules/sdk_os/os_cinder.sh
+++ b/core/sdk_sh/modules/sdk_os/os_cinder.sh
@@ -1,0 +1,97 @@
+# CUBE SDK
+
+# PROG must be set before sourcing this file
+if [ -z "$PROG" ] ; then
+    echo "Error: PROG not set" >&2
+    exit 1
+fi
+
+_os_cinder_get_volume_backend_pool_by_volume_type()
+{
+    # for internal use only, not properly formatted into JSON
+    # input: _os_cinder_get_volume_backend_by_volume_type <volume_type>
+    # output: <pool1>\n<pool2>
+    local volume_type="${1:-"CubeStorage"}"
+
+    local exec_output=""
+    local exec_error=""
+
+    local volume_backend=""
+    if ! _hex_function exec_output exec_error $OPENSTACK volume type show "$volume_type" -c properties -f json ; then
+        return 1
+    fi
+    if ! _hex_function exec_output exec_error jq -r ".properties.volume_backend_name" <(printf "%s" "$exec_output") ; then
+        return 1
+    fi
+    volume_backend="$exec_output"
+    if [ -z "$volume_backend" ] ; then
+        volume_backend="ceph"
+    fi
+
+    if ! _hex_function exec_output exec_error $OPENSTACK volume backend pool list -c Name -f json ; then
+        return 1
+    fi
+    if ! _hex_function exec_output exec_error jq -r ".[] | select(.Name | test(\"@${volume_backend}#\")) | .Name" <(printf "%s" "$exec_output") ; then
+        return 1
+    fi
+
+    echo -n "$exec_output"
+}
+
+os_cinder_get_volume_backend_pool_by_volume_type()
+{
+    # input: os_cinder_get_volume_backend_pool_by_volume_type <volume_type>
+    # output: [
+    #   <pool1>,
+    #   <pool2>
+    # ]
+    local volume_type="${1:-"CubeStorage"}"
+
+    local exec_output=""
+    local exec_error=""
+
+    local volume_backend_pool="[]"
+    if ! _hex_function exec_output exec_error _os_cinder_get_volume_backend_pool_by_volume_type "$volume_type" ; then
+        echo -n "$volume_backend_pool"
+        return 1
+    fi
+
+    local pool=""
+    while read -r pool ; do
+        volume_backend_pool="$(jq -c \
+            --arg pool "$pool" \
+            '. += [$pool]' \
+            <(printf "%s" "$volume_backend_pool"))"
+    done <<< "$exec_output"
+    echo -n "$volume_backend_pool"
+}
+
+os_cinder_get_volume_backend_host_by_volume_type()
+{
+    # input: os_cinder_get_volume_backend_host_by_volume_type <volume_type>
+    # output: [
+    #   <host1>,
+    #   <host2>
+    # ]
+    local volume_type="${1:-"CubeStorage"}"
+
+    local exec_output=""
+    local exec_error=""
+
+    local volume_backend_host="[]"
+    if ! _hex_function exec_output exec_error _os_cinder_get_volume_backend_pool_by_volume_type "$volume_type" ; then
+        echo -n "$volume_backend_host"
+        return 1
+    fi
+
+    local pool=""
+    local host=""
+    while read -r pool ; do
+        host="$(echo "$pool" | cut -d "@" -f1)"
+        volume_backend_host="$(jq -c \
+            --arg host "$host" \
+            '. += [$host]' \
+            <(printf "%s" "$volume_backend_host"))"
+    done <<< "$exec_output"
+    echo -n "$volume_backend_host"
+}


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Get volume backend pools when backends have similar names
- Separate import logics based on business logics

#### Which issue(s) this PR fixes

- Fix #516 

#### Special notes for your reviewer

Please refer to https://github.com/bigstack-oss/cubecos/issues/516#issuecomment-3799966785 for more details.

#### Additional documentation
