### PR TITLE
fix(health): don't spend the auto-repair maxerr budget while cluster is not ready

### DIFF
--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -108,16 +108,21 @@ _health_fail_log()
     if [ "$ERR_CODE" == "0" ] ; then
         rm -f /tmp/health_${srv}_error.count
     else
-        let "count = $count + 1"
         echo "==============================" >> /var/log/health_${srv}_error.log
         echo $(date) >> /var/log/health_${srv}_error.log
-        echo "failed count: $count" >> /var/log/health_${srv}_error.log
         echo "error code: $ERR_CODE" >> /var/log/health_${srv}_error.log
         echo "error desc: $description" >> /var/log/health_${srv}_error.log
         echo -e "$ERR_MSG" $'\n' >> /var/log/health_${srv}_error.log
-        echo $count > /tmp/health_${srv}_error.count
-        if [ $count -lt $maxerr ] ; then
-            if cube_cluster_ready ; then
+        # Only spend the maxerr auto-repair budget on failures the system could act on.
+        # While the cluster is not ready the auto_repair below is skipped, so counting
+        # those rounds would exhaust maxerr and, once the cluster comes ready, permanently
+        # gate auto_repair off -- the count only resets on a passing check, which can't
+        # happen without the repair. So increment (and attempt) only when ready.
+        if cube_cluster_ready ; then
+            let "count = $count + 1"
+            echo "failed count: $count" >> /var/log/health_${srv}_error.log
+            echo $count > /tmp/health_${srv}_error.count
+            if [ $count -lt $maxerr ] ; then
                 local auto_repair_func="_health_${srv}_auto_repair"
                 if Quiet type $auto_repair_func 2>/dev/null ; then
                     query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixing\""


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`_health_fail_log()` (the tail every `health_<svc>_check` calls) incremented the
per-service consecutive-failure counter **before** both gates:

```sh
let "count = $count + 1"               # unconditional
echo $count > /tmp/health_${srv}_error.count
if [ $count -lt $maxerr ] ; then       # budget gate
    if cube_cluster_ready ; then       # only repair when ready
        _health_${srv}_auto_repair ...
```

So a service that is NG while the cluster is **not ready** still burns its
`maxerr` budget even though `auto_repair` is skipped. Once `count >= maxerr` the
budget gate closes permanently — the counter only resets on a passing check,
which can't happen without a repair — so auto-repair stays disabled even after
the cluster becomes ready (`maxerr` is small: `/etc/alert.level`, observed 3).

This PR moves the increment (and the count-file write) inside the
`cube_cluster_ready` gate, so only failures the system could actually act on
spend the budget. Failure **logging** stays unconditional.

#### Which issue(s) this PR fixes

Fixes #1062

#### Special notes for your reviewer

> - The two conditions are swapped (`cube_cluster_ready` now outer, `count<maxerr`
>   inner); nesting depth and the `auto_repair` block are otherwise unchanged.
> - `cube_cluster_ready` is `cmd hex_sdk cube_node_ready` (a cross-node call). This
>   version calls it on every failing check (previously only when `count<maxerr`).
>   If that extra call for permanently-capped services (e.g. `fc_link`) is a
>   concern, it can be collapsed to
>   `if [ $count -lt $maxerr ] && cube_cluster_ready ; then` — same call frequency,
>   with a harmless off-by-one in the attempt count (`maxerr` vs `maxerr-1`).
> - Verified live: octavia-hm0 counter had exceeded `maxerr` during a not-ready
>   recovery window, so `check_repair` no longer repaired it; a direct
>   `_health_octavia_auto_repair` (which bypasses the counter) fixed it, confirming
>   only the gate was at fault.

#### Additional documentation

```docs
```
