### PR TITLE
feat: add `supportTypes` and `profileCountLimit` to gpu_device_list function

### DIFF
--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -238,6 +238,20 @@ fbc_sess=%s,fbc_fps=%s,fbc_latency=%s\n" \
     done
 }
 
+# Returns a stringified JSON array conforming to the following schema:
+# {
+#   id: string
+#   name: string
+#   type: "unset" | "pgpu" | "sriovVgpu" | "migBackedVgpu"
+#   supportTypes: ("pgpu" | "sriovVgpu" | "migBackedVgpu")[]
+#   pciAddress: string
+#   profileCountLimit: number | null
+#   status: "unassigned" | "idle" | "inUse"
+#   allocation: {
+#     current: number
+#     total: number
+#   }
+# }[]
 gpu_device_list()
 {
     local gpu_config="[]"
@@ -267,6 +281,20 @@ gpu_device_list()
         name=$(echo "$name" | xargs)
         pci_bus_id=$(echo "$pci_bus_id" | xargs)
 
+        local vgpu_support_out
+        vgpu_support_out=$($NVIDIA_SMI vgpu -s -i "$pci_bus_id" 2>/dev/null)
+
+        local support_types='["pgpu"]'
+        if echo "$vgpu_support_out" | grep -q "vGPU Type ID"; then
+            support_types=$(echo "$support_types" | jq -c '. + ["sriovVgpu"]')
+        fi
+
+        local mig_mode_out
+        mig_mode_out=$($NVIDIA_SMI -i "$pci_bus_id" --query-gpu=mig.mode.current --format=csv,noheader,nounits 2>/dev/null | xargs)
+        if [ "$mig_mode_out" = "Enabled" ] || [ "$mig_mode" = "Disabled" ]; then
+            support_types=$(echo "$support_types" | jq -c '. + ["migBackedVgpu"]')
+        fi
+
         local gpu_type
         gpu_type=$(echo "$gpu_config" | jq -r --arg id "$uuid" \
             'map(select(.id == $id)) | if length > 0 then .[0].type else "" end')
@@ -274,12 +302,14 @@ gpu_device_list()
         if [ -z "$gpu_type" ] || [ "$gpu_type" = "null" ]; then
             output=$(echo "$output" | jq -c \
                 --arg id "$uuid" --arg name "$name" --arg pciAddress "$pci_bus_id" \
-                '. + [{id:$id, name:$name, type:"unset", pciAddress:$pciAddress, status:"unassigned", allocation:null}]')
+                --argjson supportTypes "$support_types" \
+                '. + [{id:$id, name:$name, type:"unset", supportTypes:$supportTypes, pciAddress:$pciAddress, profileCountLimit:null, status:"unassigned", allocation:null}]')
             continue
         fi
 
         local status="idle"
         local allocation
+        local profile_count_limit="null"
 
         if [ "$gpu_type" = "pgpu" ]; then
             local pci_bus pci_slot
@@ -319,16 +349,38 @@ gpu_device_list()
 
             allocation=$(jq -c -n --argjson c "$current" --argjson t "$total" \
                 '{current:$c, total:$t}')
+
+            if [ "$gpu_type" = "sriovVgpu" ]; then
+                local pci_sysfs
+                pci_sysfs=$(echo "$pci_bus_id" | tr '[:upper:]' '[:lower:]' | cut -c5-)
+                local totalvfs
+                totalvfs=$(cat "/sys/bus/pci/devices/${pci_sysfs}/sriov_totalvfs" 2>/dev/null | tr -d '[:space:]')
+                if echo "$totalvfs" | grep -qE '^[0-9]+$'; then
+                    profile_count_limit="$totalvfs"
+                fi
+            elif [ "$gpu_type" = "migBackedVgpu" ]; then
+                local mig_max
+                mig_max=$($NVIDIA_SMI mig -lgip -i "$pci_bus_id" 2>/dev/null | \
+                    grep -E '\|\s+[0-9]+\s+MIG\s+[0-9]+g\.' | \
+                    awk '{gsub(/\|/, ""); print $5}' | \
+                    sort -n | tail -1)
+                if echo "$mig_max" | grep -qE '^[0-9]+$'; then
+                    profile_count_limit="$mig_max"
+                fi
+            fi
+
         fi
 
         output=$(echo "$output" | jq -c \
             --arg id "$uuid" \
             --arg name "$name" \
             --arg type "$gpu_type" \
+            --argjson supportTypes "$support_types" \
             --arg pciAddress "$pci_bus_id" \
+            --argjson profileCountLimit "$profile_count_limit" \
             --arg status "$status" \
             --argjson allocation "$allocation" \
-            '. + [{id:$id, name:$name, type:$type, pciAddress:$pciAddress, status:$status, allocation:$allocation}]')
+            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, profileCountLimit:$profileCountLimit,, status:$status, allocation:$allocation}]')
     done <<< "$gpu_csv"
 
     echo "$output"

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -282,16 +282,19 @@ gpu_device_list()
         pci_bus_id=$(echo "$pci_bus_id" | xargs)
 
         local vgpu_support_out
-        vgpu_support_out=$($NVIDIA_SMI vgpu -s -i "$pci_bus_id" 2>/dev/null)
+        vgpu_support_out=$($NVIDIA_SMI vgpu -s -v -i "$pci_bus_id" 2>/dev/null)
+
+        local profile_names
+        profile_names=$(echo "$vgpu_support_out" | grep "Name" | awk '{print $NF}')
 
         local support_types='["pgpu"]'
-        if echo "$vgpu_support_out" | grep -q "vGPU Type ID"; then
+        # SR-IOV profiles are named "<board> XX-YY" (e.g. "... DC-2B" and "DC-12Q")
+        if echo "$profile_names" | grep -qE '^[A-Za-z]+-[0-9]+[A-Za-z]+$'; then
             support_types=$(echo "$support_types" | jq -c '. + ["sriovVgpu"]')
         fi
 
-        local mig_mode_out
-        mig_mode_out=$($NVIDIA_SMI -i "$pci_bus_id" --query-gpu=mig.mode.current --format=csv,noheader,nounits 2>/dev/null | xargs)
-        if [ "$mig_mode_out" = "Enabled" ] || [ "$mig_mode" = "Disabled" ]; then
+        # MIG-backed profiles are named "<board> XX-YY-ZZ" (e.g. "... DC-1-2Q" and "DC-4-96A")
+        if echo "$profile_names" | grep -qE '^[A-Za-z]+-[0-9]+-[0-9]+[A-Za-z]+$'; then
             support_types=$(echo "$support_types" | jq -c '. + ["migBackedVgpu"]')
         fi
 
@@ -359,13 +362,18 @@ gpu_device_list()
                     profile_count_limit="$totalvfs"
                 fi
             elif [ "$gpu_type" = "migBackedVgpu" ]; then
-                local mig_max
-                mig_max=$($NVIDIA_SMI mig -lgip -i "$pci_bus_id" 2>/dev/null | \
+                local total_fb_memory_mib
+                total_fb_memory_mib=$($NVIDIA_SMI -i "$pci_bus_id" --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | xargs)
+
+                local min_slice_gib
+                min_slice_gib=$($NVIDIA_SMI mig -lgip -i "$pci_bus_id" 2>/dev/null | \
                     grep -E '\|\s+[0-9]+\s+MIG\s+[0-9]+g\.' | \
-                    awk '{gsub(/\|/, ""); print $5}' | \
-                    sort -n | tail -1)
-                if echo "$mig_max" | grep -qE '^[0-9]+$'; then
-                    profile_count_limit="$mig_max"
+                    awk '{gsub(/\|/, ""); print $6}' | \
+                    sort -n | head -1)
+
+                if echo "$total_fb_memory_mib" | grep -qE '^[0-9]+$' && echo "$min_slice_gib" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
+                    # Number of total VRAM divided by the smallest MIG GPU instance VRAM size.
+                    profile_count_limit=$(awk -v total="$total_fb_memory_mib" -v slice="$min_slice_gib" 'BEGIN{printf "%d", total / (slice * 1024)}')
                 fi
             fi
 
@@ -380,7 +388,7 @@ gpu_device_list()
             --argjson profileCountLimit "$profile_count_limit" \
             --arg status "$status" \
             --argjson allocation "$allocation" \
-            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, profileCountLimit:$profileCountLimit,, status:$status, allocation:$allocation}]')
+            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, profileCountLimit:$profileCountLimit, status:$status, allocation:$allocation}]')
     done <<< "$gpu_csv"
 
     echo "$output"


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Add the following two fields to the output of `gpu_device_list` function:

1. `supportTypes: ("pgpu" | "sriovVgpu" | "migBackedVgpu")[]`
   <img width="1142" height="770" alt="image" src="https://github.com/user-attachments/assets/798bf946-0480-4c4f-b59d-7c3fa005a9c5" />
2. `profileCountLimit: number | null`
   The value will be `null` if the GPU is either in `unassigned` status or does not support vGPU.
   <img width="1086" height="1068" alt="image" src="https://github.com/user-attachments/assets/b185383e-30be-4439-98e3-fb1f617bab91" />

#### Which issue(s) this PR fixes

We need this for #818

#### Special notes for your reviewer

Try it out with dedicated `.sh` file on 150.1:

```bash
[sky150 ~]# sh 860-list-gpu-resources.sh gpu_device_list
[{"id":"GPU-28eca022-0c66-97c1-a527-17e900626924","name":"NVIDIA RTX A2000","type":"unset","supportTypes":["pgpu"],"pciAddress":"00000000:86:00.0","profileCountLimit":null,"status":"unassigned","allocation":null}]
[sky150 ~]#
```

#### Additional documentation

None