### PR TITLE
chore: update heavyfs ruby version

### DIFF
--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -138,7 +138,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) dnf -y install $(ERLANG)
 
 # ruby-3.1.2-141.module_el9+156+2e0939d1 has no i686 and conflicts with ruby-3.0.4-161.el9.i686.rpm
-RUBY := ruby-3.0.4-161.el9
+RUBY := ruby-3.0.7-166.el9
 LOCKED_DNF += $(RUBY)
 
 OPENSSL_VER := 3.5.1-6.el9

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -3,7 +3,7 @@
 
 # Unknown system variable 'innodb_version' since MariaDB 10.10
 # ROOTFS_DNF += mariadb-server mariadb-server-galera rsync
-MARIADB_VER := 10.5.27-1.el9_5.0.2
+MARIADB_VER := 10.5.29-3.el9_7
 # rpmfind.net is often not responsive
 # MARIADB_URL := https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages
 MARIADB_URL := https://ftp.icm.edu.pl/packages/linux-rocky/9/devel/x86_64/os/Packages/m


### PR DESCRIPTION
#### What type of PR is this?

Chore

#### What this PR does / why we need it

Update heavyfs Ruby version from `ruby-3.0.4-161.el9` to `ruby-3.0.4-161.el9.x86_64`.

#### Which issue(s) this PR fixes

None

#### Special notes for your reviewer

[This Jenkins job](https://10.32.200.10/job/centos9_cubecos_steven_200.13/9/execution/node/85/log/) failed with message "Error: No package ruby-3.0.4-161.el9 available":

<img width="748" height="251" alt="{17C64162-FC2B-4E44-A5A9-C845C5BA0FA0}" src="https://github.com/user-attachments/assets/981f94e4-cf0e-4dc7-9fb5-cb736f59f1f6" />

I'm not sure which version is the best alternative, but I found `ruby-3.0.4-161.el9.x86_64.rpm` [here](https://pkgs.org/download/ruby) and it looks good? 🤔 

#### Additional documentation

None
