### PR TITLE
fix(ui): hardcoded logo image paths in login template

### DIFF
--- a/core/horizon/theme/templates/auth/login.html
+++ b/core/horizon/theme/templates/auth/login.html
@@ -1,4 +1,4 @@
-{% load i18n branding %}
+{% load i18n branding static %}
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" class="login-cube">
   <head>
@@ -13,13 +13,13 @@
   </head>
   <body id="splash" ng-app='horizon.app' class="login-cube">
     <a href="http://www.bigstack.co/" id="bigstack">
-      <img src="../../static/themes/cube/images/bigstack-logo.png" alt="Bigstack" />
+      <img src="{% static 'themes/cube/images/bigstack-logo.png' %}" alt="Bigstack Logo" />
     </a>
     <div class="container">
       <div class="row-fluid">
         <div class="span12">
           <div id="brand">
-            <img src="../../static/themes/cube/images/cube-logo.png" width="250" height="83" style="margin:0" fetchpriority="high" >
+            <img src="{% static 'themes/cube/images/cube-logo.png' %}" width="250" height="83" style="margin:0" fetchpriority="high" >
           </div><!--/#brand-->
         </div><!--/.span*-->
         {% include 'auth/_login.html' %}


### PR DESCRIPTION
Supersede #961 UI/UX: Hardcoded Logo Image Paths in Login Template

## Summary

UI/UX: Hardcoded Logo Image Paths in Login Template

## Problem

**Severity**: `Medium` | **File**: `core/horizon/theme/templates/auth/login.html:L15`

The login.html template contains hardcoded relative paths for logo images (../../static/themes/cube/images/bigstack-logo.png and cube-logo.png). This creates maintenance issues and potential 404 errors if the URL structure changes. Additionally, the alt text for the Bigstack logo is not descriptive enough for accessibility.

## Solution

Use Django's static template tag ({% static 'path/to/image.png' %}) instead of hardcoded relative paths. Improve alt text to be more descriptive of the company/product.

## Changes

- `core/horizon/theme/templates/auth/login.html` (modified)