### PR TITLE
fix(hex_sdk): avoid word splitting while parsing the node list

### DIFF
--- a/core/sdk_sh/modules.pre/sdk_02-var-runtime.sh
+++ b/core/sdk_sh/modules.pre/sdk_02-var-runtime.sh
@@ -6,20 +6,20 @@ if [ -z "$PROG" ] ; then
     exit 1
 fi
 
-CUBE_NODE_LIST_JSON=$(cubectl node list -j)
-CUBE_NODE_CONTROL_JSON=$(cubectl node list -j -r control)
-CUBE_NODE_COMPUTE_JSON=$(cubectl node list -j -r compute)
-CUBE_NODE_STORAGE_JSON=$(cubectl node list -j -r storage)
+CUBE_NODE_LIST_JSON="$(cubectl node list -j)"
+CUBE_NODE_CONTROL_JSON="$(cubectl node list -j -r control)"
+CUBE_NODE_COMPUTE_JSON="$(cubectl node list -j -r compute)"
+CUBE_NODE_STORAGE_JSON="$(cubectl node list -j -r storage)"
 CUBE_NODE_LIST_IPS=($(cubectl node list | cut -d"," -f2))
-CUBE_NODE_MANAGEMENT_IP=$(echo $CUBE_NODE_LIST_JSON | jq .[].ip | jq -r .management | grep -v null)
-CUBE_NODE_PROVIDER_IP=$(echo $CUBE_NODE_LIST_JSON | jq .[].ip | jq -r .provider | grep -v null)
-CUBE_NODE_OVERLAY_IP=$(echo $CUBE_NODE_LIST_JSON | jq .[].ip | jq -r .overlay | grep -v null)
-CUBE_NODE_STORAGE_IP=$(echo $CUBE_NODE_LIST_JSON | jq .[].ip | jq -r .storage | grep -v null)
-CUBE_NODE_CLUSTER_IP=$(echo $CUBE_NODE_LIST_JSON | jq .[].ip | jq -r ".[\"storage-cluster\"] // empty" | grep -v null)
-CUBE_NODE_LIST_HOSTNAMES=($(echo $CUBE_NODE_LIST_JSON | jq -r .[].hostname))
-CUBE_NODE_CONTROL_HOSTNAMES=($(echo $CUBE_NODE_CONTROL_JSON | jq -r .[].hostname))
-CUBE_NODE_COMPUTE_HOSTNAMES=($(echo $CUBE_NODE_COMPUTE_JSON | jq -r .[].hostname))
-CUBE_NODE_STORAGE_HOSTNAMES=($(echo $CUBE_NODE_STORAGE_JSON | jq -r .[].hostname))
+CUBE_NODE_MANAGEMENT_IP=$(echo "$CUBE_NODE_LIST_JSON" | jq .[].ip | jq -r .management | grep -v null)
+CUBE_NODE_PROVIDER_IP=$(echo "$CUBE_NODE_LIST_JSON" | jq .[].ip | jq -r .provider | grep -v null)
+CUBE_NODE_OVERLAY_IP=$(echo "$CUBE_NODE_LIST_JSON" | jq .[].ip | jq -r .overlay | grep -v null)
+CUBE_NODE_STORAGE_IP=$(echo "$CUBE_NODE_LIST_JSON" | jq .[].ip | jq -r .storage | grep -v null)
+CUBE_NODE_CLUSTER_IP=$(echo "$CUBE_NODE_LIST_JSON" | jq .[].ip | jq -r ".[\"storage-cluster\"] // empty" | grep -v null)
+CUBE_NODE_LIST_HOSTNAMES=($(echo "$CUBE_NODE_LIST_JSON" | jq -r .[].hostname))
+CUBE_NODE_CONTROL_HOSTNAMES=($(echo "$CUBE_NODE_CONTROL_JSON" | jq -r .[].hostname))
+CUBE_NODE_COMPUTE_HOSTNAMES=($(echo "$CUBE_NODE_COMPUTE_JSON" | jq -r .[].hostname))
+CUBE_NODE_STORAGE_HOSTNAMES=($(echo "$CUBE_NODE_STORAGE_JSON" | jq -r .[].hostname))
 
 if [ -f /etc/appliance/state/configured ] ; then
     INFLUX="timeout $SRVTO /usr/bin/influx -host $(shared_id)"


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Avoid word splitting while parsing the node list

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
