### PR TITLE
docs(issue-templates): require cubecos handbook knowledge update as an output artifact

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -52,3 +52,11 @@ Insert content here.
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -35,3 +35,11 @@ Insert content here.
 1. **Use Case 1:** description
 2. **Use Case 2:** description
 3. **Use Case 3:** description
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -41,3 +41,11 @@ Insert content here.
 > Links to design prototypes or wireframes (if applicable).
 
 None
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -26,3 +26,11 @@ TBD
 > Summarize the findings and the conclusion drawn from the investigation.
 
 TBD
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -24,3 +24,11 @@ Insert content here.
 
 ## Notes (Optional)
 Insert content here.
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -30,3 +30,11 @@ As a **[type of user]**, I want **[some goal]** so that **[some reason]**.
 >| 3 | Medium | Moderate workload; requires some focus, but risks are well-managed.
 >| 5 | High | High complexity; difficult to implement, requiring significant time and effort.
 >| 8 | Very High | Extreme complexity or high uncertainty. If possible, this should be divided into multiple user stories.
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).


### PR DESCRIPTION
## What

Adds an **Output artifacts (Definition of Done)** block to the six work-item issue templates — `epic`, `user-story`, `feature`, `task`, `spike`, `bug` — so every new issue created from a template carries a **handbook knowledge-update deliverable** alongside the usual code, docs, and config changes.

The added block (as a trackable checkbox):

```markdown
## Output artifacts (Definition of Done)

> Beyond code, docs, and config changes, completing this issue must also deliver:

- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
```

## Why

We've started treating "update the cubecos handbook" as a real deliverable on epics/stories (e.g. #935, #960, #881). Baking it into the templates persists that expectation for **all** future issues instead of hand-appending it each time.

## Scope / notes

- Touches only `.github/ISSUE_TEMPLATE/*.md` for the six work-item types. Legacy/duplicate templates (`bug_report`, `feature_request`, `custom`) are intentionally left out.
- **Convention, not enforcement:** templates pre-fill new issues but the section can be deleted, and issues opened via raw API/`gh`/bots won't get it. If we want a hard guarantee, a follow-up `issues.opened` GitHub Action could auto-append it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)