### PR TITLE
fix(cinder): make type checking work

### DIFF
--- a/core/sdk_sh/modules/sdk_cinder.sh
+++ b/core/sdk_sh/modules/sdk_cinder.sh
@@ -3097,8 +3097,8 @@ isTestVolumeSuccessful: $isTestVolumeSuccessful | test("true")
     _hex_function \
         exec_output \
         exec_error \
-        jq -r \
-        ".[] | select(.Name == \"dell-emc-sc-fc\") | length > 0" \
+        jq -e \
+        "any(.[]; .Name == \"${name}\")" \
         <(printf "%s" "$exec_output")
     if [[ "$?" != "0" ]] ; then
         jq -c -n \


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Make the not working type checking statement work

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

Although we have the testing external storage name hardcoded in the script, the testing statement itself was not working at all, so it did not impact v3.1.0. We only have a not working check, which always returned true. But, after the change in this PR, we have the check working with input external storage name.

#### Additional documentation
