### PR TITLE
fix(opensearch): skip opensearch rpm repo metadata gpg key checks since upstream key signing did not match

### DIFF
--- a/core/elk/opensearch/opensearch.repo
+++ b/core/elk/opensearch/opensearch.repo
@@ -2,7 +2,7 @@
 name=OpenSearch 2.x
 baseurl=https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/yum
 enabled=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgcheck=1
 gpgkey=https://artifacts.opensearch.org/publickeys/opensearch.pgp
 autorefresh=1


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Skip OpenSearch RPM repo metadata GPG key checks since upstream key signing did not match

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
