### PR TITLE
fix: source Device dashboard Host variable from existing host tag

### DIFF
--- a/core/grafana/provisioning/dashboards/device.json
+++ b/core/grafana/provisioning/dashboards/device.json
@@ -4285,7 +4285,7 @@
           "value": "DESKTOP-ENMHMJG"
         },
         "datasource": "influxdb-telegraf",
-        "definition": "SHOW TAG VALUES FROM \"ipmi_sensor\" WITH KEY = \"hostname\"",
+        "definition": "SHOW TAG VALUES FROM \"ipmi_sensor\" WITH KEY = \"host\"",
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -4293,7 +4293,7 @@
         "multi": false,
         "name": "HOST",
         "options": [],
-        "query": "SHOW TAG VALUES FROM \"ipmi_sensor\" WITH KEY = \"hostname\"",
+        "query": "SHOW TAG VALUES FROM \"ipmi_sensor\" WITH KEY = \"host\"",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

The Device dashboard's `$HOST` template variable queried `SHOW TAG VALUES FROM "ipmi_sensor" WITH KEY = "hostname"`. That tag does **not exist** — `ipmi_sensor` points are tagged with **`host`** (the Telegraf agent hostname), not `hostname`. The query returned nothing, so the **Host dropdown was empty** and could not filter the dashboard by node.

Fix: query the `host` tag instead, so the dropdown lists the node.

#### Which issue(s) this PR fixes

None

#### Special notes for your reviewer

None

#### Additional documentation

None