### PR TITLE
feat(boot): parallel etcd quorum join, local-zk kafka, ceph-ordered services

### DIFF
--- a/core/cubectl/app/cmd/cmd_this-node.go
+++ b/core/cubectl/app/cmd/cmd_this-node.go
@@ -18,7 +18,12 @@ var ()
 
 func runThisnodeStart(cmd *cobra.Command, args []string) error {
 	if cubeSettings.IsRole(util.ROLE_CONTROL) {
-		if _, _, err := util.ExecCmd("systemctl", "start", "etcd"); err != nil {
+		// Start etcd non-blocking, then wait (bounded) for it to serve, so
+		// parallel node reboots form quorum instead of each blocking serially.
+		if _, _, err := util.ExecCmd("systemctl", "start", "--no-block", "etcd"); err != nil {
+			return errors.WithStack(err)
+		}
+		if err := waitEtcdHealthy(60 * time.Second); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/core/cubectl/app/cmd/global.go
+++ b/core/cubectl/app/cmd/global.go
@@ -57,6 +57,29 @@ func getEtcdClient(addrs ...string) (*clientv3.Client, error) {
 	return cli, nil
 }
 
+// waitEtcdHealthy polls local etcd until it serves a request or the timeout elapses.
+func waitEtcdHealthy(timeout time.Duration) error {
+	cli, err := getEtcdClient("localhost")
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
+		_, err = cli.Get(ctx, "health")
+		cancel()
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.Wrap(err, "etcd did not become healthy in time")
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
 func etcdMemberAdd(ctrlIPs []string, name string, myIp string) (uint64, error) {
 	cli, err := getEtcdClient(ctrlIPs...)
 	if err != nil {

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -1080,6 +1080,7 @@ CONFIG_MODULE(cinder, Init, Parse, 0, 0, Commit);
 CONFIG_REQUIRES(cinder, keystone);
 CONFIG_REQUIRES(cinder, memcache);
 CONFIG_REQUIRES(cinder, libvirtd);
+CONFIG_REQUIRES(cinder, ceph);
 
 CONFIG_MIGRATE(cinder, "/etc/cube/cos/cinder");
 CONFIG_MIGRATE(cinder, CINDER_BACKEND_DIR);

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -702,6 +702,7 @@ CONFIG_MODULE(glance, 0, Parse, 0, 0, Commit);
 CONFIG_REQUIRES(glance, keystone);
 CONFIG_REQUIRES(glance, memcache);
 CONFIG_REQUIRES(glance, cinder);
+CONFIG_REQUIRES(glance, ceph);
 // extra tunings
 CONFIG_OBSERVES(glance, cubesys, ParseCube, NotifyCube);
 CONFIG_OBSERVES(glance, rabbitmq, ParseRabbitMQ, NotifyMQ);

--- a/core/modules/config_kafka.cpp
+++ b/core/modules/config_kafka.cpp
@@ -148,7 +148,8 @@ UpdateCfg(bool ha, const std::string hostname, const std::string sharedId,
         }
 
         kafkaCfg[GLOBAL_SEC]["listeners"] = "PLAINTEXT://" + ctrlIp + ":9095";
-        kafkaCfg[GLOBAL_SEC]["zookeeper.connect"] = sharedId + ":2181";
+        // use the node's local zookeeper, not the VIP (avoids haproxy hop / boot stalls).
+        kafkaCfg[GLOBAL_SEC]["zookeeper.connect"] = ctrlIp + ":2181";
         kafkaCfg[GLOBAL_SEC]["zookeeper.connection.timeout.ms"] = "60000";
         kafkaCfg[GLOBAL_SEC]["log.dirs"] = KAFKA_DIR;
         kafkaCfg[GLOBAL_SEC]["log.retention.bytes"] = "67108864";  // 64MB
@@ -258,13 +259,16 @@ Commit(bool modified, int dryLevel)
     WriteLogRotateConf(zk_log_conf);
 
     WriteConfig(KAFKA_CONF, SB_SEC_WFMT, '=', kafkaCfg);
+    // wait for local zookeeper to accept connections before starting kafka.
+    if (enabled)
+        HexUtilSystemF(0, 0, "%s wait_for_service %s 2181 60", HEX_SDK, myip.c_str());
     SystemdCommitService(enabled, KAFKA_NAME, true);
     WriteLogRotateConf(kafka_log_conf);
 
     // run update topics in non-master control nodes
     // master node zk may not have quorum in upgrade and cause a long run
     if (access(CUBE_MIGRATE, F_OK) == 0)
-        UpdateTopics(s_ha, enabled & !isMaster, sharedId);
+        UpdateTopics(s_ha, enabled & !isMaster, myip);
 
     return true;
 }
@@ -273,8 +277,8 @@ static int
 ClusterReadyMain(int argc, char **argv)
 {
     bool isCtrl = IsControl(s_eCubeRole);
-    std::string sharedId = G(SHARED_ID);
-    UpdateTopics(s_ha, isCtrl, sharedId);
+    std::string myip = G(MGMT_ADDR);            // topic ops on the local broker
+    UpdateTopics(s_ha, isCtrl, myip);
 
     return EXIT_SUCCESS;
 }
@@ -294,8 +298,8 @@ UpdateTopicMain(int argc, char **argv)
     }
 
     bool isCtrl = IsControl(s_eCubeRole);
-    std::string sharedId = G(SHARED_ID);
-    UpdateTopics(s_ha, isCtrl, sharedId);
+    std::string myip = G(MGMT_ADDR);            // topic ops on the local broker
+    UpdateTopics(s_ha, isCtrl, myip);
 
     return EXIT_SUCCESS;
 }
@@ -315,8 +319,8 @@ RecreateTopicMain(int argc, char **argv)
     }
 
     bool isCtrl = IsControl(s_eCubeRole);
-    std::string sharedId = G(SHARED_ID);
-    RecreateTopic(s_ha, isCtrl, sharedId, argv[1]);
+    std::string myip = G(MGMT_ADDR);            // topic op on the local broker
+    RecreateTopic(s_ha, isCtrl, myip, argv[1]);
 
     return EXIT_SUCCESS;
 }

--- a/core/modules/config_monasca.cpp
+++ b/core/modules/config_monasca.cpp
@@ -682,6 +682,7 @@ CONFIG_MODULE(monasca_setup, 0, 0, 0, 0, CommitLast);
 
 // startup sequence
 CONFIG_REQUIRES(monasca, memcache);
+CONFIG_REQUIRES(monasca, ceph);
 //CONFIG_REQUIRES(monasca, kafka);
 //CONFIG_REQUIRES(monasca, influxdb);
 

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -906,6 +906,7 @@ CONFIG_MODULE(nova, Init, Parse, 0, 0, Commit);
 // startup sequence
 CONFIG_REQUIRES(nova, libvirtd);
 CONFIG_REQUIRES(nova, memcache);
+CONFIG_REQUIRES(nova, ceph);
 //CONFIG_REQUIRES(nova, glance);
 
 CONFIG_MIGRATE(nova, "/etc/nova/nova.d");


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Removes three serial long-poles in boot-time service start ordering (part of the ~45 → ~20 min cluster boot-time initiative):

- **Parallel etcd quorum join** — `cubectl this-node start` now starts etcd with `systemctl start --no-block` and then polls local etcd (bounded, 60 s) until it serves. Control nodes rebooting together form quorum concurrently instead of each blocking serially inside `systemctl start`.
- **kafka on local zookeeper** — `zookeeper.connect` now points at the node's own `<mgmt-ip>:2181` instead of the VIP, removing the haproxy/VIP-placement dependency from kafka's boot path; the commit waits (`wait_for_service`, bounded 60 s) for local zk to accept connections before starting kafka, and topic create/update/recreate ops run against the local broker.
- **ceph-ordered OpenStack services** — `CONFIG_REQUIRES(<svc>, ceph)` for cinder, glance, nova, monasca, so the commit scheduler brings them up after storage instead of letting them fail into retry cycles.

#### Which issue(s) this PR fixes

Fixes #1070

#### Special notes for your reviewer

> `waitEtcdHealthy` returns the underlying etcd error wrapped on timeout, so a genuinely broken etcd still fails `this-node start` with a clear cause. `wait_for_service` already exists in `proj_functions` on develop — no sdk change needed here.

#### Additional documentation

```docs
Handbook: kb/cubecos/architecture/cluster-boot-time-optimization.md (etcd + kafka/zk + service-ordering levers; tracking link added).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So64xm2uahGXMhX7JLT8M1
