### PR TITLE
fix(build): bump up to kernel-6.12.69

### DIFF
--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -159,15 +159,15 @@ rootfs_install::
 rootfs_install::
 	$(Q)wget https://raw.githubusercontent.com/python/cpython/main/Lib/encodings/cp437.py -P $(ROOTDIR)/usr/lib64/python3.9/encodings/
 
-# install no constraint packages first
-$(call PROJ_INSTALL_PIP_NC,,$(ROOTFS_PIP_NC))
-$(call PROJ_INSTALL_PIP,-b "$(OPS_GITHUB_BRANCH)" -d "$(ROOTFS_PIP_DL_FROM)",$(ROOTFS_PIP))
-
 # cannot install both python3-google-auth-1:2.28.0-1.el9.noarch from @commandline and python3-google-auth-1:1.30.0-1.el9s.noarch from centos-openstack-yoga
 LOCKED_DNF += python3-google-auth-1.30.0-1.el9s
 
 $(call PROJ_INSTALL_DNF_NOARCH,-d "$(ROOTFS_DNF_DL_FROM)","$(ROOTFS_DNF)")
 # $(call PROJ_INSTALL_DNF_NOARCH,-n,"$(ROOTFS_DNF_NS)")
+
+# install no constraint packages first
+$(call PROJ_INSTALL_PIP_NC,,$(ROOTFS_PIP_NC))
+$(call PROJ_INSTALL_PIP,-b "$(OPS_GITHUB_BRANCH)" -d "$(ROOTFS_PIP_DL_FROM)",$(ROOTFS_PIP))
 
 # Allow admin to be sudoers
 rootfs_install::

--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -88,7 +88,7 @@ RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3
 # kernel packages
-ARG KER_VER="6.12.64"
+ARG KER_VER="6.12.69"
 ARG KER_REL="1.el9"
 ARG KER_ARC="x86_64"
 ARG HEX_KERNEL="kernel-${KER_VER}-${KER_REL} kernel-core-${KER_VER}-${KER_REL} kernel-modules-${KER_VER}-${KER_REL} kernel-devel-${KER_VER}-${KER_REL}"


### PR DESCRIPTION
- fix(build): pip install neutron-vpnaas misses XStatic libs

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
