### PR TITLE
fix(set_ready): drop redundant neutron/octavia/kafka work + align csi image tags

### DIFF
--- a/core/cubectl/app/util/ceph/csi-drivers.go
+++ b/core/cubectl/app/util/ceph/csi-drivers.go
@@ -39,25 +39,25 @@ var (
 		{
 			Registry: "registry.k8s.io",
 			Name:     "sig-storage/csi-snapshotter",
-			Tag:      "v7.0.0",
+			Tag:      "v8.2.0",
 			LocalTar: fmt.Sprintf("%s/ceph-csi-snapshotter.tar", CsiLocalStore),
 		},
 		{
 			Registry: "registry.k8s.io",
 			Name:     "sig-storage/csi-resizer",
-			Tag:      "v1.10.0",
+			Tag:      "v1.11.1",
 			LocalTar: fmt.Sprintf("%s/ceph-csi-resizer.tar", CsiLocalStore),
 		},
 		{
 			Registry: "registry.k8s.io",
 			Name:     "sig-storage/csi-provisioner",
-			Tag:      "v4.0.0",
+			Tag:      "v5.0.1",
 			LocalTar: fmt.Sprintf("%s/ceph-csi-provisioner.tar", CsiLocalStore),
 		},
 		{
 			Registry: "registry.k8s.io",
 			Name:     "sig-storage/csi-attacher",
-			Tag:      "v4.5.0",
+			Tag:      "v4.6.1",
 			LocalTar: fmt.Sprintf("%s/ceph-csi-attacher.tar", CsiLocalStore),
 		},
 		{

--- a/core/modules/config_kafka.cpp
+++ b/core/modules/config_kafka.cpp
@@ -75,12 +75,12 @@ RecreateTopic(bool ha, bool run, const std::string sharedId, const char* topic)
 
     const char cmd[] = "/opt/kafka/bin/kafka-topics.sh";
 
-    HexUtilSystemF(0, 0, "%s --delete --topic %s --bootstrap-server %s:9095 >/dev/null 2>&1",
-                         cmd, topic, sharedId.c_str());
-
+    // __consumer_offsets is managed by Kafka itself; leave it alone.
     if (std::string(topic) == "__consumer_offsets")
         return true;
 
+    // Ensure the topic exists with 6 partitions without deleting it first, so a
+    // re-apply (e.g. set_ready) doesn't drop existing topic data.
     HexUtilSystemF(0, 0, "%s --create --topic %s --partitions 6 --bootstrap-server %s:9095 --replication-factor %d --if-not-exists >/dev/null 2>&1",
                          cmd, topic, sharedId.c_str(), ha ? 2 : 1);
     HexUtilSystemF(0, 0, "%s --alter --topic %s --partitions 6 --bootstrap-server %s:9095 >/dev/null 2>&1",

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -729,10 +729,8 @@ ClusterReadyMain(int argc, char **argv)
     if (!enabled)
         return EXIT_SUCCESS;
 
-    if (IsControl(s_eCubeRole)) {
-        std::string cidr = GetMgmtCidr(s_mgmtCidr.newValue(), 0);
-        HexUtilSystemF(0, 0, HEX_SDK " os_octavia_init %s", cidr.c_str());
-    }
+    // os_octavia_init runs on the cluster_start trigger (ReinitMain); skip the
+    // duplicate run here since set_ready fires cluster_ready then cluster_start.
 
     return EXIT_SUCCESS;
 }

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -1864,7 +1864,12 @@ _health_neutron_auto_repair()
 
 health_neutron_repair()
 {
-    cmd $HEX_CFG bootstrap neutron
+    # A full neutron bootstrap is expensive (~75s) and set_ready invokes this
+    # twice; only re-bootstrap when the OVN/neutron agents aren't already healthy.
+    local agent_alive="$($OPENSTACK network agent list -f value -c Alive 2>/dev/null)"
+    if [ -z "$agent_alive" ] || echo "$agent_alive" | grep -qi False ; then
+        cmd $HEX_CFG bootstrap neutron
+    fi
 
     $HEX_SDK ovn_neutron_db_sync
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind bug

#### What this PR does / why we need it

Removes redundant (and partly destructive) work in `cluster set_ready` / cluster bring-up, and fixes the ceph-csi image version drift that breaks `k3s_last`:

- **neutron** (`sdk_health.sh`): gate the full `bootstrap neutron` in `health_neutron_repair()` on an OVN/neutron agent-alive check — `set_ready` invoked it unconditionally twice (~148s).
- **octavia** (`config_octavia.cpp`): drop the duplicate `os_octavia_init` from the `cluster_ready` trigger; it still runs via `cluster_start`→`ReinitMain`, so cluster recycle is unaffected.
- **kafka** (`config_kafka.cpp`): remove the destructive `--delete`; `--create --if-not-exists` + `--alter` is idempotent and keeps topic data on re-apply.
- **csi** (`csi-drivers.go`): align all 4 image tags with `core/k3s/ceph-csi/Makefile` (snapshotter v8.2.0, resizer v1.11.1, provisioner v5.0.1, attacher v4.6.1); stale tags made `k3s_last` fail with `No such image`.

Net effect: `set_ready` ~26 min → ~21 min, no topic data loss on re-apply, and `k3s_last` completes with all csi images synced.

#### Which issue(s) this PR fixes

Fixes #1027

#### Special notes for your reviewer

> Note

Verified end-to-end on a single-node R630 via PXE/SoL — baseline (`a8d3efc`) vs patched A/B:

| Metric | Baseline | Patched |
|---|---|---|
| neutron full bootstrap | 2× (~148s) | 0× (agents Alive) |
| `os_octavia_init` | 2× | 1× |
| kafka `--delete` | 11 | 0 (topics retained) |
| csi sync | fails @ snapshotter v7.0.0 | all 6 push, `k3s_last` exits 0 |
| `set_ready` wall-time | ~26 min | ~21 min |

Recycle was validated via the documented `cluster poweroff` → boot auto-bootstrap (not `cluster stop`/`start`): octavia re-inits on the `cluster_start` trigger, graceful poweroff is clean from a healthy state, and `cluster check` returns `ok` for all 27 service groups. No regression (ceph HEALTH_OK, tenant instance ACTIVE).

The csi drift turned out to be systemic — fixing snapshotter alone exposed the next three stale tags; all four are aligned to the Makefile here.

#### Additional documentation

```docs

```
