### PR TITLE
fix(cmd): bound remote ssh + command so a wedged node can't hang cmd()

### DIFF
--- a/core/sdk_sh/modules.pre/sdk_cmd.sh
+++ b/core/sdk_sh/modules.pre/sdk_cmd.sh
@@ -77,6 +77,9 @@ cmd()
     [ ${#_cmd_nodes[@]} -ne 0 ] || _cmd_nodes=( "${CUBE_NODE_LIST_HOSTNAMES[@]}" )
 
     [ "x$reverse" = "xfalse" ] || _cmd_nodes=( $(printf '%s\n' "${_cmd_nodes[@]}" | tac | tr '\n' ' ') )
+    # bound connect + liveness so a wedged remote can't block cmd() (timeout wrapper caps total).
+    local _ssh_opts="-o LogLevel=quiet -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
+    local _ssh_to="${CMD_SSH_TIMEOUT:-600}"
     declare -A _cmd_nodes_pids=()
     declare -A _cmd_nodes_rets=()
     declare -A _cmd_nodes_logs=()
@@ -88,7 +91,7 @@ cmd()
             _cmd_nodes_logs[$_cmd_node]="$(mktemp -u /tmp/cmd_${node}.XXXX)"
             if [ "x$dryrun" = "xfalse" ] ; then
                 if is_sshable $_cmd_node ; then
-                    ssh -o LogLevel=quiet $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@" >${_cmd_nodes_logs[$_cmd_node]} 2>&1 &
+                    timeout $_ssh_to ssh $_ssh_opts $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@" >${_cmd_nodes_logs[$_cmd_node]} 2>&1 &
                 else
                     false &
                 fi
@@ -122,7 +125,7 @@ cmd()
             _cmd_node_log="$(mktemp -u /tmp/cmd_${node}.XXXX)"
             if [ "x$dryrun" = "xfalse" ] ; then
                 if is_sshable $_cmd_node ; then
-                    ssh -o LogLevel=quiet $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@" >$_cmd_node_log 2>&1
+                    timeout $_ssh_to ssh $_ssh_opts $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@" >$_cmd_node_log 2>&1
                     _cmd_node_ret=$?
                 else
                     _cmd_node_ret=1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`cmd()` fans work out to cluster nodes over ssh with **no timeout**. A wedged remote — a hung service restart, a stuck/half-down node — blocks `cmd()` and therefore every caller (notably the rolling-restart drain prepare) **forever**.

This adds:
- ssh connect + liveness bounds (`ConnectTimeout=10`, `ServerAliveInterval=15`, `ServerAliveCountMax=4`), and
- a `timeout` wrapper capping the total remote command time (`CMD_SSH_TIMEOUT`, default 600s),

on **both** the parallel and serial `cmd()` paths. Healthy nodes are unaffected; only the pathological hang is bounded.

Part of the **cluster boot-time reduction** initiative (~45 → ~20 min) — several boot/recovery long-poles trace back to an unbounded `cmd()`.

#### Which issue(s) this PR fixes

Fixes #1064

#### Special notes for your reviewer

> Foundational — the rolling-restart and health-repair paths (separate PRs) rely on `cmd()` not hanging. Single-file change to `core/sdk_sh/modules.pre/sdk_cmd.sh`; no behavior change on reachable, responsive nodes. `CMD_SSH_TIMEOUT` is overridable per-caller.

#### Additional documentation

```docs
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BsEFmoqhuJ83AAx4ZfVwo