### PR TITLE
feat(gpu): support nvidia rtx a2000

### DIFF
--- a/core/nvidia/nvidia.mk
+++ b/core/nvidia/nvidia.mk
@@ -11,7 +11,6 @@ rootfs_install::
 	$(Q)mount -o bind /dev $(ROOTDIR)/dev || true
 	$(Q)chroot $(ROOTDIR) sh /root/$(NVIDIA_DRIVER) \
 		--kernel-name=$(KERNEL_VERS) \
-		--kernel-module-type=open \
 		-s || true
 	$(Q)umount -l $(ROOTDIR)/sys || true
 	$(Q)umount -l $(ROOTDIR)/dev || true

--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -89,7 +89,7 @@ RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3
 # kernel packages
-ARG KER_VER="6.12.82"
+ARG KER_VER="6.12.87"
 ARG KER_REL="1.el9"
 ARG KER_ARC="x86_64"
 ARG HEX_KERNEL="kernel-${KER_VER}-${KER_REL} kernel-core-${KER_VER}-${KER_REL} kernel-modules-${KER_VER}-${KER_REL} kernel-devel-${KER_VER}-${KER_REL}"


### PR DESCRIPTION
#### What type of PR is this?

- feat

#### What this PR does / why we need it

- Support older Nvidia GPU cards, like RTX PRO A2000
- Bump Linux kernel from 6.12.82 to 6.12.87

#### Which issue(s) this PR fixes

- Related to #860
- Fix CVE Copy Fail https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.12.87&id=67f1f0933cc3d78dde222842bcad2778ec7a0b88
  - Fix https://github.com/bigstack-oss/cubecos-private/issues/80
- Fix CVE Dirty Frag https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.12.87&id=b54edf1e9a3fd3491bdcb82a21f8d21315271e0d
  - Fix https://github.com/bigstack-oss/cubecos-private/issues/85

#### Special notes for your reviewer

#### Additional documentation
