### PR TITLE
fix(octavia): recover octavia-hm0 on non-master nodes after reboot/rolling-restart

### DIFF
--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2203,7 +2203,15 @@ _health_octavia_auto_repair()
 
     for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
         if remote_run $node hex_sdk is_first_three_compute_node ; then
-            if ! is_remote_running $node octavia-worker ; then
+            # octavia-hm0 missing/down/unrouted (codes 5/6/7): lightweight bring-up
+            # on that node -- fast + idempotent (no port recreate, no reconfig, no
+            # service churn), so it's overlap-safe on the periodic auto_repair. The
+            # heavy reinit_octavia stays in health_octavia_repair (deliberate path).
+            if ! remote_run $node ovs-vsctl port-to-br octavia-hm0 >/dev/null 2>&1 \
+               || remote_run $node ip link show octavia-hm0 2>/dev/null | grep -q DOWN \
+               || ! remote_run $node route -n 2>/dev/null | grep -q octavia-hm0 ; then
+                Quiet -n remote_run $node hex_sdk os_octavia_hm0_up
+            elif ! is_remote_running $node octavia-worker ; then
                 remote_systemd_restart $node octavia-worker
             elif ! is_remote_running $node octavia-health-manager ; then
                 remote_systemd_restart $node octavia-health-manager
@@ -2214,10 +2222,22 @@ _health_octavia_auto_repair()
 
 health_octavia_repair()
 {
-    # master node should run first before other nodes
-    local master=$CUBE_NODE_CONTROL_HOSTNAMES
+    # Deliberate full repair: reinit_octavia on EVERY relevant node, not just
+    # master + the invoking node. Master runs first (it owns the shared lb-mgmt
+    # resources, and non-master node_init ssh's to it for the CIDR); then every
+    # other first-three-compute node runs in parallel. reinit_octavia is heavy
+    # (~2min/node incl. ReconfigMain), but this is the serialized, operator/roll
+    # -triggered path -- it can't overlap a periodic round, so the cost is fine.
+    local master=$CUBE_NODE_CONTROL_HOSTNAMES node pids=""
     Quiet -n remote_run $master $HEX_CFG reinit_octavia
-    cmd $HEX_CFG reinit_octavia
+    for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
+        [ "$node" = "$master" ] && continue
+        if remote_run $node hex_sdk is_first_three_compute_node ; then
+            Quiet -n remote_run $node $HEX_CFG reinit_octavia &
+            pids="$pids $!"
+        fi
+    done
+    for p in $pids ; do wait "$p" ; done
 }
 
 health_designate_report()

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1632,54 +1632,59 @@ os_octavia_node_init()
     fi
 
     local port_ip=$1
-    local cidr=$2
-    local port_id=
-    local subnet_id=
     local port_name="octavia-hmgr-port-$(hostname)"
 
     local init=$($OPENSTACK port list -f value | grep $port_name | grep ACTIVE | wc -l)
     if [ $init -eq 0 ] ; then
-        # sanitize dependent resources before re-creating Octavia
+        # sanitize dependent resources before re-creating the health-mgr port
         $OPENSTACK port list -f value | grep $port_name | cut -d' ' -f1 | xargs -i $OPENSTACK port delete {} || true
         /usr/bin/ovs-vsctl del-port br-int octavia-hm0 || true
 
-        port_id=$($OPENSTACK port create --security-group lb-hmgr-sec-grp --device-owner Octavia:health-mgr --host=$(hostname) -c id -f value --network lb-mgmt-net --fixed-ip subnet=lb-mgmt-subnet,ip-address=$port_ip $port_name 2>/dev/null)
-    else
-        port_id=$($OPENSTACK port list -f value | grep $port_name | awk '{print $1}')
-        # if port exists, honor original settings because it could be an upgraded cluster
-        port_ip=$($OPENSTACK port show $port_name | grep "fixed_ips.*ip_address" | awk -F"'" '{print $2}')
-        subnet_id=$($OPENSTACK port show $port_name | grep "fixed_ips.*ip_address" | awk -F"'" '{print $4}')
-        cidr=$($OPENSTACK subnet show $subnet_id | grep cidr | awk '{print $4}')
+        $OPENSTACK port create --security-group lb-hmgr-sec-grp --device-owner Octavia:health-mgr --host=$(hostname) --network lb-mgmt-net --fixed-ip subnet=lb-mgmt-subnet,ip-address=$port_ip $port_name >/dev/null 2>&1
     fi
 
-    if [ -z "$port_id" ] ; then
-        return 0
-    fi
-
-    local port_mac=$($OPENSTACK port show -c mac_address -f value $port_id)
-
-    if ! /usr/bin/ovs-vsctl port-to-br octavia-hm0 >/dev/null 2>&1 ; then
-        /usr/bin/ovs-vsctl -- --may-exist add-port br-int octavia-hm0 -- set Interface octavia-hm0 type=internal -- set Interface octavia-hm0 external-ids:iface-status=active -- set Interface octavia-hm0 external-ids:attached-mac=$port_mac -- set Interface octavia-hm0 external-ids:iface-id=$port_id -- set Interface octavia-hm0 external-ids:skip_cleanup=true
-    fi
-    if ! /sbin/ip link show octavia-hm0 | grep -q $port_mac ; then
-        /sbin/ip link set octavia-hm0 address $port_mac || true
-    fi
-    if /sbin/ip link show octavia-hm0 | grep -q DOWN ; then
-        /sbin/ip link set octavia-hm0 up || true
-    fi
-    if ! /sbin/ip addr show octavia-hm0 | grep -q $port_ip ; then
-        /sbin/ip addr add $port_ip dev octavia-hm0 || true
-    fi
-    if ! /usr/sbin/route -n | grep -q octavia-hm0 ; then
-        /sbin/ip route del $cidr dev octavia-hm0 || true
-        /sbin/ip route add $cidr dev octavia-hm0 || true
-    fi
+    # bring the interface up from the neutron port -- single source of the ovs/ip
+    # bring-up logic, shared with the lightweight auto-repair path.
+    os_octavia_hm0_up || return 0
 
     if ! systemctl status octavia-worker >/dev/null 2>&1 ; then
         systemctl start octavia-worker
     fi
     if ! systemctl status octavia-health-manager >/dev/null 2>&1 ; then
         systemctl start octavia-health-manager
+    fi
+}
+
+# Lightweight octavia-hm0 recovery: bring the health-manager interface back up
+# (ovs port + link + ip + route) from the EXISTING neutron port only. Unlike
+# reinit_octavia it does NOT recreate the port or run ReconfigMain/service
+# reconfig -- so it's ~seconds and idempotent, hence safe to call from the
+# periodic auto_repair. Returns non-zero (defer to full reinit_octavia) if the
+# node's neutron port is gone -- that heavier case belongs to deliberate repair.
+os_octavia_hm0_up()
+{
+    [ -f /run/cube_commit_done ] || return 0
+
+    local port_name="octavia-hmgr-port-$(hostname)"
+    local port_id=$($OPENSTACK port list -f value | grep "$port_name" | awk '{print $1}' | head -1)
+    [ -n "$port_id" ] || return 1                       # no port -> needs full reinit
+
+    local show=$($OPENSTACK port show "$port_id" 2>/dev/null)
+    local port_ip=$(echo "$show" | grep "fixed_ips.*ip_address" | awk -F"'" '{print $2}')
+    local subnet_id=$(echo "$show" | grep "fixed_ips.*ip_address" | awk -F"'" '{print $4}')
+    local port_mac=$(echo "$show" | awk '/ mac_address /{print $4}')
+    local cidr=$($OPENSTACK subnet show "$subnet_id" 2>/dev/null | awk '/ cidr /{print $4}')
+    [ -n "$port_ip" ] && [ -n "$port_mac" ] && [ -n "$cidr" ] || return 1
+
+    if ! /usr/bin/ovs-vsctl port-to-br octavia-hm0 >/dev/null 2>&1 ; then
+        /usr/bin/ovs-vsctl -- --may-exist add-port br-int octavia-hm0 -- set Interface octavia-hm0 type=internal -- set Interface octavia-hm0 external-ids:iface-status=active -- set Interface octavia-hm0 external-ids:attached-mac=$port_mac -- set Interface octavia-hm0 external-ids:iface-id=$port_id -- set Interface octavia-hm0 external-ids:skip_cleanup=true
+    fi
+    /sbin/ip link show octavia-hm0 | grep -q "$port_mac" || /sbin/ip link set octavia-hm0 address $port_mac || true
+    /sbin/ip link show octavia-hm0 | grep -q DOWN && /sbin/ip link set octavia-hm0 up || true
+    /sbin/ip addr show octavia-hm0 | grep -q "$port_ip" || /sbin/ip addr add $port_ip dev octavia-hm0 || true
+    if ! /usr/sbin/route -n | grep -q octavia-hm0 ; then
+        /sbin/ip route del $cidr dev octavia-hm0 2>/dev/null || true
+        /sbin/ip route add $cidr dev octavia-hm0 || true
     fi
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

#1028 dropped the per-control-node `os_octavia_init` from the `cluster_ready`
trigger, assuming `cluster_start`→`ReinitMain` covers it. But `ReinitMain` runs
`os_octavia_init` only on the master (`IS_MASTER`), so after a reboot or rolling
restart the **non-master** control nodes' `octavia-hm0` is never brought up: the
health-manager can't receive amphora heartbeats, load balancers go OFFLINE and
amphorae to ERROR. It passed single-node validation because a lone node is always
the master.

- add `os_octavia_hm0_up`: lightweight, idempotent ovs/ip bring-up of
  `octavia-hm0` from the existing neutron port (~seconds; no port recreate, no
  ReconfigMain, no service churn) — single source of the bring-up logic.
- `os_octavia_node_init`: delegate its bring-up to `os_octavia_hm0_up` (dedup).
- `_health_octavia_auto_repair`: on codes 5/6/7 run the lightweight bring-up on
  the affected node — fast enough to be overlap-safe on the periodic check.
- `health_octavia_repair`: run the heavy `reinit_octavia` on ALL first-three
  compute nodes (master first, rest in parallel), not just master + invoker.

#### Which issue(s) this PR fixes

Refs #1027

> This repairs the octavia-hm0 regression introduced by **#1028** (which closed
> **#1027** — its bullet 2 was the octavia `os_octavia_init` dedup). #1027 is
> closed, so linking with `Refs` rather than reopening it. Switch to `Fixes` if
> you'd prefer to reopen/track there.

#### Special notes for your reviewer

> Two SDK files — `sdk_os.sh` (bring-up) + `sdk_health.sh` (auto-repair wiring).
> No image/registry changes, air-gapped safe. Overlap-safe on the periodic health
> check (lightweight path; heavy `reinit_octavia` stays deliberate).

#### Additional documentation

```docs
(octavia-hm0 recovery not yet captured in the handbook kb — follow-up)
```
