### PR TITLE
fix(terraform): use filesystem mirror to avoid checksum mismatches of patched terraform provider binaries

### DIFF
--- a/core/cubectl/app/config/config_rancher.go
+++ b/core/cubectl/app/config/config_rancher.go
@@ -637,11 +637,6 @@ func commitRancher() error {
 			zap.S().Warn(errors.WithStack(err))
 		}
 
-		_, outErr, err := util.ExecCmd("/usr/local/bin/terraform", fmt.Sprintf("-chdir=%s", terraformWorkDir), "init", "-upgrade")
-		if err != nil {
-			zap.S().Warn(errors.Wrap(err, outErr))
-		}
-
 		// Create token and eanble keycloak auth
 		if err := terraformExec("apply", "rancher", []string{"cube_controller=" + cubeSettings.GetControllerIp()}, []string{}); err != nil {
 			zap.S().Warn(errors.WithStack(err))

--- a/core/terraform/override.tfrc
+++ b/core/terraform/override.tfrc
@@ -1,7 +1,9 @@
 provider_installation {
-  dev_overrides {
-    "registry.terraform.io/rancher/rancher2" = "/var/lib/terraform/.terraform/providers/registry.terraform.io/rancher/rancher2/7.0.0/linux_amd64"
-    "registry.terraform.io/mrparkers/keycloak" = "/var/lib/terraform/.terraform/providers/registry.terraform.io/mrparkers/keycloak/3.10.0/linux_amd64"
+  filesystem_mirror {
+    path    = "/var/lib/terraform/patched-registry"
+    include = ["registry.terraform.io/rancher/*", "registry.terraform.io/mrparkers/*", "registry.terraform.io/terraform-providers/*"]
   }
-  direct {}
+  direct {
+    exclude = ["registry.terraform.io/rancher/*", "registry.terraform.io/mrparkers/*", "registry.terraform.io/terraform-providers/*"]
+  }
 }

--- a/core/terraform/scripts/terraform-action.sh
+++ b/core/terraform/scripts/terraform-action.sh
@@ -3,6 +3,7 @@
 export TF_CLI_CONFIG_FILE=/etc/cube/cos/terraform/configs/override.tfrc
 
 pushd /tmp >/dev/null 2>&1
+timeout -k 1s 60s /usr/local/bin/terraform -chdir=/var/lib/terraform init -upgrade
 timeout -k 1s 60s /usr/local/bin/terraform -chdir=/var/lib/terraform "$@"
 [ $? -eq 0 ] || exit 1
 

--- a/core/terraform/terraform.mk
+++ b/core/terraform/terraform.mk
@@ -4,7 +4,12 @@ rootfs_install::
 	$(Q)cp -f $(TOP_BLDDIR)/core/terraform/terraform-core/terraform-core $(ROOTDIR)/usr/local/bin/terraform
 	$(Q)cp -f $(COREDIR)/terraform/scripts/* $(ROOTDIR)/usr/local/bin/
 	$(Q)cp -rf $(TOP_BLDDIR)/core/terraform/terraform/ $(ROOTDIR)/var/lib/
-	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/terraform/configs
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/terraform/values
-	$(Q)cp -f $(COREDIR)/terraform/override.tfrc $(ROOTDIR)/etc/cube/cos/terraform/configs/
 	$(Q)cp -f $(COREDIR)/terraform/values/* $(ROOTDIR)/etc/cube/cos/terraform/values/
+	$(Q)# patch terraform providers for CVEs
+	$(Q)chroot $(ROOTDIR) mkdir -p /var/lib/terraform/patched-registry
+	$(Q)chroot $(ROOTDIR) rsync -avz --progress /var/lib/terraform/.terraform/providers/ /var/lib/terraform/patched-registry/
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/terraform/configs
+	$(Q)cp -f $(COREDIR)/terraform/override.tfrc $(ROOTDIR)/etc/cube/cos/terraform/configs/
+	$(Q)chroot $(ROOTDIR) cp -f /etc/cube/cos/terraform/configs/override.tfrc /root/.terraformrc
+	$(Q)chroot $(ROOTDIR) rm -f /var/lib/terraform/.terraform.lock.hcl


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Use filesystem mirror to avoid checksum mismatches of patched terraform provider binaries

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
