### PR TITLE
fix(keycloak): set required file permissions on keycloak idp xml file for keystone mellon to work

### DIFF
--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -568,9 +568,19 @@ syncSamlMetadata(const std::string myip)
     HexUtilSystemF(
         0,
         0,
-        "hex_sdk cmd -cv scp root@%s:%s %s",
+        HEX_SDK " cmd -cv scp root@%s:%s %s",
         myip.c_str(),
         tmpFile.fileName.c_str(),
+        KEYCLOAK_SAML_METADATA_FILE);
+    HexUtilSystemF(
+        0,
+        0,
+        HEX_SDK " cmd chmod 664 %s",
+        KEYCLOAK_SAML_METADATA_FILE);
+    HexUtilSystemF(
+        0,
+        0,
+        HEX_SDK " cmd chown root:admin %s",
         KEYCLOAK_SAML_METADATA_FILE);
 
     // clean up the temporary file


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Set required file permissions on Keycloak IDP XML file for Keystone Mellon to work

#### Which issue(s) this PR fixes

- Fix #685 

#### Special notes for your reviewer

#### Additional documentation
