### PR TITLE
 chore(kernel): bump kernel from 6.12.74 to 6.12.82

### DIFF
--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -88,7 +88,7 @@ RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3
 # kernel packages
-ARG KER_VER="6.12.74"
+ARG KER_VER="6.12.82"
 ARG KER_REL="1.el9"
 ARG KER_ARC="x86_64"
 ARG HEX_KERNEL="kernel-${KER_VER}-${KER_REL} kernel-core-${KER_VER}-${KER_REL} kernel-modules-${KER_VER}-${KER_REL} kernel-devel-${KER_VER}-${KER_REL}"


### PR DESCRIPTION
#### What type of PR is this?

- chore

#### What this PR does / why we need it

- Bump the kernel version since the old kernel packages were dropped in the upstream.

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
