### PR TITLE
fix(k3s): correct bash syntax error while waiting for metrics-server api service

### DIFF
--- a/core/modules/config_k3s.cpp
+++ b/core/modules/config_k3s.cpp
@@ -114,7 +114,7 @@ Commit(bool modified, int dryLevel)
         true,
         true,
         {},
-        "/usr/local/bin/kubectl get apiservice v1beta1.metrics.k8s.io -o jsonpath='{.status.conditions[?(@.type==\"Available\")].status");
+        "/usr/local/bin/kubectl get apiservice v1beta1.metrics.k8s.io -o jsonpath='{.status.conditions[?(@.type==\"Available\")].status}'");
     if (ar.exitCode != 0) {
         // fall through the error
         HexLogError("k3s: check metrics-server api service, %s", ar.stderrOutput.c_str());


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Correct the bash syntax error while waiting for metrics-server api service

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
