### PR TITLE
feat: 763 PCIe need to expand to maximum

### DIFF
--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -460,6 +460,7 @@ UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::s
         cfg["DEFAULT"]["state_path"] = "/var/lib/nova";
         cfg["DEFAULT"]["instances_path"] = "$state_path/instances";
         cfg["libvirt"]["hw_machine_type"] = hwType.c_str();
+        cfg["libvirt"]["num_pcie_ports"] = "28";
         cfg["libvirt"]["swtpm_enabled"] = "True";
         cfg["libvirt"]["ovmf_path"] = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd";
         cfg["libvirt"]["images_type"] = "rbd";


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it

Set default PCIe ports to 28.

#### Which issue(s) this PR fixes

Fixes #763

#### Special notes for your reviewer

Test Plan (Tested):
1. Now we  can attach 6 or more private networks to a virtual machine.
2. exec `lspci | grep -i "Root port" | wc -l ` and the output is `28`.

#### Additional documentation

Reference: https://docs.bigstack.co/docs/knowledge-base/cubecos/increase-pcie-ports-for-multiple-nic-support. 
