### PR TITLE
feat(mariadb): bump mariadb from 10.5.x to 10.6.x for openstack antelope

### DIFF
--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -79,6 +79,10 @@ rootfs_install::
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) dnf -y install centos-release-nfs-ganesha5
 
+# Disable module mariadb from CentOS Stream 9 - AppStream repo to avoid dependency conflicts after switching to MariaDB official repo
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) dnf module disable mariadb -y
+
 # Lock kernel to known good version
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) dnf install -y 'dnf-command(versionlock)'

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -35,6 +35,7 @@ ROOTFS_DNF += rsync
 ROOTFS_DNF_NOARCH += python3-PyMySQL
 
 rootfs_install::
-	$(Q)mv $(ROOTDIR)/etc/my.cnf.d/galera.cnf $(ROOTDIR)/etc/my.cnf.d/galera.cnf.orig
+	$(Q)# /etc/my.cnf.d/galera.cnf came from centos stream 9 appstream repo, mariadb repo mariadb does not have this default config
+	$(Q)# mv $(ROOTDIR)/etc/my.cnf.d/galera.cnf $(ROOTDIR)/etc/my.cnf.d/galera.cnf.orig
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/default_dbs/
 	$(Q)chroot $(ROOTDIR) sh -c "tar -cf - var/lib/mysql | pigz -9 > /etc/default_dbs/mysql.tgz"

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -3,14 +3,33 @@
 
 # Unknown system variable 'innodb_version' since MariaDB 10.10
 # ROOTFS_DNF += mariadb-server mariadb-server-galera rsync
-MARIADB_VER := 10.5.27-1.el9_5.0.2
 # rpmfind.net is often not responsive
 # MARIADB_URL := https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages
-MARIADB_URL := https://ftp.icm.edu.pl/packages/linux-rocky/9/devel/x86_64/os/Packages/m
-MARIADB_LOCKED_RPMS := mariadb-$(MARIADB_VER) mariadb-backup-$(MARIADB_VER) mariadb-common-$(MARIADB_VER) mariadb-errmsg-$(MARIADB_VER)
-MARIADB_LOCKED_RPMS += mariadb-gssapi-server-$(MARIADB_VER) mariadb-server-$(MARIADB_VER) mariadb-server-galera-$(MARIADB_VER) mariadb-server-utils-$(MARIADB_VER)
-LOCKED_DNF += $(MARIADB_LOCKED_RPMS)
+
+MARIADB_VER := 10.6.26-1.el9
+GALERA_VER := 26.4.26-1.el9
+MARIADB_URL := https://mirror.mariadb.org/yum/10.6/rocky9-amd64/rpms
+
+# Official MariaDB package list
+# Note: we dropped errmsg and server-utils as they are now bundled
+MARIADB_LOCKED_RPMS := MariaDB-client-$(MARIADB_VER) \
+                       MariaDB-server-$(MARIADB_VER) \
+                       MariaDB-common-$(MARIADB_VER) \
+                       MariaDB-shared-$(MARIADB_VER) \
+                       MariaDB-backup-$(MARIADB_VER) \
+                       MariaDB-gssapi-server-$(MARIADB_VER)
+
+# Galera library is versioned differently than the database engine
+GALERA_RPM := galera-4-$(GALERA_VER)
+
+LOCKED_DNF += $(MARIADB_LOCKED_RPMS) $(GALERA_RPM)
+
+# Map URLs for MariaDB packages
 $(foreach mariadb_rpm,$(MARIADB_LOCKED_RPMS),$(eval ROOTFS_DNF_DL_FROM += $(MARIADB_URL)/$(mariadb_rpm).x86_64.rpm))
+
+# Map URL for Galera package
+ROOTFS_DNF_DL_FROM += $(MARIADB_URL)/$(GALERA_RPM).x86_64.rpm
+
 ROOTFS_DNF += rsync
 ROOTFS_DNF_NOARCH += python3-PyMySQL
 

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -23,6 +23,7 @@ MARIADB_LOCKED_RPMS := MariaDB-client-$(MARIADB_VER) \
 GALERA_RPM := galera-4-$(GALERA_VER)
 
 LOCKED_DNF += $(MARIADB_LOCKED_RPMS) $(GALERA_RPM)
+BLKLST_DNF += mariadb-connector-c mariadb-connector-c-config
 
 # Map URLs for MariaDB packages
 $(foreach mariadb_rpm,$(MARIADB_LOCKED_RPMS),$(eval ROOTFS_DNF_DL_FROM += $(MARIADB_URL)/$(mariadb_rpm).x86_64.rpm))


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Bump MariaDB from 10.5.x to 10.6.x for Openstack Antelope

#### Which issue(s) this PR fixes

- Close #624 

#### Special notes for your reviewer

#### Additional documentation
