### PR TITLE
fix(cluster): stop cluster poweroff deadlocking on cephfs umount

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -356,13 +356,14 @@ cube_cluster_power()
     if [ "x${MASTER_CONTROL:-NOMASTER}" != "x$(hostname)" ] ; then
         remote_run ${MASTER_CONTROL:-NOMASTER} "$HEX_SDK cube_cluster_power $1"
     else
-        cmd "timeout $SRVSTO umount $CEPHFS_STORE_DIR" || true
+        # lazy umount: ceph is paused here, a blocking umount wedges in D-state
+        cmd "timeout $SRVSTO umount -l $CEPHFS_STORE_DIR" || true
         cmd "systemctl stop ceph-osd@*"
         cmd -c "systemctl stop ceph-mds@\$HOSTNAME"
         cmd -c "systemctl stop ceph-mgr@\$HOSTNAME"
         cmd -c "systemctl stop ceph-mon@\$HOSTNAME"
 
-        cmd -c "source /usr/sbin/hex_tuning /etc/settings.txt ; MASTER_CONTROL=\$T_cubesys_controller ; API_TOKEN=\$(cat /var/run/cube-cos-api/node_token) ; curl -X POST http://\$(hex_sdk mgmt_ip):8082/api/v1/datacenters/\$MASTER_CONTROL/nodes/drain -H \'Node: $HOSTNAME\' -H \'Authorization: Bearer \${API_TOKEN}\'"
+        cmd -c "source /usr/sbin/hex_tuning /etc/settings.txt ; MASTER_CONTROL=\$T_cubesys_controller ; API_TOKEN=\$(cat /var/run/cube-cos-api/node_token) ; curl --max-time 30 -X POST http://\$(hex_sdk mgmt_ip):8082/api/v1/datacenters/\$MASTER_CONTROL/nodes/drain -H \'Node: $HOSTNAME\' -H \'Authorization: Bearer \${API_TOKEN}\'"
         for N in $(cubectl node list -j | jq -r .[].hostname | tac) ; do
             timeout $SRVSTO $HEX_SDK remote_run $N "$PWRCMD" || true
         done


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`cluster poweroff` (and `powercycle`, which shares the path) could **deadlock indefinitely** and never power the nodes off. In `cube_cluster_power off` (`core/main/proj_functions`) the master runs `umount $CEPHFS_STORE_DIR` **after** `ceph_enter_maintenance` has set the ceph `pause` flag. A blocking umount then wedges in uninterruptible **D-state** flushing through paused I/O, and the `timeout` wrapper cannot kill a D-state process — so the whole sequence hangs at the umount and never reaches `systemctl stop ceph-osd@*` / `/sbin/poweroff`.

Fix:
- **Lazy umount** (`umount -l`) — detaches without blocking on paused ceph I/O, so the poweroff can never wedge there (the node's own `/sbin/poweroff` cleans up the rest).
- Add **`--max-time 30`** to the drain `curl` — the next unbounded call in the same path.

#### Which issue(s) this PR fixes

Fixes #1059

#### Special notes for your reviewer

> Validated on a live 3-node cluster: the unpatched `cluster poweroff` hung **>40 min** in D-state at `umount /mnt/cephfs` (recovered only via IPMI force-off). With the patch, `cluster poweroff` completes and powers off all three nodes in **~7 min**, and the cluster boots back to healthy. One fix covers both `poweroff` and `powercycle` since they share `cube_cluster_power`.
