### PR TITLE
893 hex_sdk set GPU to passthrough mode

### DIFF
--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -174,6 +174,7 @@ hex_config_MODULES += config_opensearch_dashboards.o
 hex_config_MODULES += config_logstash.o
 hex_config_MODULES += config_kafka.o
 hex_config_MODULES += config_prometheus.o
+hex_config_MODULES += config_gpu.o
 
 PROGRAMS += hex_config
 

--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -1,0 +1,32 @@
+// CUBE SDK
+
+#include <unistd.h>
+#include <hex/log.h>
+#include <hex/filesystem.h>
+#include <hex/process_util.h>
+#include <hex/config_module.h>
+#include <hex/dryrun.h>
+
+static const char GPU_CONFIG_DIR[]  = "/etc/cube/cos/gpu";
+static const char GPU_CONFIG_FILE[] = "/etc/cube/cos/gpu/config.json";
+
+static bool
+Commit(bool modified, int dryLevel)
+{
+    HEX_DRYRUN_BARRIER(dryLevel, true);
+
+    if (HexMakeDir(GPU_CONFIG_DIR, "root", "root", 0755) != 0) {
+        HexLogError("Failed to create GPU config directory: %s", GPU_CONFIG_DIR);
+        return false;
+    }
+
+    if (access(GPU_CONFIG_FILE, F_OK) != 0) {
+        HexUtilSystemF(0, 0, "echo '[]' > %s", GPU_CONFIG_FILE);
+    }
+
+    return true;
+}
+
+CONFIG_MODULE(gpu, 0, 0, 0, 0, Commit);
+
+CONFIG_MIGRATE(gpu, GPU_CONFIG_DIR);

--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -21,6 +21,17 @@ Commit(bool modified, int dryLevel)
     }
 
     if (access(GPU_CONFIG_FILE, F_OK) != 0) {
+        /* Data in `config.json` is an array with the following data structure:
+        {
+          id: string
+          type: 'pgpu' | 'sriovVgpu' | 'migBackedVgpu'
+          profiles: {
+            id: number
+            count: number
+            alias: string
+          }[] | null
+        }
+        */
         HexUtilSystemF(0, 0, "echo '[]' > %s", GPU_CONFIG_FILE);
     }
 

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -549,29 +549,18 @@ gpu_pgpu_attached_instance_get()
 
 gpu_resource_set()
 {
-    local gpu_uuid="$1"
-    shift
+    local gpu_id="$1"
+    local new_type="$2"
+    local profiles="$3"
 
-    local new_type=""
-    local profiles=""
-    local has_profiles_option=0
-
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            -type) new_type="$2"; shift 2 ;;
-            -profiles) profiles="$2"; has_profiles_option=1; shift 2 ;;
-            *) echo "Error: unknown option '$1'" >&2; exit 1 ;;
-        esac
-    done
-
-    if [ -z "$gpu_uuid" ]; then
-        echo "Error: GPU UUID is required" >&2
-        exit 1
+    if [ -z "$gpu_id" ]; then
+        echo "Error: gpu_id is required" >&2
+        return 1
     fi
 
     if [ -z "$new_type" ]; then
-        echo "Error: -type is required" >&2
-        exit 1
+        echo "Error: new_type is required" >&2
+        return 1
     fi
 
     case "$new_type" in
@@ -582,13 +571,25 @@ gpu_resource_set()
             ;;
     esac
 
-    if [ "$new_type" = "pgpu" ] && [ "$has_profiles_option" = "1" ]; then
-        echo "Error: -profiles is not allowed when type is pgpu" >&2
+    if [ "$new_type" = "pgpu" ] && [ -n "$profiles" ]; then
+        echo "Error: profiles is not allowed when new_type is pgpu" >&2
         exit 1
     fi
+    
+    if [[ "$new_type" == "sriovVgpu" || "$new_type" == "migBackedVgpu" ]]; then
+        if [ -z "$profiles" ]; then
+            echo "Error: profiles is required when new_type is sriovVgpu or migBackedVgpu" >&2
+            exit 1
+        fi
+        
+        echo "TODO: perform profiles argument validation."
+        # Schema: an array of profiles `{ id: number, count: number }[]`
+        # In addition to the format, we must also validate the existence
+        # and capacity constraints (for MIG-backed) of the provided profiles.
+    fi
 
-    if ! $NVIDIA_SMI --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | grep -qF "$gpu_uuid"; then
-        echo "Error: GPU UUID '$gpu_uuid' not found" >&2
+    if ! $NVIDIA_SMI --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | grep -qF "$gpu_id"; then
+        echo "Error: GPU UUID '$gpu_id' not found" >&2
         exit 1
     fi
 
@@ -598,21 +599,20 @@ gpu_resource_set()
     fi
 
     local gpu_config="[]"
-    local raw
-    raw=$(cat "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
-    if echo "$raw" | jq -e 'type == "array"' >/dev/null 2>&1; then
-        gpu_config="$raw"
+    local raw_config
+    raw_config=$(cat "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
+    if echo "$raw_config" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        gpu_config="$raw_config"
     fi
 
     local current_type
-    current_type=$(echo "$gpu_config" | jq -r --arg id "$gpu_uuid" \
+    current_type=$(echo "$gpu_config" | jq -r --arg id "$gpu_id" \
         'map(select(.id == $id)) | if length > 0 then .[0].type else "unset" end')
 
     local pci_bus_id
-    pci_bus_id=$($NVIDIA_SMI --query-gpu=uuid,pci.bus_id --format=csv,noheader,nounits 2>/dev/null | \
-        awk -F',' -v uuid="$gpu_uuid" 'index($1, uuid) {print $2}' | xargs)
+    pci_bus_id=$($NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null)
     if [ -z "$pci_bus_id" ]; then
-        echo "Error: could not get PCI bus ID for GPU $gpu_uuid" >&2
+        echo "Error: could not get PCI bus ID for GPU $gpu_id" >&2
         exit 1
     fi
 
@@ -625,7 +625,7 @@ gpu_resource_set()
             for vm_id in $(virsh list --state-running --uuid 2>/dev/null); do
                 if virsh dumpxml "$vm_id" 2>/dev/null | \
                     grep -q "bus='0x${pci_bus}'.*slot='0x${pci_slot}'"; then
-                    echo "Error: GPU card $gpu_uuid is in-use" >&2
+                    echo "Error: GPU card $gpu_id is in-use" >&2
                     exit 1
                 fi
             done
@@ -634,16 +634,16 @@ gpu_resource_set()
         if [ "$current_type" = "sriovVgpu" ]; then
             unset_sriov_vgpu "$pci_bus_id"
         elif [ "$current_type" = "migBackedVgpu" ]; then
-            unset_mig_backed_vgpu "$gpu_uuid"
+            unset_mig_backed_vgpu "$gpu_id"
         fi
 
         local new_config
         new_config=$(echo "$gpu_config" | jq -c \
-            --arg id "$gpu_uuid" \
+            --arg id "$gpu_id" \
             'map(select(.id != $id)) + [{id:$id, type:"pgpu", profiles:null}]')
 
         echo "$new_config" > "$GPU_CONFIG_FILE_PATH"
-        echo "Successfully update GPU $gpu_uuid to pgpu"
+        echo "Successfully update GPU $gpu_id to pgpu"
     else
         echo "Error: type '$new_type' is not yet implemented" >&2
         exit 1

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -547,6 +547,130 @@ gpu_pgpu_attached_instance_get()
     echo "null"
 }
 
+gpu_resource_set()
+{
+    local gpu_uuid="$1"
+    shift
+
+    local new_type=""
+    local profiles=""
+    local has_profiles_option=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -type) new_type="$2"; shift 2 ;;
+            -profiles) profiles="$2"; has_profiles_option=1; shift 2 ;;
+            *) echo "Error: unknown option '$1'" >&2; exit 1 ;;
+        esac
+    done
+
+    if [ -z "$gpu_uuid" ]; then
+        echo "Error: GPU UUID is required" >&2
+        exit 1
+    fi
+
+    if [ -z "$new_type" ]; then
+        echo "Error: -type is required" >&2
+        exit 1
+    fi
+
+    case "$new_type" in
+        pgpu|sriovVgpu|migBackedVgpu) ;;
+        *)
+            echo "Error: invalid type '$new_type'. Must be one of: pgpu, sriovVgpu, migBackedVgpu" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ "$new_type" = "pgpu" ] && [ "$has_profiles_option" = "1" ]; then
+        echo "Error: -profiles is not allowed when type is pgpu" >&2
+        exit 1
+    fi
+
+    if ! $NVIDIA_SMI --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | grep -qF "$gpu_uuid"; then
+        echo "Error: GPU UUID '$gpu_uuid' not found" >&2
+        exit 1
+    fi
+
+    if [ ! -f "$GPU_CONFIG_FILE_PATH" ]; then
+        echo "Error: GPU config file not found at $GPU_CONFIG_FILE_PATH" >&2
+        exit 1
+    fi
+
+    local gpu_config="[]"
+    local raw
+    raw=$(cat "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
+    if echo "$raw" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        gpu_config="$raw"
+    fi
+
+    local current_type
+    current_type=$(echo "$gpu_config" | jq -r --arg id "$gpu_uuid" \
+        'map(select(.id == $id)) | if length > 0 then .[0].type else "unset" end')
+
+    local pci_bus_id
+    pci_bus_id=$($NVIDIA_SMI --query-gpu=uuid,pci.bus_id --format=csv,noheader,nounits 2>/dev/null | \
+        awk -F',' -v uuid="$gpu_uuid" 'index($1, uuid) {print $2}' | xargs)
+    if [ -z "$pci_bus_id" ]; then
+        echo "Error: could not get PCI bus ID for GPU $gpu_uuid" >&2
+        exit 1
+    fi
+
+    if [ "$new_type" = "pgpu" ]; then
+        # Check if GPU is currently in-use by any VM
+        if [ "$current_type" = "pgpu" ]; then
+            local pci_bus pci_slot
+            pci_bus=$(echo "$pci_bus_id" | awk -F: '{print tolower($2)}')
+            pci_slot=$(echo "$pci_bus_id" | awk -F: '{print $3}' | awk -F. '{print tolower($1)}')
+            for vm_id in $(virsh list --state-running --uuid 2>/dev/null); do
+                if virsh dumpxml "$vm_id" 2>/dev/null | \
+                    grep -q "bus='0x${pci_bus}'.*slot='0x${pci_slot}'"; then
+                    echo "Error: GPU card $gpu_uuid is in-use" >&2
+                    exit 1
+                fi
+            done
+        fi
+
+        if [ "$current_type" = "sriovVgpu" ]; then
+            unset_sriov_vgpu "$pci_bus_id"
+        elif [ "$current_type" = "migBackedVgpu" ]; then
+            unset_mig_backed_vgpu "$gpu_uuid"
+        fi
+
+        local new_config
+        new_config=$(echo "$gpu_config" | jq -c \
+            --arg id "$gpu_uuid" \
+            'map(select(.id != $id)) + [{id:$id, type:"pgpu", profiles:null}]')
+
+        echo "$new_config" > "$GPU_CONFIG_FILE_PATH"
+        echo "Successfully update GPU $gpu_uuid to pgpu"
+    else
+        echo "Error: type '$new_type' is not yet implemented" >&2
+        exit 1
+    fi
+}
+
+unset_sriov_vgpu()
+{
+    # nvidia-smi uses 8-char domain (00000000:bb:ss.f); sysfs uses 4-char (0000:bb:ss.f)
+    local pci_addr
+    pci_addr=$(echo "$1" | sed 's/^[0-9a-fA-F]\{4\}//')
+    local numvfs_path="/sys/bus/pci/devices/${pci_addr}/sriov_numvfs"
+    if [ ! -f "$numvfs_path" ]; then
+        echo "Error: sriov_numvfs not found at $numvfs_path" >&2
+        exit 1
+    fi
+    echo 0 > "$numvfs_path"
+}
+
+unset_mig_backed_vgpu()
+{
+    if ! $NVIDIA_SMI -i "$1" -mig 0; then
+        echo "Error: failed to disable MIG mode for GPU $1" >&2
+        exit 1
+    fi
+}
+
 gpu_host_stats()
 {
     if ! gpu_is_installed; then


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

- Add `gpu_resource_set` command to `sdk_gpu.sh` for pGPU.

#### Which issue(s) this PR fixes

Fixes #893

#### Special notes for your reviewer

Try it out on 150.1 (with dedicated shell script)

1. Change directory to `/etc/cube/cos/gpu/`
2. Verify GPU UUID
   ```bash
   [sky150 /etc/cube/cos/gpu]# nvidia-smi -L
   GPU 0: NVIDIA RTX A2000 (UUID: GPU-28eca022-0c66-97c1-a527-17e900626924)
   [sky150 /etc/cube/cos/gpu]#
   ```
3. Inspect current `config.json`
   ```bash
   [sky150 /etc/cube/cos/gpu]# cat config.json
   []
   [sky150 /etc/cube/cos/gpu]#
   ```
4. Run script
   ```bash
   [sky150 /etc/cube/cos/gpu]# sh ~/893-gpu-resource-set-pgpu.sh GPU-28eca022-0c66-97c1-a527-17e900626924 -type pgpu
   Successfully update GPU GPU-28eca022-0c66-97c1-a527-17e900626924 to pgpu
   [sky150 /etc/cube/cos/gpu]#
   ```
5. Verify `config.json` is updated
   ```bash
   [sky150 /etc/cube/cos/gpu]# cat config.json
   [{"id":"GPU-28eca022-0c66-97c1-a527-17e900626924","type":"pgpu","profiles":null}]
   [sky150 /etc/cube/cos/gpu]#
   ```

#### Additional documentation

None
