### PR TITLE
fix: cut steady-state log flooding (ssh multiplexing, sdk_is self-check, pacemaker pe-error)

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -273,6 +273,11 @@ cube_cluster_start()
         /usr/sbin/hex_config trigger cluster_start
     fi
 
+    # Reapply pacemaker scheduler props now the cluster is up; the set in
+    # config_pacemaker SetupCluster (pacemaker_last) is lost if the CIB isn't
+    # ready yet, leaving single-node flooding STONITH errors + unbounded pe-error.
+    Quiet -n pcs property set stonith-enabled=false pe-error-series-max="1000" pe-warn-series-max="1000" cluster-recheck-interval="5min"
+
     if $OPENSTACK image list -f value | grep -q "Cirros active" ; then
         cmd rm -f /etc/glance/cirros-0.4.0-x86_64-disk.qcow2
         cmd rm -f /etc/glance/alpine-tools.qcow2

--- a/core/modules/config_cubesys.cpp
+++ b/core/modules/config_cubesys.cpp
@@ -114,6 +114,11 @@ WriteSshConfig(void)
     fprintf(fout, "CheckHostIP no\n");
     fprintf(fout, "StrictHostKeyChecking no\n");
     fprintf(fout, "UserKnownHostsFile /dev/null\n");
+    // Multiplex repeated connections so health checks (one ssh per service per
+    // node) reuse a single session instead of flooding sshd/logind/sudo.
+    fprintf(fout, "ControlMaster auto\n");
+    fprintf(fout, "ControlPath /run/cube-ssh-%%C\n");
+    fprintf(fout, "ControlPersist 30s\n");
     fclose(fout);
 
     return true;
@@ -355,11 +360,14 @@ Commit(bool modified, int dryLevel)
         // https://github.com/cornfeedhobo/ssh-keydgen
         HexUtilSystemF(0, 0, "echo %s | /usr/sbin/ssh-keydgen -t rsa -f %s", s_seed.c_str(), KEYFILE);
         HexUtilSystemF(0, 0, "cat %s >> %s", KEYFILE_PUB, AUTHORIZED_KEYS);
-        WriteSshConfig();
         HexSetFileMode(KEYFILE, "root", "root", 0600);
         HexSetFileMode(KEYFILE_PUB, "root", "root", 0600);
         HexSetFileMode(AUTHORIZED_KEYS, "root", "root", 0644);
     }
+
+    // (Re)write ssh_config on every commit, not just at keygen, so config changes
+    // (e.g. ControlMaster) also land on reboot/upgrade. Idempotent.
+    WriteSshConfig();
 
     WriteModprobeUsbConfig();
     WriteLogRotateConf(log_conf);

--- a/core/sdk_sh/modules.pre/sdk_is.sh
+++ b/core/sdk_sh/modules.pre/sdk_is.sh
@@ -11,9 +11,19 @@ is_running()
     systemctl show -p SubState $1 | grep -q running
 }
 
+# True when $1 is this node; lets is_remote_* skip ssh-to-self.
+is_local_node()
+{
+    [ "$1" = "$HOSTNAME" ] || [ "$1" = "$(hostname -s)" ] || [ "$1" = "localhost" ] || [ "$1" = "127.0.0.1" ]
+}
+
 is_remote_running()
 {
-    ssh root@$1 $HEX_SDK is_running $2 >/dev/null 2>&1
+    if is_local_node "$1" ; then
+        is_running $2
+    else
+        ssh root@$1 $HEX_SDK is_running $2 >/dev/null 2>&1
+    fi
 }
 
 is_active()
@@ -23,7 +33,11 @@ is_active()
 
 is_remote_active()
 {
-    ssh root@$1 $HEX_SDK is_active $2 >/dev/null 2>&1
+    if is_local_node "$1" ; then
+        is_active $2
+    else
+        ssh root@$1 $HEX_SDK is_active $2 >/dev/null 2>&1
+    fi
 }
 
 is_centos()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Cut steady-state log flooding found post-FTS on a single-node install:

- **ssh ControlMaster multiplexing** in the generated `/etc/ssh/ssh_config` — the
  health framework's per-service-per-node ssh checks reuse one session instead of
  flooding sshd/logind/sudo (a `cluster check` dropped from **118 self-ssh logins
  to ~1**, 0 within the persist window). `WriteSshConfig()` now runs on every
  commit so this also lands on reboot/upgrade, not just fresh install.
- **sdk_is** short-circuits `is_remote_running`/`is_remote_active` to the local
  `is_running`/`is_active` when the target is this node (skip ssh-to-self).
- **pacemaker**: reapply `stonith-enabled=false` + `pe-error-series-max` in
  `cube_cluster_start` — the `SetupCluster` set is lost when the CIB isn't up yet,
  leaving single-node STONITH-error flooding and unbounded `pe-error` file growth.

#### Which issue(s) this PR fixes

Refs #1029

> #1029 spans three repos — this is the **cubecos** half. The air-gapped
> `dnf-makecache` half ships in **bigstack-oss/hex#119**; the cos-api Debug
> poll-logging half in the companion **cube-cos-api** PR. Keep #1029 open until all
> three land.

#### Special notes for your reviewer

> **No hex submodule bump here** — the `dnf-makecache` change is delivered by
> hex#119, not this PR (avoids a dangling submodule pointer on develop).
> Air-gapped safe: config-only, no new install/runtime fetches.

#### Additional documentation

```docs
kb/cubecos/known-issues/steady-state-log-floods-corrections.md  — in handbook PR #35
```
