### PR TITLE
feat(security): restrict RabbitMQ 5672/15672/25672 to cluster nodes via SERVICE-INT (cubecos-private#73)

### DIFF
--- a/core/modules/config_cubesys.cpp
+++ b/core/modules/config_cubesys.cpp
@@ -72,6 +72,7 @@ CONFIG_TUNING_INT(CUBESYS_LOG_DEFAULT_RP, "cubesys.log.default.retention", TUNIN
 CONFIG_TUNING_INT(CUBESYS_CONNTABLE_MAX, "cubesys.conntable.max", TUNING_PUB, "Set max connection table size.", 262144, 0, INT_MAX);
 CONFIG_TUNING_INT(CUBESYS_ALERT_LEVEL, "cubesys.alert.level", TUNING_PUB, "Set health alert sensible level. (0: default, 1: highly sensitive)", 0, 0, INT_MAX);
 CONFIG_TUNING_BOOL(CUBESYS_PROBEUSB, "cubesys.probeusb", TUNING_PUB, "Set true to allow loading USB drivers.", false);
+CONFIG_TUNING_BOOL(CUBESYS_FW_RESTRICT_AMQP, "cubesys.fw.restrict_amqp", TUNING_PUB, "Set true to restrict AMQP (5672) to cluster nodes only. Mitigation for AMQP cleartext auth exposure.", false);
 
 // using external tunings
 CONFIG_TUNING_SPEC(NET_HOSTNAME);

--- a/core/modules/config_cubesys.cpp
+++ b/core/modules/config_cubesys.cpp
@@ -72,7 +72,6 @@ CONFIG_TUNING_INT(CUBESYS_LOG_DEFAULT_RP, "cubesys.log.default.retention", TUNIN
 CONFIG_TUNING_INT(CUBESYS_CONNTABLE_MAX, "cubesys.conntable.max", TUNING_PUB, "Set max connection table size.", 262144, 0, INT_MAX);
 CONFIG_TUNING_INT(CUBESYS_ALERT_LEVEL, "cubesys.alert.level", TUNING_PUB, "Set health alert sensible level. (0: default, 1: highly sensitive)", 0, 0, INT_MAX);
 CONFIG_TUNING_BOOL(CUBESYS_PROBEUSB, "cubesys.probeusb", TUNING_PUB, "Set true to allow loading USB drivers.", false);
-CONFIG_TUNING_BOOL(CUBESYS_FW_RESTRICT_AMQP, "cubesys.fw.restrict_amqp", TUNING_PUB, "Set true to restrict AMQP (5672) to cluster nodes only. Mitigation for AMQP cleartext auth exposure.", false);
 
 // using external tunings
 CONFIG_TUNING_SPEC(NET_HOSTNAME);

--- a/core/sdk_sh/modules/sdk_network.sh
+++ b/core/sdk_sh/modules/sdk_network.sh
@@ -316,8 +316,7 @@ _set_ipt_service_int()
 
     iptables -A $chain -p tcp --match multiport --dports 5900:5999 -j DROP # drop all direct vnc access, except for internal nodes
     iptables -A $chain -p tcp --dport 3306 -j DROP # drop Database Open Access (database-open-access 3306)
-    source hex_tuning $SETTINGS_TXT cubesys.fw.restrict_amqp
-    [ "x$T_cubesys_fw_restrict_amqp" != "xtrue" ] || iptables -A $chain -p tcp --dport 5672 -j DROP # drop AMQP open access, except for internal nodes
+    iptables -A $chain -p tcp --dport 5672 -j DROP # drop AMQP Cleartext Authentication (amqp-cleartext-authentication 5672), except for internal nodes
     iptables -A $chain -p icmp --icmp-type timestamp-request -j DROP # drop ICMP timestamp requests
 
     iptables -nv -L INPUT 2>/dev/null | grep -q $chain || iptables -A INPUT -j $chain

--- a/core/sdk_sh/modules/sdk_network.sh
+++ b/core/sdk_sh/modules/sdk_network.sh
@@ -317,6 +317,8 @@ _set_ipt_service_int()
     iptables -A $chain -p tcp --match multiport --dports 5900:5999 -j DROP # drop all direct vnc access, except for internal nodes
     iptables -A $chain -p tcp --dport 3306 -j DROP # drop Database Open Access (database-open-access 3306)
     iptables -A $chain -p tcp --dport 5672 -j DROP # drop AMQP Cleartext Authentication (amqp-cleartext-authentication 5672), except for internal nodes
+    iptables -A $chain -p tcp --dport 15672 -j DROP # drop RabbitMQ management UI/API (rabbitmq-management 15672), except for internal nodes
+    iptables -A $chain -p tcp --dport 25672 -j DROP # drop RabbitMQ Erlang distribution (erlang-distribution 25672), except for internal nodes
     iptables -A $chain -p icmp --icmp-type timestamp-request -j DROP # drop ICMP timestamp requests
 
     iptables -nv -L INPUT 2>/dev/null | grep -q $chain || iptables -A INPUT -j $chain

--- a/core/sdk_sh/modules/sdk_network.sh
+++ b/core/sdk_sh/modules/sdk_network.sh
@@ -316,6 +316,8 @@ _set_ipt_service_int()
 
     iptables -A $chain -p tcp --match multiport --dports 5900:5999 -j DROP # drop all direct vnc access, except for internal nodes
     iptables -A $chain -p tcp --dport 3306 -j DROP # drop Database Open Access (database-open-access 3306)
+    source hex_tuning $SETTINGS_TXT cubesys.fw.restrict_amqp
+    [ "x$T_cubesys_fw_restrict_amqp" != "xtrue" ] || iptables -A $chain -p tcp --dport 5672 -j DROP # drop AMQP open access, except for internal nodes
     iptables -A $chain -p icmp --icmp-type timestamp-request -j DROP # drop ICMP timestamp requests
 
     iptables -nv -L INPUT 2>/dev/null | grep -q $chain || iptables -A INPUT -j $chain


### PR DESCRIPTION
## What & why

RabbitMQ listens on **5672** with cleartext `PLAIN`/`AMQPLAIN` auth (Nessus 87733, issue https://github.com/bigstack-oss/cubecos-private/issues/73). This hardcodes firewall rules that restrict RabbitMQ's externally exposed ports to cluster nodes only — a **compensating control** to remove the external exposure, per the decision in spike #884.

Per review, the scope was extended beyond AMQP **5672** to the other RabbitMQ listeners: **15672** (rabbitmq_management HTTP UI/API) and **25672** (Erlang distribution, inter-node/CLI).

**This is a mitigation, not a compliance fix.** 5672 stays cleartext; anything already inside the cluster (or a compromised node) can still sniff it. TLS (5671) is the root fix and must be tracked as a **separate follow-up**. Please do **not** mark https://github.com/bigstack-oss/cubecos-private/issues/73 resolved on this PR alone.

## Change

Three hardcoded DROPs in `sdk_network.sh` `_set_ipt_service_int()`, appended after the existing per-node `-s <ip> ACCEPT` allowlist and `-i lo ACCEPT`, following the existing 3306 / VNC "open access" DROP convention. Cluster nodes / loopback stay allowed; all other sources are dropped.

- **5672** (AMQP, cleartext auth): the original finding.
- **15672** (management UI/API): enabled on every control node (`config_rabbitmq.cpp` `SetupCheck`) and bound to 0.0.0.0. Nothing in-product consumes the management API remotely — `sdk_rabbitmq.sh` only uses `rabbitmqctl` over the local Erlang distribution — so restricting it is side-effect free.
- **25672** (Erlang distribution): inter-node clustering traffic rides the management IPs already in the allowlist; local `rabbitmqctl` stays on loopback. epmd **4369** is intentionally left as-is for a separate discussion.

Per review, the original opt-in tuning (`cubesys.fw.restrict_amqp`) was dropped: nothing invokes `_set_ipt_service_int` on commit, so the tuning would only take effect on cluster start / reboot — violating the apply-on-commit tuning policy. Hardcode is simpler and gets the default right: a cleartext-auth port should never be reachable from outside the cluster.

Safe for all roles: rabbitmq-server is only enabled on control-capable roles (`config_rabbitmq.cpp:315`, `IsControl && enabled`; `role_cubesys.h:16-25,79`), so the DROPs are a no-op everywhere else — same situation as the existing hardcoded 3306 rule.

> Change-point note: `config_cubesys.cpp:WriteIptablesConfig()` writes `/etc/sysconfig/iptables` but its `iptables-restore` is commented out — that file is never applied. The live SERVICE-INT chain is built by `sdk_network.sh:_set_ipt_service_int()` (via `cube_cluster_start`), so the rules belong there.

## How it takes effect

The rules land whenever `cube_cluster_start` rebuilds the chain: boot (`bootstrap_cube_config:36`), `cluster> set_ready` [4/6], `cluster> start`, `boot> cluster_sync`.

- **Firmware upgrade**: nodes reboot into the new rootfs (PPU does rolling evac+reboot automatically), boot runs `cube_cluster_start` → rules apply with zero operator action.
- **Fixpack**: `post_install.sh` invokes `hex_sdk network_ipt_serviceint` (applies immediately, no reboot). No extra snapshot handling is needed — the `/run/iptables` refresh is already covered by the corresponding flow (see review discussion; `cube_cluster_start` pairs the rebuild with `iptables-save > /run/iptables`, proj_functions:295 → 301).

## Testing (single-node dev 1cc, kube-router platform)

- With the rule applied, from a non-node host (10.1.0.254): `nmap -p 5672` → `filtered` (was `open`).
- SERVICE-INT DROP packet counter incremented → confirms the packet reaches SERVICE-INT even though it is appended to INPUT **after** the kube-router / kube-proxy chains (host-port 5672 is not intercepted by kube-router).
- Local services unaffected: rabbit connections all from `10.1.0.1` `running`; nova-conductor / scheduler / compute all `up`.
- **15672/25672** (added per review) use the identical allowlist-then-DROP mechanism; the same 1cc port scan spot-check for these two ports is pending (folded into Open item 1).

## Open items

1. **Multi-node validation**: validated only on a single-node 1cc; the "other cluster nodes still allowed / don't miss compute" path needs a multi-node cluster (e.g. sky150), now covering all three ports (5672/15672/25672 → `filtered` from outside, clustering and `rabbitmqctl` unaffected between nodes). Known caveat: the allowlist regenerates only when `_set_ipt_service_int` reruns, so after adding a node, run `cluster start` so existing nodes allow the new node's IP.
2. **Production Go/No-Go**: confirm the real Nessus scanner source IP is **outside** the cluster allowlist before closing the finding on production.
3. **External AMQP consumers**: acknowledged in review — no current customer wires external consumers to 5672, so hardcode is safe for now; keeping in mind.

Refs: spike #884
