### PR TITLE
feat(cluster): workload-preserving rolling restart (boot-relay drain/reboot/restore + CLI)

### DIFF
--- a/core/cubectl/app/util/ceph/csi-chart.go
+++ b/core/cubectl/app/util/ceph/csi-chart.go
@@ -10,13 +10,37 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 )
 
+// Bound each ceph call; retry to ride out mon/mgr still recovering on cold boot.
+const (
+	cephConnectTimeout  = "10"
+	cephReadyAttempts   = 30
+	subVolGroupAttempts = 5
+)
+
+// InitDefaultSubVolumeGroup creates the CSI cephfs subvolume group, waiting for
+// ceph to be reachable then retrying the idempotent create -- the mon/mgr may
+// still be recovering on a cold boot.
 func InitDefaultSubVolumeGroup() error {
-       _, outErr, err := util.ExecCmd("timeout", "30", "ceph", "fs", "subvolumegroup", "create", "cephfs", DefaultFsSubVolumeGroup)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to init default sub volume group(%s): %s", DefaultFsSubVolumeGroup, outErr)
+	// Wait until a mon answers.
+	if err := util.Retry(func() error {
+		_, stderr, err := util.ExecCmd("ceph", "--connect-timeout", cephConnectTimeout, "-s")
+		if err != nil {
+			return errors.Wrapf(err, "ceph not reachable yet: %s", stderr)
+		}
+		return nil
+	}, cephReadyAttempts); err != nil {
+		return errors.Wrap(err, "ceph did not become reachable for subvolumegroup create")
 	}
 
-	return nil
+	// Create the subvolume group (idempotent); retry while the mgr volumes module comes up.
+	return util.Retry(func() error {
+		_, stderr, err := util.ExecCmd("ceph", "--connect-timeout", cephConnectTimeout,
+			"fs", "subvolumegroup", "create", "cephfs", DefaultFsSubVolumeGroup)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to init default sub volume group(%s): %s", DefaultFsSubVolumeGroup, stderr)
+		}
+		return nil
+	}, subVolGroupAttempts)
 }
 
 func customizeCsiFsValues() (*values.Options, error) {

--- a/core/elk/logstash/eventdb/event-key-to-msg.yml
+++ b/core/elk/logstash/eventdb/event-key-to-msg.yml
@@ -18,6 +18,12 @@ CMP02001I: instance HA segment is created
 CMP02002I: instance HA segment is deleted
 CMP02003I: a compute node in maintenance mode is back to be in production
 
+CLU00001I: cluster rolling restart started
+CLU00002I: cluster rolling restart resumed
+CLU00003I: cluster rolling restart aborted
+CLU00004W: cluster rolling restart paused on failure
+CLU00005I: cluster rolling restart completed
+
 PLC00001I: cube node policy is successfully applied
 PLC00002I: cube cluster policy is successfully applied
 

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -89,33 +89,66 @@ RollingEvacuateAndReboot()
         # hex_sdk os_nova_instance_hardreboot $(hex_sdk os_nova_list ID STATUS POWERSTATE | grep -i -e error -e nostate | cut -d" " -f1)
     fi
     if [ "x$upgrading" = "xfalse" ]; then
+        # If this boot follows a rolling restart, the cluster may take many
+        # minutes to become ready (single-node ceph/cephfs recovery). Wait so the
+        # VM restore + relay advance below run against a ready cluster instead of
+        # being skipped. Bounded; marker removed once consumed.
+        ROLLING_RECOVER=0
+        if [ -e /etc/appliance/state/rolling_restart_recover ] ; then
+            for _i in $(seq 1 90) ; do hex_sdk cube_cluster_ready && break ; sleep 20 ; done
+            rm -f /etc/appliance/state/rolling_restart_recover
+            ROLLING_RECOVER=1
+        fi
         if hex_sdk cube_cluster_ready ; then
             msg="Cluster checking and repairing"
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
             hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
             hex_sdk cmd "rm -f /tmp/health_*error.count"
-            hex_cli -c cluster check # kick off auto_repair
-            hex_cli -c cluster check_repair # safe net in case auto_repair is not enough
-            if hex_cli -c cluster check Storage | grep -i " ok " ; then
-                rsync -ar /var/lib/ceph /store/
+            # Normal boots only: the full 'cluster check' kicks per-service
+            # auto_repair. Rolling-restart boots SKIP it -- on a single node its
+            # ceph_mds auto_repair restarts the lone MDS while it is still settling,
+            # forcing a ~8 min cephfs replay that stalls recovery. The focused
+            # essential gate below covers the live-migration path instead.
+            if [ "$ROLLING_RECOVER" != "1" ] ; then
+                hex_cli -c cluster check # kick off auto_repair
             fi
-            msg="Cluster checked and repaired"
-            echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
-            hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
-            need_be_active_servers="$(cat /mnt/cephfs/nova/instances/active_running 2>/dev/null)"
-            if [ "x$need_be_active_servers" != "x" ] ; then
-                for i in $need_be_active_servers ; do
+            # Restore recorded VMs (always), synchronously, before the gate below.
+            # active_running holds one VM per line as "<id> [disposition]" --
+            # disposition recorded by the drain: suspended (resume), stopped
+            # (start), or empty/legacy (reset+hardreboot). Read line-by-line.
+            if [ -s /mnt/cephfs/nova/instances/active_running ] ; then
+                while read -r i disp _ ; do
+                    [ -z "$i" ] && continue
                     if hex_sdk os_nova_list id status powerstate |  grep -i "$i active running" ; then
                         continue
                     else
-                        hex_sdk os_nova_instance_reset $i
-                        hex_sdk os_nova_instance_hardreboot $i
-                        msg="Reset and booted non-active server: $i"
+                        hex_sdk power_vm_restore "$i" "$disp"
+                        msg="Restored server: $i ${disp:+($disp)}"
                         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
                         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
                     fi
-                done
+                done < /mnt/cephfs/nova/instances/active_running
             fi
+            # Normal boots only: ceph backup to /store. Skipped on rolling-restart
+            # boots -- the 'cluster check Storage' probe blocks on MDS replay.
+            if [ "$ROLLING_RECOVER" != "1" ] && hex_cli -c cluster check Storage | grep -i " ok " ; then
+                rsync -ar /var/lib/ceph /store/
+            fi
+            if [ "$ROLLING_RECOVER" = "1" ] ; then
+                # Rolling restart only needs the live-migration path verified --
+                # run the focused essential check+repair (fast, ~tens of seconds)
+                # instead of the full 28-group safe-net sweep.
+                hex_sdk cluster_check_repair_essential 1
+                msg="Cluster ready; live-migration essential services checked"
+            else
+                # Normal boot (powercycle, reboot, cold/crash recovery): the
+                # 'cluster check' above already kicked per-service auto_repair for
+                # anything NG, so a second full check_repair pass is redundant.
+                # Rely on auto_repair + systemd restart policies.
+                msg="Cluster ready"
+            fi
+            echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+            hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
         else
             msg="Cluster check and repair skipped as not all nodes are bootstrapped and synced"
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
@@ -135,6 +168,9 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
     else
         echo "Starting auto bootstrap" >> $BOOTSTRAP_CUBE_MODE
+        # Boot-relay advance is driven by cube_cluster_start (power_roll_advance,
+        # idempotent, every boot) -- intentionally NOT chained onto the bring-up
+        # below, where a non-zero exit could silently skip it and wedge the roll.
         if [ "x$MASTER_CONTROL" = "x$T_net_hostname" ] ; then
             if [ $(hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -eq 0 -o $CLUSTER_SIZE -eq 0 ] ; then
                 echo "YES" | hex_cli -c cluster stop

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -23,6 +23,7 @@ BootstrapAndClusterstart()
         msg="Bootstrapping CubeCOS"
         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
+        [ -e /etc/appliance/state/rolling_restart_recover ] && hex_sdk _power_roll_set_phase_ts "$(hostname)" bootstrapping   # rolling_restart phase timing
         bash -c "hex_config -p bootstrap standalone-done | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
         if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
             msg="Bootstrap error: $(journalctl | grep hex | egrep -i 'failed to commit')"
@@ -33,6 +34,7 @@ BootstrapAndClusterstart()
             msg="Starting cluster"
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
             hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
+            [ -e /etc/appliance/state/rolling_restart_recover ] && hex_sdk _power_roll_set_node_status "$(hostname)" finalizing   # rolling_restart: status + phase ts (until power_roll_advance -> done)
             bash -c "hex_sdk -v cube_cluster_start | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
             return 0
         fi

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -145,10 +145,8 @@ RollingEvacuateAndReboot()
                 hex_sdk cluster_check_repair_essential 1
                 msg="Cluster ready; live-migration essential services checked"
             else
-                # Normal boot (powercycle, reboot, cold/crash recovery): the
-                # 'cluster check' above already kicked per-service auto_repair for
-                # anything NG, so a second full check_repair pass is redundant.
-                # Rely on auto_repair + systemd restart policies.
+                # Normal boot: 'cluster check' above kicks per-service auto_repair;
+                # master runs full check_repair centrally once all nodes ready.
                 msg="Cluster ready"
             fi
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
@@ -181,6 +179,11 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
                 echo "YES" | hex_cli -c cluster stop
             fi
             BootstrapAndClusterstart && RollingEvacuateAndReboot
+            # Master waits (bounded) for all nodes committed+synced, then runs one
+            # detached full check_repair -- the single full pass, healing what the
+            # per-node auto_repair/essential passes miss.
+            for _i in $(seq 1 90) ; do hex_sdk cube_cluster_ready && break ; sleep 20 ; done
+            hex_sdk cluster_check_repair_async
         elif [ "x$T_cubesys_role" = "xcontrol" -o "x$T_cubesys_role" = "xcontrol-converged" -o "x$T_cubesys_role" = "xedge-core" -o "x$T_cubesys_role" = "xmoderator" ] ; then
             if [ $(hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -eq 0 -o $CLUSTER_SIZE -eq 0 ] ; then
                 echo "YES" | hex_cli -c cluster stop

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -23,6 +23,7 @@ BootstrapAndClusterstart()
         msg="Bootstrapping CubeCOS"
         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
+        hex_sdk power_bootup_mark bootstrapping   # cluster bootup status: entering the config commit
         [ -e /etc/appliance/state/rolling_restart_recover ] && hex_sdk _power_roll_set_phase_ts "$(hostname)" bootstrapping   # rolling_restart phase timing
         bash -c "hex_config -p bootstrap standalone-done | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
         if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
@@ -34,6 +35,7 @@ BootstrapAndClusterstart()
             msg="Starting cluster"
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
             hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
+            hex_sdk power_bootup_mark finalizing   # cluster bootup status: entering cluster_start (+ master check_repair)
             [ -e /etc/appliance/state/rolling_restart_recover ] && hex_sdk _power_roll_set_node_status "$(hostname)" finalizing   # rolling_restart: status + phase ts (until power_roll_advance -> done)
             bash -c "hex_sdk -v cube_cluster_start | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
             return 0
@@ -170,6 +172,7 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
     else
         echo "Starting auto bootstrap" >> $BOOTSTRAP_CUBE_MODE
+        hex_sdk power_bootup_mark powering_up   # cluster bootup status: node entered boot bring-up (stamps kernel boot time)
         # Boot-relay advance is driven by cube_cluster_start (power_roll_advance,
         # idempotent, every boot) -- intentionally NOT chained onto the bring-up
         # below, where a non-zero exit could silently skip it and wedge the roll.

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -116,11 +116,11 @@ RollingEvacuateAndReboot()
             if [ "$ROLLING_RECOVER" != "1" ] ; then
                 hex_cli -c cluster check # kick off auto_repair
             fi
-            # Restore recorded VMs (always), synchronously, before the gate below.
-            # active_running holds one VM per line as "<id> [disposition]" --
-            # disposition recorded by the drain: suspended (resume), stopped
-            # (start), or empty/legacy (reset+hardreboot). Read line-by-line.
-            if [ -s /mnt/cephfs/nova/instances/active_running ] ; then
+            # Rolling-restart only: restore recorded VMs now (services stay up). Poweroff/
+            # powercycle defers to boot-end check_repair (power_restore_recorded_vms).
+            # active_running: "<id> [disposition]" -- suspended (resume), stopped (start),
+            # or empty/legacy (reset+hardreboot).
+            if [ "$ROLLING_RECOVER" = "1" ] && [ -s /mnt/cephfs/nova/instances/active_running ] ; then
                 while read -r i disp _ ; do
                     [ -z "$i" ] && continue
                     if hex_sdk os_nova_list id status powerstate |  grep -i "$i active running" ; then

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -53,6 +53,7 @@ hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_opensearch.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_os.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_os/os_cinder.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_ovn.sh
+hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_power.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_preset.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_rabbitmq.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_security.sh

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -448,32 +448,6 @@ cube_cluster_power()
     fi
 }
 
-cube_node_repair()
-{
-    repair_pid=$(cat $CLUSTER_REPAIR 2>/dev/null)
-    if ps -p ${repair_pid:-NOPID} >/dev/null 2>&1 ; then
-        ps $repair_pid
-        ps -o etime $repair_pid
-        return 1
-    else
-        $HEX_SDK check_repair &
-        echo $! >$CLUSTER_REPAIR
-        wait $! && rm -f $CLUSTER_REPAIR
-    fi
-}
-
-cube_cluster_repair()
-{
-    source /usr/sbin/hex_tuning /etc/settings.txt
-    if [ "x$T_cubesys_control_hosts" = "x" ] ; then
-        export MASTER_CONTROL=$T_cubesys_controller
-        [ -n "$MASTER_CONTROL" ] || MASTER_CONTROL=$T_net_hostname
-    else
-        export MASTER_CONTROL=$(echo $T_cubesys_control_hosts | cut -d"," -f1)
-    fi
-    remote_run ${MASTER_CONTROL:-NOMASTER} "$HEX_SDK cube_node_repair"
-}
-
 cube_remote_cluster_check()
 {
     # If this node is control (non moderator), return 1 to run CLI cluster check locally
@@ -1089,16 +1063,6 @@ cube_cluster_ppu()
     fi
 }
 
-cluster_check()
-{
-    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if is_remote_running $node influxdb ; then
-            VERBOSE=1 remote_run $node "HEX_HEALTH_LAST=1 hex_cli -c cluster check"
-            break
-        fi
-    done
-}
-
 # Live-migration essential service comps (rolling restart). Repairable only --
 # just the services the drain/live-migration path depends on. Used as a health
 # gate by rolling restart (same version both sides of the reboot); NOT for
@@ -1143,29 +1107,39 @@ cluster_check_repair_essential()
     return $rc
 }
 
+# Wait until every node has committed (CUBE_DONE marker), bounded by $1 seconds
+# (default 1500). Returns 0 when all committed, 1 on timeout.
+cube_wait_all_committed()
+{
+    local timeout=${1:-1500} waited=0 nodes n allup
+    nodes=$(cubectl node list -j 2>/dev/null | jq -r '.[].hostname')
+    [ -n "$nodes" ] || return 0
+    while [ $waited -lt $timeout ] ; do
+        allup=1
+        for n in $nodes ; do
+            remote_run "$n" "[ -e $CUBE_DONE ]" || { allup=0 ; break ; }
+        done
+        [ "$allup" = 1 ] && return 0
+        sleep 10 ; waited=$((waited+10))
+    done
+    return 1
+}
+
 cluster_check_repair_async()
 {
     # Run the final cluster check_repair off the caller's critical path so the
     # operator gets their prompt back immediately and can start using the box.
     # The result is popped onto the console device(s) and broadcast (wall) when
     # it finishes. Detached via setsid so it survives the parent CLI exiting.
+    # Held until all nodes have committed so it fires once on a settled cluster.
     setsid bash -c '
-        out=$(hex_cli -c cluster check_repair 2>&1)
+        hex_sdk cube_wait_all_committed 1500
+        out=$(hex_cli -c cluster check_repair 2>&1 | grep -av "Broken pipe")
         # Restore VMs recorded at cluster stop, now that services are healed.
         hex_sdk power_restore_recorded_vms
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null
     ' </dev/null >/dev/null 2>&1 &
-}
-
-cluster_check_repair()
-{
-    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if is_remote_running $node influxdb ; then
-            VERBOSE=1 remote_run $node "HEX_HEALTH_LAST=1 hex_cli -c cluster check_repair"
-            break
-        fi
-    done
 }
 
 node_bootstrap_status()

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -272,6 +272,7 @@ cube_cluster_start()
     # "command not found" (proj_functions doesn't source modules/, where
     # power_roll_advance lives).
     hex_sdk power_roll_advance "$HOSTNAME"
+    hex_sdk power_bootup_mark done   # cluster bootup status: this node's boot bring-up complete
 }
 
 # Shared env for the split cube_cluster_start halves.

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -257,6 +257,26 @@ cube_commit_done()
 
 cube_cluster_start()
 {
+    # New rolling-restart design: the per-node half runs on every node's boot;
+    # the master runs the cluster-wide half ONCE, after all nodes are up (the
+    # master is rolled last, so that lands at the end of the roll). Non-master /
+    # single-node-rejoin boots do only the per-node half.
+    cube_cluster_start_node
+    cube_cluster_start_cluster_if_master
+    # Boot-relay step: a node returning from a rolling restart finalizes itself
+    # (restore its suspended VMs, mark done) and kicks the next node. Called here
+    # so it runs on EVERY node's boot, decoupled from the bring-up's exit status
+    # -- relying on a chained call in bootstrap_cube_config let a single non-zero
+    # silently skip the advance and wedge the roll. Idempotent, so a duplicate
+    # call from the boot script is harmless. Via hex_sdk -- a bare call would be
+    # "command not found" (proj_functions doesn't source modules/, where
+    # power_roll_advance lives).
+    hex_sdk power_roll_advance "$HOSTNAME"
+}
+
+# Shared env for the split cube_cluster_start halves.
+_cube_cluster_start_env()
+{
     source /usr/sbin/hex_tuning /etc/settings.txt
     if [ "x$T_cubesys_control_hosts" = "x" ] ; then
         export MASTER_CONTROL=$T_cubesys_controller
@@ -264,9 +284,38 @@ cube_cluster_start()
     else
         export MASTER_CONTROL=$(echo $T_cubesys_control_hosts | cut -d"," -f1)
     fi
+}
 
+# Per-node half: runs on EVERY node's boot/recovery to bring this node's local
+# services into the cluster (node_start trigger + per-node fixups). Idempotent.
+cube_cluster_start_node()
+{
+    _cube_cluster_start_env
     Quiet -n ip neigh flush all
-    Quiet -n $HEX_SDK ceph_leave_maintenance # ensure storage is working (healing itself if necessary) before other actions
+    Quiet -n $HEX_SDK ceph_leave_maintenance # ensure storage is working before other actions
+    if [ "$VERBOSE" == "1" ] ; then
+        /usr/sbin/hex_config -p trigger node_start
+    else
+        /usr/sbin/hex_config trigger node_start
+    fi
+    # Reapply pacemaker scheduler props now the cluster is up (CIB may not have
+    # been ready when config_pacemaker set them).
+    Quiet -n pcs property set stonith-enabled=false pe-error-series-max="1000" pe-warn-series-max="1000" cluster-recheck-interval="5min"
+    cmd "$HEX_SDK network_ipt_serviceint" # customized iptables
+    Quiet -n $HEX_SDK ceph_osd_set_bucket_host # assign osds to customized ceph buckets
+    Quiet -n $HEX_SDK os_resume_hypervisor     # resume hypervisors disabled due to ins-ha
+    Quiet -n killall /usr/sbin/hex_banner # refresh console banner
+    ( $HEX_SDK toggle_health_check | grep ceph_osd | grep -q disabled ) || Quiet -n $HEX_SDK toggle_health_check ceph_osd
+    iptables-save > /run/iptables
+    touch $CLUSTER_SYNC
+}
+
+# Cluster-wide half: runs ONCE from the master when all nodes are up (master
+# rolled last => end of roll; or after a full bring-up). All ops idempotent.
+cube_cluster_start_cluster()
+{
+    _cube_cluster_start_env
+    touch /run/cube_cluster_wide.ran # marker: this node ran the cluster-wide half (expect: master only)
     if [ "$VERBOSE" == "1" ] ; then
         /usr/sbin/hex_config -p trigger cluster_start
     else
@@ -285,25 +334,13 @@ cube_cluster_start()
         [ ! -e /etc/glance/cirros-0.4.0-x86_64-disk.qcow2 ] || $HEX_SDK os_image_import /etc/glance cirros-0.4.0-x86_64-disk.qcow2 Cirros
         [ ! -e /etc/glance/alpine-tools.qcow2 ] || $HEX_SDK os_image_import /etc/glance alpine-tools.qcow2 Alpine
     fi
-    for i in $($OPENSTACK image list -f value | grep "Cirros queued" | cut -d " " -f1) ; do
-        [ $cnt -le 1 ] || $OPENSTACK image delete $i
-    done
     local cnt=0
     for i in $($OPENSTACK image list -f value | grep "Cirros active" | cut -d " " -f1) ; do
         ((cnt++))
         [ $cnt -le 1 ] || $OPENSTACK image delete $i
     done
 
-    touch $CLUSTER_SYNC
-
     cmd "$HEX_SDK migrate_fixpack"
-    cmd "$HEX_SDK network_ipt_serviceint" # customized iptables
-    Quiet -n $HEX_SDK ceph_osd_set_bucket_host # assign osds to customized ceph buckets
-    Quiet -n $HEX_SDK os_resume_hypervisor     # resume hypervisors disabled due to ins-ha
-    Quiet -n killall /usr/sbin/hex_banner # refresh console banner to display up-to-date cluster info.
-    # by default disable ceph_osd which in case of disk failures cannot be handled by software
-    ( $HEX_SDK toggle_health_check | grep ceph_osd | grep -q disabled ) || Quiet -n $HEX_SDK toggle_health_check ceph_osd
-    iptables-save > /run/iptables
     nohup bash -c "$HEX_SDK git_init" >/dev/null 2>&1 &
 
     $OPENSTACK ec2 credentials list --user admin -c Access -c Secret -f value 2>/dev/null | head -n 1 > /run/ec2.key
@@ -318,6 +355,29 @@ cube_cluster_start()
     fi
     keys=$keys timeout $SRVSTO $HEX_SDK os_s3_bucket_create admin log >/dev/null 2>&1
     Quiet -n cubectl node rsync /run/ec2.key
+}
+
+# Master-only, run-once gate for the cluster-wide half. The master waits until
+# every node has finished its per-node start (CLUSTER_SYNC marker), then runs
+# the cluster-wide half once. Since the master is rolled last, on a rolling
+# restart this fires at the end of the roll; on a full bring-up it fires once
+# all nodes are up. A non-master node -- or a single node rejoining a live
+# cluster -- never runs it (its boot path calls only cube_cluster_start_node).
+cube_cluster_start_cluster_if_master()
+{
+    _cube_cluster_start_env
+    [ "x$MASTER_CONTROL" = "x$T_net_hostname" ] || return 0
+    local nodes=$(cubectl node list -j 2>/dev/null | jq -r '.[].hostname')
+    local _i n allup
+    for _i in $(seq 1 90) ; do
+        allup=1
+        for n in $nodes ; do
+            remote_run "$n" "[ -e $CLUSTER_SYNC ]" || { allup=0 ; break ; }
+        done
+        [ "$allup" = 1 ] && break
+        sleep 20
+    done
+    cube_cluster_start_cluster
 }
 
 cube_cluster_stop()
@@ -1019,6 +1079,63 @@ cluster_check()
             break
         fi
     done
+}
+
+# Live-migration essential service comps (rolling restart). Repairable only --
+# just the services the drain/live-migration path depends on. Used as a health
+# gate by rolling restart (same version both sides of the reboot); NOT for
+# rolling upgrade, where mixed-version skew makes these checks report NG as an
+# expected transient. Tier 1 (foundational: DB/MQ/auth/VIP/clock/mon) is checked
+# first; tier 2 (compute/network/data) in parallel after.
+ROLLING_ESSENTIAL_TIER1="mysql rabbitmq memcache httpd haproxy haproxy_ha clock ceph_mon"
+ROLLING_ESSENTIAL_TIER2="nova neutron ceph_osd ceph_mds"
+
+_essential_check_one()
+{
+    # $1=comp $2=repair(1|0). Returns 0 if healthy (after optional repair).
+    local c=$1 repair=$2
+    if _OVERRIDE_MAX_ERR=1 $HEX_SDK health_${c}_check >/dev/null 2>&1 ; then
+        printf ' %-14s ok\n' "$c"
+        return 0
+    fi
+    if [ "$repair" = "1" ] ; then
+        $HEX_SDK health_${c}_repair >/dev/null 2>&1
+        if _OVERRIDE_MAX_ERR=1 $HEX_SDK health_${c}_check >/dev/null 2>&1 ; then
+            printf ' %-14s repaired\n' "$c"
+            return 0
+        fi
+    fi
+    printf ' %-14s FAIL\n' "$c" >&2
+    return 1
+}
+
+cluster_check_repair_essential()
+{
+    # $1=repair (1) or check-only (0, default). Only the live-migration path.
+    # 2-tier: services within each tier run in parallel; tier 1 (foundational)
+    # completes before tier 2 (dependent).
+    local repair=${1:-0} rc=0 c p pids
+    for tier in "$ROLLING_ESSENTIAL_TIER1" "$ROLLING_ESSENTIAL_TIER2" ; do
+        pids=""
+        for c in $tier ; do
+            _essential_check_one "$c" "$repair" & pids="$pids $!"
+        done
+        for p in $pids ; do wait "$p" || rc=1 ; done
+    done
+    return $rc
+}
+
+cluster_check_repair_async()
+{
+    # Run the final cluster check_repair off the caller's critical path so the
+    # operator gets their prompt back immediately and can start using the box.
+    # The result is popped onto the console device(s) and broadcast (wall) when
+    # it finishes. Detached via setsid so it survives the parent CLI exiting.
+    setsid bash -c '
+        out=$(hex_cli -c cluster check_repair 2>&1)
+        con=$(hex_sdk GetKernelConsoleDevices)
+        { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null
+    ' </dev/null >/dev/null 2>&1 &
 }
 
 cluster_check_repair()

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -383,8 +383,25 @@ cube_cluster_start_cluster_if_master()
 
 cube_cluster_stop()
 {
-    if timeout $SRVTO $HEX_SDK health_ceph_mds_check ; then
-        ! $HEX_SDK os_nova_list || $HEX_SDK os_nova_list id status powerstate | grep -i 'active running' | cut -d' ' -f1 > $CEPHFS_NOVA_DIR/instances/active_running
+    # Cleanly stop running VMs before nodes go down, recording each "stopped" to the
+    # shared cephfs record; power_restore_recorded_vms restarts them at boot-end.
+    # Gate on nova being queryable, NOT health_ceph_mds_check (can fail mid-shutdown
+    # and silently skip the snapshot).
+    local _vm _i _active
+    _active=$($HEX_SDK os_nova_list id status powerstate 2>/dev/null | grep -i 'active running' | cut -d' ' -f1)
+    if [ -n "$_active" ] && mountpoint -q /mnt/cephfs ; then
+        mkdir -p $CEPHFS_NOVA_DIR/instances
+        : > $CLUSTER_ACTIVE_RUNNING
+        for _vm in $_active ; do
+            [ "$($OPENSTACK server show "$_vm" -f value -c status 2>/dev/null)" = ERROR ] && os_nova_instance_reset "$_vm"
+            $OPENSTACK server stop "$_vm" >/dev/null 2>&1
+            echo "$_vm stopped" >> $CLUSTER_ACTIVE_RUNNING
+        done
+        # bounded wait for guests to reach SHUTOFF so the reboot does not hard-kill them
+        for _i in $(seq 1 20) ; do
+            [ -z "$($HEX_SDK os_nova_list id status powerstate 2>/dev/null | grep -i 'active running')" ] && break
+            sleep 3
+        done
     fi
     rm -f /var/lib/corosync/*
     rm -rf /var/lib/rabbitmq/mnesia/*
@@ -1134,6 +1151,8 @@ cluster_check_repair_async()
     # it finishes. Detached via setsid so it survives the parent CLI exiting.
     setsid bash -c '
         out=$(hex_cli -c cluster check_repair 2>&1)
+        # Restore VMs recorded at cluster stop, now that services are healed.
+        hex_sdk power_restore_recorded_vms
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null
     ' </dev/null >/dev/null 2>&1 &

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -955,6 +955,15 @@ ClusterRollingRestartMain(int argc, const char** argv)
         return CLI_SUCCESS;
     }
 
+    // status_watch: redraw roll status every 30s until Ctrl-C.
+    if (sub == "status_watch") {
+        HexSystemF(0, "while true ; do clear 2>/dev/null ; "
+                      "echo \"cluster rolling_restart status_watch  @ $(date '+%%F %%T')  "
+                      "(refresh 30s, Ctrl-C to exit)\" ; echo ; "
+                      "%s power_roll_status ; sleep 30 ; done", HEX_SDK);
+        return CLI_SUCCESS;
+    }
+
     if (sub == "continue" || sub == "abort") {
         HexSystemF(0, HEX_SDK " power_roll_decision %s", sub.c_str());
         HexLogEvent(sub == "continue" ? "CLU00002I" : "CLU00003I",
@@ -1064,7 +1073,7 @@ CLI_MODE_COMMAND("cluster", "powercycle", ClusterPowercycleMain, NULL,
 
 CLI_MODE_COMMAND("cluster", "rolling_restart", ClusterRollingRestartMain, NULL,
     "reboot nodes one at a time, evacuating workloads first.",
-    "rolling_restart [<host> ...|dryrun [<host> ...]|status|continue|abort]");
+    "rolling_restart [<host> ...|dryrun [<host> ...]|status|status_watch|continue|abort]");
 
 CLI_MODE_COMMAND("cluster", "recreate", ClusterRecreateMain, NULL,
     "CAUTION! mark to recreate the cluster.",

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -1032,6 +1032,28 @@ ClusterRollingRestartMain(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
+// cluster bootup: per-node boot/recovery phase timing. status = one-shot;
+// status_watch = redraw every 30s until Ctrl-C.
+static int
+ClusterBootupMain(int argc, const char** argv)
+{
+    std::string sub = (argc == 2) ? argv[1] : "status";
+
+    if (sub == "status") {
+        HexSystemF(0, HEX_SDK " power_bootup_status");
+        return CLI_SUCCESS;
+    }
+    if (sub == "status_watch") {
+        HexSystemF(0, "while true ; do clear 2>/dev/null ; "
+                      "echo \"cluster bootup status_watch  @ $(date '+%%F %%T')  "
+                      "(refresh 30s, Ctrl-C to exit)\" ; echo ; "
+                      "%s power_bootup_status ; sleep 30 ; done", HEX_SDK);
+        return CLI_SUCCESS;
+    }
+    CliPrintf("usage: cluster bootup [status|status_watch]");
+    return CLI_INVALID_ARGS;
+}
+
 CLI_MODE(CLI_TOP_MODE, "cluster", "Work with cube cluster.",
     !HexStrictIsErrorState() && !FirstTimeSetupRequired());
 
@@ -1074,6 +1096,10 @@ CLI_MODE_COMMAND("cluster", "powercycle", ClusterPowercycleMain, NULL,
 CLI_MODE_COMMAND("cluster", "rolling_restart", ClusterRollingRestartMain, NULL,
     "reboot nodes one at a time, evacuating workloads first.",
     "rolling_restart [<host> ...|dryrun [<host> ...]|status|status_watch|continue|abort]");
+
+CLI_MODE_COMMAND("cluster", "bootup", ClusterBootupMain, NULL,
+    "cluster power-up / boot-recovery status (per-node phase timing).",
+    "bootup [status|status_watch]");
 
 CLI_MODE_COMMAND("cluster", "recreate", ClusterRecreateMain, NULL,
     "CAUTION! mark to recreate the cluster.",

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -500,6 +500,18 @@ void * ThreadClusterCheckRepairItem(void *thargs) {
     return NULL;
 }
 
+struct TierItemArg {
+    const CheckRepairItem* item;
+    int repair;
+    int result;
+};
+
+void * ThreadCheckRepairItemTier(void *thargs) {
+    TierItemArg* a = (TierItemArg*)thargs;
+    a->result = ClusterCheckRepairItem(*a->item, true, a->repair);
+    return NULL;
+}
+
 static int
 ClusterCheckRepairMain(int argc, const char** argv)
 {
@@ -526,6 +538,14 @@ ClusterCheckRepairMain(int argc, const char** argv)
         return CLI_SUCCESS;
     }
 
+    // Essential suite: only the live-migration path. Used as a health gate by
+    // rolling restart; not for rolling upgrade (mixed-version skew reports NG).
+    if (argc >= 2 && strcmp(argv[1], "essential") == 0) {
+        CliPrintf("Live-migration essential services%s:", repair ? " (check + repair)" : "");
+        HexSystemF(0, HEX_SDK " cluster_check_repair_essential %d", repair);
+        return CLI_SUCCESS;
+    }
+
     if (argc >= 2 && CliMatchCmdHelper(argc, argv, 1, CubeHasRole(R_CORE) ? E_SRVCMD : SRVCMD, &index, &service)) {
         CliPrintf("invalid service %s", service.c_str());
         return CLI_INVALID_ARGS;
@@ -544,23 +564,42 @@ ClusterCheckRepairMain(int argc, const char** argv)
 
     if (index >= 0) {
         ClusterCheckRepairItem(srv, true, repair);
-    } else if (repair) {
-        for (int i = 0 ; i < TOP ; i++) {
-            int ret = ClusterCheckRepairItem(s_services[i], true, repair);
-            if (ret != 0 && s_services[i].failthru == false) {
-                CliPrint("A critical service could not be repaired. Stop checking.");
-                break;
-            }
-        }
     } else {
-        pthread_t thread_id[TOP];
-        for (int i = 0 ; i < TOP ; i++) {
-            if (pthread_create(&thread_id[i], NULL, ThreadClusterCheckRepairItem, (void *)&s_services[i]) != 0) {
-                CliPrintf("Failed to start threads in parallel %ld, %s.", (long)thread_id[i], s_services[i].display.c_str());
-                return -1;
+        // 2-tier parallel: foundational groups (failthru==false) run in parallel,
+        // then the dependent groups (failthru==true) run in parallel. For
+        // check_repair, if a foundational group can't be repaired, stop before
+        // the dependent tier -- preserves the original failthru "stop on critical
+        // failure" semantics while parallelizing within each tier.
+        bool critical_failed = false;
+        for (int tier = 0 ; tier < 2 && !critical_failed ; tier++) {
+            bool foundational = (tier == 0);
+            std::vector<pthread_t> tids;
+            std::vector<TierItemArg*> args;
+            for (int i = 0 ; i < TOP ; i++) {
+                if (s_services[i].failthru == foundational)
+                    continue; // not this tier
+                TierItemArg* a = new TierItemArg{ &s_services[i], repair, 0 };
+                pthread_t tid;
+                if (pthread_create(&tid, NULL, ThreadCheckRepairItemTier, (void *)a) != 0) {
+                    CliPrintf("Failed to start thread for %s.", s_services[i].display.c_str());
+                    delete a;
+                    continue;
+                }
+                tids.push_back(tid);
+                args.push_back(a);
             }
+            for (size_t k = 0 ; k < tids.size() ; k++)
+                pthread_join(tids[k], NULL);
+            if (foundational && repair) {
+                for (size_t k = 0 ; k < args.size() ; k++)
+                    if (args[k]->result != 0)
+                        critical_failed = true;
+            }
+            for (size_t k = 0 ; k < args.size() ; k++)
+                delete args[k];
         }
-        for (int i = 0 ; i < TOP ; i++) pthread_join(thread_id[i], NULL);
+        if (critical_failed)
+            CliPrint("A critical service could not be repaired. Stop checking.");
     }
 
     return CLI_SUCCESS;
@@ -822,10 +861,11 @@ ClusterReadyMain(int argc, const char** argv)
     CliPrintf("[5/6] Strengthening password");
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run hex_sdk cmd " HEX_CFG " cube_password_init");
 
-    CliPrintf("[6/6] Cluster check and repair");
+    CliPrintf("[6/6] Cluster check and repair started in the background.");
+    CliPrintf("      The box is ready to use now; the result will pop up here when it completes.");
     HexSpawn(0, HEX_SDK, "host_local_run", "hex_sdk", "-m force",  "health_neutron_repair", ZEROCHAR_PTR);
-    HexSpawn(0, HEX_SDK, "cmd", "-co", "hex_cli -c cluster check_repair", ZEROCHAR_PTR);
     HexSpawn(0, HEX_SDK, "cmd", "rm -f /tmp/health_*_error.count", ZEROCHAR_PTR);
+    HexSystemF(0, HEX_SDK " cluster_check_repair_async");
 
     CliPrintf("Done");
 
@@ -900,6 +940,89 @@ ClusterErrcodeDumpMain(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
+static int
+ClusterRollingRestartMain(int argc, const char** argv)
+{
+    /*
+     * [0]="rolling_restart"
+     * [1]=[status|continue|abort]   control sub-commands (used alone)
+     * [1..]=<host> ...              explicit targets to start on; none = all
+     */
+    std::string sub = (argc == 2) ? argv[1] : "";
+
+    if (sub == "status") {
+        HexSystemF(0, HEX_SDK " power_roll_status");
+        return CLI_SUCCESS;
+    }
+
+    if (sub == "continue" || sub == "abort") {
+        HexSystemF(0, HEX_SDK " power_roll_decision %s", sub.c_str());
+        HexLogEvent(sub == "continue" ? "CLU00002I" : "CLU00003I",
+            "%s,category=cluster,sub=rolling_restart,action=%s",
+            CliEventAttrs().c_str(), sub.c_str());
+        return CLI_SUCCESS;
+    }
+
+    // dryrun [<host>...]: print the plan (node order + per-VM disposition) and
+    // change nothing. Read-only, so no readiness gate / confirmation.
+    if (argc >= 2 && std::string(argv[1]) == "dryrun") {
+        std::string targets;
+        for (int i = 2; i < argc; i++) {
+            if (!targets.empty()) targets += " ";
+            targets += argv[i];
+        }
+        HexSystemF(0, HEX_SDK " power_roll_plan %s", targets.c_str());
+        return CLI_SUCCESS;
+    }
+
+    // Fail fast: reject a NEW roll if one is already running/paused, before the
+    // dryrun + confirmation, so the operator isn't walked through a plan only to
+    // be refused at start. (status/continue/abort/dryrun above still work mid-roll.)
+    if (HexSystemF(0, HEX_SDK " power_roll_active") == 0) {
+        CliPrintf("A rolling restart is already in progress.");
+        CliPrintf("Run \"cluster rolling_restart status\" to follow it, or \"continue\"/\"abort\".");
+        return CLI_SUCCESS;
+    }
+
+    if (!ClusterReadyCheck())
+        return CLI_SUCCESS;
+
+    // Any remaining args are an explicit target list; none means whole cluster.
+    std::string hosts;
+    for (int i = 1; i < argc; i++) {
+        if (!hosts.empty())
+            hosts += " ";
+        hosts += argv[i];
+    }
+
+    // Always dryrun first: show the operator the real plan (which VMs migrate vs.
+    // get suspended+restored, in a highlighted section) so confirming is informed
+    // consent for that interruption. The roll then runs autonomously.
+    HexSystemF(0, HEX_SDK " power_roll_plan %s", hosts.c_str());
+    CliPrintf("");
+    CliPrintf("Confirming runs the roll autonomously: live-migrate what can move,");
+    CliPrintf("suspend+restore the highlighted VMs, reboot each node (master last).");
+    CliPrintf("It pauses for you only if a migratable VM unexpectedly fails.");
+    if (hosts.empty())
+        CliPrintf("Scope: every node in the cluster.");
+    else
+        CliPrintf("Scope: %s", hosts.c_str());
+    CliPrintf("If this node is included it will be rebooted during the roll, ending this session.");
+    CliPrintf("Job state is shared on cephfs, so follow progress from another node");
+    CliPrintf("(or the cluster VIP) with \"cluster rolling_restart status\".");
+    CliPrintf("If it pauses on a failure, resume with \"cluster rolling_restart continue\" or stop with \"abort\".");
+
+    if (!CliReadConfirmation())
+        return CLI_SUCCESS;
+
+    HexSystemF(0, HEX_SDK " power_roll_start %s", hosts.c_str());
+
+    HexLogEvent("CLU00001I", "%s,category=cluster,sub=rolling_restart,action=start,scope=%s",
+        CliEventAttrs().c_str(), hosts.empty() ? "all" : hosts.c_str());
+
+    return CLI_SUCCESS;
+}
+
 CLI_MODE(CLI_TOP_MODE, "cluster", "Work with cube cluster.",
     !HexStrictIsErrorState() && !FirstTimeSetupRequired());
 
@@ -938,6 +1061,10 @@ CLI_MODE_COMMAND("cluster", "poweroff", ClusterPoweroffMain, NULL,
 CLI_MODE_COMMAND("cluster", "powercycle", ClusterPowercycleMain, NULL,
     "power cycle all nodes in cube cluster.",
     "powercycle");
+
+CLI_MODE_COMMAND("cluster", "rolling_restart", ClusterRollingRestartMain, NULL,
+    "reboot nodes one at a time, evacuating workloads first.",
+    "rolling_restart [<host> ...|dryrun [<host> ...]|status|continue|abort]");
 
 CLI_MODE_COMMAND("cluster", "recreate", ClusterRecreateMain, NULL,
     "CAUTION! mark to recreate the cluster.",

--- a/core/modules/config_haproxy.cpp
+++ b/core/modules/config_haproxy.cpp
@@ -526,5 +526,5 @@ CONFIG_MODULE(haproxy, Init, Parse, 0, 0, Commit);
 CONFIG_OBSERVES(haproxy, cubesys, ParseCube, NotifyCube);
 CONFIG_REQUIRES(haproxy, pacemaker);
 
-CONFIG_TRIGGER_WITH_SETTINGS(haproxy, "cluster_start", ClusterStartMain);
+CONFIG_TRIGGER_WITH_SETTINGS(haproxy, "node_start", ClusterStartMain);
 

--- a/core/modules/config_k3s.cpp
+++ b/core/modules/config_k3s.cpp
@@ -168,4 +168,4 @@ CONFIG_OBSERVES(k3s_last, nova, ParseNova, NotifyNova);
 // Inculde embedded etcd and all workloads and pv on k3s
 CONFIG_MIGRATE(k3s, "/var/lib/rancher/k3s");
 
-CONFIG_TRIGGER_WITH_SETTINGS(k3s_last, "cluster_start", ClusterStartMain);
+CONFIG_TRIGGER_WITH_SETTINGS(k3s_last, "node_start", ClusterStartMain);

--- a/core/modules/config_libvirtd.cpp
+++ b/core/modules/config_libvirtd.cpp
@@ -158,4 +158,4 @@ CONFIG_REQUIRES(libvirtd, cube_scan);
 // extra tunings
 CONFIG_OBSERVES(libvirtd, cubesys, ParseCube, NotifyCube);
 
-CONFIG_TRIGGER_WITH_SETTINGS(libvirtd, "cluster_start", ClusterStartMain);
+CONFIG_TRIGGER_WITH_SETTINGS(libvirtd, "node_start", ClusterStartMain);

--- a/core/modules/config_telegraf.cpp
+++ b/core/modules/config_telegraf.cpp
@@ -373,7 +373,7 @@ CONFIG_REQUIRES(telegraf, kafka);
 CONFIG_OBSERVES(telegraf, cubesys, ParseCube, NotifyCube);
 CONFIG_OBSERVES(telegraf, kapacitor, ParseKapacitor, NotifyKapacitor);
 
-CONFIG_TRIGGER_WITH_SETTINGS(telegraf, "cluster_start", ClusterStartMain);
+CONFIG_TRIGGER_WITH_SETTINGS(telegraf, "node_start", ClusterStartMain);
 
 CONFIG_MIGRATE(telegraf, DEV_LIST);
 

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -509,6 +509,10 @@ health_hacluster_check()
 
 _health_hacluster_auto_repair()
 {
+    # Skip auto-repair unless all control nodes are ready (avoid churn while corosync reforms).
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        remote_run $node "$HEX_SDK cube_node_ready" >/dev/null 2>&1 || return 0
+    done
     health_hacluster_repair
     if [ $ERR_CODE -eq 6 ] ; then
         health_ceph_mds_repair
@@ -544,7 +548,7 @@ health_hacluster_repair()
             elif [ "x$node" = "x$HOSTNAME" -a "x$node" = "x$master" ] ; then
                 $HEX_SDK pacemaker_node_stop $node
             else
-                $HEX_SDK pacemaker_node_start $node
+                # Peer already in the ring: don't restart it, just reconcile vaw.
                 cmd -co "pcs resource remove vaw" # v3.0.0 or older doesn't have vaw, hindering VIP to start
             fi
         done
@@ -687,6 +691,28 @@ health_rabbitmq_check()
 
 health_rabbitmq_repair()
 {
+    local total=${#CUBE_NODE_CONTROL_HOSTNAMES[@]}
+    local stats=$($HEX_CFG status_rabbitmq 2>/dev/null)
+    local running=$(echo "$stats" | jq -r '.running_nodes[]?' 2>/dev/null)
+    local running_cnt=$(echo "$running" | grep -c .)
+    local partition=$(echo "$stats" | jq -r '.partitions[]?' 2>/dev/null | grep -c .)
+    local seed=$(echo "$running" | head -1)
+
+    # Healthy core (running majority, no partition): rejoin only missing nodes, preserve state.
+    if [ "$running_cnt" -ge $(( total / 2 + 1 )) ] && [ "$partition" -eq 0 ] ; then
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            echo "$running" | grep -q "rabbit@$node$" && continue
+            remote_run $node "systemctl restart rabbitmq-server"
+            sleep 8
+            if ! $HEX_CFG status_rabbitmq 2>/dev/null | jq -r '.running_nodes[]?' | grep -q "rabbit@$node$" ; then
+                # stale/split mnesia: reset only this node and rejoin the core
+                remote_run $node "rabbitmqctl stop_app ; rabbitmqctl reset ; rabbitmqctl join_cluster $seed ; rabbitmqctl start_app"
+            fi
+        done
+        return 0
+    fi
+
+    # No healthy core (majority down or partitioned) -- full rebuild.
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
         remote_systemd_stop $node rabbitmq-server
         remote_run $node rm -rf /var/lib/rabbitmq/mnesia/*
@@ -743,16 +769,33 @@ health_mysql_check()
 _health_mysql_repair()
 {
     local ts=$(date +%Y%m%d-%H%M%S)
-    local master=$CUBE_NODE_CONTROL_HOSTNAMES
 
-    cmd -c "hex_sdk remote_systemd_stop \$HOSTNAME mariadb ; killall -9 mariadbd ; rm -f /var/lib/mysql/mysql.sock"
+    # If a galera primary is still live, rejoin it instead of bootstrapping (avoids split-brain).
+    local primary=""
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if [ "$(remote_run $node "mysql -u root -N -e \"show status like 'wsrep_cluster_status'\" 2>/dev/null | awk '{print \$2}'")" = "Primary" ] ; then
+            primary=$node ; break
+        fi
+    done
+
+    if [ -n "$primary" ] ; then
+        # rejoin every non-Synced node: clear wedged unit, disarm bootstrap, plain start
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            [ "$(remote_run $node "mysql -u root -N -e \"show status like 'wsrep_local_state_comment'\" 2>/dev/null | awk '{print \$2}'")" = "Synced" ] && continue
+            remote_run $node "systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; rm -f /var/lib/mysql/mysql.sock ; sed -i 's/safe_to_bootstrap: 1/safe_to_bootstrap: 0/' /var/lib/mysql/grastate.dat ; systemctl start mariadb"
+        done
+        return 0
+    fi
+
+    # No primary: bootstrap a fresh cluster from the last control node, rest join.
     cmd -c "cp -rp /var/lib/mysql /var/lib/mysql-\${HOSTNAME}-${ts}"
     local cnt=0
     for node in $(for n in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do echo $n ; done | tac) ; do
         ((cnt++))
         if [ $cnt -eq 1 ] ; then # last control node
-            remote_run $node "sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/' /var/lib/mysql/grastate.dat"
+            remote_run $node "systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/' /var/lib/mysql/grastate.dat"
             remote_run $node galera_new_cluster
+            remote_run $node "sed -i 's/safe_to_bootstrap: 1/safe_to_bootstrap: 0/' /var/lib/mysql/grastate.dat"
         else
             remote_systemd_start $node mariadb
         fi
@@ -761,7 +804,9 @@ _health_mysql_repair()
 
 health_mysql_repair()
 {
-    cmd -cor "timeout $SRVTO systemctl stop mariadb ; killall -9 mariadbd ; systemctl start mariadb"
+    # mariadb.service is SendSIGKILL=no, so a hung stop wedges the unit: try restart,
+    # else force-clear the wedge (kill + reset-failed) and start.
+    cmd -cor "timeout $SRVTO systemctl restart mariadb || { systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; systemctl start mariadb ; }"
     if ! health_mysql_check ; then
         # multiple attempts to fix is needed, especially after rolling-upgrade
         for i in 1 2 3 ; do
@@ -858,6 +903,15 @@ health_vip_repair()
     fi
     # if first time setup not completed or cluster in rolling upgrade process, ensure master node has VIP
     if [ ! -e /etc/appliance/state/configured ] || is_node_rolling_upgrade ; then
+        # Wait (<=60s) for stable all-online membership before moving the VIP.
+        for _w in $(seq 1 12) ; do
+            local _st=$(pcs status 2>/dev/null)
+            local _online=$(echo "$_st" | grep -i " online" | cut -d "[" -f2 | cut -d "]" -f1 | awk '{print NF}')
+            if [ "$_online" = "${#CUBE_NODE_CONTROL_HOSTNAMES[@]}" ] && ! echo "$_st" | grep -qiE "pending|in progress" ; then
+                break
+            fi
+            sleep 5
+        done
         local master=$CUBE_NODE_CONTROL_HOSTNAMES
         if remote_run $master "pcs resource status vip" | grep -q Started ; then
             for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
@@ -1257,16 +1311,32 @@ health_ceph_report()
     _health_report ${FUNCNAME[0]}
 }
 
+# Returns 0 if ceph has a blocking health check (data unavailable, capacity,
+# corruption, no quorum); 1 if only transient recovery checks are non-OK.
+_ceph_blocking_health()
+{
+    local stats="${1:-$($CEPH status -f json 2>/dev/null)}"
+    local c
+    for c in $(echo "$stats" | jq -r '.health.checks | keys[]' 2>/dev/null) ; do
+        case "$c" in
+            PG_AVAILABILITY|OSD_FULL|OSD_BACKFILLFULL|OSD_NEARFULL|\
+            POOL_FULL|POOL_NEAR_FULL|POOL_BACKFILLFULL|\
+            PG_BACKFILL_FULL|PG_RECOVERY_FULL|PG_DAMAGED|OSD_SCRUB_ERRORS|\
+            MON_DOWN|MON_CLOCK_SKEW|FS_WITH_FAILED_MDS|MDS_ALL_DOWN|MDS_DAMAGE)
+                return 0 ;;
+        esac
+    done
+    return 1
+}
+
 health_ceph_check()
 {
     local stats=$($CEPH status -f json)
     local service_stats="$(echo $stats | jq -r .health.status)"
 
     ERR_LOG="journalctl -n $ERR_LOGSIZE -u ceph-mon@$HOSTNAME"
-    if [ "$service_stats" = "HEALTH_WARN" ] ; then
-        ERR_CODE=1
-    elif [ "$service_stats" = "HEALTH_ERR" ] ; then
-        ERR_CODE=2
+    if [ "$service_stats" != "HEALTH_OK" ] && _ceph_blocking_health "$stats" ; then
+        [ "$service_stats" = "HEALTH_ERR" ] && ERR_CODE=2 || ERR_CODE=1
     fi
 
     ERR_MSG="`$CEPH health detail`"
@@ -1498,13 +1568,15 @@ health_ceph_osd_check()
     local total=$(echo $stats | jq -r .osdmap.num_osds)
     local uposd=$(echo $stats | jq -r .osdmap.num_up_osds)
     local inosd=$(echo $stats | jq -r .osdmap.num_in_osds)
-    if [ "$total" != "$uposd" ] ; then
-        ERR_CODE=1
-    elif [ "$total" != "$inosd" ] ; then
-        ERR_CODE=2
-    elif cmd "$HEX_SDK ceph_osd_list" | sort -t. -n -k2 | egrep -q "warning|fail" ; then
+    if cmd "$HEX_SDK ceph_osd_list" | sort -t. -n -k2 | egrep -q "warning|fail" ; then
+        # device hardware fault -- always a fault, even mid-recovery
         ERR_CODE=3
         ERR_LOG="dmesg | grep -i -e fail -e error"
+    elif [ "$total" != "$uposd" ] ; then
+        # OSDs still rejoining -- only a fault if data is unavailable
+        _ceph_blocking_health "$stats" && ERR_CODE=1
+    elif [ "$total" != "$inosd" ] ; then
+        _ceph_blocking_health "$stats" && ERR_CODE=2
     fi
 
     ERR_MSG+="`$CEPH health detail`"
@@ -3408,6 +3480,22 @@ _health_neutron_deep_repair()
 
 _health_datapipe_deep_repair()
 {
+    # This wipes+rebuilds the datapipe, so gate it behind a cooldown to avoid
+    # thrashing a stack that is still converging after boot.
+    local _dp_marker=/run/cube_datapipe_deep_repair.ts _dp_cooldown=900
+    local _dp_now _dp_last
+    _dp_now=$(date +%s)
+    if [ -f "$_dp_marker" ] ; then
+        _dp_last=$(cat "$_dp_marker" 2>/dev/null) ; [ -n "$_dp_last" ] || _dp_last=0
+        if [ $((_dp_now - _dp_last)) -lt $_dp_cooldown ] ; then
+            return 0   # in cooldown: let the datapipe finish converging, don't thrash
+        fi
+    else
+        echo "$_dp_now" > "$_dp_marker" 2>/dev/null
+        return 0       # first call this boot: seed the timer, give it time to converge
+    fi
+    echo "$_dp_now" > "$_dp_marker" 2>/dev/null
+
     cmd -c systemctl stop zookeeper kafka logstash kapacitor influxdb monasca-forwarder monasca-persister telegraf
     Quiet -n sleep 10
     cmd -c "rm -rf /tmp/zookeeper/* /var/lib/kafka/* /var/lib/logstash/*"

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1347,7 +1347,8 @@ _os_pre_failure_host_evacuation()
             cmd -c $HEX_SDK stale_api_check_repair neutron-server 9696 neutron-server server 0
             cmd -c $HEX_SDK stale_api_check_repair openstack-cinder-api 8776 cinder-api python3 0
 
-            if [ $($OPENSTACK compute service list -f value -c Status -c State | grep -v -i "enabled up" | wc -l) -ge 1 ] ; then
+            # restart only "enabled down" services; leave "disabled" (drained/maintenance) hosts alone.
+            if [ $($OPENSTACK compute service list -f value -c Status -c State | grep -ci "enabled down") -ge 1 ] ; then
                 cmd -c systemctl restart openstack-nova-scheduler
                 cmd -c systemctl restart openstack-nova-conductor
                 cmd -p systemctl restart openstack-nova-compute

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -1,0 +1,712 @@
+# sdk_power.sh -- node/cluster power lifecycle: the rolling-restart machinery.
+#
+# Extracted from proj_functions + sdk_os.sh. Follows the hex_sdk module
+# convention (sdk_power.sh <-> power_* functions), so `hex_sdk power_yyy`
+# sources just this module; private helpers _power_* resolve via the
+# all-modules fallback. Available in every roll context: the CLI, the
+# control-node drain, remote_run, and each node's boot path (cube_cluster_start
+# -> power_roll_advance).
+# --- Rolling restart -------------------------------------------------------
+# Operator-triggered, workload-preserving reboot of every node, one at a time.
+# Built as a boot-relay: the job state lives on shared cephfs and is advanced
+# from each node's boot path, so the chain survives the node it is rebooting --
+# including the node the operator triggered it from and the master control node.
+# Compute workloads are live-migrated off a node before it goes down. Because
+# the state is shared, progress is readable from any node ("rolling_restart
+# status"); it is also what cube-cos-api / cos-ui will drive later.
+
+ROLLING_RESTART_DIR=/mnt/cephfs/rolling_restart
+ROLLING_RESTART_JOB=$ROLLING_RESTART_DIR/job.json
+
+_power_roll_set_str()
+{
+    jq --arg v "$2" ".$1=\$v" $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+}
+
+_power_roll_set_raw()
+{
+    jq --argjson v "$2" ".$1=\$v" $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+}
+
+_power_roll_set_node_status()
+{
+    jq --arg h "$1" --arg s "$2" '(.nodes[]|select(.hostname==$h).status)=$s' $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+}
+
+_power_roll_set_node_num()
+{
+    jq --arg h "$1" --argjson v "$3" "(.nodes[]|select(.hostname==\$h).$2)=\$v" $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+}
+
+_power_roll_pause()
+{
+    _power_roll_set_str reason "$1"
+    _power_roll_set_str state paused
+    echo "rolling restart paused: $1" >&2
+    /usr/sbin/hex_log_event -e CLU00004W "interface=system,host=$HOSTNAME,category=cluster,sub=rolling_restart,action=pause,reason=$1"
+}
+
+_power_roll_drain_poll()
+{
+    # Background helper (runs on the control node driving the evacuation):
+    # refresh the in-flight host's progress in the job state until the drain
+    # finishes (sentinel removed). A VM is "handled" once it leaves ACTIVE on
+    # this host -- live-migrating/migrated, or paused-in-place for a non-
+    # migratable passthrough VM. vms_paused isolates the paused ones (they take
+    # reboot downtime); migrated = vms_done - vms_paused. init_inactive is the
+    # VMs already non-ACTIVE at start (e.g. SHUTOFF), excluded from "paused".
+    local host=$1 total=$2 sentinel=$3 allstart=$4
+    local init_inactive=$(( allstart - total ))
+    [ $init_inactive -lt 0 ] && init_inactive=0
+    while [ -e "$sentinel" ] ; do
+        sleep 5
+        local states
+        states=$($OPENSTACK server list --host "$host" --all-projects -f value -c Status 2>/dev/null) || continue
+        local hall=$(printf '%s\n' "$states" | grep -c .)
+        local active=$(printf '%s\n' "$states" | grep -c '^ACTIVE$')
+        local migrating=$(printf '%s\n' "$states" | grep -c '^MIGRATING$')
+        local handled=$(( total - active ))
+        [ $handled -lt 0 ] && handled=0
+        local paused=$(( hall - active - init_inactive - migrating ))
+        [ $paused -lt 0 ] && paused=0
+        _power_roll_set_node_num "$host" vms_done $handled
+        _power_roll_set_node_num "$host" vms_paused $paused
+    done
+}
+
+_power_roll_kick()
+{
+    # Drain (if compute-bearing) and reboot one node. Pauses the job on any
+    # gate failure so an operator can decide. Dispatches OpenStack work to the
+    # master control node, which holds the credentials.
+    local host=$1
+    local role=$(jq -r --arg h "$host" '.nodes[]|select(.hostname==$h)|.role' $ROLLING_RESTART_JOB)
+    local ip=$(jq -r --arg h "$host" '.nodes[]|select(.hostname==$h)|.ip' $ROLLING_RESTART_JOB)
+    local master=$(cubectl node list | head -n1 | awk -F',' '{print $1}')
+
+    # Never take a second node down while another is still away.
+    if ! $HEX_SDK cube_cluster_ready ; then
+        _power_roll_pause "cluster not ready before rolling $host"
+        return 1
+    fi
+    for n in $(cubectl node list -j | jq -r '.[].ip.management') ; do
+        [ "x$n" = "x$ip" ] && continue
+        if ! is_sshable $n ; then
+            _power_roll_pause "node $n is unreachable; will not take $host down too"
+            return 1
+        fi
+    done
+
+    _power_roll_set_str inflight "$host"
+    _power_roll_set_node_num "$host" started $(date +%s)
+    _power_roll_set_raw deadline $(( $(date +%s) + ${ROLLING_NODE_TIMEOUT:-3600} ))
+
+    case "$role" in
+        *compute*|control-converged|edge-core)
+            _power_roll_set_node_status "$host" draining
+            echo "evacuating workloads off $host"
+            if ! remote_run $master "$HEX_SDK power_node_evacuate $host" ; then
+                local stuck=""
+                [ -s "$ROLLING_RESTART_DIR/.stuck.$host" ] && stuck=": $(tr '\n' ' ' < "$ROLLING_RESTART_DIR/.stuck.$host")"
+                _power_roll_pause "could not live-migrate all workloads off $host${stuck} -- migrate or stop them, then run rolling_restart continue"
+                return 1
+            fi
+            ;;
+    esac
+
+    if ! is_sshable $ip ; then
+        _power_roll_pause "$host ($ip) is unreachable"
+        return 1
+    fi
+
+    _power_roll_set_node_status "$host" rebooting
+    echo "rebooting $host"
+    # Drop a local marker so the node's boot path waits for the cluster to be
+    # ready (single-node ceph recovery can take ~20 min) before running the VM
+    # restore + relay advance, instead of checking once early and skipping.
+    ssh root@$ip "touch /etc/appliance/state/rolling_restart_recover ; echo YES | hex_cli -c reboot" >/dev/null 2>&1
+    return 0
+}
+
+# Nova-DB helpers for the roll. Always-sourced (modules glob) so both the drain
+# and the dry-run can reach them in any hex_sdk context.
+
+# UUIDs of VMs that cannot live-migrate, in ONE nova DB query instead of a
+# per-VM openstack call. PCI/GPU passthrough is the signal (allocated rows in
+# pci_devices). Stable for a roll, so callers fetch it once and test membership.
+_power_nonmigratable_vms()
+{
+    $MYSQL -u root -N -D nova -e \
+        "SELECT DISTINCT instance_uuid FROM pci_devices WHERE instance_uuid IS NOT NULL" 2>/dev/null
+}
+
+# Per-host EFFECTIVE free RAM(MB) and vCPUs from the nova DB (one query). The
+# allocation ratios come from compute_nodes, which nova derives from the cubecos
+# overcommit tunings (nova.overcommit.cpu/ram.ratio) -- so this reflects the
+# tuning without a hard-coded value. Applying them matters because CPU is
+# typically overcommitted; a raw vcpus-vcpus_used would go negative and wrongly
+# reject every VM. Output: "host ram vcpu".
+_power_host_free_capacity()
+{
+    $MYSQL -u root -N -D nova -e \
+        "SELECT hypervisor_hostname, memory_mb * ram_allocation_ratio - memory_mb_used, vcpus * cpu_allocation_ratio - vcpus_used FROM compute_nodes WHERE deleted = 0" 2>/dev/null
+}
+
+# Best-effort: could a VM of $ram MB / $vcpu cores fit on some host other than
+# $exclude, given the current free-capacity snapshot ($cap)? Approximate --
+# ignores cumulative fill during the roll and nova's NUMA/affinity weighing;
+# used only for the --dry-run hint.
+_power_capacity_fits_elsewhere()
+{
+    local cap=$1 exclude=$2 ram=$3 vcpu=$4
+    echo "$cap" | awk -v ex="$exclude" -v r="$ram" -v c="$vcpu" \
+        '$1 != ex && $2 >= r && $3 >= c { ok = 1 } END { exit !ok }'
+}
+
+power_roll_plan()
+{
+    # Dry run: print the roll plan -- node order and, per VM, what would happen
+    # (live-migrate vs pause+restore) -- and change nothing. Mirrors the node
+    # ordering in power_roll_start.
+    local want="$*"
+    local master=$(cubectl node list | head -n1 | awk -F',' '{print $1}')
+    local ncompute=$(cubectl node -r compute list -j | jq -r '.[].hostname' | grep -c .)
+    local nonmig=$(_power_nonmigratable_vms)       # one DB query: passthrough VMs
+    local cap=$(_power_host_free_capacity)         # one DB query: per-host free ram/vcpu
+    # All active VMs, one DB query: "uuid host ram_mb vcpu name" (no per-VM API).
+    local allvms=$($MYSQL -u root -N -D nova -e \
+        "SELECT uuid, host, memory_mb, vcpus, display_name FROM instances WHERE deleted = 0 AND vm_state = 'active'" 2>/dev/null)
+    local order=$(cubectl node list -j | jq -r --arg want "$want" '
+        ($want | split(" ") | map(select(length > 0))) as $sel
+        | [ .[] | select(($sel|length)==0 or (.hostname as $h | $sel | index($h))) ]
+        | sort_by(
+            (if (.role|test("compute")) then 0 elif (.role|test("storage")) then 1 else 2 end))
+        | .[] | .hostname + " " + .role')
+
+    echo "Rolling restart plan (dry run) -- no changes will be made."
+    echo "Order: compute -> storage -> control; master ($master) rolled last."
+    echo
+    local host role id vmhost ram vcpu name hostvms reason
+    local interrupt=""   # cannot-migrate VMs, collected for the highlighted section
+    while read -r host role ; do
+        [ -z "$host" ] && continue
+        echo "== $host ($role) =="
+        hostvms=$(echo "$allvms" | awk -v h="$host" '$2 == h')
+        [ -z "$hostvms" ] && { echo "  (no running VMs)" ; continue ; }
+        while read -r id vmhost ram vcpu name ; do
+            [ -z "$id" ] && continue
+            reason=""
+            if echo "$nonmig" | grep -qFx "$id" ; then
+                reason="PCI/GPU passthrough"
+            elif [ "$ncompute" -le 1 ] ; then
+                reason="single hypervisor"
+            elif ! _power_capacity_fits_elsewhere "$cap" "$host" "$ram" "$vcpu" ; then
+                reason="may not fit on another host"
+            fi
+            if [ -n "$reason" ] ; then
+                echo "  $name: cannot live-migrate ($reason)"
+                interrupt="${interrupt}    $host / $name  ($reason)"$'\n'
+            else
+                echo "  $name: live-migrate (no downtime)"
+            fi
+        done <<< "$hostvms"
+    done <<< "$order"
+    echo
+    if [ -n "$interrupt" ] ; then
+        echo "!! ==================================================================="
+        echo "!! WILL BE INTERRUPTED -- the following VMs cannot be live-migrated and"
+        echo "!! will be SUSPENDED, then restored after their node reboots, incurring"
+        echo "!! reboot downtime:"
+        echo "!!"
+        printf '%s' "$interrupt"
+        echo "!!"
+        echo "!! Confirming the rolling restart ACKNOWLEDGES this downtime."
+        echo "!! ==================================================================="
+        echo
+    else
+        echo "All running VMs can be live-migrated -- no workload downtime expected."
+        echo
+    fi
+    echo "(Capacity is a current snapshot; will decides actual placement at run time.)"
+}
+
+# Exit 0 if a roll is currently running or paused. The CLI uses this to fail fast
+# (reject a new roll before the dryrun+confirm); power_roll_start re-checks under
+# a lock as the real mutex.
+power_roll_active()
+{
+    # A node mid-roll-recovery hasn't mounted cephfs yet, so the shared job.json
+    # is unreadable there. The local roll-recover marker (dropped by the kick
+    # before reboot, cleared at boot once the cluster is ready) covers that
+    # window, so the running roll is detected even on the node being rebooted.
+    # The shared job state covers every other node.
+    [ -e /etc/appliance/state/rolling_restart_recover ] && return 0
+    [ -e "$ROLLING_RESTART_JOB" ] || return 1
+    case "$(jq -r .state "$ROLLING_RESTART_JOB" 2>/dev/null)" in
+        running|paused) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+power_roll_start()
+{
+    mkdir -p $ROLLING_RESTART_DIR
+
+    # Serialize start across nodes: the check-and-claim must be atomic so two
+    # operators triggering from different hosts can't both create a job. The
+    # lock is held only over the critical section, then released before the
+    # reboot kick; thereafter the job's own state="running" is the mutex.
+    (
+        flock -x -w 10 200 || { echo "could not acquire rolling-restart lock" >&2 ; exit 1 ; }
+
+        local cur="none"
+        [ -e "$ROLLING_RESTART_JOB" ] && cur=$(jq -r .state $ROLLING_RESTART_JOB 2>/dev/null)
+        if [ "$cur" = "running" -o "$cur" = "paused" ] ; then
+            echo "a rolling restart is already in progress (state: $cur)" >&2
+            exit 1
+        fi
+
+        if ! $HEX_SDK cube_cluster_ready ; then
+            echo "cluster is not ready; refusing to start a rolling restart" >&2
+            exit 1
+        fi
+
+        # Optional explicit target list (positional args); empty = whole cluster.
+        local want="$*"
+
+        # Order: compute -> storage -> control, with the master control node last.
+        local master=$(cubectl node list | head -n1 | awk -F',' '{print $1}')
+        local nodes=$(cubectl node list -j | jq -c --arg m "$master" --arg want "$want" '
+            ($want | split(" ") | map(select(length > 0))) as $sel
+            | [ .[]
+                | select(($sel | length) == 0 or (.hostname as $h | $sel | index($h)))
+                | {hostname: .hostname, role: .role, ip: .ip.management, status: "pending", started: 0, finished: 0, vms_total: 0, vms_done: 0} ]
+            | sort_by(
+                (if (.role|test("compute")) then 0 elif (.role|test("storage")) then 1 else 2 end),
+                (if .hostname==$m then 1 else 0 end))')
+
+        # Reject any requested host that is not a real cluster node.
+        if [ -n "$want" ] ; then
+            local matched=$(echo "$nodes" | jq -r '.[].hostname')
+            for w in $want ; do
+                echo "$matched" | grep -qx "$w" || { echo "unknown node: $w" >&2 ; exit 1 ; }
+            done
+        fi
+
+        jq -n --argjson nodes "$nodes" \
+            '{state:"running", inflight:"", deadline:0, reason:"", decision:"", nodes:$nodes}' \
+            > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+    ) 200>"$ROLLING_RESTART_DIR/.lock"
+    [ $? -eq 0 ] || return 1
+
+    echo "rolling restart started across $(jq '.nodes|length' $ROLLING_RESTART_JOB) node(s)"
+    # Only warn about a self-reboot if this node is actually in the roll; with an
+    # explicit target list the operator's node may be excluded. State is shared
+    # on cephfs, so progress is followable from any node either way.
+    if jq -e --arg h "$HOSTNAME" 'any(.nodes[]; .hostname==$h)' $ROLLING_RESTART_JOB >/dev/null ; then
+        echo "NOTE: $HOSTNAME will be rebooted as part of this roll; once it goes down,"
+        echo "      run \"cluster rolling_restart status\" from another node to follow progress."
+    else
+        echo "follow progress with \"cluster rolling_restart status\"."
+    fi
+    power_roll_advance
+}
+
+power_roll_advance()
+{
+    # Called from each node's boot path. No-op unless a job is running.
+    # Finalizes the node that just came back, then kicks the next one.
+    local booted=${1:-$HOSTNAME}
+
+    [ -e "$ROLLING_RESTART_JOB" ] || return 0
+    [ "$(jq -r .state $ROLLING_RESTART_JOB 2>/dev/null)" = "running" ] || return 0
+
+    local master=$(cubectl node list | head -n1 | awk -F',' '{print $1}')
+    local inflight=$(jq -r '.inflight // ""' $ROLLING_RESTART_JOB)
+
+    if [ -n "$inflight" ] && [ "x$inflight" = "x$booted" ] ; then
+        # Restore the VMs this node suspended/stopped for its reboot (downtime
+        # acknowledged at confirm time). Dispatch to the master (holds creds).
+        local arun="$CEPHFS_NOVA_DIR/instances/active_running" vm disp
+        if [ -s "$arun" ] ; then
+            while read -r vm disp _ ; do
+                [ -z "$vm" ] && continue
+                Quiet -n remote_run $master "$HEX_SDK power_vm_restore $vm $disp"
+            done < "$arun"
+            : > "$arun"
+        fi
+        case "$(jq -r --arg h "$booted" '.nodes[]|select(.hostname==$h)|.role' $ROLLING_RESTART_JOB)" in
+            *compute*|control-converged|edge-core)
+                Quiet -n remote_run $master "$HEX_SDK power_node_resume $booted" ;;
+        esac
+        _power_roll_set_node_num "$booted" finished $(date +%s)
+        _power_roll_set_node_status "$booted" done
+        _power_roll_set_str inflight ""
+    fi
+
+    # Only advance once the in-flight node has been finalized. A spurious reboot
+    # of any other node must not kick the next one.
+    [ -z "$(jq -r '.inflight // ""' $ROLLING_RESTART_JOB)" ] || return 0
+
+    local next=$(jq -r 'first(.nodes[]|select(.status=="pending")|.hostname) // ""' $ROLLING_RESTART_JOB)
+    if [ -z "$next" ] ; then
+        _power_roll_set_str state done
+        echo "rolling restart complete"
+        /usr/sbin/hex_log_event -e CLU00005I "interface=system,host=$HOSTNAME,category=cluster,sub=rolling_restart,action=complete"
+        return 0
+    fi
+
+    _power_roll_kick "$next"
+}
+
+power_roll_status()
+{
+    if [ ! -e "$ROLLING_RESTART_JOB" ] ; then
+        echo "no rolling restart job found"
+        return 0
+    fi
+
+    local state=$(jq -r .state $ROLLING_RESTART_JOB)
+    local inflight=$(jq -r '.inflight // ""' $ROLLING_RESTART_JOB)
+    local reason=$(jq -r '.reason // ""' $ROLLING_RESTART_JOB)
+
+    echo "state:    $state"
+    [ -n "$inflight" ] && echo "inflight: $inflight"
+    [ -n "$reason" ] && echo "reason:   $reason"
+    if [ "$state" = "running" ] && [ -n "$inflight" ] ; then
+        local deadline=$(jq -r '.deadline // 0' $ROLLING_RESTART_JOB)
+        if [ "$(date +%s)" -gt "$deadline" ] ; then
+            echo "warning:  $inflight has not returned within the expected window (stalled)"
+        fi
+    fi
+    echo ""
+    local now=$(date +%s)
+    local window=${ROLLING_NODE_TIMEOUT:-3600}
+    printf " %-20s %-18s %-9s %-10s %s\n" "node" "role" "status" "vms(m+p/tot)" "elapsed"
+    jq -r '.nodes[]|"\(.hostname)\t\(.role)\t\(.status)\t\(.started // 0)\t\(.finished // 0)\t\(.vms_total // 0)\t\(.vms_done // 0)\t\(.vms_paused // 0)"' $ROLLING_RESTART_JOB | \
+        while IFS=$'\t' read -r h r s st fin vt vd vp ; do
+            el="-"
+            if [ "$st" -gt 0 ] ; then
+                end=$fin
+                [ "$end" -gt 0 ] || end=$now
+                secs=$(( end - st ))
+                el=$(printf '%dm%02ds' $(( secs / 60 )) $(( secs % 60 )))
+                [ "$fin" -eq 0 ] && [ "$secs" -gt "$window" ] && el="$el (stalled)"
+            fi
+            vms="-"
+            if [ "$s" = "draining" ] ; then
+                mig=$(( vd - vp )) ; [ $mig -lt 0 ] && mig=0
+                if [ "${vp:-0}" -gt 0 ] ; then vms="${mig}m+${vp}p/$vt" ; else vms="$mig/$vt" ; fi
+            fi
+            printf " %-20s %-18s %-9s %-10s %s\n" "$h" "$r" "$s" "$vms" "$el"
+        done
+}
+
+power_roll_status_json()
+{
+    # Machine-readable progress for API/UI integration. Projects the job state
+    # into the same envelope cube-cos-api uses for firmware rolling upgrade
+    # (firmwares.Upgrade / Progress / SystemUpdateProgress), so the Go layer can
+    # unmarshal it directly and cos-ui can reuse its existing progress views.
+    if [ ! -e "$ROLLING_RESTART_JOB" ] ; then
+        echo '{"isRollingApplied":true,"state":"none","reason":"","progresses":[]}'
+        return 0
+    fi
+
+    jq '
+        (.inflight // "") as $inf
+        | (.state // "") as $state
+        | (.reason // "") as $reason
+        | {
+            isRollingApplied: true,
+            state: $state,
+            reason: $reason,
+            progresses: [ .nodes[]
+                | (($state == "paused") and (.hostname == $inf)) as $failed
+                | (.vms_total // 0) as $vt
+                | (.vms_done // 0) as $vd
+                | (if .status == "draining" then "evacuting vms on host"
+                   elif .status == "rebooting" then "rebooting"
+                   elif .status == "done" then "succeeded"
+                   else "pending" end) as $phase
+                | {
+                    host: .hostname,
+                    phase: $phase,
+                    status: {
+                        current: (if $failed then "failed" else $phase end),
+                        isProcessing: (((.status == "draining") or (.status == "rebooting")) and ($failed | not)),
+                        processPercent: (
+                            if .status == "done" then 100
+                            elif $failed then 0
+                            elif .status == "rebooting" then 75
+                            elif .status == "draining" then (if $vt > 0 then (($vd / $vt) * 50 | floor) else 25 end)
+                            else 0 end),
+                        description: (if $failed then $reason else "" end),
+                        vmsTotal: $vt,
+                        vmsDone: $vd
+                    }
+                } ]
+        }' $ROLLING_RESTART_JOB
+}
+
+power_roll_decision()
+{
+    [ -e "$ROLLING_RESTART_JOB" ] || { echo "no rolling restart in progress" >&2 ; return 1 ; }
+    local cur=$(jq -r .state $ROLLING_RESTART_JOB 2>/dev/null)
+    if [ "$cur" != "paused" ] ; then
+        echo "rolling restart is $cur, not paused -- \"$1\" applies only to a paused roll" >&2
+        return 1
+    fi
+
+    case "$1" in
+        continue)
+            # Reset the node that failed back to a clean pending so the resume
+            # re-kicks it first (its status is draining/rebooting, not pending).
+            local stuck=$(jq -r '.inflight // ""' $ROLLING_RESTART_JOB)
+            if [ -n "$stuck" ] ; then
+                _power_roll_set_node_status "$stuck" pending
+                _power_roll_set_node_num "$stuck" started 0
+                _power_roll_set_node_num "$stuck" vms_total 0
+                _power_roll_set_node_num "$stuck" vms_done 0
+            fi
+            _power_roll_set_str inflight ""
+            _power_roll_set_str reason ""
+            _power_roll_set_str state running
+            power_roll_advance
+            ;;
+        abort)
+            _power_roll_set_str state aborted
+            echo "rolling restart aborted"
+            ;;
+        *)
+            echo "usage: power_roll_decision continue|abort" >&2
+            return 1
+            ;;
+    esac
+}
+
+# --- VM pause/restore + host drain/evacuate/resume for the roll -------------
+# Pause a non-migratable VM ahead of its host's reboot so the boot path can
+# restore it. Prefer state-preserving suspend; fall back to a graceful stop for
+# passthrough VMs (libvirt managedsave fails on an assigned device). Echoes the
+# disposition ("suspended"|"stopped") for the active_running record.
+_power_vm_pause()
+{
+    local vm=$1 i st
+    if $OPENSTACK server suspend "$vm" >/dev/null 2>&1 ; then
+        for i in $(seq 1 6) ; do
+            [ "$($OPENSTACK server show "$vm" -f value -c status 2>/dev/null)" = SUSPENDED ] && { echo suspended ; return 0 ; }
+            sleep 3
+        done
+    fi
+    # suspend did not take (e.g. passthrough) -> clear any ERROR, graceful stop
+    st=$($OPENSTACK server show "$vm" -f value -c status 2>/dev/null)
+    [ "x$st" = "xERROR" ] && os_nova_instance_reset "$vm"
+    $OPENSTACK server stop "$vm" >/dev/null 2>&1
+    for i in $(seq 1 12) ; do
+        [ "$($OPENSTACK server show "$vm" -f value -c status 2>/dev/null)" = SHUTOFF ] && break
+        sleep 3
+    done
+    echo stopped
+}
+
+# Restore a VM by the disposition recorded in active_running (run on host boot).
+# Single-node "suspended" resume races cephfs cold-recovery, so recover it in a
+# detached background job; multi-node resumes inline.
+power_vm_restore()
+{
+    local vm=$1 disp=$2
+    case "$disp" in
+        suspended)
+            if [ "$(cubectl node list 2>/dev/null | grep -c .)" -le 1 ] ; then
+                setsid $HEX_SDK power_vm_resume_async "$vm" >/dev/null 2>&1 &
+            else
+                $OPENSTACK server resume "$vm" >/dev/null 2>&1
+            fi
+            ;;
+        stopped)   $OPENSTACK server start  "$vm" >/dev/null 2>&1 ;;
+        *)         os_nova_instance_reset "$vm" ; os_nova_instance_hardreboot "$vm" ;;
+    esac
+}
+
+# Detached single-node resume recovery (see power_vm_restore): retry 5x/30s,
+# resuming while SUSPENDED and reset+hard-reboot on ERROR.
+power_vm_resume_async()
+{
+    local vm=$1 i st
+    for i in $(seq 1 5) ; do
+        st=$($OPENSTACK server show "$vm" -f value -c status 2>/dev/null)
+        [ "$st" = ACTIVE ] && return 0
+        case "$st" in
+            SUSPENDED) $OPENSTACK server resume "$vm" >/dev/null 2>&1 ;;
+            ERROR)     os_nova_instance_reset "$vm" ; os_nova_instance_hardreboot "$vm" ;;
+        esac
+        sleep 30
+    done
+}
+
+power_drain_host()
+{
+    # Drain $from_host before a planned reboot. Migratable VMs are live-migrated
+    # off, up to max_concurrent_live_migrations at a time. nova owns each
+    # migration's convergence (auto-converge -> force_complete -> post-copy
+    # guarantees completion); the drain never imposes its own deadline or aborts
+    # a migration. VMs that cannot live-migrate (PCI/passthrough, etc.) are
+    # suspended and recorded for restore on boot; that downtime is acknowledged
+    # up front via the CLI dryrun+confirm. A *migratable* VM that nova reports
+    # errored is an unacknowledged
+    # surprise -> reported via a non-zero return so the caller pauses the roll for
+    # an operator. Host-scoped analog of os_pre_failure_host_evacuation_sequential.
+    local from_host=${1:-$HOSTNAME}
+    local env=${2:-default}
+    local server_list_array=( $($OPENSTACK server list --host "$from_host" --all-projects --status ACTIVE -f value -c ID) )
+    local host_array=($(cubectl node -r compute list -j | jq -r .[].hostname | grep -v $from_host))
+    local num_host=${#host_array[@]}
+
+    if [ ${#server_list_array[@]} -gt 0 ] && [ $num_host -eq 0 ] ; then
+        echo "no other compute host to receive workloads from $from_host" >&2
+        return 1
+    fi
+
+    for i in 1 2 3 ; do
+        if _os_pre_failure_host_evacuation $env ; then
+            break
+        else
+            sleep 10
+        fi
+    done
+
+    # Honor nova's concurrency cap. nova owns each migration's convergence
+    # (completion_timeout -> force_complete -> post-copy guarantees completion),
+    # so the drain never imposes its own deadline or aborts a migration -- it
+    # reacts only to nova's verdict (landed, or nova-reported error).
+    local maxconc=$(awk -F= '/^\[/{s=$0} s=="[DEFAULT]" && /^[ \t]*max_concurrent_live_migrations[ \t]*=/{gsub(/[ \t]/,"",$2);print $2;exit}' /etc/nova/nova.conf 2>/dev/null)
+    # Default to 3 (config_nova's value) when nova.conf has none; nova enforces its own cap.
+    [ -n "$maxconc" ] && [ "$maxconc" -ge 1 ] 2>/dev/null || maxconc=3
+
+    local nonmig=$(_power_nonmigratable_vms)   # one DB query, reused for all VMs
+    local tlog=${ROLLING_RESTART_DIR:-/tmp}/drain_timing.${from_host}.log
+    : > "$tlog"
+
+    local arun="$CEPHFS_NOVA_DIR/instances/active_running" disp
+    mkdir -p "$(dirname "$arun")" ; : > "$arun"
+
+    # Partition: non-migratable VMs are suspended + recorded for restore on boot
+    # (downtime acknowledged at confirm time); migratable VMs queue for the pool.
+    local sid st host
+    local -a pending=() stuck=()
+    for sid in ${server_list_array[@]} ; do
+        if echo "$nonmig" | grep -qFx "$sid" ; then
+            disp=$(_power_vm_pause "$sid")
+            echo "$sid $disp" >> "$arun"
+            echo "suspend+restore $sid ($disp)"
+            echo "$(date +%s) suspend $sid" >> "$tlog"
+        else
+            pending+=("$sid")
+        fi
+    done
+
+    # Concurrent pool: up to $maxconc migrations in flight. nova bounds each one's
+    # duration (force_complete/post-copy); the drain waits for nova's outcome and
+    # never stops a migration itself.
+    local -A started=()
+    while [ ${#pending[@]} -gt 0 ] || [ ${#started[@]} -gt 0 ] ; do
+        while [ ${#started[@]} -lt "$maxconc" ] && [ ${#pending[@]} -gt 0 ] ; do
+            sid=${pending[0]} ; pending=("${pending[@]:1}")
+            if nova live-migration "$sid" 2>/dev/null ; then
+                started[$sid]=$(date +%s)
+                echo "${started[$sid]} start $sid (inflight ${#started[@]}/${maxconc})" >> "$tlog"
+                echo "migrating $sid off $from_host"
+            else
+                stuck+=("$sid")   # request rejected (e.g. no valid host)
+                echo "$(date +%s) reject $sid" >> "$tlog"
+            fi
+        done
+        sleep 5
+        for sid in "${!started[@]}" ; do
+            host=$($MYSQL -u root -N -D nova -e "SELECT host FROM instances WHERE uuid='$sid'" 2>/dev/null)
+            st=$($MYSQL -u root -N -D nova -e "SELECT status FROM migrations WHERE instance_uuid='$sid' ORDER BY id DESC LIMIT 1" 2>/dev/null)
+            if [ -n "$host" ] && [ "$host" != "$from_host" ] ; then
+                echo "$(date +%s) done $sid -> $host ($(( $(date +%s) - ${started[$sid]} ))s)" >> "$tlog"
+                unset 'started[$sid]'
+            elif [ "x$st" = "xerror" -o "x$st" = "xfailed" -o "x$st" = "xcancelled" ] ; then
+                echo "$(date +%s) error $sid ($st)" >> "$tlog"
+                stuck+=("$sid") ; unset 'started[$sid]'
+            fi
+            # otherwise still in flight -> nova converges/force-completes it; keep waiting.
+        done
+    done
+
+    # A migratable VM that nova reports errored is an unacknowledged interruption.
+    # Do NOT reboot under it: report so the caller pauses the roll for an operator.
+    if [ ${#stuck[@]} -gt 0 ] ; then
+        printf '%s\n' "${stuck[@]}" > "${ROLLING_RESTART_DIR:-/tmp}/.stuck.${from_host}"
+        echo "could not live-migrate off $from_host (stuck/error, needs operator): ${stuck[*]}" >&2
+        return 1
+    fi
+    rm -f "${ROLLING_RESTART_DIR:-/tmp}/.stuck.${from_host}"
+    return 0
+}
+
+power_node_evacuate()
+{
+    # Disable scheduling on a compute host and live-migrate all of its
+    # workloads off before a planned reboot. Run on a control node.
+    local host=$1
+
+    # No other compute host to receive VMs (e.g. single-node cluster): we
+    # cannot live-migrate. Record the host's running VMs to active_running so
+    # the boot path (bootstrap_cube_config) restarts them after the reboot,
+    # then proceed. Workloads incur reboot downtime, unavoidable with one
+    # hypervisor. Same record-then-restore-on-boot path that powercycle uses.
+    local others=$(cubectl node -r compute list -j | jq -r '.[].hostname' | grep -v "^$host$" | grep -c .)
+    if [ "$others" -eq 0 ] ; then
+        mkdir -p $CEPHFS_NOVA_DIR/instances
+        $OPENSTACK server list --host "$host" --all-projects --status ACTIVE -f value -c ID > $CEPHFS_NOVA_DIR/instances/active_running
+        return 0
+    fi
+
+    $OPENSTACK compute service set --disable --disable-reason "rolling restart" $host nova-compute
+
+    # Record the drainable VM count (ACTIVE only -- SHUTOFF/SUSPENDED VMs are not
+    # live-migrated, so counting them would make the denominator unreachable) plus
+    # the starting on-host total (lets the poll separate migrated from paused), and
+    # poll drain progress into the job state.
+    local total=$($OPENSTACK server list --host "$host" --all-projects --status ACTIVE -f value -c ID 2>/dev/null | grep -c .)
+    local allstart=$($OPENSTACK server list --host "$host" --all-projects -f value -c ID 2>/dev/null | grep -c .)
+    _power_roll_set_node_num "$host" vms_total $total
+    _power_roll_set_node_num "$host" vms_done 0
+    _power_roll_set_node_num "$host" vms_paused 0
+    local sentinel=$ROLLING_RESTART_DIR/.draining.$host
+    : > $sentinel
+    _power_roll_drain_poll "$host" "$total" "$sentinel" "$allstart" &
+    local poll_pid=$!
+
+    power_drain_host $host upgrade
+    local rc=$?
+    rm -f $sentinel ; kill $poll_pid 2>/dev/null ; wait $poll_pid 2>/dev/null
+
+    if [ $rc -ne 0 ] ; then
+        $OPENSTACK compute service set --enable $host nova-compute
+        return 1
+    fi
+
+    _power_roll_set_node_num "$host" vms_done $total
+    return 0
+}
+
+power_node_resume()
+{
+    # Re-enable a compute host and clear its instance-HA maintenance flag
+    # after a planned reboot. Run on a control node.
+    local host=$1
+
+    for u in $($OPENSTACK segment list -f value -c uuid) ; do
+        for n in $($OPENSTACK segment host list $u -f value -c name) ; do
+            if [ "x$n" = "x$host" ] ; then
+                $OPENSTACK segment host update $u $host --on_maintenance False
+            fi
+        done
+    done
+    $OPENSTACK compute service set --enable $host nova-compute
+}

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -698,6 +698,29 @@ power_vm_resume_async()
     done
 }
 
+# Shared cephfs record of VMs running before a cluster poweroff/powercycle, written
+# by cube_cluster_stop so the master can read it regardless of which node wrote it.
+CLUSTER_ACTIVE_RUNNING=$CEPHFS_NOVA_DIR/instances/active_running
+
+# Restore recorded VMs to their prior running state. Must run from the boot-end
+# check_repair (after nova/cinder/ceph and cephfs have recovered). Idempotent: skips
+# already-ACTIVE VMs, resets+re-drives the rest; clears the record once all are back.
+power_restore_recorded_vms()
+{
+    is_control_node || return 0
+    [ -s "$CLUSTER_ACTIVE_RUNNING" ] || return 0
+    local i disp st _pending=0
+    while read -r i disp _ ; do
+        [ -z "$i" ] && continue
+        st=$($OPENSTACK server show "$i" -f value -c status 2>/dev/null)
+        [ "$st" = ACTIVE ] && continue
+        [ "$st" = ERROR ] && os_nova_instance_reset "$i"
+        power_vm_restore "$i" "$disp"
+        _pending=1
+    done < "$CLUSTER_ACTIVE_RUNNING"
+    [ $_pending -eq 0 ] && rm -f "$CLUSTER_ACTIVE_RUNNING"
+}
+
 power_drain_host()
 {
     # Drain $from_host before a planned reboot. Migratable VMs are live-migrated

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -258,6 +258,89 @@ power_roll_plan()
 # Exit 0 if a roll is currently running or paused. The CLI uses this to fail fast
 # (reject a new roll before the dryrun+confirm); power_roll_start re-checks under
 # a lock as the real mutex.
+# ===================== cluster bootup status =====================
+# Full cluster power-up has no driver and cephfs is down during boot, so each node
+# self-records its boot phase to a local /run file; power_bootup_status aggregates.
+# Phases: powering_up -> bootstrapping -> finalizing -> done (anchored to kernel boot).
+BOOTUP_STATUS_FILE=/run/cube_bootup_status
+
+# Record a boot-phase transition locally. Stamps kernel boot time once, then
+# appends "<phase> <epoch>".
+power_bootup_mark()
+{
+    local phase=$1
+    [ -n "$phase" ] || return 0
+    if [ ! -e "$BOOTUP_STATUS_FILE" ] ; then
+        local btime=$(awk '/^btime/{print $2}' /proc/stat 2>/dev/null)
+        [ -n "$btime" ] && echo "boot $btime" > "$BOOTUP_STATUS_FILE"
+    fi
+    echo "$phase $(date +%s)" >> "$BOOTUP_STATUS_FILE"
+}
+
+# Aggregate every node's local bootup record into a table. Unreachable nodes are
+# still powering up (POST/early boot); flags the least-progressed node.
+power_bootup_status()
+{
+    local now=$(date +%s)
+    # Read nodes into an array (not a while-read pipe): ssh below eats stdin and
+    # would drop every node after the first. </dev/null on the ssh calls too.
+    local nodelines line ; mapfile -t nodelines < <(cubectl node list -j 2>/dev/null | jq -r '.[]|"\(.hostname)\t\(.role)\t\(.ip.management)"')
+    local rows="" minidx=3 anyactive=0 h role ip
+    for line in "${nodelines[@]}" ; do
+        IFS=$'\t' read -r h role ip <<< "$line"
+        [ -z "$h" ] && continue
+        local content="" reach=0
+        local committed=0
+        if is_sshable "$ip" </dev/null >/dev/null 2>&1 ; then
+            reach=1
+            content=$(remote_run "$ip" "cat $BOOTUP_STATUS_FILE 2>/dev/null ; [ -e /run/cube_commit_done ] && echo __COMMITTED__" </dev/null)
+            echo "$content" | grep -q __COMMITTED__ && committed=1
+            content=$(printf '%s\n' "$content" | grep -v __COMMITTED__)
+        fi
+        local bt=$(echo "$content" | awk '$1=="boot"{print $2}' | tail -1)
+        local bs=$(echo "$content" | awk '$1=="bootstrapping"{print $2}' | tail -1)
+        local fn=$(echo "$content" | awk '$1=="finalizing"{print $2}' | tail -1)
+        local dn=$(echo "$content" | awk '$1=="done"{print $2}' | tail -1)
+        # Each phase's own duration, kept separately. Running phase shows now-<start>
+        # with trailing '*'; -1 => not reached yet (printed as '-').
+        local idx phase pu bsd fnd tot pu_p=0 bs_p=0 fn_p=0 tot_p=0
+        if [ "$reach" = 0 ] ; then
+            pu=-1 ; bsd=-1 ; fnd=-1 ; tot=-1 ; phase="powering_up" ; idx=0 ; anyactive=1
+        else
+            if   [ -n "$bs" ] ; then pu=$(( bs - ${bt:-$bs} ))
+            elif [ -n "$bt" ] ; then pu=$(( now - bt )) ; pu_p=1
+            else pu=-1 ; fi
+            if   [ -n "$fn" ] ; then bsd=$(( fn - bs ))
+            elif [ -n "$bs" ] ; then bsd=$(( now - bs )) ; bs_p=1
+            else bsd=-1 ; fi
+            if   [ -n "$dn" ] ; then fnd=$(( dn - fn ))
+            elif [ -n "$fn" ] ; then fnd=$(( now - fn )) ; fn_p=1
+            else fnd=-1 ; fi
+            if   [ -n "$dn" ] ; then phase="done" ; idx=3 ; tot=$(( dn - ${bt:-$dn} ))
+            elif [ -n "$fn" ] ; then phase="finalizing" ; idx=2 ; tot=$(( now - ${bt:-$fn} )) ; tot_p=1 ; anyactive=1
+            elif [ -n "$bs" ] ; then phase="bootstrapping" ; idx=1 ; tot=$(( now - ${bt:-$bs} )) ; tot_p=1 ; anyactive=1
+            elif [ -z "$bt" ] && [ "$committed" = 1 ] ; then phase="done" ; idx=3 ; tot=-1   # up, booted pre-instrumentation (no this-boot record)
+            else phase="powering_up" ; idx=0 ; anyactive=1 ; [ -n "$bt" ] && { tot=$(( now - bt )) ; tot_p=1 ; } || tot=-1 ; fi
+        fi
+        [ "$idx" -lt "$minidx" ] && minidx=$idx
+        rows="${rows}${h}\t${pu}\t${pu_p}\t${bsd}\t${bs_p}\t${fnd}\t${fn_p}\t${tot}\t${tot_p}\t${phase}\t${idx}\t${reach}\n"
+    done
+
+    local state="complete" ; [ "$anyactive" = 1 ] && state="in progress"
+    echo "state:    $state   (* = phase still in progress)"
+    echo ""
+    printf " %-14s %-11s %-13s %-11s %-11s %-14s %s\n" "node" "powering_up" "bootstrapping" "finalizing" "total" "phase" "note"
+    printf "%b" "$rows" | while IFS=$'\t' read -r h pu pup bsd bsp fnd fnp tot totp phase idx reach ; do
+        [ -z "$h" ] && continue
+        _c() { local s=$1 p=$2 ; [ "$s" -ge 0 ] 2>/dev/null || { echo "-" ; return ; } ; local o="$(( s/60 ))m$(printf %02d $(( s%60 )))s" ; [ "$p" = 1 ] && o="${o}*" ; echo "$o" ; }
+        local note=""
+        if [ "$reach" = 0 ] ; then note="<- unreachable (POST/early boot)"
+        elif [ "$state" = "in progress" ] && [ "$idx" = "$minidx" ] && [ "$phase" != done ] ; then note="<- watch (slowest)"
+        fi
+        printf " %-14s %-11s %-13s %-11s %-11s %-14s %s\n" "$h" "$(_c "$pu" "$pup")" "$(_c "$bsd" "$bsp")" "$(_c "$fnd" "$fnp")" "$(_c "$tot" "$totp")" "$phase" "$note"
+    done
+}
+
 power_roll_active()
 {
     # A node mid-roll-recovery hasn't mounted cephfs yet, so the shared job.json

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -18,25 +18,43 @@
 ROLLING_RESTART_DIR=/mnt/cephfs/rolling_restart
 ROLLING_RESTART_JOB=$ROLLING_RESTART_DIR/job.json
 
-_power_roll_set_str()
+# Locked read-modify-write of the shared job.json, retried across a cephfs/MDS
+# failover window. Temp name expanded once per attempt (avoids lost updates).
+_power_roll_write()
 {
-    jq --arg v "$2" ".$1=\$v" $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+    local i t
+    for i in $(seq 1 30) ; do
+        t=$ROLLING_RESTART_JOB.tmp.$$.$i
+        if ( flock -w 15 200 || exit 3
+             jq "$@" $ROLLING_RESTART_JOB > "$t" && [ -s "$t" ] && mv "$t" $ROLLING_RESTART_JOB || { rm -f "$t" ; exit 4 ; }
+           ) 200>$ROLLING_RESTART_DIR/.lock 2>/dev/null ; then
+            return 0
+        fi
+        rm -f "$t" 2>/dev/null ; mkdir -p $ROLLING_RESTART_DIR 2>/dev/null ; sleep 2
+    done
+    return 1
 }
 
-_power_roll_set_raw()
-{
-    jq --argjson v "$2" ".$1=\$v" $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
-}
+_power_roll_set_str() { _power_roll_write --arg v "$2" ".$1=\$v" ; }
 
+_power_roll_set_raw() { _power_roll_write --argjson v "$2" ".$1=\$v" ; }
+
+# Set node status and stamp phase_ts[status]=now for per-phase durations.
 _power_roll_set_node_status()
 {
-    jq --arg h "$1" --arg s "$2" '(.nodes[]|select(.hostname==$h).status)=$s' $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+    _power_roll_write --arg h "$1" --arg s "$2" --argjson ts "$(date +%s)" \
+        '(.nodes[]|select(.hostname==$h)) |= (.status=$s | .phase_ts=((.phase_ts//{}) + {($s):$ts}))'
 }
 
-_power_roll_set_node_num()
+# Stamp a phase timestamp without changing .status. No-op if no job exists.
+_power_roll_set_phase_ts()
 {
-    jq --arg h "$1" --argjson v "$3" "(.nodes[]|select(.hostname==\$h).$2)=\$v" $ROLLING_RESTART_JOB > $ROLLING_RESTART_JOB.tmp && mv $ROLLING_RESTART_JOB.tmp $ROLLING_RESTART_JOB
+    [ -e "$ROLLING_RESTART_JOB" ] || return 0
+    _power_roll_write --arg h "$1" --arg p "$2" --argjson ts "$(date +%s)" \
+        '(.nodes[]|select(.hostname==$h)) |= (.phase_ts=((.phase_ts//{}) + {($p):$ts}))'
 }
+
+_power_roll_set_node_num() { _power_roll_write --arg h "$1" --argjson v "$3" "(.nodes[]|select(.hostname==\$h).$2)=\$v" ; }
 
 _power_roll_pause()
 {
@@ -119,12 +137,19 @@ _power_roll_kick()
         return 1
     fi
 
-    _power_roll_set_node_status "$host" rebooting
     echo "rebooting $host"
     # Drop a local marker so the node's boot path waits for the cluster to be
     # ready (single-node ceph recovery can take ~20 min) before running the VM
     # restore + relay advance, instead of checking once early and skipping.
     ssh root@$ip "touch /etc/appliance/state/rolling_restart_recover ; echo YES | hex_cli -c reboot" >/dev/null 2>&1
+    # Wait (bounded) for the node to drop off the network before flipping to
+    # "rebooting", so the reachability-based "bootstrapping" inference can't misfire.
+    local _i
+    for _i in $(seq 1 120) ; do
+        ping -c1 -W2 "$ip" >/dev/null 2>&1 || break
+        sleep 2
+    done
+    _power_roll_set_node_status "$host" rebooting
     return 0
 }
 
@@ -383,8 +408,10 @@ power_roll_status()
     local now=$(date +%s)
     local window=${ROLLING_NODE_TIMEOUT:-3600}
     printf " %-20s %-18s %-9s %-10s %s\n" "node" "role" "status" "vms(m+p/tot)" "elapsed"
-    jq -r '.nodes[]|"\(.hostname)\t\(.role)\t\(.status)\t\(.started // 0)\t\(.finished // 0)\t\(.vms_total // 0)\t\(.vms_done // 0)\t\(.vms_paused // 0)"' $ROLLING_RESTART_JOB | \
-        while IFS=$'\t' read -r h r s st fin vt vd vp ; do
+    jq -r '.nodes[]|"\(.hostname)\t\(.role)\t\(.status)\t\(.started // 0)\t\(.finished // 0)\t\(.vms_total // 0)\t\(.vms_done // 0)\t\(.vms_paused // 0)\t\(.ip // "")"' $ROLLING_RESTART_JOB | \
+        while IFS=$'\t' read -r h r s st fin vt vd vp ip ; do
+            # a "rebooting" node that is back on the network is bootstrapping
+            [ "$s" = "rebooting" ] && [ -n "$ip" ] && ping -c1 -W1 "$ip" >/dev/null 2>&1 && s="bootstrapping"
             el="-"
             if [ "$st" -gt 0 ] ; then
                 end=$fin
@@ -400,6 +427,26 @@ power_roll_status()
             fi
             printf " %-20s %-18s %-9s %-10s %s\n" "$h" "$r" "$s" "$vms" "$el"
         done
+
+    # Per-node phase breakdown, each phase's own duration kept separately.
+    # '*' = still in progress, '-' = not reached.
+    _rollphase() { local a=$1 b=$2 ; [ "${a:-0}" -gt 0 ] 2>/dev/null || { echo "-" ; return ; } ; local e=$b ip=0 ; [ "${b:-0}" -gt 0 ] 2>/dev/null || { e=$now ; ip=1 ; } ; local s=$(( e - a )) ; [ $s -lt 0 ] && s=0 ; local o=$(printf '%dm%02ds' $(( s/60 )) $(( s%60 ))) ; [ $ip = 1 ] && o="${o}*" ; echo "$o" ; }
+    # A phase ends at the first later boundary that exists, so a lost intermediate
+    # stamp folds into the prior phase and self-corrects instead of ticking '*' forever.
+    _firstpos() { local x ; for x in "$@" ; do [ "${x:-0}" -gt 0 ] 2>/dev/null && { echo "$x" ; return ; } ; done ; echo 0 ; }
+    echo ""
+    printf " %-20s %-10s %-10s %-13s %-11s %-9s\n" "node" "draining" "rebooting" "bootstrapping" "finalizing" "total"
+    jq -r '.nodes[]|"\(.hostname)\t\(.started//0)\t\(.finished//0)\t\(.phase_ts.draining//0)\t\(.phase_ts.rebooting//0)\t\(.phase_ts.bootstrapping//0)\t\(.phase_ts.finalizing//0)\t\(.phase_ts.done//0)"' $ROLLING_RESTART_JOB | \
+        while IFS=$'\t' read -r h st fin dr rb bs fn dn ; do
+            d_ts=$dr ; [ "$d_ts" = 0 ] && d_ts=$st
+            e_ts=$dn ; [ "$e_ts" = 0 ] && e_ts=$fin
+            printf " %-20s %-10s %-10s %-13s %-11s %-9s\n" "$h" \
+                "$(_rollphase "$d_ts" "$(_firstpos "$rb" "$bs" "$fn" "$e_ts")")" \
+                "$(_rollphase "$rb" "$(_firstpos "$bs" "$fn" "$e_ts")")" \
+                "$(_rollphase "$bs" "$(_firstpos "$fn" "$e_ts")")" \
+                "$(_rollphase "$fn" "$e_ts")" \
+                "$(_rollphase "$d_ts" "$e_ts")"
+        done
 }
 
 power_roll_status_json()
@@ -413,7 +460,16 @@ power_roll_status_json()
         return 0
     fi
 
-    jq '
+    # "bootstrapping" is inferred, not stored: the inflight node is bootstrapping
+    # once it's back on the network, before it writes "finalizing".
+    local _inf _infip _boot=0
+    _inf=$(jq -r '.inflight // ""' "$ROLLING_RESTART_JOB")
+    if [ -n "$_inf" ] ; then
+        _infip=$(jq -r --arg h "$_inf" '.nodes[]|select(.hostname==$h)|.ip // ""' "$ROLLING_RESTART_JOB")
+        [ -n "$_infip" ] && ping -c1 -W1 "$_infip" >/dev/null 2>&1 && _boot=1
+    fi
+
+    jq --arg boot "$_boot" '
         (.inflight // "") as $inf
         | (.state // "") as $state
         | (.reason // "") as $reason
@@ -426,7 +482,9 @@ power_roll_status_json()
                 | (.vms_total // 0) as $vt
                 | (.vms_done // 0) as $vd
                 | (if .status == "draining" then "evacuting vms on host"
+                   elif (.status == "rebooting" and .hostname == $inf and $boot == "1") then "bootstrapping"
                    elif .status == "rebooting" then "rebooting"
+                   elif .status == "finalizing" then "finalizing"
                    elif .status == "done" then "succeeded"
                    else "pending" end) as $phase
                 | {
@@ -434,10 +492,11 @@ power_roll_status_json()
                     phase: $phase,
                     status: {
                         current: (if $failed then "failed" else $phase end),
-                        isProcessing: (((.status == "draining") or (.status == "rebooting")) and ($failed | not)),
+                        isProcessing: (((.status == "draining") or (.status == "rebooting") or (.status == "finalizing")) and ($failed | not)),
                         processPercent: (
                             if .status == "done" then 100
                             elif $failed then 0
+                            elif .status == "finalizing" then 90
                             elif .status == "rebooting" then 75
                             elif .status == "draining" then (if $vt > 0 then (($vd / $vt) * 50 | floor) else 25 end)
                             else 0 end),
@@ -453,8 +512,14 @@ power_roll_decision()
 {
     [ -e "$ROLLING_RESTART_JOB" ] || { echo "no rolling restart in progress" >&2 ; return 1 ; }
     local cur=$(jq -r .state $ROLLING_RESTART_JOB 2>/dev/null)
-    if [ "$cur" != "paused" ] ; then
-        echo "rolling restart is $cur, not paused -- \"$1\" applies only to a paused roll" >&2
+    # "continue" only applies to a paused roll; "abort" also works on a "running"
+    # roll (so a wedged/zombie roll whose driver died is still cleanable).
+    if [ "$1" = "continue" ] && [ "$cur" != "paused" ] ; then
+        echo "rolling restart is $cur, not paused -- \"continue\" applies only to a paused roll" >&2
+        return 1
+    fi
+    if [ "$1" = "abort" ] && [ "$cur" != "paused" ] && [ "$cur" != "running" ] ; then
+        echo "rolling restart is $cur -- nothing to abort" >&2
         return 1
     fi
 
@@ -475,6 +540,11 @@ power_roll_decision()
             power_roll_advance
             ;;
         abort)
+            # Re-enable the in-flight node's nova-compute (the drain may have left it
+            # disabled) so scheduling resumes.
+            local inflight=$(jq -r '.inflight // ""' $ROLLING_RESTART_JOB)
+            [ -n "$inflight" ] && Quiet -n $OPENSTACK compute service set --enable "$inflight" nova-compute
+            _power_roll_set_str inflight ""
             _power_roll_set_str state aborted
             echo "rolling restart aborted"
             ;;


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Implements workload-preserving **cluster rolling restart** — reboot cluster nodes one at a time without dropping tenant workloads:

- **boot-relay drain/reboot/restore** (`power_sdk.sh`, `proj_functions`, `bootstrap_cube_config`): live-migrate/evacuate a node's instances to peers, reboot it, then restore. On a single node with no migration target the running set is recorded and restarted on the way back up. Concurrency-bounded; fail-fast guarded.
- **rolling-restart CLI** (`cli_cluster.cpp`): `cluster rolling_restart` — always dry-run + explicit confirm, with a fail-fast guard and `-c status`.
- **ceph cold-recovery** (`csi-chart.go`): bounded retry of the CSI subvolume-group create so a cold boot rides out mon/mgr recovery.
- Event strings (`event-key-to-msg.yml`) for the `CLU00004W`/`CLU00005I` rolling-restart events; minor config-module ordering fixups.

Air-gapped safe — no new install/runtime fetches.

#### Which issue(s) this PR fixes

Refs #1035

#### Special notes for your reviewer

> [hex #119](https://github.com/bigstack-oss/hex/pull/119) has **merged** (fast-forward, so its head `61b1712` is the hex `develop` SHA this PR's submodule pointer references — same commit develop's own hex bump points at). Branch is rebased onto latest `develop`; no longer stacked on anything. Ready for review.