### PR TITLE
feat(gpu): add GPU Utilization and VRAM history panels to Device dash…

### DIFF
--- a/core/grafana/provisioning/dashboards/device.json
+++ b/core/grafana/provisioning/dashboards/device.json
@@ -2815,6 +2815,80 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "id": 50,
+          "title": "GPU Utilization",
+          "type": "timeseries",
+          "datasource": "influxdb-telegraf",
+          "description": "Physical GPU compute workload % per card. Grouped by PCI ID and GPU model name.",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 41 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0, "max": 100,
+              "custom": { "lineWidth": 2, "fillOpacity": 10 }
+            }
+          },
+          "targets": [{
+            "datasource": "influxdb-telegraf",
+            "measurement": "gpu.host",
+            "policy": "def",
+            "resultFormat": "time_series",
+            "select": [[{"params":["util_gpu"],"type":"field"},{"params":[],"type":"mean"}]],
+            "tags": [{"key":"host","operator":"=~","value":"/^$GPU_HOST$/"}],
+            "groupBy": [
+              {"params":["$__interval"],"type":"time"},
+              {"params":["pciid"],"type":"tag"},
+              {"params":["name"],"type":"tag"},
+              {"params":["linear"],"type":"fill"}
+            ],
+            "alias": "$tag_name ($tag_pciid)"
+          }]
+        },
+        {
+          "id": 51,
+          "title": "GPU VRAM Usage",
+          "type": "timeseries",
+          "datasource": "influxdb-telegraf",
+          "description": "Physical GPU framebuffer (VRAM) used and total per card in MiB.",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 41 },
+          "fieldConfig": {
+            "defaults": { "unit": "decmbytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } },
+            "overrides": [{
+              "matcher": {"id":"byRegexp","options":"^Total.*"},
+              "properties": [
+                {"id":"custom.lineStyle","value":{"dash":[10,10],"fill":"dash"}},
+                {"id":"color","value":{"fixedColor":"gray","mode":"fixed"}}
+              ]
+            }]
+          },
+          "targets": [
+            {
+              "datasource": "influxdb-telegraf",
+              "measurement": "gpu.host", "policy": "def", "resultFormat": "time_series",
+              "select": [[{"params":["mem_used"],"type":"field"},{"params":[],"type":"mean"}]],
+              "tags": [{"key":"host","operator":"=~","value":"/^$GPU_HOST$/"}],
+              "groupBy": [
+                {"params":["$__interval"],"type":"time"},
+                {"params":["pciid"],"type":"tag"},{"params":["name"],"type":"tag"},
+                {"params":["linear"],"type":"fill"}
+              ],
+              "alias": "Used — $tag_name ($tag_pciid)"
+            },
+            {
+              "datasource": "influxdb-telegraf",
+              "measurement": "gpu.host", "policy": "def", "resultFormat": "time_series",
+              "select": [[{"params":["mem_total"],"type":"field"},{"params":[],"type":"mean"}]],
+              "tags": [{"key":"host","operator":"=~","value":"/^$GPU_HOST$/"}],
+              "groupBy": [
+                {"params":["$__interval"],"type":"time"},
+                {"params":["pciid"],"type":"tag"},{"params":["name"],"type":"tag"},
+                {"params":["linear"],"type":"fill"}
+              ],
+              "alias": "Total — $tag_name ($tag_pciid)"
+            }
+          ]
         }
       ],
       "title": "System",
@@ -4294,6 +4368,29 @@
         "name": "HOST",
         "options": [],
         "query": "SHOW TAG VALUES FROM \"ipmi_sensor\" WITH KEY = \"host\"",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "influxdb-telegraf",
+        "definition": "SHOW TAG VALUES FROM \"gpu.host\" WITH KEY = \"host\"",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "GPU Host",
+        "multi": false,
+        "name": "GPU_HOST",
+        "options": [],
+        "query": "SHOW TAG VALUES FROM \"gpu.host\" WITH KEY = \"host\"",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does / why we need it

Adds GPU workload history to the Grafana **Device** dashboard
(`device.json`, UID `i-device`) — the infra half of #824 / #825:

- **Panel 50 — GPU Utilization** (#824): `mean(util_gpu)` %, 0–100, one line per card (grouped by `pciid` + `name`).
- **Panel 51 — GPU VRAM Usage** (#825): `mem_used` (solid) and `mem_total` (grey dashed) in MiB, same grouping.
- **Hidden `$GPU_HOST` variable**: sourced from `gpu.host` `host` tag, lets a single node be selected via URL for backend deep-links.

#### Which issue(s) this PR fixes

Part of #824, #825

#### Special notes for your reviewer

**Blocked by #1017** (`fix(hex_sdk): match uppercase GPU ...`). Without that collector fix, `gpu.host` receives no data and these panels render empty.
Merge #1017 first.

#### Additional documentation

None
