### PR TITLE
fix: stop error/warning log flooding on HA clusters

### DIFF
--- a/core/masakari/yoga_patch/masakarimonitors/hostmonitor/host_handler/handle_host.py
+++ b/core/masakari/yoga_patch/masakarimonitors/hostmonitor/host_handler/handle_host.py
@@ -124,53 +124,30 @@ class HandleHost(driver.DriverBase):
                 LOG.info("Works on pacemaker-remote.")
                 return 0
 
-        # Check whether the necessary parameters are set.
-        if CONF.host.corosync_multicast_interfaces is None or \
-            CONF.host.corosync_multicast_ports is None:
-            msg = ("corosync_multicast_interfaces or "
-                   "corosync_multicast_ports is not set.")
-            LOG.error("%s", msg)
-            return 2
-
-        # Check whether the corosync communication is normal.
-        corosync_multicast_interfaces = \
-            CONF.host.corosync_multicast_interfaces.split(',')
-        corosync_multicast_ports = \
-            CONF.host.corosync_multicast_ports.split(',')
-
-        if len(corosync_multicast_interfaces) != len(corosync_multicast_ports):
-            msg = ("Incorrect parameters corosync_multicast_interfaces or "
-                   "corosync_multicast_ports.")
-            LOG.error("%s", msg)
-            return 2
-
-        is_nic_normal = False
-        for num in range(0, len(corosync_multicast_interfaces)):
-            cmd_str = ("timeout %s tcpdump -n -c 1 -p -i %s port %s") \
-                % (CONF.host.tcpdump_timeout,
-                   corosync_multicast_interfaces[num],
-                   corosync_multicast_ports[num])
-            command = cmd_str.split()
-
-            try:
-                # Execute tcpdump command.
-                out, err = utils.execute(*command, run_as_root=True)
-
-                # If command doesn't raise exception, nic is normal.
-                msg = ("Corosync communication using '%s' is normal.") \
-                    % corosync_multicast_interfaces[num]
-                LOG.info("%s", msg)
-                is_nic_normal = True
-                break
-            except Exception:
-                msg = ("Corosync communication using '%s' is failed.") \
-                    % corosync_multicast_interfaces[num]
-                LOG.warning("%s", msg)
-
-        if is_nic_normal is False:
+        # Check corosync communication by querying corosync directly with
+        # corosync-cfgtool, instead of sniffing a packet on a configured
+        # interface with tcpdump. The packet sniff was multicast-era,
+        # timing-dependent and interface-sensitive (knet/unicast and a
+        # mismatched interface produced false failures while corosync was
+        # healthy); corosync-cfgtool reports ring/link health transport- and
+        # interface-independently.
+        try:
+            out, err = utils.execute('corosync-cfgtool', '-s',
+                                     run_as_root=True)
+        except Exception:
             LOG.error("Corosync communication is failed.")
             return 1
 
+        # Healthy when corosync responds and a link is up: knet shows peers
+        # 'connected'; udpu/multicast shows 'no faults'. A faulty ring or an
+        # isolated node (no connected peer) is a failure.
+        lowered = out.lower()
+        if 'faulty' in lowered or ('connected' not in lowered
+                                   and 'no faults' not in lowered):
+            LOG.error("Corosync communication is failed: %s", out)
+            return 1
+
+        LOG.info("Corosync communication is normal.")
         return 0
 
     def _check_host_status_by_crmadmin(self):

--- a/core/modules/config_haproxy.cpp
+++ b/core/modules/config_haproxy.cpp
@@ -360,6 +360,7 @@ WriteConfig(bool ha, const std::string& ctrlVip,
         }
         else if (srvlist[i][SRV_CONN] == "mysql") {
             fprintf(fout, "  timeout client  10h\n");
+            fprintf(fout, "  timeout server  10h\n");
             fprintf(fout, "  option  mysql-check\n");
         }
 

--- a/core/modules/config_logstash.cpp
+++ b/core/modules/config_logstash.cpp
@@ -346,6 +346,9 @@ Commit(bool modified, int dryLevel)
 
 CONFIG_MODULE(logstash, 0, 0, 0, 0, Commit);
 CONFIG_REQUIRES(logstash, kafka);
+// order logstash after its output sinks (influxdb/kapacitor)
+CONFIG_REQUIRES(logstash, influxdb);
+CONFIG_REQUIRES(logstash, kapacitor);
 
 // extra tunings
 CONFIG_OBSERVES(logstash, net, ParseNet, NotifyNet);

--- a/core/modules/config_masakari.cpp
+++ b/core/modules/config_masakari.cpp
@@ -329,7 +329,8 @@ MasakariService(const bool enabled)
     if(IsCompute(s_eCubeRole)) {
         SystemdCommitService(enabled, IMON_NAME);
         SystemdCommitService(enabled, PMON_NAME);
-        SystemdCommitService(enabled, HMON_NAME);
+        // hostmonitor needs corosync/pacemaker; only run it under HA
+        SystemdCommitService(enabled && s_ha, HMON_NAME);
     }
 
     return true;

--- a/core/modules/config_masakari.cpp
+++ b/core/modules/config_masakari.cpp
@@ -1,6 +1,7 @@
 // CUBE SDK
 
 #include <hex/log.h>
+#include <hex/parse.h>
 #include <hex/pidfile.h>
 #include <hex/filesystem.h>
 #include <hex/process.h>
@@ -64,6 +65,9 @@ static bool s_bConfigChanged = false;
 static bool s_bEndpointChanged = false;
 
 static CubeRole_e s_eCubeRole;
+// HA read directly from the raw setting; s_ha's operator bool() (m_new) defaults
+// unreliably when settings are parsed with isNew=false (e.g. restart_masakari).
+static bool s_haEnabled = false;
 
 // rotate daily and enable copytruncate
 static LogRotateConf log_conf("masakari", "/var/log/masakari/*.log", DAILY, 128, 0, true);
@@ -328,9 +332,11 @@ MasakariService(const bool enabled)
 
     if(IsCompute(s_eCubeRole)) {
         SystemdCommitService(enabled, IMON_NAME);
-        SystemdCommitService(enabled, PMON_NAME);
-        // hostmonitor needs corosync/pacemaker; only run it under HA
-        SystemdCommitService(enabled && s_ha, HMON_NAME);
+        // host/process monitors drive host-failure HA and need corosync/pacemaker;
+        // only run them under HA. processmonitor also revives hostmonitor via
+        // process_list.yaml, so it must be gated too or the flood returns.
+        SystemdCommitService(enabled && s_haEnabled, PMON_NAME);
+        SystemdCommitService(enabled && s_haEnabled, HMON_NAME);
     }
 
     return true;
@@ -390,6 +396,8 @@ static bool
 ParseCube(const char *name, const char *value, bool isNew)
 {
     ParseTune(name, value, isNew, 2);
+    if (std::string(name) == "cubesys.ha")
+        HexParseBool(value, &s_haEnabled);
     return true;
 }
 

--- a/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ib_network.py
+++ b/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ib_network.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2017 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+
+import monasca_agent.collector.checks as checks
+
+log = logging.getLogger(__name__)
+
+# According to https://community.mellanox.com/docs/DOC-2572 these fields
+# are divided by the number of lanes, so we need to multiply them by the lane
+# count to get a number valid for the link as a whole.
+_FIELDS_TO_MULTIPLY_BY_LANE_COUNT = {
+    'port_rcv_data',
+    'port_xmit_data'
+}
+
+_METRIC_NAME_PREFIX = "ibnet"
+_IB_DEVICE_PATH = "/sys/class/infiniband/"
+_IB_COUNTER_PATH = "ports/1/counters/"
+
+
+class IBNetwork(checks.AgentCheck):
+    def __init__(self, name, init_config, agent_config):
+        super(IBNetwork, self).__init__(name, init_config, agent_config)
+
+    @staticmethod
+    def _get_lane_count():
+        # It is possible that we could get the number of lanes from the driver,
+        # for example:
+        #
+        # # cat /sys/class/infiniband/mlx5_0/ports/1/rate
+        # 100 Gb/sec (4X EDR)
+        #
+        # However, according to the following PR this isn't expected to change:
+        # https://github.com/prometheus/node_exporter/pull/579 so hard code it
+        # for now.
+        return 4
+
+    def _normalise_counter(self, field, counter):
+        if field in _FIELDS_TO_MULTIPLY_BY_LANE_COUNT:
+            counter *= self._get_lane_count()
+        return counter
+
+    def _read_counter(self, device, field):
+        counter_path = os.path.join(
+            _IB_DEVICE_PATH, device, _IB_COUNTER_PATH, field)
+        with open(counter_path) as f:
+            counter = f.read()
+        counter = int(counter.rstrip())
+        counter = self._normalise_counter(field, counter)
+        return counter
+
+    @staticmethod
+    def _get_devices():
+        return os.listdir(_IB_DEVICE_PATH)
+
+    @staticmethod
+    def _get_fields(device):
+        try:
+            return os.listdir(os.path.join(
+                _IB_DEVICE_PATH, device, _IB_COUNTER_PATH))
+        except OSError:
+            return []
+
+    def check(self, instance):
+        dimensions = self._set_dimensions(None, instance)
+
+        for device in self._get_devices():
+            for field in self._get_fields(device):
+                counter = self._read_counter(device, field)
+                metric_name = '{0}.{1}'.format(_METRIC_NAME_PREFIX, field)
+                self.rate(metric_name,
+                          counter,
+                          device_name=device,
+                          dimensions=dimensions)
+            log.debug('Collected network interface status for device {0}'.
+                      format(device))

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2349,11 +2349,11 @@ health_masakari_check()
             fi
         done
         for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
-            if ! is_remote_running $node masakari-processmonitor ; then
+            if [ "$T_cubesys_ha" = "true" ] && ! is_remote_running $node masakari-processmonitor ; then
                 ERR_MSG+="masakari-processmonitor on $node is not running\n"
                 ERR_CODE=5
                 ERR_LOG="journalctl -n $ERR_LOGSIZE -u masakari-processmonitor"
-            elif [ "$cubesys_ha" = "true" ] && ! is_remote_running $node masakari-hostmonitor ; then
+            elif [ "$T_cubesys_ha" = "true" ] && ! is_remote_running $node masakari-hostmonitor ; then
                 ERR_MSG+="masakari-hostmonitor on $node is not running\n"
                 ERR_CODE=6
                 ERR_LOG="journalctl -n $ERR_LOGSIZE -u masakari-hostmonitor"
@@ -2379,9 +2379,9 @@ _health_masakari_auto_repair()
         fi
     done
     for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
-        if ! is_remote_running $node masakari-processmonitor ; then
+        if [ "$T_cubesys_ha" = "true" ] && ! is_remote_running $node masakari-processmonitor ; then
             remote_systemd_restart $node masakari-processmonitor
-        elif [ "$cubesys_ha" = "true" ] && ! is_remote_running $node masakari-hostmonitor ; then
+        elif [ "$T_cubesys_ha" = "true" ] && ! is_remote_running $node masakari-hostmonitor ; then
             remote_systemd_restart $node masakari-hostmonitor
         elif ! is_remote_running $node masakari-instancemonitor ; then
             remote_systemd_restart $node masakari-instancemonitor

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2330,6 +2330,7 @@ health_masakari_report()
 
 health_masakari_check()
 {
+    source hex_tuning $SETTINGS_TXT cubesys.ha
     stale_api_check_repair masakari-api 15868 masakari-api python3
 
     $CURL -sf http://$HOSTNAME:15868 >/dev/null
@@ -2352,7 +2353,7 @@ health_masakari_check()
                 ERR_MSG+="masakari-processmonitor on $node is not running\n"
                 ERR_CODE=5
                 ERR_LOG="journalctl -n $ERR_LOGSIZE -u masakari-processmonitor"
-            elif ! is_remote_running $node masakari-hostmonitor ; then
+            elif [ "$cubesys_ha" = "true" ] && ! is_remote_running $node masakari-hostmonitor ; then
                 ERR_MSG+="masakari-hostmonitor on $node is not running\n"
                 ERR_CODE=6
                 ERR_LOG="journalctl -n $ERR_LOGSIZE -u masakari-hostmonitor"
@@ -2369,6 +2370,7 @@ health_masakari_check()
 
 _health_masakari_auto_repair()
 {
+    source hex_tuning $SETTINGS_TXT cubesys.ha
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
         if ! is_remote_running $node masakari-api ; then
             remote_systemd_restart $node masakari-api
@@ -2379,7 +2381,7 @@ _health_masakari_auto_repair()
     for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
         if ! is_remote_running $node masakari-processmonitor ; then
             remote_systemd_restart $node masakari-processmonitor
-        elif ! is_remote_running $node masakari-hostmonitor ; then
+        elif [ "$cubesys_ha" = "true" ] && ! is_remote_running $node masakari-hostmonitor ; then
             remote_systemd_restart $node masakari-hostmonitor
         elif ! is_remote_running $node masakari-instancemonitor ; then
             remote_systemd_restart $node masakari-instancemonitor


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Config/policy-layer corrections for the error/warning log floods on HA control-converged clusters:

- **masakari**: probe corosync via `corosync-cfgtool -s` (not a `tcpdump` sniff); gate both hostmonitor and processmonitor to run only under HA (robust HA read); SDK health check gated on HA.
- **haproxy**: add `timeout server` to the galera listen so idle DB connections aren't cut (stops `MySQL server has gone away (2013)` / aborted-connection floods).
- **monasca `ib_network`**: skip NICs without a counters dir (e.g. irdma) instead of raising.
- **logstash**: start after influxdb/kapacitor to stop the boot-time error flood.

#### Which issue(s) this PR fixes

Fixes #1029

#### Special notes for your reviewer

> Purely config/policy modules + the masakari `handle_host.py` and monasca `ib_network.py` patches. 6 commits, 6 files, CI green.

#### Additional documentation

```docs
kb/cubecos/known-issues/error-log-floods-corrections.md (drafted)
```
