### PR TITLE
fix(cinder): check volumes from all projects before deleting the external storage

### DIFF
--- a/core/sdk_sh/modules/sdk_cinder.sh
+++ b/core/sdk_sh/modules/sdk_cinder.sh
@@ -1712,7 +1712,7 @@ cinder_is_volume_type_in_use()
         return 1
     fi
 
-    _hex_function exec_output exec_error $OPENSTACK volume list --long -f json
+    _hex_function exec_output exec_error $OPENSTACK volume list --all-projects --long -f json
     if [[ "$?" != "0" ]] || ! json_is_array "$exec_output" ; then
         return 0
     fi


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Check volumes from all projects before deleting the external storage
  - In case we still have any volumes or volume-backed images from the storage, then it gets deleted. Those volumes and images would all be dangling resources, which would cause VM creations with them to fail.

#### Which issue(s) this PR fixes

- Fix #554 

#### Special notes for your reviewer

#### Additional documentation
