### PR TITLE
feat(nova): cap concurrent live-migrations at 3 for rolling restart

### DIFF
--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -490,6 +490,11 @@ UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::s
         // kept short so planned drains stay bounded/predictable (post-copy backstops
         // sooner); the 2 GiB floor keeps tiny guests from being cut off too early.
         cfg["libvirt"]["live_migration_completion_timeout"] = "15";
+        // cap on concurrent outbound live-migrations per compute host. The
+        // rolling-restart drain reads and honors this value, so it is the single
+        // source of truth for migration parallelism. 3 overlaps migrations on a
+        // fast fabric; on a saturated link nova still serializes within the cap.
+        cfg["DEFAULT"]["max_concurrent_live_migrations"] = "3";
         std::string cpuVirtInstr = HexUtilPOpen("echo -n $(egrep -o '(vmx|svm)' /proc/cpuinfo | uniq)");
         if (cpuVirtInstr == "svm")
             cfg["libvirt"]["cpu_model_extra_flags"] = cpuVirtInstr;


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Set `max_concurrent_live_migrations = 3` in `config_nova` so the rolling-restart
drain can migrate several VMs in parallel — nova's default of `1` serializes the
drain — while bounding load on a shared migration link. `power_drain_host` reads
this value from `nova.conf` and treats it as the single source of truth for
migration parallelism (no separate knob to drift).

#### Which issue(s) this PR fixes

Refs #1031

#### Special notes for your reviewer

> Config-only — 5 lines in `config_nova.cpp`, slotted next to the
> `live_migration_completion_timeout` set by the now-merged live-migration
> hardening (#1032). Pairs with the rolling-restart drain (separate PR, gated on
> hex#119) which honors this cap. Air-gapped safe — no new fetches.

#### Additional documentation

```docs
kb/cubecos/architecture/rolling-restart-drain-contract.md  — "Honor max_concurrent_live_migrations (defaulted to 3 in config_nova.cpp)"
kb/cubecos/adrs/0001-live-migration-hardening.md           — max_concurrent_live_migrations tuning rationale
```
