### PR TITLE
fix(app): fix an arg parsing issue for app_register

### DIFF
--- a/core/modules/cli_app.cpp
+++ b/core/modules/cli_app.cpp
@@ -27,8 +27,6 @@ appRegisterMain(int argc, const char** argv)
     int ret;
     std::string app_path = argv[1];
     std::string app_fw_name = argv[2];
-    std::string skip_flag = argv[3];
-
     CliPrintf("installing app: %s...", app_path.c_str());
 
     if(argc == 4){


### PR DESCRIPTION
#### What type of PR is this?

Fix

<br/>

#### What this PR does / why we need it

Fix an arg parsing issue for app_register

<br/>

#### Which issue(s) this PR fixes

https://github.com/bigstack-oss/cubecos/issues/849

<br/>

#### Test Results

Make sure the 2 cases regarding with or without skip_flavor below will be passed.

Without skip_flavor option

```sh
qa200> app app_register /var/update/cube-portal-2.1.0+rev4053.pigz appfw-rke2-110
installing app: /var/update/cube-portal-2.1.0+rev4053.pigz...
INFO[0000] Saving config to /root/.rancher/cli2.json
INFO[0000] Setting new context to project Default
INFO[0000] Saving config to /root/.rancher/cli2.json
Cluster "appfw-rke2-110" set.
2.1.0-72fbde733
Login Succeeded!
uploading image - localhost/extensions/portal:2.1.0-72fbde733 to appfw-rke2-110.registry.cubecos.com/extensions/portal:2.1.0-72fbde733 ...
Getting image source signatures
Copying blob 22834468dd1f skipped: already exists
Copying blob 08b533e5f5fa skipped: already exists
Copying blob 1a74c98d665e skipped: already exists
Copying blob 086bbe15541f skipped: already exists
Copying blob 76cbedd71a05 skipped: already exists
Copying config 842f835577 done   |
Writing manifest to image destination
uploading image - localhost/extensions/worker:2.1.0-72fbde733 to appfw-rke2-110.registry.cubecos.com/extensions/worker:2.1.0-72fbde733 ...
Getting image source signatures
Copying blob 9294b0de234f skipped: already exists
...
... <skip> ...
...
+----------------------------+----------------------------------------------------------+
| Field                      | Value                                                    |
+----------------------------+----------------------------------------------------------+
| OS-FLV-DISABLED:disabled   | False                                                    |
| OS-FLV-EXT-DATA:ephemeral  | 0                                                        |
| description                | None                                                     |
| disk                       | 320                                                      |
| id                         | 52030dd5-55f7-4944-bfd4-05bb7d6950fc                     |
| name                       | storage.large                                            |
| os-flavor-access:is_public | True                                                     |
| properties                 | hw:cpu_cores='2', hw:cpu_sockets='1', hw:cpu_threads='2' |
| ram                        | 8192                                                     |
| rxtx_factor                | 1.0                                                      |
| swap                       |                                                          |
| vcpus                      | 4                                                        |
+----------------------------+----------------------------------------------------------+
+----------------------------+----------------------------------------------------------+
| Field                      | Value                                                    |
+----------------------------+----------------------------------------------------------+
| OS-FLV-DISABLED:disabled   | False                                                    |
| OS-FLV-EXT-DATA:ephemeral  | 0                                                        |
| description                | None                                                     |
| disk                       | 640                                                      |
| id                         | c2efce84-78b3-4e22-9ceb-5aa37e9a7524                     |
| name                       | storage.xlarge                                           |
| os-flavor-access:is_public | True                                                     |
| properties                 | hw:cpu_cores='3', hw:cpu_sockets='1', hw:cpu_threads='2' |
| ram                        | 16384                                                    |
| rxtx_factor                | 1.0                                                      |
| swap                       |                                                          |
| vcpus                      | 6                                                        |
+----------------------------+----------------------------------------------------------+
+----------------------------+----------------------------------------------------------+
| Field                      | Value                                                    |
+----------------------------+----------------------------------------------------------+
| OS-FLV-DISABLED:disabled   | False                                                    |
| OS-FLV-EXT-DATA:ephemeral  | 0                                                        |
| description                | None                                                     |
| disk                       | 1280                                                     |
| id                         | 6796e52d-d56e-4703-908f-9f9614c14a09                     |
| name                       | storage.2xlarge                                          |
| os-flavor-access:is_public | True                                                     |
| properties                 | hw:cpu_cores='2', hw:cpu_sockets='2', hw:cpu_threads='2' |
| ram                        | 32768                                                    |
| rxtx_factor                | 1.0                                                      |
| swap                       |                                                          |
| vcpus                      | 8                                                        |
+----------------------------+----------------------------------------------------------+
...
... <skip> ...
...
issuer.cert-manager.io/selfsigned-issuer serverside-applied
app installed successfully
```

<br/>

With skip_flavor option

```sh
qa200> app app_register /var/update/cube-portal-2.1.0+rev4053.pigz appfw-rke2-110 skip_flavor
installing app: /var/update/cube-portal-2.1.0+rev4053.pigz...
INFO[0000] Saving config to /root/.rancher/cli2.json
INFO[0000] Setting new context to project Default
INFO[0000] Saving config to /root/.rancher/cli2.json
Cluster "appfw-rke2-110" set.
2.1.0-72fbde733
Login Succeeded!
uploading image - localhost/extensions/portal:2.1.0-72fbde733 to appfw-rke2-110.registry.cubecos.com/extensions/portal:2.1.0-72fbde733 ...
Getting image source signatures
Copying blob 086bbe15541f skipped: already exists
Copying blob 22834468dd1f skipped: already exists
Copying blob 1a74c98d665e skipped: already exists
Copying blob 08b533e5f5fa skipped: already exists
Copying blob 76cbedd71a05 skipped: already exists
Copying config 842f835577 done   |
Writing manifest to image destination
uploading image - localhost/extensions/worker:2.1.0-72fbde733 to appfw-rke2-110.registry.cubecos.com/extensions/worker:2.1.0-72fbde733 ...
Getting image source signatures
...
... <skip> ...
...
issuer.cert-manager.io/selfsigned-issuer serverside-applied
app installed successfully
```
