### PR TITLE
build(make): stop redundant rebuilds and clean up build output

### DIFF
--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -56,6 +56,9 @@ $(RPMBUILD_RPMS): $(RPMBUILD_SOURCES) build_number
 	$(call RUN_CMD_TIMED, \
 		rpmbuild -bb --nodeps --define "_topdir $(CURDIR)/$(RPMBUILD_DIR)" --define "version `cat version`" --define "build_number `cat build_number`" $(RPMBUILD_DIR)/SPECS/$(PKG_NAME).spec,\
 		"  BUILD   $(PKG_NAME)-`cat version`-1.el9.`cat build_number`.x86_64.rpm")
+	# rpmbuild writes into RPMS/x86_64/, so RPMS's own mtime never advances and it
+	# is remade every run; touch advances it (as SOURCES does above).
+	$(Q)touch $@
 
 # move the built rpm back to the local directory
 $(API_RPM): $(RPMBUILD_RPMS)

--- a/core/docker/Makefile
+++ b/core/docker/Makefile
@@ -31,7 +31,7 @@ run-registry: $(REGISTRY_TAR)
 
 .PHONY: rm-registry
 rm-registry:
-	$(Q)podman rm -ivf registry >/dev/null
+	$(Q)podman rm -ivf registry $(QEND)
 
 .PHONY .IGNORE: push-image
 push-image:

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -200,6 +200,11 @@ include $(shell for m in $(HEAVY_COMPONENTS); do ls $(COREDIR)/$$m/$$m.mk; done)
 $(shell for r in $(LOCKED_DNF); do echo $$r >> $(LOCKED_RPMS); done)
 $(shell for r in $(BLKLST_DNF); do echo $$r >> $(BLKLST_RPMS); done)
 
+# Component artifacts baked into the rootfs — prereqs so a component rebuild
+# forces a rootfs rebuild (with touch $@ below). Scoped to HEAVY_COMPONENTS, not
+# core/main (circular). Not covered: remote dnf/pip + bare-binary/dir deliverables.
+HEAVY_DELIVERABLES := $(wildcard $(foreach m,$(HEAVY_COMPONENTS),$(TOP_BLDDIR)/core/$(m)/*.rpm $(TOP_BLDDIR)/core/$(m)/*.tgz))
+
 ifneq ($(RC),)
 heavyfs_install::
 	$(Q)cp -f /etc/resolv.conf $(HEAVYFS)/etc/resolv.conf
@@ -219,12 +224,17 @@ rootfs.cgz:
 	$(Q)umount pkg
 	$(Q)rmdir pkg
 
-$(HEAVYFS): rootfs.cgz $(shell for m in $(HEAVY_COMPONENTS); do find $(COREDIR)/$$m -type f -name '*.mk' -o -name Makefile; done)
+$(HEAVYFS): rootfs.cgz $(HEAVY_DELIVERABLES) $(shell for m in $(HEAVY_COMPONENTS); do find $(COREDIR)/$$m -type f -name '*.mk' -o -name Makefile; done)
 	$(call RUN_CMD_TIMED, $(SHELL) $(HEX_SCRIPTSDIR)/mountrootfs -s -D '$(MAKECMD) ROOTDIR=@ROOTDIR@ PROJ_BUILD_LABEL="heavyfs" heavyfs_install' $< $@, "  GEN     $@")
 	$(Q)cp -f /etc/resolv.conf $@/etc/resolv.conf
+	# mountrootfs leaves the dir's mtime frozen from the base rootfs; touch so it
+	# isn't rebuilt every run.
+	$(Q)touch $@
 else
-$(HEAVYFS): $(HEX_FULL_ROOTFS) $(shell for m in $(HEAVY_COMPONENTS); do find $(COREDIR)/$$m -type f -name '*.mk' -o -name Makefile; done)
+$(HEAVYFS): $(HEX_FULL_ROOTFS) $(HEAVY_DELIVERABLES) $(shell for m in $(HEAVY_COMPONENTS); do find $(COREDIR)/$$m -type f -name '*.mk' -o -name Makefile; done)
 	$(call RUN_CMD_TIMED, $(SHELL) $(HEX_SCRIPTSDIR)/mountrootfs -s -D '$(MAKECMD) ROOTFS_DNF_NOARCH_P1="$(ROOTFS_DNF_NOARCH_P1)" ROOTFS_DNF_DL_FROM="$(ROOTFS_DNF_DL_FROM)" ROOTFS_DNF="$(addsuffix .x86_64,$(ROOTFS_DNF)) $(ROOTFS_DNF_NOARCH)" ROOTFS_PIP="$(ROOTFS_PIP)" ROOTFS_PIP_NC="$(ROOTFS_PIP_NC)" ROOTFS_PIP_DL_FROM="$(ROOTFS_PIP_DL_FROM)" ROOTDIR=@ROOTDIR@ PROJ_BUILD_LABEL="heavyfs" rootfs_install' $< $@, "  GEN     $@")
+	# touch: advance frozen dir mtime (see above).
+	$(Q)touch $@
 endif
 
 rootfs_install::

--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -75,6 +75,8 @@ $(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
 	$(Q)mkdir -p $(RPMBUILD_DIR)/SOURCES
 	$(Q)mv $@.tgz $(RPMBUILD_DIR)/SOURCES/$(PKG_NAME)-`cat version`.tar.gz
 	$(Q)rm -r ./source
+	# touch so SOURCES's mtime advances; else remade every run into RPMS/login.rpm.
+	$(Q)touch $@
 
 # build the login rpm package
 $(RPMBUILD_RPMS): $(RPMBUILD_SOURCES) build_number keycloak_version
@@ -82,7 +84,7 @@ $(RPMBUILD_RPMS): $(RPMBUILD_SOURCES) build_number keycloak_version
 	$(Q)mkdir -p $(RPMBUILD_DIR)/RPMS/x86_64
 	$(Q)# enable nvm
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
-	$(call RUN_CMD_SILENT, \
+	$(call RUN_CMD_TIMED, \
 		cd $(GIT_DIR) && \
 		nvm use $(QEND) && \
 		cd - && \

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -220,10 +220,11 @@ hex_cli_LIBS += $(PROJ_LIBDIR)/libcube_sdk.a
 
 PROGRAMS += hex_cli
 
-hex_crashd_SRCS = $(HEX_TOPDIR)/src/hex_crashd/crash_main.c
-hex_crashd_LIBS = $(HEX_SDK_LIB)
-hex_crashd_LDLIBS = $(HEX_SDK_LDLIBS)
-PROGRAMS += hex_crashd
+# NOTE: do not relist hex_crashd here. The hex submodule already builds it
+# (hex/src/Makefile: SUBDIRS += hex_crashd) with the same HEX_SDK libs and
+# installs it via hex_crashd.mk (included by hex_sdk.mk). Relisting it with an
+# absolute _SRCS path built it a second time AND, because OBJS = SRCS-with-.o,
+# wrote crash_main.o/.d into hex/src/hex_crashd (source-tree pollution).
 
 # Install hex command post scripts
 $(call PROJ_INSTALL_SCRIPT,,$(SRCDIR)/post-scripts/hex_translate/translate.post.sh,./etc/hex_translate/post.d/)

--- a/core/prometheus/Makefile
+++ b/core/prometheus/Makefile
@@ -24,6 +24,9 @@ $(PROM_TOOL): $(PROM_SRC)
         make build,"  BUILD   $(PROM_BIN)")
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
+	# Binaries build into $(PROM_SRC)/, so target 'promtool' is never created and
+	# make reruns this every time; touch a stamp (rootfs_install uses the real ones).
+	$(Q)touch $@
 
 BUILD += $(PROM_TOOL)
 BUILDCLEAN += $(PROM_TOOL) $(PROM_SRC)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Several build targets were remade on **every** `make` run even with no changes, because their recipes never advanced the target's own mtime (make is purely mtime-based and keeps no "already built" memory). This wasted a lot of time — `heavy_rootfs` alone is ~37 min per rebuild — and two cosmetic issues cluttered the output.

Fixes, all in the same family (make the recipe leave a `$@` whose mtime beats its prereqs):

| File | Fix |
|---|---|
| `core/heavyfs/Makefile` | `touch heavy_rootfs` (mountrootfs leaves its dir mtime frozen from the base rootfs) + declare component deliverables as prereqs so the now-incremental rule still rebuilds on a real component change (no stale image) |
| `core/api/Makefile` | `touch rpmbuild/RPMS` (rpmbuild writes into `RPMS/x86_64/`, never bumping the top-level dir mtime) |
| `core/prometheus/Makefile` | `touch` a `promtool` stamp (binaries build into `prometheus-source/`, so the target file was never created) |
| `core/keycloak/Makefile` | `touch rpmbuild/SOURCES` (was missing the `touch` the api rule has) + time the `cube-cos-login` build (`RUN_CMD_SILENT` → `RUN_CMD_TIMED`) |
| `core/docker/Makefile` | silence the podman cgroups-v1 warning leaking from `rm-registry` (`>/dev/null` → `$(QEND)`) |

Each fix was validated with `make -d` / dry-runs: the target goes quiet on a no-change rebuild and still rebuilds when a real input changes.

Plus one fix in the broader "redundant build / clean up output" theme but with a **different root cause** (a redundant *duplicate* build that also pollutes the source tree):

| File | Fix |
|---|---|
| `core/main/cube.mk` | Drop the redundant `hex_crashd` relist. The hex submodule already builds `hex_crashd` (`hex/src/Makefile: SUBDIRS += hex_crashd`) with the same `HEX_SDK` libs and installs it via `hex_crashd.mk` (included by `hex_sdk.mk`), so `cube.mk` built it a **second time** every run. Worse, it referenced an absolute `_SRCS` path (`$(HEX_TOPDIR)/src/hex_crashd/crash_main.c`); since the framework derives `OBJS` as `SRCS`-with-`.o`, the `%.o:%.c` rule wrote `crash_main.o`/`.d` **into `hex/src/hex_crashd`** (the submodule source tree) instead of the out-of-tree build dir. After removal, `hex_crashd` is still built (out-of-tree) and installed unchanged. |

#### Which issue(s) this PR fixes

Fixes #1005

#### Special notes for your reviewer

- All commits are GPG-signed and DCO signed-off.
- The `core/main/cube.mk` `hex_crashd` removal is safe: verified the cube build descends into the hex submodule (`Makefile: SUBDIRS += hex` -> `make -C hex` -> `src/` SUBDIRS) which builds `hex_crashd`, and `hex_crashd.mk` (via `hex_sdk.mk`) installs `$(HEX_BINDIR)/hex_crashd` into `./usr/sbin`. No functional change -- only the duplicate in-tree build is gone.
- The `heavy_rootfs` `touch` deliberately pairs with the new `HEAVY_DELIVERABLES` prerequisites — `touch` alone would make incremental builds fast but able to ship a stale rootfs; the deliverable deps restore correctness. Remote dnf/pip packages and bare-binary/dir deliverables remain outside make's incrementality (documented inline).
- A separate, related fix for the non-idempotent `%prep` in the `cube-cos-api` repo will be sent as its own PR there (different repo).

#### Additional documentation

```docs

```

