### PR TITLE
893 feat: hex_config gpu_resource_set functionality for passthrough mode

### DIFF
--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -1,14 +1,143 @@
 // CUBE SDK
 
+#include <cstring>
+#include <fstream>
+#include <sstream>
 #include <unistd.h>
 #include <hex/log.h>
 #include <hex/filesystem.h>
+#include <hex/process.h>
 #include <hex/process_util.h>
 #include <hex/config_module.h>
 #include <hex/dryrun.h>
+#include <third_party/json11.hpp>
 
 static const char GPU_CONFIG_DIR[]  = "/etc/cube/cos/gpu";
 static const char GPU_CONFIG_FILE[] = "/etc/cube/cos/gpu/config.json";
+
+// Looks up GPU gpuId via gpu_device_list, the single source of truth for
+// GPU id/name/type/pciAddress - it already unions live nvidia-smi data with
+// `config.json` entries, specifically for GPUs no longer visible to nvidia-smi
+// after bound to vfio-pci.
+// Returns json11::Json() (null) if the command fails or the GPU isn't found.
+static json11::Json
+FindGpuDevice(const char* gpuId)
+{
+    const std::string deviceListJson = HexUtilPOpen(HEX_SDK " gpu_device_list");
+
+    std::string jsonError;
+    const json11::Json deviceList = json11::Json::parse(deviceListJson, jsonError);
+
+    if (!jsonError.empty()) {
+        return json11::Json();
+    }
+
+    for (const json11::Json& entry : deviceList.array_items()) {
+        if (entry["id"].is_string() && entry["id"].string_value() == gpuId) {
+            return entry;
+        }
+    }
+
+    return json11::Json();
+}
+
+static void
+ResourceSetUsage(void)
+{
+    fprintf(stderr, "Usage: %s gpu_resource_set <gpu_id> <new_type> [profiles]\n", HexLogProgramName());
+}
+
+static int
+ResourceSetMain(int argc, char* argv[])
+{
+    /*
+     * [0]="gpu_resource_set", [1]=<gpu_id>, [2]=<new_type>, [3]=[profiles]
+     */
+    if (argc < 3 || argc > 4) {
+        HexLogError("gpu_resource_set: invalid number of arguments");
+        ResourceSetUsage();
+        return EXIT_FAILURE;
+    }
+
+    const char* gpuId   = argv[1];
+    const char* newType  = argv[2];
+    const char* profiles = (argc == 4) ? argv[3] : "";
+
+    if (strcmp(newType, "pgpu") != 0 &&
+        strcmp(newType, "sriovVgpu") != 0 &&
+        strcmp(newType, "migBackedVgpu") != 0) {
+        HexLogError("gpu_resource_set: invalid type '%s'. Must be one of: pgpu, sriovVgpu, migBackedVgpu", newType);
+        return EXIT_FAILURE;
+    }
+
+    if (strcmp(newType, "pgpu") == 0 && profiles[0] != '\0') {
+        HexLogError("gpu_resource_set: profiles is not allowed when new_type is pgpu");
+        return EXIT_FAILURE;
+    }
+
+    if (
+        (strcmp(newType, "sriovVgpu") == 0 || strcmp(newType, "migBackedVgpu") == 0) &&
+        profiles[0] == '\0'
+    ) {
+        HexLogError("gpu_resource_set: profiles is required when new_type is sriovVgpu or migBackedVgpu");
+        return EXIT_FAILURE;
+    }
+
+    if (access(GPU_CONFIG_FILE, F_OK) != 0) {
+        HexLogError("gpu_resource_set: GPU config file not found at %s", GPU_CONFIG_FILE);
+        return EXIT_FAILURE;
+    }
+
+    if (HexUtilSystemF(0, 0, HEX_SDK " gpu_resource_set_check %s %s %s", gpuId, newType, profiles) != 0) {
+        HexLogError("gpu_resource_set: pre-condition check failed for GPU %s", gpuId);
+        return EXIT_FAILURE;
+    }
+
+    // Existence already confirmed by gpu_resource_set_validate above; this
+    // is purely to fetch name/pciAddress for binding and persisting.
+    const json11::Json device = FindGpuDevice(gpuId);
+    if (!device.is_object()) {
+        HexLogError("gpu_resource_set: GPU %s not found", gpuId);
+        return EXIT_FAILURE;
+    }
+
+    const std::string name = device["name"].is_string() ? device["name"].string_value() : "";
+    const std::string pciAddress = device["pciAddress"].is_string() ? device["pciAddress"].string_value() : "";
+    if (name.empty() || pciAddress.empty()) {
+        HexLogError("gpu_resource_set: GPU %s is missing name/pciAddress in the config file", gpuId);
+        return EXIT_FAILURE;
+    }
+
+    if (HexUtilSystemF(0, 0, HEX_SDK " gpu_unset_current_type %s", gpuId) != 0) {
+        HexLogError("gpu_resource_set: failed to unset current type for GPU %s", gpuId);
+        return EXIT_FAILURE;
+    }
+
+    if (strcmp(newType, "pgpu") == 0) {
+        if (HexUtilSystemF(0, 0, HEX_SDK " gpu_bind_vfio_pci %s", pciAddress.c_str()) != 0) {
+            HexLogError("gpu_resource_set: failed to bind GPU %s to vfio-pci for passthrough", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        if (HexUtilSystemF(0, 0,
+                "tmp=$(mktemp) && jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" "
+                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"pgpu\", pciAddress:$pciAddress, profiles:null}]' %s > \"$tmp\" && mv \"$tmp\" %s",
+                gpuId, name.c_str(), pciAddress.c_str(), GPU_CONFIG_FILE, GPU_CONFIG_FILE) != 0) {
+            HexLogError("gpu_resource_set: failed to persist GPU %s config", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        HexLogInfo("gpu_resource_set: successfully updated GPU %s to pgpu", gpuId);
+        return EXIT_SUCCESS;
+    } else if (strcmp(newType, "sriovVgpu") == 0) {
+        // TODO
+    } else if (strcmp(newType, "migBackedVgpu") == 0) {
+        // TODO
+    }
+
+    HexLogError("gpu_resource_set: unhandled type %s", newType);
+    return EXIT_FAILURE;
+}
 
 static bool
 Commit(bool modified, int dryLevel)
@@ -24,7 +153,9 @@ Commit(bool modified, int dryLevel)
         /* Data in `config.json` is an array with the following data structure:
         {
           id: string
+          name: string
           type: 'pgpu' | 'sriovVgpu' | 'migBackedVgpu'
+          pciAddress: string
           profiles: {
             id: number
             count: number
@@ -33,6 +164,50 @@ Commit(bool modified, int dryLevel)
         }
         */
         HexUtilSystemF(0, 0, "echo '[]' > %s", GPU_CONFIG_FILE);
+        return true;
+    }
+
+    // Hardware driver bindings (e.g. vfio-pci passthrough) do not survive a
+    // reboot or an OS upgrade on their own, but Commit() runs on every boot
+    // (via bootstrap) and every settings commit, so re-apply persisted
+    // policy here rather than relying on static modprobe.d config.
+    std::ifstream configStream(GPU_CONFIG_FILE);
+    std::stringstream buffer;
+    buffer << configStream.rdbuf();
+
+    std::string jsonError;
+    const json11::Json gpuConfig = json11::Json::parse(buffer.str(), jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("Failed to parse GPU config file %s: %s", GPU_CONFIG_FILE, jsonError.c_str());
+        return false;
+    }
+
+    for (const json11::Json& entry : gpuConfig.array_items()) {
+        if (!entry["id"].is_string() || !entry["type"].is_string()) {
+            continue;
+        }
+
+        const std::string id = entry["id"].string_value();
+        const std::string type = entry["type"].string_value();
+
+        if (type == "pgpu") {
+            if (!entry["pciAddress"].is_string() || entry["pciAddress"].string_value().empty()) {
+                HexLogError("GPU %s has type pgpu but no recorded pciAddress; cannot re-apply binding", id.c_str());
+                return false;
+            }
+
+            const std::string pciAddress = entry["pciAddress"].string_value();
+
+            // Re-apply by PCI bus address, not by GPU UUID: once a GPU is
+            // bound to vfio-pci it is no longer enumerable by nvidia-smi,
+            // so a UUID-based lookup would fail here on every Commit() run
+            // after the first.
+            if (HexUtilSystemF(0, 0, HEX_SDK " gpu_bind_vfio_pci %s", pciAddress.c_str()) != 0) {
+                HexLogError("Failed to re-apply pgpu passthrough binding for GPU %s", id.c_str());
+                return false;
+            }
+        }
+        // TODO: re-apply sriovVgpu / migBackedVgpu once gpu_resource_set supports them.
     }
 
     return true;
@@ -41,3 +216,5 @@ Commit(bool modified, int dryLevel)
 CONFIG_MODULE(gpu, 0, 0, 0, 0, Commit);
 
 CONFIG_MIGRATE(gpu, GPU_CONFIG_DIR);
+
+CONFIG_COMMAND(gpu_resource_set, ResourceSetMain, ResourceSetUsage);

--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -10,6 +10,7 @@
 #include <hex/process_util.h>
 #include <hex/config_module.h>
 #include <hex/dryrun.h>
+#include <hex/tempfile.h>
 #include <third_party/json11.hpp>
 
 static const char GPU_CONFIG_DIR[]  = "/etc/cube/cos/gpu";
@@ -119,10 +120,22 @@ ResourceSetMain(int argc, char* argv[])
             return EXIT_FAILURE;
         }
 
+        HexTempFile tmpFile;
+        if (tmpFile.fd() < 0) {
+            HexLogError("gpu_resource_set: failed to create a temporary file");
+            return EXIT_FAILURE;
+        }
+        tmpFile.close();
+
         if (HexUtilSystemF(0, 0,
-                "tmp=$(mktemp) && jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" "
-                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"pgpu\", pciAddress:$pciAddress, profiles:null}]' %s > \"$tmp\" && mv \"$tmp\" %s",
-                gpuId, name.c_str(), pciAddress.c_str(), GPU_CONFIG_FILE, GPU_CONFIG_FILE) != 0) {
+                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" "
+                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"pgpu\", pciAddress:$pciAddress, profiles:null}]' %s > %s",
+                gpuId, name.c_str(), pciAddress.c_str(), GPU_CONFIG_FILE, tmpFile.path()) != 0) {
+            HexLogError("gpu_resource_set: failed to build updated GPU config for %s", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        if (HexUtilSystemF(0, 0, "mv %s %s", tmpFile.path(), GPU_CONFIG_FILE) != 0) {
             HexLogError("gpu_resource_set: failed to persist GPU %s config", gpuId);
             return EXIT_FAILURE;
         }

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -433,6 +433,71 @@ gpu_device_list()
             '. + [{id:$id, name:$name, type:$type, supportTypes:["pgpu"], pciAddress:$pciAddress, profileCountLimit:null, status:$status, allocation:$allocation}]')
     done <<< "$(echo "$pgpu_ids" | jq -c '.[]' 2>/dev/null)"
 
+    # The union above only catches vfio-pci-bound GPUs that config.json
+    # already knows about. A GPU can be bound to vfio-pci without a
+    # matching config record (e.g. bound outside of gpu_resource_set, or
+    # after the config file is lost/reset), and such a GPU is invisible to
+    # both nvidia-smi and the config-file union, so it would never be
+    # enumerated. Close that gap by searching the PCI bus directly (by
+    # NVIDIA vendor ID 10de) for devices actually held by vfio-pci.
+    local sysfs_addr
+    for sysfs_addr in $(lspci -Dnn -d 10de: 2>/dev/null | awk '{print $1}'); do
+        local driver_path="/sys/bus/pci/devices/${sysfs_addr}/driver"
+        [ -e "$driver_path" ] || continue
+        [ "$(basename "$(readlink -f "$driver_path")")" = "vfio-pci" ] || continue
+
+        # config.json/nvidia-smi use an 8-char PCI domain (00000000:bb:ss.f);
+        # lspci -D / sysfs use a 4-char domain (0000:bb:ss.f).
+        local already_listed
+        already_listed=$(echo "$output" | jq -r --arg addr "$sysfs_addr" \
+            '[.[] | select((.pciAddress // "" | ascii_downcase | .[4:]) == $addr)] | length')
+        [ "$already_listed" != "0" ] && continue
+
+        local entry
+        entry=$(echo "$gpu_config" | jq -c --arg addr "$sysfs_addr" \
+            '[.[] | select((.pciAddress // "" | ascii_downcase | .[4:]) == $addr)] | .[0] // empty')
+
+        local uuid name pci_address
+        if [ -n "$entry" ]; then
+            uuid=$(echo "$entry" | jq -r '.id')
+            name=$(echo "$entry" | jq -r '.name // "unknown"')
+            pci_address=$(echo "$entry" | jq -r '.pciAddress')
+        else
+            uuid="$sysfs_addr"
+            name=$(lspci -s "$sysfs_addr" | sed -E 's/^[0-9a-f:.]+ [^:]+: //')
+            [ -z "$name" ] && name="unknown"
+            pci_address="0000${sysfs_addr}"
+        fi
+
+        local pci_bus pci_slot
+        pci_bus=$(echo "$sysfs_addr" | awk -F: '{print tolower($2)}')
+        pci_slot=$(echo "$sysfs_addr" | awk -F: '{print $3}' | awk -F. '{print tolower($1)}')
+
+        local in_use=0
+        for vm_id in $(virsh list --state-running --uuid 2>/dev/null); do
+            if virsh dumpxml "$vm_id" 2>/dev/null | \
+                grep -q "bus='0x${pci_bus}'.*slot='0x${pci_slot}'"; then
+                in_use=1
+                break
+            fi
+        done
+
+        local status="idle"
+        local allocation='{"current":0,"total":1}'
+        if [ "$in_use" = "1" ]; then
+            status="inUse"
+            allocation='{"current":1,"total":1}'
+        fi
+
+        output=$(echo "$output" | jq -c \
+            --arg id "$uuid" \
+            --arg name "$name" \
+            --arg pciAddress "$pci_address" \
+            --arg status "$status" \
+            --argjson allocation "$allocation" \
+            '. + [{id:$id, name:$name, type:"pgpu", supportTypes:["pgpu"], pciAddress:$pciAddress, profileCountLimit:null, status:$status, allocation:$allocation}]')
+    done
+
     echo "$output"
 }
 

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -271,14 +271,12 @@ gpu_device_list()
 
     local gpu_csv
     gpu_csv=$($NVIDIA_SMI --query-gpu=uuid,name,pci.bus_id --format=csv,noheader,nounits 2>/dev/null)
-    if [ -z "$gpu_csv" ]; then
-        jq -c -n '[]'
-        return 0
-    fi
 
     local output="[]"
 
     while IFS=',' read -r uuid name pci_bus_id; do
+        [ -z "$uuid" ] && continue
+
         uuid=$(echo "$uuid" | xargs)
         name=$(echo "$name" | xargs)
         pci_bus_id=$(echo "$pci_bus_id" | xargs)
@@ -382,6 +380,58 @@ gpu_device_list()
             --argjson allocation "$allocation" \
             '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, sriovVgpuProfileCountLimit:$sriovVgpuProfileCountLimit, status:$status, allocation:$allocation}]')
     done <<< "$gpu_csv"
+
+    # GPUs already bound to vfio-pci (type "pgpu") are no longer enumerable
+    # by nvidia-smi, so they're missing from $output above. Union them back
+    # in using the properties recorded in the config file.
+    local recorded_gpu_ids
+    recorded_gpu_ids=$(echo "$output" | jq -c '[.[].id]')
+
+    local pgpu_ids
+    pgpu_ids=$(echo "$gpu_config" | jq -c --argjson targetIds "$recorded_gpu_ids" \
+        '[.[] | select(($targetIds | index(.id)) == null)]')
+
+    while IFS= read -r entry; do
+        [ -z "$entry" ] || [ "$entry" = "null" ] && continue
+
+        local uuid name gpu_type pci_address
+        uuid=$(echo "$entry" | jq -r '.id')
+        name=$(echo "$entry" | jq -r '.name // "unknown"')
+        gpu_type=$(echo "$entry" | jq -r '.type')
+        pci_address=$(echo "$entry" | jq -r '.pciAddress // ""')
+
+        local status="idle"
+        local allocation='{"current":0,"total":1}'
+
+        if [ "$gpu_type" = "pgpu" ] && [ -n "$pci_address" ]; then
+            local pci_bus pci_slot
+            pci_bus=$(echo "$pci_address" | awk -F: '{print tolower($2)}')
+            pci_slot=$(echo "$pci_address" | awk -F: '{print $3}' | awk -F. '{print tolower($1)}')
+
+            local in_use=0
+            for vm_id in $(virsh list --state-running --uuid 2>/dev/null); do
+                if virsh dumpxml "$vm_id" 2>/dev/null | \
+                    grep -q "bus='0x${pci_bus}'.*slot='0x${pci_slot}'"; then
+                    in_use=1
+                    break
+                fi
+            done
+
+            if [ "$in_use" = "1" ]; then
+                status="inUse"
+                allocation='{"current":1,"total":1}'
+            fi
+        fi
+
+        output=$(echo "$output" | jq -c \
+            --arg id "$uuid" \
+            --arg name "$name" \
+            --arg type "$gpu_type" \
+            --arg pciAddress "$pci_address" \
+            --arg status "$status" \
+            --argjson allocation "$allocation" \
+            '. + [{id:$id, name:$name, type:$type, supportTypes:["pgpu"], pciAddress:$pciAddress, profileCountLimit:null, status:$status, allocation:$allocation}]')
+    done <<< "$(echo "$pgpu_ids" | jq -c '.[]' 2>/dev/null)"
 
     echo "$output"
 }
@@ -547,7 +597,9 @@ gpu_pgpu_attached_instance_get()
     echo "null"
 }
 
-gpu_resource_set()
+# Full validation for gpu_resource_set: gpu_id, new_type, profiles required-ness
+# for the given type, GPU existence, and in-use status.
+gpu_resource_set_check()
 {
     local gpu_id="$1"
     local new_type="$2"
@@ -567,108 +619,89 @@ gpu_resource_set()
         pgpu|sriovVgpu|migBackedVgpu) ;;
         *)
             echo "Error: invalid type '$new_type'. Must be one of: pgpu, sriovVgpu, migBackedVgpu" >&2
-            exit 1
+            return 1
             ;;
     esac
 
-    if [ "$new_type" = "pgpu" ] && [ -n "$profiles" ]; then
-        echo "Error: profiles is not allowed when new_type is pgpu" >&2
-        exit 1
-    fi
-    
     if [[ "$new_type" == "sriovVgpu" || "$new_type" == "migBackedVgpu" ]]; then
-        if [ -z "$profiles" ]; then
-            echo "Error: profiles is required when new_type is sriovVgpu or migBackedVgpu" >&2
-            exit 1
-        fi
-        
-        echo "TODO: perform profiles argument validation."
+        echo "TODO: perform profiles argument validation." >&2
         # Schema: an array of profiles `{ id: number, count: number }[]`
         # In addition to the format, we must also validate the existence
         # and capacity constraints (for MIG-backed) of the provided profiles.
     fi
 
-    if ! $NVIDIA_SMI --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | grep -qF "$gpu_id"; then
-        echo "Error: GPU UUID '$gpu_id' not found" >&2
-        exit 1
+    local device
+    device=$(gpu_device_list | jq -c --arg id "$gpu_id" 'map(select(.id == $id)) | .[0] // null')
+
+    if [ "$device" = "null" ]; then
+        echo "Error: GPU UUID $gpu_id not found" >&2
+        return 1
     fi
 
-    if [ ! -f "$GPU_CONFIG_FILE_PATH" ]; then
-        echo "Error: GPU config file not found at $GPU_CONFIG_FILE_PATH" >&2
-        exit 1
+    if [ "$(echo "$device" | jq -r '.status')" = "inUse" ]; then
+        echo "Error: GPU $gpu_id is in-use" >&2
+        return 1
     fi
+}
 
-    local gpu_config="[]"
-    local raw_config
-    raw_config=$(cat "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
-    if echo "$raw_config" | jq -e 'type == "array"' >/dev/null 2>&1; then
-        gpu_config="$raw_config"
-    fi
+# Unsets whatever vGPU mode the GPU is currently configured for,
+# according to the config file, so it is free to be reconfigured.
+# This function does nothing if the target GPU is currently configured
+# as pGPU.
+gpu_unset_current_type()
+{
+    local gpu_id="$1"
 
     local current_type
-    current_type=$(echo "$gpu_config" | jq -r --arg id "$gpu_id" \
-        'map(select(.id == $id)) | if length > 0 then .[0].type else "unset" end')
+    current_type=$(jq -r --arg id "$gpu_id" \
+        'map(select(.id == $id)) | if length > 0 then .[0].type else "" end' \
+        "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
 
-    local pci_bus_id
-    pci_bus_id=$($NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null)
-    if [ -z "$pci_bus_id" ]; then
-        echo "Error: could not get PCI bus ID for GPU $gpu_id" >&2
-        exit 1
-    fi
-
-    if [ "$new_type" = "pgpu" ]; then
-        # Check if GPU is currently in-use by any VM
-        if [ "$current_type" = "pgpu" ]; then
-            local pci_bus pci_slot
-            pci_bus=$(echo "$pci_bus_id" | awk -F: '{print tolower($2)}')
-            pci_slot=$(echo "$pci_bus_id" | awk -F: '{print $3}' | awk -F. '{print tolower($1)}')
-            for vm_id in $(virsh list --state-running --uuid 2>/dev/null); do
-                if virsh dumpxml "$vm_id" 2>/dev/null | \
-                    grep -q "bus='0x${pci_bus}'.*slot='0x${pci_slot}'"; then
-                    echo "Error: GPU card $gpu_id is in-use" >&2
-                    exit 1
-                fi
-            done
+    if [ "$current_type" = "sriovVgpu" ]; then
+        local pci_bus_id
+        pci_bus_id=$($NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null)
+        
+        # nvidia-smi uses 8-char domain (00000000:bb:ss.f); sysfs uses 4-char (0000:bb:ss.f)
+        local pci_addr
+        pci_addr=$(echo "$pci_bus_id" | sed 's/^[0-9a-fA-F]\{4\}//')
+        local numvfs_path="/sys/bus/pci/devices/${pci_addr}/sriov_numvfs"
+        if [ ! -f "$numvfs_path" ]; then
+            echo "Error: sriov_numvfs not found at $numvfs_path" >&2
+            exit 1
         fi
-
-        if [ "$current_type" = "sriovVgpu" ]; then
-            unset_sriov_vgpu "$pci_bus_id"
-        elif [ "$current_type" = "migBackedVgpu" ]; then
-            unset_mig_backed_vgpu "$gpu_id"
+        echo 0 > "$numvfs_path"
+    elif [ "$current_type" = "migBackedVgpu" ]; then
+        if ! $NVIDIA_SMI -i "$gpu_id" -mig 0; then
+            echo "Error: failed to disable MIG mode for GPU $gpu_id" >&2
+            exit 1
         fi
-
-        local new_config
-        new_config=$(echo "$gpu_config" | jq -c \
-            --arg id "$gpu_id" \
-            'map(select(.id != $id)) + [{id:$id, type:"pgpu", profiles:null}]')
-
-        echo "$new_config" > "$GPU_CONFIG_FILE_PATH"
-        echo "Successfully update GPU $gpu_id to pgpu"
-    else
-        echo "Error: type '$new_type' is not yet implemented" >&2
-        exit 1
     fi
 }
 
-unset_sriov_vgpu()
+# Binds the PCI device identified by PCI address to vfio-pci for PCI passthrough.
+# Pure sysfs operation - does not depend on nvidia-smi being able to see the
+# device, so it is safe to call during hex_config Commit() re-apply, after the
+# device is no longer enumerable by nvidia-smi.
+gpu_bind_vfio_pci()
 {
     # nvidia-smi uses 8-char domain (00000000:bb:ss.f); sysfs uses 4-char (0000:bb:ss.f)
-    local pci_addr
-    pci_addr=$(echo "$1" | sed 's/^[0-9a-fA-F]\{4\}//')
-    local numvfs_path="/sys/bus/pci/devices/${pci_addr}/sriov_numvfs"
-    if [ ! -f "$numvfs_path" ]; then
-        echo "Error: sriov_numvfs not found at $numvfs_path" >&2
-        exit 1
-    fi
-    echo 0 > "$numvfs_path"
-}
+    local sysfs_pci_addr
+    sysfs_pci_addr=$(echo "$1" | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]')
 
-unset_mig_backed_vgpu()
-{
-    if ! $NVIDIA_SMI -i "$1" -mig 0; then
-        echo "Error: failed to disable MIG mode for GPU $1" >&2
-        exit 1
+    modprobe vfio-pci
+
+    local driver_path="/sys/bus/pci/devices/${sysfs_pci_addr}/driver"
+    if [ -e "$driver_path" ]; then
+        local current_driver
+        current_driver=$(basename "$(readlink -f "$driver_path")")
+        if [ "$current_driver" != "vfio-pci" ]; then
+            echo "$sysfs_pci_addr" > "/sys/bus/pci/drivers/${current_driver}/unbind" 2>/dev/null
+        fi
     fi
+
+    echo "$sysfs_pci_addr" > /sys/bus/pci/drivers/vfio-pci/bind 2>/dev/null
+
+    [ "$(basename "$(readlink -f "$driver_path" 2>/dev/null)" 2>/dev/null)" = "vfio-pci" ]
 }
 
 gpu_host_stats()


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Add `gpu_resource_set <gpuId> <newType> [profiles]` command to `hex_config` for GPU resource update.
[UI use case](https://www.figma.com/design/Z4v1zkTLGVts3tsDTc7AMH/-COS--COS-3.2-GPU-Productization?node-id=105-10333&t=TnmGLa6JS7bNrbxo-0):
<img width="4395" height="748" alt="image" src="https://github.com/user-attachments/assets/6104459f-07eb-4903-8ddf-f4596dff981c" />

#### Which issue(s) this PR fixes

Fixes #893

#### Special notes for your reviewer

This PR covers only passthrough (pGPU) mode update.

#### Additional documentation

None
