### PR TITLE
fix(ceph): defer lifting data-movement flags until OSDs rejoin on boot

### DIFF
--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -342,14 +342,50 @@ ceph_enter_maintenance()
     Quiet $CEPH osd set pause
 }
 
+# Wait (bounded) for all OSDs stably up. Gotcha: under `nodown` the osdmap
+# reads all-up while stale, so first wait for a real down before trusting it.
+ceph_wait_all_osds_up()
+{
+    local timeout=${1:-1800} i=0 saw_down=0 stable=0 need d t u
+    while [ $i -lt $timeout ] ; do
+        d=$($CEPH status -f json 2>/dev/null)
+        t=$(echo "$d" | jq -r .osdmap.num_osds 2>/dev/null)
+        u=$(echo "$d" | jq -r .osdmap.num_up_osds 2>/dev/null)
+        if [ -n "$t" ] && [ "$t" != "null" ] && [ -n "$u" ] ; then
+            if [ "$u" -lt "$t" ] ; then
+                saw_down=1 ; stable=0            # a real down: map is now truthful
+            else
+                stable=$((stable+1))
+                # after a real down, 20s stable is enough; else 60s to skip stale window
+                [ "$saw_down" = 1 ] && need=4 || need=12
+                [ $stable -ge $need ] && return 0
+            fi
+        fi
+        sleep 5 ; i=$((i+5))
+    done
+    return 0   # bounded: proceed even if not all up, never block boot
+}
+
+# Lift the data-movement suppressors, only once all OSDs are back (avoids
+# needless rebalance/backfill on a clean power-cycle).
+ceph_finish_maintenance()
+{
+    ceph_wait_all_osds_up 1800
+    sleep 15   # let PGs peer after the last OSD rejoined
+    Quiet $CEPH osd unset norecover
+    Quiet $CEPH osd unset norebalance
+    Quiet $CEPH osd unset nobackfill
+    Quiet $CEPH osd unset noout
+}
+
 ceph_leave_maintenance()
 {
+    # unblock client I/O immediately so the cluster is usable on boot
     Quiet $CEPH osd unset pause
     Quiet $CEPH osd unset nodown
-    Quiet $CEPH osd unset nobackfill
-    Quiet $CEPH osd unset norebalance
-    Quiet $CEPH osd unset norecover
-    Quiet $CEPH osd unset noout
+    # defer lifting noout/norebalance/nobackfill/norecover until all OSDs are
+    # back; backgrounded so it never gates the boot
+    nohup bash -c "$HEX_SDK ceph_finish_maintenance" >/dev/null 2>&1 &
 }
 
 ceph_maintenance_status()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

On boot, `ceph_leave_maintenance()` lifted **all** maintenance flags at once — before the cluster's OSDs had rejoined. After a power-cycle this kicks off a recovery/rebalance/backfill storm against PGs whose OSDs are simply still booting, churning disk/network and delaying boot-to-healthy substantially.

This PR splits the flag lift in two:

- **Immediately**: unset `pause` + `nodown`, so client I/O is unblocked as soon as the node boots.
- **Deferred (background, bounded)**: `ceph_finish_maintenance` waits (≤30 min) via `ceph_wait_all_osds_up` until all OSDs are stably up, then unsets `noout`/`norebalance`/`nobackfill`/`norecover`. A clean power-cycle therefore causes no needless data movement.

`ceph_wait_all_osds_up` handles the `nodown` gotcha: while `nodown` is set the osdmap can read all-up while stale, so it only trusts a short (20 s) stable window after seeing a real down, and otherwise requires a longer (60 s) stable window.

Part of the cluster boot-time reduction initiative (~45 → ~20 min).

#### Which issue(s) this PR fixes

Fixes #1068

#### Special notes for your reviewer

> The deferred lift is backgrounded with `nohup … &` so it never gates the boot path, and the wait is bounded so a genuinely dead OSD can't keep the flags set forever (it falls through and lifts them at the 30-min cap).

#### Additional documentation

```docs
Handbook: kb/cubecos/architecture/cluster-boot-time-optimization.md (ceph rebalance-deferral lever; tracking link added).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So64xm2uahGXMhX7JLT8M1
