### PR TITLE
build(make): make rpm components rebuild incrementally

### DIFF
--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -27,11 +27,11 @@ $(GIT_DIR):
 		"  CLONE   $(GITHUB_URL)")
 
 version: $(GIT_DIR)
-	$(Q)head -n 1 $(GIT_DIR)/VERSION >> version
+	$(Q)head -n 1 $(GIT_DIR)/VERSION > version
 
 build_number: $(GIT_DIR)
 	$(Q)cd $(GIT_DIR) && \
-		git rev-parse --short HEAD >> ../build_number
+		git rev-parse --short HEAD > ../build_number
 
 # prepare the rpm build directory
 $(RPMBUILD_DIR):
@@ -39,7 +39,9 @@ $(RPMBUILD_DIR):
 	$(Q)cd $(RPMBUILD_DIR) && mkdir BUILD SRPMS SPECS
 
 # make the source tarball
-$(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
+# RPMBUILD_DIR is order-only (|): the rule writes rpmbuild/SOURCES.tgz into it,
+# bumping the dir's mtime every build, which would otherwise rebuild SOURCES forever.
+$(RPMBUILD_SOURCES): $(GIT_DIR) version | $(RPMBUILD_DIR)
 	$(Q)mkdir ./source
 	$(Q)cp -r $(GIT_DIR)/.git/ ./source/
 	$(Q)cd ./source && git checkout . $(QEND)
@@ -56,8 +58,6 @@ $(RPMBUILD_RPMS): $(RPMBUILD_SOURCES) build_number
 	$(call RUN_CMD_TIMED, \
 		rpmbuild -bb --nodeps --define "_topdir $(CURDIR)/$(RPMBUILD_DIR)" --define "version `cat version`" --define "build_number `cat build_number`" $(RPMBUILD_DIR)/SPECS/$(PKG_NAME).spec,\
 		"  BUILD   $(PKG_NAME)-`cat version`-1.el9.`cat build_number`.x86_64.rpm")
-	# rpmbuild writes into RPMS/x86_64/, so RPMS's own mtime never advances and it
-	# is remade every run; touch advances it (as SOURCES does above).
 	$(Q)touch $@
 
 # move the built rpm back to the local directory

--- a/core/appctl/Makefile
+++ b/core/appctl/Makefile
@@ -28,11 +28,11 @@ $(GIT_DIR):
 	$(Q)cd $@ && git lfs pull
 
 version: $(GIT_DIR)
-	$(Q)head -n 1 $(GIT_DIR)/VERSION >> version
+	$(Q)head -n 1 $(GIT_DIR)/VERSION > version
 
 build_number: $(GIT_DIR)
 	$(Q)cd $(GIT_DIR) && \
-		git rev-parse --short HEAD >> ../build_number
+		git rev-parse --short HEAD > ../build_number
 
 # prepare the rpm build directory
 $(RPMBUILD_DIR):
@@ -40,7 +40,8 @@ $(RPMBUILD_DIR):
 	$(Q)cd $(RPMBUILD_DIR) && mkdir BUILD SRPMS SPECS
 
 # make the source tarball
-$(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
+# RPMBUILD_DIR order-only: rule writes rpmbuild/SOURCES.tgz into it (bumps dir mtime).
+$(RPMBUILD_SOURCES): $(GIT_DIR) version | $(RPMBUILD_DIR)
 	$(Q)mkdir ./source
 	$(Q)cp -r $(GIT_DIR)/.git/ ./source/
 	$(Q)cd ./source && git checkout . $(QEND)

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -227,13 +227,10 @@ rootfs.cgz:
 $(HEAVYFS): rootfs.cgz $(HEAVY_DELIVERABLES) $(shell for m in $(HEAVY_COMPONENTS); do find $(COREDIR)/$$m -type f -name '*.mk' -o -name Makefile; done)
 	$(call RUN_CMD_TIMED, $(SHELL) $(HEX_SCRIPTSDIR)/mountrootfs -s -D '$(MAKECMD) ROOTDIR=@ROOTDIR@ PROJ_BUILD_LABEL="heavyfs" heavyfs_install' $< $@, "  GEN     $@")
 	$(Q)cp -f /etc/resolv.conf $@/etc/resolv.conf
-	# mountrootfs leaves the dir's mtime frozen from the base rootfs; touch so it
-	# isn't rebuilt every run.
 	$(Q)touch $@
 else
 $(HEAVYFS): $(HEX_FULL_ROOTFS) $(HEAVY_DELIVERABLES) $(shell for m in $(HEAVY_COMPONENTS); do find $(COREDIR)/$$m -type f -name '*.mk' -o -name Makefile; done)
 	$(call RUN_CMD_TIMED, $(SHELL) $(HEX_SCRIPTSDIR)/mountrootfs -s -D '$(MAKECMD) ROOTFS_DNF_NOARCH_P1="$(ROOTFS_DNF_NOARCH_P1)" ROOTFS_DNF_DL_FROM="$(ROOTFS_DNF_DL_FROM)" ROOTFS_DNF="$(addsuffix .x86_64,$(ROOTFS_DNF)) $(ROOTFS_DNF_NOARCH)" ROOTFS_PIP="$(ROOTFS_PIP)" ROOTFS_PIP_NC="$(ROOTFS_PIP_NC)" ROOTFS_PIP_DL_FROM="$(ROOTFS_PIP_DL_FROM)" ROOTDIR=@ROOTDIR@ PROJ_BUILD_LABEL="heavyfs" rootfs_install' $< $@, "  GEN     $@")
-	# touch: advance frozen dir mtime (see above).
 	$(Q)touch $@
 endif
 

--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -48,17 +48,17 @@ version: $(GIT_DIR)
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(Q)cd $(GIT_DIR) && \
 		nvm use $(QEND) && \
-		node -p "require('./packages/cube-frontend-keycloak-login/package.json').version" >> ../version
+		node -p "require('./packages/cube-frontend-keycloak-login/package.json').version" > ../version
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
 
 build_number: $(GIT_DIR)
 	$(Q)cd $(GIT_DIR) && \
-		git rev-parse --short HEAD >> ../build_number
+		git rev-parse --short HEAD > ../build_number
 
 keycloak_version: $(GIT_DIR)
 	$(Q)cd $(GIT_DIR) && \
-		head -n 1 ./packages/cube-frontend-keycloak-login/KEYCLOAK_VERSION >> ../keycloak_version
+		head -n 1 ./packages/cube-frontend-keycloak-login/KEYCLOAK_VERSION > ../keycloak_version
 
 # prepare the rpm build directory
 $(RPMBUILD_DIR):
@@ -66,7 +66,8 @@ $(RPMBUILD_DIR):
 	$(Q)cd $(RPMBUILD_DIR) && mkdir BUILD SRPMS SPECS
 
 # make the source tarball
-$(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
+# RPMBUILD_DIR order-only: rule writes rpmbuild/SOURCES.tgz into it (bumps dir mtime).
+$(RPMBUILD_SOURCES): $(GIT_DIR) version | $(RPMBUILD_DIR)
 	$(Q)mkdir ./source
 	$(Q)cp -r $(GIT_DIR)/.git/ ./source/
 	$(Q)cd ./source && git checkout . $(QEND)
@@ -75,7 +76,6 @@ $(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
 	$(Q)mkdir -p $(RPMBUILD_DIR)/SOURCES
 	$(Q)mv $@.tgz $(RPMBUILD_DIR)/SOURCES/$(PKG_NAME)-`cat version`.tar.gz
 	$(Q)rm -r ./source
-	# touch so SOURCES's mtime advances; else remade every run into RPMS/login.rpm.
 	$(Q)touch $@
 
 # build the login rpm package

--- a/core/prometheus/Makefile
+++ b/core/prometheus/Makefile
@@ -24,8 +24,6 @@ $(PROM_TOOL): $(PROM_SRC)
         make build,"  BUILD   $(PROM_BIN)")
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
-	# Binaries build into $(PROM_SRC)/, so target 'promtool' is never created and
-	# make reruns this every time; touch a stamp (rootfs_install uses the real ones).
 	$(Q)touch $@
 
 BUILD += $(PROM_TOOL)

--- a/core/ui/Makefile
+++ b/core/ui/Makefile
@@ -37,13 +37,13 @@ version: $(GIT_DIR)
 	$(Q)sed -i 's/^#//g' $$BASH_ENV
 	$(Q)cd $(GIT_DIR) && \
 		nvm use $(QEND) && \
-		node -p "require('./packages/cube-frontend-web-app/package.json').version" >> ../version
+		node -p "require('./packages/cube-frontend-web-app/package.json').version" > ../version
 	$(Q)# disable nvm
 	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
 
 build_number: $(GIT_DIR)
 	$(Q)cd $(GIT_DIR) && \
-		git rev-parse --short HEAD >> ../build_number
+		git rev-parse --short HEAD > ../build_number
 
 # prepare the rpm build directory
 $(RPMBUILD_DIR):
@@ -51,7 +51,8 @@ $(RPMBUILD_DIR):
 	$(Q)cd $(RPMBUILD_DIR) && mkdir BUILD SRPMS SPECS
 
 # make the source tarball
-$(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
+# RPMBUILD_DIR order-only: rule writes rpmbuild/SOURCES.tgz into it (bumps dir mtime).
+$(RPMBUILD_SOURCES): $(GIT_DIR) version | $(RPMBUILD_DIR)
 	$(Q)mkdir ./source
 	$(Q)cp -r $(GIT_DIR)/.git/ ./source/
 	$(Q)cd ./source && git checkout . $(QEND)
@@ -60,6 +61,7 @@ $(RPMBUILD_SOURCES): $(RPMBUILD_DIR) $(GIT_DIR) version
 	$(Q)mkdir -p $(RPMBUILD_DIR)/SOURCES
 	$(Q)mv $@.tgz $(RPMBUILD_DIR)/SOURCES/$(PKG_NAME)-`cat version`.tar.gz
 	$(Q)rm -r ./source
+	$(Q)touch $@
 
 # build the ui rpm package
 $(RPMBUILD_RPMS): $(RPMBUILD_SOURCES) build_number


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order: review and merge bigstack-oss/hex#117 first.**
> This PR bumps the `hex` submodule to the `projppu` nohup -> `$(QEND)` fix commit.
> If hex#117 is squash-merged (changing the commit hash), re-point the submodule to
> the resulting `develop` commit before merging this PR.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Follow-up to #1006 — finishes making the build incremental. The "cgz / heavy_rootfs
rebuild every pass" had a deeper driver: the RPM components (api/ui/keycloak/appctl)
**always rebuilt** because their `SOURCES` rule writes `rpmbuild/SOURCES.tgz` **into**
the `rpmbuild` dir, bumping its mtime on every build — and `SOURCES` listed
`$(RPMBUILD_DIR)` as a normal (timestamp) prerequisite. So `SOURCES -> RPMS -> rpm ->
heavy_rootfs -> rootfs.cgz -> pkg -> initramfs/cgz` all re-ran with no source change.

Fix: make `$(RPMBUILD_DIR)` an **order-only** prerequisite (`target: realdeps | $(RPMBUILD_DIR)`).
Since `ui.rpm`/`api.rpm` are `heavy_rootfs` prerequisites, this is what finally lets
`heavy_rootfs` (and the whole tail) settle.

Also in these files:
- `version`/`build_number` written with `>` not `>>` (the `>>` doubled the file on a
  rebuild — e.g. `v3.1.0v3.1.0` — which then corrupted the rpm filename).
- ui/keycloak: `touch $@` on `SOURCES`.
- removed tab-indented recipe comments that `make` echoed into the build output.

**Submodule bump:** updates `hex` to the `projppu` nohup -> `$(QEND)` build-output
cleanup (bigstack-oss/hex#117) — see the merge-order note above.

#### Validation

`make centos9-jail enter` then `make pxe` twice. Pass 2 (no changes):
```
GEN  build.mk
LD   checkauth
LD   pamauth
BUILD shell image (0s)
```
No rpm / heavy_rootfs / rootfs.cgz / pkg / cgz rebuilds, no echoed comments, 0 source
artifacts, rc=0. (`checkauth`/`pamauth`/`build.mk` are one-time pass1->pass2 mtime
settling — a 3rd `make pxe` is fully silent.)

#### Which issue(s) this PR fixes

Refs #1005

#### Special notes for your reviewer

- The `hex_crashd` source-pollution fix already landed separately as `9d49838`.
