### PR TITLE
fix(watcher): make the optimization goals functional (metrics, datasource, collectors)

### DIFF
--- a/core/modules/config_haproxy.cpp
+++ b/core/modules/config_haproxy.cpp
@@ -305,7 +305,7 @@ WriteConfig(bool ha, const std::string& ctrlVip,
         { "heat_api_cfn", "8000", "http", "" },
         { "barbican_api", "9311", "http", "ctrl" },
         { "masakari_api", "15868", "http", "" },
-        { "monasca_api", "8070", "tcp", "notcpka" },
+        { "monasca_api", "8070", "tcp", "notcpka hsclose" },
         { "octavia_api", "9876", "tcp", "" },
         { "designate_api", "9001", "http", "ctrl" },
         { "watcher_api", "9322", "tcp", "ctrl" },
@@ -366,6 +366,11 @@ WriteConfig(bool ha, const std::string& ctrlVip,
 
         if (srvlist[i][SRV_OPTS].find("notcpka") == std::string::npos)
             fprintf(fout, "  option  tcpka\n");
+
+        // close the backend connection per response so haproxy never reuses a
+        // keepalive conn the backend httpd already timed out (RemoteDisconnected)
+        if (srvlist[i][SRV_OPTS].find("hsclose") != std::string::npos)
+            fprintf(fout, "  option  http-server-close\n");
 
         fprintf(fout, "  option  tcplog\n");
 

--- a/core/modules/config_monasca.cpp
+++ b/core/modules/config_monasca.cpp
@@ -35,6 +35,8 @@ static const char GROUP[] = "monasca";
 #define LIBVIRT_YAML "/etc/monasca/agent/conf.d.in/libvirt.yaml"
 #define MCACHE_YAML "/etc/monasca/agent/conf.d.in/mcache.yaml"
 #define HTTP_CHECK_YAML "/etc/monasca/agent/conf.d.in/http_check.yaml"
+#define IPMI_SENSORS_YAML "/etc/monasca/agent/conf.d.in/ipmi_sensors.yaml"
+#define RDT_L3_YAML "/etc/monasca/agent/conf.d.in/rdt_l3.yaml"
 
 #define CONF_D_DIR "/etc/monasca/agent/conf.d/"
 
@@ -179,7 +181,7 @@ SyncAgentConf()
     }
 
     if (IsCompute(s_eCubeRole)) {
-        HexSystemF(0, "cp -f %s " CONF_D_DIR, LIBVIRT_YAML);
+        HexSystemF(0, "cp -f %s %s %s " CONF_D_DIR, LIBVIRT_YAML, IPMI_SENSORS_YAML, RDT_L3_YAML);
     }
 
     return true;
@@ -197,6 +199,10 @@ WriteAgentConfTemplates(const std::string& ctrlIp, const std::string& sharedId, 
             HexLogError("failed to update %s", LIBVIRT_YAML);
             return false;
         }
+
+        // no @VARS@ in these; materialize .yaml from .yaml.in
+        HexSystemF(0, "cp -f %s %s", IPMI_SENSORS_YAML IN_EXT, IPMI_SENSORS_YAML);
+        HexSystemF(0, "cp -f %s %s", RDT_L3_YAML IN_EXT, RDT_L3_YAML);
     }
 
     if (IsControl(s_eCubeRole)) {

--- a/core/monasca/agent/conf.d.in/ipmi_sensors.yaml.in
+++ b/core/monasca/agent/conf.d.in/ipmi_sensors.yaml.in
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+  - built_by: cube
+    # logical metric -> ipmitool sensor name; override per hardware
+    sensors:
+      host_outlet_temp: Outlet-TMP
+      host_inlet_temp: PSU1_Inlet_TEMP
+      host_airflow: FAN1-SPEED
+      host_power: PSU1_POUT

--- a/core/monasca/agent/conf.d.in/libvirt.yaml.in
+++ b/core/monasca/agent/conf.d.in/libvirt.yaml.in
@@ -27,4 +27,5 @@ init_config:
   vm_ping_check_enable: false
   vnic_collection_period: 0
 
-instances: []
+instances:
+  - built_by: cube

--- a/core/monasca/agent/conf.d.in/rdt_l3.yaml.in
+++ b/core/monasca/agent/conf.d.in/rdt_l3.yaml.in
@@ -1,0 +1,4 @@
+init_config:
+
+instances:
+  - built_by: cube

--- a/core/monasca/agent/monasca-agent.sudoers
+++ b/core/monasca/agent/monasca-agent.sudoers
@@ -1,0 +1,4 @@
+# The monasca collector runs as mon-agent (unprivileged). Let it read hardware
+# sensors over IPMI and Intel RDT cache occupancy via pqos for the Watcher
+# metric collectors (ipmi_sensors / rdt_l3 checks).
+mon-agent ALL=(root) NOPASSWD: /usr/bin/ipmitool, /usr/bin/pqos

--- a/core/monasca/api/monasca-api-wsgi.conf.in
+++ b/core/monasca/api/monasca-api-wsgi.conf.in
@@ -3,7 +3,7 @@ Listen @BIND_ADDR@8070
 TraceEnable off
 
 <VirtualHost *:8070>
-    WSGIDaemonProcess monasca-api processes=5 threads=1 user=monasca display-name=%{GROUP}
+    WSGIDaemonProcess monasca-api processes=8 threads=4 user=monasca display-name=%{GROUP}
     WSGIProcessGroup monasca-api
     WSGIApplicationGroup monasca-api
     WSGIScriptAlias / /usr/local/lib/python3.9/site-packages/monasca_api/api/wsgi.py

--- a/core/monasca/monasca.mk
+++ b/core/monasca/monasca.mk
@@ -71,6 +71,8 @@ rootfs_install::
 
 rootfs_install::
 	$(Q)[ -d $(MONASCA_PATCHDIR) ] && cp -rf $(MONASCA_PATCHDIR)/* $(MONASCA_SRCDIR)/ || /bin/true
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/monasca/agent/monasca-agent.sudoers ./etc/sudoers.d/monasca-agent
+	$(Q)chroot $(ROOTDIR) chmod 440 /etc/sudoers.d/monasca-agent
 
 rootfs_install::
 	$(Q)$(COREDIR)/monasca/santize-monasca-log4j.sh $(BLDDIR)/heavy_rootfs/usr/local/lib/python3.9/site-packages/monasca_agent/collector/checks/libs

--- a/core/monasca/monasca.mk
+++ b/core/monasca/monasca.mk
@@ -16,6 +16,10 @@ ROOTFS_PIP += monasca-persister
 ROOTFS_PIP += monasca-statsd
 ROOTFS_PIP += python-monascaclient
 
+# intel-cmt-cat provides pqos, used by the rdt_l3 agent plugin for per-VM L3
+# cache occupancy. Installed via the centralized dnf pass in core/heavyfs.
+ROOTFS_DNF += intel-cmt-cat
+
 # config file examples are copied from github repo: openstack-ansible-os_monasca
 # monasca common
 # ROOTFS_PIP_DL_FROM += https://github.com/openstack/monasca-common.git
@@ -61,6 +65,8 @@ rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/monasca/agent/conf.d.in/libvirt.yaml.in .$(MONASCA_CONF_DIR)/agent/conf.d.in
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/monasca/agent/conf.d.in/mcache.yaml.in .$(MONASCA_CONF_DIR)/agent/conf.d.in
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/monasca/agent/conf.d.in/http_check.yaml.in .$(MONASCA_CONF_DIR)/agent/conf.d.in
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/monasca/agent/conf.d.in/ipmi_sensors.yaml.in .$(MONASCA_CONF_DIR)/agent/conf.d.in
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/monasca/agent/conf.d.in/rdt_l3.yaml.in .$(MONASCA_CONF_DIR)/agent/conf.d.in
 	$(Q)chroot $(ROOTDIR) chmod 644 $(MONASCA_CONF_DIR)/agent/conf.d.in
 
 rootfs_install::

--- a/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ipmi_sensors.py
+++ b/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ipmi_sensors.py
@@ -27,7 +27,7 @@ class IpmiSensors(checks.AgentCheck):
         for metric, sensor in sensors.items():
             try:
                 out = subprocess.check_output(
-                    ['ipmitool', 'sensor', 'reading', sensor],
+                    ['sudo', '-n', 'ipmitool', 'sensor', 'reading', sensor],
                     timeout=15, stderr=subprocess.DEVNULL).decode()
                 value = float(out.split('|')[1].strip())
             except (OSError, subprocess.SubprocessError, IndexError, ValueError) as e:

--- a/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ipmi_sensors.py
+++ b/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ipmi_sensors.py
@@ -1,0 +1,36 @@
+# Monasca agent check: host hardware sensors via IPMI.
+# Feeds Watcher thermal_optimization / airflow_optimization / saving_energy.
+import subprocess
+
+import monasca_agent.collector.checks as checks
+
+
+class IpmiSensors(checks.AgentCheck):
+    """Publish host_outlet_temp / host_inlet_temp / host_airflow / host_power
+    read from the local BMC via `ipmitool sensor reading`.
+
+    The logical-metric -> IPMI sensor-name map is hardware specific; override it
+    per node via the instance `sensors:` dict. Missing sensors / no BMC are
+    skipped, so the check is safe on hosts without IPMI.
+    """
+
+    DEFAULT_SENSORS = {
+        'host_outlet_temp': 'Outlet-TMP',
+        'host_inlet_temp': 'PSU1_Inlet_TEMP',
+        'host_airflow': 'FAN1-SPEED',
+        'host_power': 'PSU1_POUT',
+    }
+
+    def check(self, instance):
+        dimensions = self._set_dimensions(None, instance)
+        sensors = instance.get('sensors') or self.DEFAULT_SENSORS
+        for metric, sensor in sensors.items():
+            try:
+                out = subprocess.check_output(
+                    ['ipmitool', 'sensor', 'reading', sensor],
+                    timeout=15, stderr=subprocess.DEVNULL).decode()
+                value = float(out.split('|')[1].strip())
+            except (OSError, subprocess.SubprocessError, IndexError, ValueError) as e:
+                self.log.debug('ipmi sensor %s unavailable: %s', sensor, e)
+                continue
+            self.gauge(metric, value, dimensions=dimensions)

--- a/core/monasca/yoga_patch/monasca_agent/collector/checks_d/rdt_l3.py
+++ b/core/monasca/yoga_patch/monasca_agent/collector/checks_d/rdt_l3.py
@@ -1,0 +1,60 @@
+# Monasca agent check: per-VM L3 cache occupancy via Intel RDT (pqos).
+# Feeds Watcher noisy_neighbor (instance_l3_cache_usage, keyed by resource_id).
+import re
+import subprocess
+
+import monasca_agent.collector.checks as checks
+
+_LLC_ROW = re.compile(r'^\s*\d+\s+\d+\s')
+
+
+class RdtL3(checks.AgentCheck):
+    """Publish instance_l3_cache_usage (LLC, KB) per VM, dimension
+    resource_id = instance uuid, read from `pqos` (intel-cmt-cat). Monitors one
+    PID at a time (RDT has a limited number of RMIDs). Skips silently if pqos or
+    RDT is unavailable.
+    """
+
+    def _vm_uuid(self, pid):
+        try:
+            with open('/proc/%s/cmdline' % pid, 'rb') as f:
+                args = f.read().split(b'\0')
+        except OSError:
+            return None
+        for i, a in enumerate(args):
+            if a == b'-uuid' and i + 1 < len(args):
+                return args[i + 1].decode(errors='ignore')
+        return None
+
+    def _llc_kb(self, pid):
+        try:
+            out = subprocess.check_output(
+                ['pqos', '-I', '-p', 'llc:%s' % pid, '-t', '1'],
+                timeout=10, stderr=subprocess.DEVNULL).decode()
+        except (OSError, subprocess.SubprocessError):
+            return None
+        val = None
+        for line in out.splitlines():
+            if _LLC_ROW.match(line):
+                val = line.split()[-1]   # LLC[KB] is the last column
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return None
+
+    def check(self, instance):
+        try:
+            pids = subprocess.check_output(
+                ['pgrep', '-f', 'guest=instance'],
+                stderr=subprocess.DEVNULL).decode().split()
+        except (OSError, subprocess.SubprocessError):
+            return
+        for pid in pids:
+            uuid = self._vm_uuid(pid)
+            if not uuid:
+                continue
+            llc = self._llc_kb(pid)
+            if llc is None:
+                continue
+            dimensions = self._set_dimensions({'resource_id': uuid}, instance)
+            self.gauge('instance_l3_cache_usage', llc, dimensions=dimensions)

--- a/core/monasca/yoga_patch/monasca_agent/collector/checks_d/rdt_l3.py
+++ b/core/monasca/yoga_patch/monasca_agent/collector/checks_d/rdt_l3.py
@@ -5,7 +5,9 @@ import subprocess
 
 import monasca_agent.collector.checks as checks
 
-_LLC_ROW = re.compile(r'^\s*\d+\s+\d+\s')
+# a data row starts with the PID; the CORE column may be a number or "err"
+# (a multi-vCPU process spans cores), so don't require a numeric core.
+_LLC_ROW = re.compile(r'^\s*\d+\s+\S+\s')
 
 
 class RdtL3(checks.AgentCheck):
@@ -29,7 +31,7 @@ class RdtL3(checks.AgentCheck):
     def _llc_kb(self, pid):
         try:
             out = subprocess.check_output(
-                ['pqos', '-I', '-p', 'llc:%s' % pid, '-t', '1'],
+                ['sudo', '-n', 'pqos', '-I', '-p', 'llc:%s' % pid, '-t', '1'],
                 timeout=10, stderr=subprocess.DEVNULL).decode()
         except (OSError, subprocess.SubprocessError):
             return None

--- a/core/watcher/metric_map.yaml
+++ b/core/watcher/metric_map.yaml
@@ -1,4 +1,12 @@
 monasca:
-  instance_cpu_usage: cpu.utilization_norm_perc
+  # per-instance metrics (queried by resource_id = instance uuid)
+  instance_cpu_usage: vm.cpu.utilization_perc
   instance_ram_usage: mem.used_gb
+  instance_l3_cache_usage: instance_l3_cache_usage
+  # per-host metrics (queried by hostname)
   host_cpu_usage: cpu.utilization_perc
+  host_ram_usage: mem.used_gb
+  host_outlet_temp: host_outlet_temp
+  host_inlet_temp: host_inlet_temp
+  host_airflow: host_airflow
+  host_power: host_power

--- a/core/watcher/metric_map.yaml
+++ b/core/watcher/metric_map.yaml
@@ -1,6 +1,8 @@
 monasca:
   # per-instance metrics (queried by resource_id = instance uuid)
-  instance_cpu_usage: vm.cpu.utilization_perc
+  # TODO: switch to vm.cpu.utilization_perc once the libvirt agent plugin
+  # reliably publishes per-VM metrics (it computes them but isn't emitting).
+  instance_cpu_usage: cpu.utilization_norm_perc
   instance_ram_usage: mem.used_gb
   instance_l3_cache_usage: instance_l3_cache_usage
   # per-host metrics (queried by hostname)

--- a/core/watcher/yoga_patch/watcher/decision_engine/datasources/monasca.py
+++ b/core/watcher/yoga_patch/watcher/decision_engine/datasources/monasca.py
@@ -169,23 +169,33 @@ class MonascaHelper(base.DataSourceBase):
 
     def get_host_ram_usage(self, resource, period,
                            aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'compute_node', 'host_ram_usage', period, aggregate,
+            granularity)
 
     def get_host_outlet_temp(self, resource, period,
                              aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'compute_node', 'host_outlet_temp', period, aggregate,
+            granularity)
 
     def get_host_inlet_temp(self, resource, period,
                             aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'compute_node', 'host_inlet_temp', period, aggregate,
+            granularity)
 
     def get_host_airflow(self, resource, period,
                          aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'compute_node', 'host_airflow', period, aggregate,
+            granularity)
 
     def get_host_power(self, resource, period,
                        aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'compute_node', 'host_power', period, aggregate,
+            granularity)
 
     def get_instance_cpu_usage(self, resource, period,
                                aggregate, granularity=None):
@@ -196,16 +206,24 @@ class MonascaHelper(base.DataSourceBase):
 
     def get_instance_ram_usage(self, resource, period,
                                aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'instance', 'instance_ram_usage', period, aggregate,
+            granularity)
 
     def get_instance_ram_allocated(self, resource, period,
                                    aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'instance', 'instance_ram_allocated', period, aggregate,
+            granularity)
 
     def get_instance_l3_cache_usage(self, resource, period,
                                     aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'instance', 'instance_l3_cache_usage', period, aggregate,
+            granularity)
 
     def get_instance_root_disk_size(self, resource, period,
                                     aggregate, granularity=None):
-        raise NotImplementedError
+        return self.statistic_aggregation(
+            resource, 'instance', 'instance_root_disk_size', period, aggregate,
+            granularity)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Makes the Watcher optimization goals functional (they fail or no-op on stock CubeCOS):

- **metric_map**: add `host_ram_usage` + the IPMI sensor metrics + `instance_l3_cache_usage`;
- **Monasca datasource**: implement the stubbed getters (were `raise NotImplementedError`) via `statistic_aggregation`;
- **monasca-agent plugins**: `ipmi_sensors` (host sensors via `ipmitool`) + `rdt_l3` (per-VM L3 via `pqos`), with a sudoers grant + `intel-cmt-cat` packaging;
- **libvirt agent plugin**: populate `instances` so per-VM metrics are collected;
- **monasca-api**: WSGI `5x1 → 8x4`; haproxy `http-server-close` on `monasca_api` (fixes `RemoteDisconnected` under load).

Verified: dummy, server_consolidation (all 3 strategies), workload_balancing (incl. a real no-reboot live migration), thermal_optimization, airflow_optimization succeed; noisy_neighbor runs.

#### Which issue(s) this PR fixes

Fixes #1033

#### Special notes for your reviewer

> Known follow-ups (not blockers): `rdt_l3` uses `pqos`-CLI → Intel-only + RMID-capped (a libpqos/`resctrl`-based collector would make it cross-vendor/AMD + scale); the libvirt plugin computes `vm.cpu.*` but isn't forwarding yet (so `instance_cpu_usage` stays on the host metric); `saving_energy` needs Ironic.

#### Additional documentation

```docs
kb/cubecos/architecture/watcher-optimization-goals.md (drafted)
```
