### PR TITLE
Add new issue templates for epic, user story, feature, task, spike, and bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,53 @@
+---
+name: Bug
+about: A defect found in a specific user story or feature that caused the system to
+  behave incorrectly.
+title: "[Bug] "
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+> A clear and concise description of what the bug is.
+
+Insert content here.
+
+## How to Reproduce
+
+> Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+> A clear and concise description of what you expected to happen.
+
+Insert content here.
+
+## Screenshots (Optional)
+
+> If applicable, add screenshots to help explain your problem.
+
+## Additional Context (Optional)
+
+> Add any other context about the problem here.
+
+Insert content here.
+
+### Device Information (Optional)
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,36 @@
+---
+name: Epic
+about: Highest-level description of the product or a major delivery of functionality.
+title: "[Epic] "
+labels: ''
+assignees: ''
+
+---
+
+# Your Epic Title
+
+## Background Story (Optional)
+
+> The motivation, trigger, and/or rationale behind this specific epic.
+
+Insert content here.
+
+## Success Criteria
+
+> Defined measurable goals for the epic to be considered complete.
+
+- **Item A:** ...
+- **Item B:** ...
+- **Item C:** ...
+
+## Existing Solution (Optional)
+
+> The current or legacy solution that the features in this epic are intended to replace.
+
+## Practical Use Cases (Optional)
+
+> Descriptions of how users are expected to interact with the new features in this epic, using real-world examples.
+
+1. **Use Case 1:** description
+2. **Use Case 2:** description
+3. **Use Case 3:** description

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,42 @@
+---
+name: Feature
+about: A distinct unit of functionality or a significant part that forms a specific
+  user story.
+title: "[Feature] "
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+> A brief summary to help everyone understand this feature.
+
+Insert content here.
+
+## Definition of Done (DoD)
+
+> A list of technical requirements must be met for completion. These may include, but are not limited to:
+>  - API data conforming to a specified structure.
+>  - An UI delivering defined functionalities.
+>  - Passing all unit tests.
+>  - Passing a code review.
+
+- [ ] Condition 1
+- [ ] Condition 2
+- [ ] Condition 3
+
+## Technical Notes
+
+> A section for tech leads to to document technical risks and/or any concerns regarding the DoD.
+
+- **Feature Owner:**
+- **Frontend:** 
+- **Backend:** 
+- **Infra:**
+
+## UI/UX Mockups (Optional)
+
+> Links to design prototypes or wireframes (if applicable).
+
+None

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,27 @@
+---
+name: Spike
+about: Necessary investigation, research, discussion, or technical exploration to
+  reduce uncertainty about any subject.
+title: "[Spike] "
+labels: ''
+assignees: ''
+
+---
+
+## Problem Description
+
+> Clearly define the issue or area of investigation, research, or discussion.
+
+Insert content here.
+
+## Validation Plan/Methods
+
+> Briefly outline how the area of investigation or possible solution will be validated or tested.
+
+TBD
+
+## Spike Result/Conclusion
+
+> Summarize the findings and the conclusion drawn from the investigation.
+
+TBD

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,29 @@
+---
+name: Task
+about: A doable, testable, smallest unit of work required to fulfill a specific feature.
+title: "[Task] "
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+> Overview of what should be done.
+
+Insert content here.
+
+## Requirements
+
+> A list of technical requirements must be met for completion. These may include, but are not limited to:
+> - API data conforming to a specified structure.
+> - A page delivering defined functionalities.
+> - Passing all unit tests.
+> - Passing a code review.
+
+- [ ] Requirement 1
+- [ ] Requirement 2
+- [ ] Requirement 3
+
+## Notes (Optional)
+Insert content here.

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,31 @@
+---
+name: User Story
+about: A concise statement written from the perspective of the person requesting a
+  new capability; it defines their role, the action they want to take, and the expected
+  outcome.
+title: "[User Story] "
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+As a **[type of user]**, I want **[some goal]** so that **[some reason]**.
+
+## Acceptance Criteria
+
+> A detailed list of conditions that must be met for the story to be accepted. These statements must focus on functional behavior and constraints rather than specific code-level implementation.
+
+- [ ] Condition 1
+- [ ] Condition 2
+- [ ] Condition 3
+
+## Story Points: ❓ 
+
+>| Points | Effort / Resources | Description |
+> | -- | -- | -- |
+>| 1 | Low | Low complexity; can be resolved easily.
+>| 3 | Medium | Moderate workload; requires some focus, but risks are well-managed.
+>| 5 | High | High complexity; difficult to implement, requiring significant time and effort.
+>| 8 | Very High | Extreme complexity or high uncertainty. If possible, this should be divided into multiple user stories.


### PR DESCRIPTION
#### What type of PR is this?

Chore

<br/>

#### What this PR does / why we need it

Thanks a lot for @steven-chiu-bigstack to provide the new issue templates for epic, user story, feature, task, spike, and bug,

but, currently, we'll still keep the original `bug_report.md` and `feature_request.md` for the time being although the new bug and feature template are provided

<br/>

#### Which issue(s) this PR fixes

None

