### PR TITLE
feat(cluster): cluster bootup status -- per-node power-up phase timing

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -145,10 +145,8 @@ RollingEvacuateAndReboot()
                 hex_sdk cluster_check_repair_essential 1
                 msg="Cluster ready; live-migration essential services checked"
             else
-                # Normal boot (powercycle, reboot, cold/crash recovery): the
-                # 'cluster check' above already kicked per-service auto_repair for
-                # anything NG, so a second full check_repair pass is redundant.
-                # Rely on auto_repair + systemd restart policies.
+                # Normal boot: 'cluster check' above kicks per-service auto_repair;
+                # master runs full check_repair centrally once all nodes ready.
                 msg="Cluster ready"
             fi
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
@@ -181,6 +179,11 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
                 echo "YES" | hex_cli -c cluster stop
             fi
             BootstrapAndClusterstart && RollingEvacuateAndReboot
+            # Master waits (bounded) for all nodes committed+synced, then runs one
+            # detached full check_repair -- the single full pass, healing what the
+            # per-node auto_repair/essential passes miss.
+            for _i in $(seq 1 90) ; do hex_sdk cube_cluster_ready && break ; sleep 20 ; done
+            hex_sdk cluster_check_repair_async
         elif [ "x$T_cubesys_role" = "xcontrol" -o "x$T_cubesys_role" = "xcontrol-converged" -o "x$T_cubesys_role" = "xedge-core" -o "x$T_cubesys_role" = "xmoderator" ] ; then
             if [ $(hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -eq 0 -o $CLUSTER_SIZE -eq 0 ] ; then
                 echo "YES" | hex_cli -c cluster stop

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -23,6 +23,7 @@ BootstrapAndClusterstart()
         msg="Bootstrapping CubeCOS"
         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
+        hex_sdk power_bootup_mark bootstrapping   # cluster bootup status: entering the config commit
         [ -e /etc/appliance/state/rolling_restart_recover ] && hex_sdk _power_roll_set_phase_ts "$(hostname)" bootstrapping   # rolling_restart phase timing
         bash -c "hex_config -p bootstrap standalone-done | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
         if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
@@ -34,6 +35,7 @@ BootstrapAndClusterstart()
             msg="Starting cluster"
             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
             hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
+            hex_sdk power_bootup_mark finalizing   # cluster bootup status: entering cluster_start (+ master check_repair)
             [ -e /etc/appliance/state/rolling_restart_recover ] && hex_sdk _power_roll_set_node_status "$(hostname)" finalizing   # rolling_restart: status + phase ts (until power_roll_advance -> done)
             bash -c "hex_sdk -v cube_cluster_start | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
             return 0
@@ -170,6 +172,7 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
         hex_sdk influx_event "${query},severity=\"I\" message=\"$msg\""
     else
         echo "Starting auto bootstrap" >> $BOOTSTRAP_CUBE_MODE
+        hex_sdk power_bootup_mark powering_up   # cluster bootup status: node entered boot bring-up (stamps kernel boot time)
         # Boot-relay advance is driven by cube_cluster_start (power_roll_advance,
         # idempotent, every boot) -- intentionally NOT chained onto the bring-up
         # below, where a non-zero exit could silently skip it and wedge the roll.

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -116,11 +116,11 @@ RollingEvacuateAndReboot()
             if [ "$ROLLING_RECOVER" != "1" ] ; then
                 hex_cli -c cluster check # kick off auto_repair
             fi
-            # Restore recorded VMs (always), synchronously, before the gate below.
-            # active_running holds one VM per line as "<id> [disposition]" --
-            # disposition recorded by the drain: suspended (resume), stopped
-            # (start), or empty/legacy (reset+hardreboot). Read line-by-line.
-            if [ -s /mnt/cephfs/nova/instances/active_running ] ; then
+            # Rolling-restart only: restore recorded VMs now (services stay up). Poweroff/
+            # powercycle defers to boot-end check_repair (power_restore_recorded_vms).
+            # active_running: "<id> [disposition]" -- suspended (resume), stopped (start),
+            # or empty/legacy (reset+hardreboot).
+            if [ "$ROLLING_RECOVER" = "1" ] && [ -s /mnt/cephfs/nova/instances/active_running ] ; then
                 while read -r i disp _ ; do
                     [ -z "$i" ] && continue
                     if hex_sdk os_nova_list id status powerstate |  grep -i "$i active running" ; then

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -448,32 +448,6 @@ cube_cluster_power()
     fi
 }
 
-cube_node_repair()
-{
-    repair_pid=$(cat $CLUSTER_REPAIR 2>/dev/null)
-    if ps -p ${repair_pid:-NOPID} >/dev/null 2>&1 ; then
-        ps $repair_pid
-        ps -o etime $repair_pid
-        return 1
-    else
-        $HEX_SDK check_repair &
-        echo $! >$CLUSTER_REPAIR
-        wait $! && rm -f $CLUSTER_REPAIR
-    fi
-}
-
-cube_cluster_repair()
-{
-    source /usr/sbin/hex_tuning /etc/settings.txt
-    if [ "x$T_cubesys_control_hosts" = "x" ] ; then
-        export MASTER_CONTROL=$T_cubesys_controller
-        [ -n "$MASTER_CONTROL" ] || MASTER_CONTROL=$T_net_hostname
-    else
-        export MASTER_CONTROL=$(echo $T_cubesys_control_hosts | cut -d"," -f1)
-    fi
-    remote_run ${MASTER_CONTROL:-NOMASTER} "$HEX_SDK cube_node_repair"
-}
-
 cube_remote_cluster_check()
 {
     # If this node is control (non moderator), return 1 to run CLI cluster check locally
@@ -1089,16 +1063,6 @@ cube_cluster_ppu()
     fi
 }
 
-cluster_check()
-{
-    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if is_remote_running $node influxdb ; then
-            VERBOSE=1 remote_run $node "HEX_HEALTH_LAST=1 hex_cli -c cluster check"
-            break
-        fi
-    done
-}
-
 # Live-migration essential service comps (rolling restart). Repairable only --
 # just the services the drain/live-migration path depends on. Used as a health
 # gate by rolling restart (same version both sides of the reboot); NOT for
@@ -1143,29 +1107,39 @@ cluster_check_repair_essential()
     return $rc
 }
 
+# Wait until every node has committed (CUBE_DONE marker), bounded by $1 seconds
+# (default 1500). Returns 0 when all committed, 1 on timeout.
+cube_wait_all_committed()
+{
+    local timeout=${1:-1500} waited=0 nodes n allup
+    nodes=$(cubectl node list -j 2>/dev/null | jq -r '.[].hostname')
+    [ -n "$nodes" ] || return 0
+    while [ $waited -lt $timeout ] ; do
+        allup=1
+        for n in $nodes ; do
+            remote_run "$n" "[ -e $CUBE_DONE ]" || { allup=0 ; break ; }
+        done
+        [ "$allup" = 1 ] && return 0
+        sleep 10 ; waited=$((waited+10))
+    done
+    return 1
+}
+
 cluster_check_repair_async()
 {
     # Run the final cluster check_repair off the caller's critical path so the
     # operator gets their prompt back immediately and can start using the box.
     # The result is popped onto the console device(s) and broadcast (wall) when
     # it finishes. Detached via setsid so it survives the parent CLI exiting.
+    # Held until all nodes have committed so it fires once on a settled cluster.
     setsid bash -c '
-        out=$(hex_cli -c cluster check_repair 2>&1)
+        hex_sdk cube_wait_all_committed 1500
+        out=$(hex_cli -c cluster check_repair 2>&1 | grep -av "Broken pipe")
         # Restore VMs recorded at cluster stop, now that services are healed.
         hex_sdk power_restore_recorded_vms
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null
     ' </dev/null >/dev/null 2>&1 &
-}
-
-cluster_check_repair()
-{
-    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if is_remote_running $node influxdb ; then
-            VERBOSE=1 remote_run $node "HEX_HEALTH_LAST=1 hex_cli -c cluster check_repair"
-            break
-        fi
-    done
 }
 
 node_bootstrap_status()

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -272,6 +272,7 @@ cube_cluster_start()
     # "command not found" (proj_functions doesn't source modules/, where
     # power_roll_advance lives).
     hex_sdk power_roll_advance "$HOSTNAME"
+    hex_sdk power_bootup_mark done   # cluster bootup status: this node's boot bring-up complete
 }
 
 # Shared env for the split cube_cluster_start halves.

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -383,8 +383,25 @@ cube_cluster_start_cluster_if_master()
 
 cube_cluster_stop()
 {
-    if timeout $SRVTO $HEX_SDK health_ceph_mds_check ; then
-        ! $HEX_SDK os_nova_list || $HEX_SDK os_nova_list id status powerstate | grep -i 'active running' | cut -d' ' -f1 > $CEPHFS_NOVA_DIR/instances/active_running
+    # Cleanly stop running VMs before nodes go down, recording each "stopped" to the
+    # shared cephfs record; power_restore_recorded_vms restarts them at boot-end.
+    # Gate on nova being queryable, NOT health_ceph_mds_check (can fail mid-shutdown
+    # and silently skip the snapshot).
+    local _vm _i _active
+    _active=$($HEX_SDK os_nova_list id status powerstate 2>/dev/null | grep -i 'active running' | cut -d' ' -f1)
+    if [ -n "$_active" ] && mountpoint -q /mnt/cephfs ; then
+        mkdir -p $CEPHFS_NOVA_DIR/instances
+        : > $CLUSTER_ACTIVE_RUNNING
+        for _vm in $_active ; do
+            [ "$($OPENSTACK server show "$_vm" -f value -c status 2>/dev/null)" = ERROR ] && os_nova_instance_reset "$_vm"
+            $OPENSTACK server stop "$_vm" >/dev/null 2>&1
+            echo "$_vm stopped" >> $CLUSTER_ACTIVE_RUNNING
+        done
+        # bounded wait for guests to reach SHUTOFF so the reboot does not hard-kill them
+        for _i in $(seq 1 20) ; do
+            [ -z "$($HEX_SDK os_nova_list id status powerstate 2>/dev/null | grep -i 'active running')" ] && break
+            sleep 3
+        done
     fi
     rm -f /var/lib/corosync/*
     rm -rf /var/lib/rabbitmq/mnesia/*
@@ -1134,6 +1151,8 @@ cluster_check_repair_async()
     # it finishes. Detached via setsid so it survives the parent CLI exiting.
     setsid bash -c '
         out=$(hex_cli -c cluster check_repair 2>&1)
+        # Restore VMs recorded at cluster stop, now that services are healed.
+        hex_sdk power_restore_recorded_vms
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null
     ' </dev/null >/dev/null 2>&1 &

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -1032,6 +1032,28 @@ ClusterRollingRestartMain(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
+// cluster bootup: per-node boot/recovery phase timing. status = one-shot;
+// status_watch = redraw every 30s until Ctrl-C.
+static int
+ClusterBootupMain(int argc, const char** argv)
+{
+    std::string sub = (argc == 2) ? argv[1] : "status";
+
+    if (sub == "status") {
+        HexSystemF(0, HEX_SDK " power_bootup_status");
+        return CLI_SUCCESS;
+    }
+    if (sub == "status_watch") {
+        HexSystemF(0, "while true ; do clear 2>/dev/null ; "
+                      "echo \"cluster bootup status_watch  @ $(date '+%%F %%T')  "
+                      "(refresh 30s, Ctrl-C to exit)\" ; echo ; "
+                      "%s power_bootup_status ; sleep 30 ; done", HEX_SDK);
+        return CLI_SUCCESS;
+    }
+    CliPrintf("usage: cluster bootup [status|status_watch]");
+    return CLI_INVALID_ARGS;
+}
+
 CLI_MODE(CLI_TOP_MODE, "cluster", "Work with cube cluster.",
     !HexStrictIsErrorState() && !FirstTimeSetupRequired());
 
@@ -1074,6 +1096,10 @@ CLI_MODE_COMMAND("cluster", "powercycle", ClusterPowercycleMain, NULL,
 CLI_MODE_COMMAND("cluster", "rolling_restart", ClusterRollingRestartMain, NULL,
     "reboot nodes one at a time, evacuating workloads first.",
     "rolling_restart [<host> ...|dryrun [<host> ...]|status|status_watch|continue|abort]");
+
+CLI_MODE_COMMAND("cluster", "bootup", ClusterBootupMain, NULL,
+    "cluster power-up / boot-recovery status (per-node phase timing).",
+    "bootup [status|status_watch]");
 
 CLI_MODE_COMMAND("cluster", "recreate", ClusterRecreateMain, NULL,
     "CAUTION! mark to recreate the cluster.",

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -509,6 +509,10 @@ health_hacluster_check()
 
 _health_hacluster_auto_repair()
 {
+    # Skip auto-repair unless all control nodes are ready (avoid churn while corosync reforms).
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        remote_run $node "$HEX_SDK cube_node_ready" >/dev/null 2>&1 || return 0
+    done
     health_hacluster_repair
     if [ $ERR_CODE -eq 6 ] ; then
         health_ceph_mds_repair
@@ -544,7 +548,7 @@ health_hacluster_repair()
             elif [ "x$node" = "x$HOSTNAME" -a "x$node" = "x$master" ] ; then
                 $HEX_SDK pacemaker_node_stop $node
             else
-                $HEX_SDK pacemaker_node_start $node
+                # Peer already in the ring: don't restart it, just reconcile vaw.
                 cmd -co "pcs resource remove vaw" # v3.0.0 or older doesn't have vaw, hindering VIP to start
             fi
         done
@@ -687,6 +691,28 @@ health_rabbitmq_check()
 
 health_rabbitmq_repair()
 {
+    local total=${#CUBE_NODE_CONTROL_HOSTNAMES[@]}
+    local stats=$($HEX_CFG status_rabbitmq 2>/dev/null)
+    local running=$(echo "$stats" | jq -r '.running_nodes[]?' 2>/dev/null)
+    local running_cnt=$(echo "$running" | grep -c .)
+    local partition=$(echo "$stats" | jq -r '.partitions[]?' 2>/dev/null | grep -c .)
+    local seed=$(echo "$running" | head -1)
+
+    # Healthy core (running majority, no partition): rejoin only missing nodes, preserve state.
+    if [ "$running_cnt" -ge $(( total / 2 + 1 )) ] && [ "$partition" -eq 0 ] ; then
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            echo "$running" | grep -q "rabbit@$node$" && continue
+            remote_run $node "systemctl restart rabbitmq-server"
+            sleep 8
+            if ! $HEX_CFG status_rabbitmq 2>/dev/null | jq -r '.running_nodes[]?' | grep -q "rabbit@$node$" ; then
+                # stale/split mnesia: reset only this node and rejoin the core
+                remote_run $node "rabbitmqctl stop_app ; rabbitmqctl reset ; rabbitmqctl join_cluster $seed ; rabbitmqctl start_app"
+            fi
+        done
+        return 0
+    fi
+
+    # No healthy core (majority down or partitioned) -- full rebuild.
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
         remote_systemd_stop $node rabbitmq-server
         remote_run $node rm -rf /var/lib/rabbitmq/mnesia/*
@@ -743,16 +769,33 @@ health_mysql_check()
 _health_mysql_repair()
 {
     local ts=$(date +%Y%m%d-%H%M%S)
-    local master=$CUBE_NODE_CONTROL_HOSTNAMES
 
-    cmd -c "hex_sdk remote_systemd_stop \$HOSTNAME mariadb ; killall -9 mariadbd ; rm -f /var/lib/mysql/mysql.sock"
+    # If a galera primary is still live, rejoin it instead of bootstrapping (avoids split-brain).
+    local primary=""
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if [ "$(remote_run $node "mysql -u root -N -e \"show status like 'wsrep_cluster_status'\" 2>/dev/null | awk '{print \$2}'")" = "Primary" ] ; then
+            primary=$node ; break
+        fi
+    done
+
+    if [ -n "$primary" ] ; then
+        # rejoin every non-Synced node: clear wedged unit, disarm bootstrap, plain start
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            [ "$(remote_run $node "mysql -u root -N -e \"show status like 'wsrep_local_state_comment'\" 2>/dev/null | awk '{print \$2}'")" = "Synced" ] && continue
+            remote_run $node "systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; rm -f /var/lib/mysql/mysql.sock ; sed -i 's/safe_to_bootstrap: 1/safe_to_bootstrap: 0/' /var/lib/mysql/grastate.dat ; systemctl start mariadb"
+        done
+        return 0
+    fi
+
+    # No primary: bootstrap a fresh cluster from the last control node, rest join.
     cmd -c "cp -rp /var/lib/mysql /var/lib/mysql-\${HOSTNAME}-${ts}"
     local cnt=0
     for node in $(for n in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do echo $n ; done | tac) ; do
         ((cnt++))
         if [ $cnt -eq 1 ] ; then # last control node
-            remote_run $node "sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/' /var/lib/mysql/grastate.dat"
+            remote_run $node "systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/' /var/lib/mysql/grastate.dat"
             remote_run $node galera_new_cluster
+            remote_run $node "sed -i 's/safe_to_bootstrap: 1/safe_to_bootstrap: 0/' /var/lib/mysql/grastate.dat"
         else
             remote_systemd_start $node mariadb
         fi
@@ -761,7 +804,9 @@ _health_mysql_repair()
 
 health_mysql_repair()
 {
-    cmd -cor "timeout $SRVTO systemctl stop mariadb ; killall -9 mariadbd ; systemctl start mariadb"
+    # mariadb.service is SendSIGKILL=no, so a hung stop wedges the unit: try restart,
+    # else force-clear the wedge (kill + reset-failed) and start.
+    cmd -cor "timeout $SRVTO systemctl restart mariadb || { systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; systemctl start mariadb ; }"
     if ! health_mysql_check ; then
         # multiple attempts to fix is needed, especially after rolling-upgrade
         for i in 1 2 3 ; do
@@ -858,6 +903,15 @@ health_vip_repair()
     fi
     # if first time setup not completed or cluster in rolling upgrade process, ensure master node has VIP
     if [ ! -e /etc/appliance/state/configured ] || is_node_rolling_upgrade ; then
+        # Wait (<=60s) for stable all-online membership before moving the VIP.
+        for _w in $(seq 1 12) ; do
+            local _st=$(pcs status 2>/dev/null)
+            local _online=$(echo "$_st" | grep -i " online" | cut -d "[" -f2 | cut -d "]" -f1 | awk '{print NF}')
+            if [ "$_online" = "${#CUBE_NODE_CONTROL_HOSTNAMES[@]}" ] && ! echo "$_st" | grep -qiE "pending|in progress" ; then
+                break
+            fi
+            sleep 5
+        done
         local master=$CUBE_NODE_CONTROL_HOSTNAMES
         if remote_run $master "pcs resource status vip" | grep -q Started ; then
             for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
@@ -1257,16 +1311,32 @@ health_ceph_report()
     _health_report ${FUNCNAME[0]}
 }
 
+# Returns 0 if ceph has a blocking health check (data unavailable, capacity,
+# corruption, no quorum); 1 if only transient recovery checks are non-OK.
+_ceph_blocking_health()
+{
+    local stats="${1:-$($CEPH status -f json 2>/dev/null)}"
+    local c
+    for c in $(echo "$stats" | jq -r '.health.checks | keys[]' 2>/dev/null) ; do
+        case "$c" in
+            PG_AVAILABILITY|OSD_FULL|OSD_BACKFILLFULL|OSD_NEARFULL|\
+            POOL_FULL|POOL_NEAR_FULL|POOL_BACKFILLFULL|\
+            PG_BACKFILL_FULL|PG_RECOVERY_FULL|PG_DAMAGED|OSD_SCRUB_ERRORS|\
+            MON_DOWN|MON_CLOCK_SKEW|FS_WITH_FAILED_MDS|MDS_ALL_DOWN|MDS_DAMAGE)
+                return 0 ;;
+        esac
+    done
+    return 1
+}
+
 health_ceph_check()
 {
     local stats=$($CEPH status -f json)
     local service_stats="$(echo $stats | jq -r .health.status)"
 
     ERR_LOG="journalctl -n $ERR_LOGSIZE -u ceph-mon@$HOSTNAME"
-    if [ "$service_stats" = "HEALTH_WARN" ] ; then
-        ERR_CODE=1
-    elif [ "$service_stats" = "HEALTH_ERR" ] ; then
-        ERR_CODE=2
+    if [ "$service_stats" != "HEALTH_OK" ] && _ceph_blocking_health "$stats" ; then
+        [ "$service_stats" = "HEALTH_ERR" ] && ERR_CODE=2 || ERR_CODE=1
     fi
 
     ERR_MSG="`$CEPH health detail`"
@@ -1498,13 +1568,15 @@ health_ceph_osd_check()
     local total=$(echo $stats | jq -r .osdmap.num_osds)
     local uposd=$(echo $stats | jq -r .osdmap.num_up_osds)
     local inosd=$(echo $stats | jq -r .osdmap.num_in_osds)
-    if [ "$total" != "$uposd" ] ; then
-        ERR_CODE=1
-    elif [ "$total" != "$inosd" ] ; then
-        ERR_CODE=2
-    elif cmd "$HEX_SDK ceph_osd_list" | sort -t. -n -k2 | egrep -q "warning|fail" ; then
+    if cmd "$HEX_SDK ceph_osd_list" | sort -t. -n -k2 | egrep -q "warning|fail" ; then
+        # device hardware fault -- always a fault, even mid-recovery
         ERR_CODE=3
         ERR_LOG="dmesg | grep -i -e fail -e error"
+    elif [ "$total" != "$uposd" ] ; then
+        # OSDs still rejoining -- only a fault if data is unavailable
+        _ceph_blocking_health "$stats" && ERR_CODE=1
+    elif [ "$total" != "$inosd" ] ; then
+        _ceph_blocking_health "$stats" && ERR_CODE=2
     fi
 
     ERR_MSG+="`$CEPH health detail`"
@@ -3408,6 +3480,22 @@ _health_neutron_deep_repair()
 
 _health_datapipe_deep_repair()
 {
+    # This wipes+rebuilds the datapipe, so gate it behind a cooldown to avoid
+    # thrashing a stack that is still converging after boot.
+    local _dp_marker=/run/cube_datapipe_deep_repair.ts _dp_cooldown=900
+    local _dp_now _dp_last
+    _dp_now=$(date +%s)
+    if [ -f "$_dp_marker" ] ; then
+        _dp_last=$(cat "$_dp_marker" 2>/dev/null) ; [ -n "$_dp_last" ] || _dp_last=0
+        if [ $((_dp_now - _dp_last)) -lt $_dp_cooldown ] ; then
+            return 0   # in cooldown: let the datapipe finish converging, don't thrash
+        fi
+    else
+        echo "$_dp_now" > "$_dp_marker" 2>/dev/null
+        return 0       # first call this boot: seed the timer, give it time to converge
+    fi
+    echo "$_dp_now" > "$_dp_marker" 2>/dev/null
+
     cmd -c systemctl stop zookeeper kafka logstash kapacitor influxdb monasca-forwarder monasca-persister telegraf
     Quiet -n sleep 10
     cmd -c "rm -rf /tmp/zookeeper/* /var/lib/kafka/* /var/lib/logstash/*"

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1347,7 +1347,8 @@ _os_pre_failure_host_evacuation()
             cmd -c $HEX_SDK stale_api_check_repair neutron-server 9696 neutron-server server 0
             cmd -c $HEX_SDK stale_api_check_repair openstack-cinder-api 8776 cinder-api python3 0
 
-            if [ $($OPENSTACK compute service list -f value -c Status -c State | grep -v -i "enabled up" | wc -l) -ge 1 ] ; then
+            # restart only "enabled down" services; leave "disabled" (drained/maintenance) hosts alone.
+            if [ $($OPENSTACK compute service list -f value -c Status -c State | grep -ci "enabled down") -ge 1 ] ; then
                 cmd -c systemctl restart openstack-nova-scheduler
                 cmd -c systemctl restart openstack-nova-conductor
                 cmd -p systemctl restart openstack-nova-compute

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -698,6 +698,29 @@ power_vm_resume_async()
     done
 }
 
+# Shared cephfs record of VMs running before a cluster poweroff/powercycle, written
+# by cube_cluster_stop so the master can read it regardless of which node wrote it.
+CLUSTER_ACTIVE_RUNNING=$CEPHFS_NOVA_DIR/instances/active_running
+
+# Restore recorded VMs to their prior running state. Must run from the boot-end
+# check_repair (after nova/cinder/ceph and cephfs have recovered). Idempotent: skips
+# already-ACTIVE VMs, resets+re-drives the rest; clears the record once all are back.
+power_restore_recorded_vms()
+{
+    is_control_node || return 0
+    [ -s "$CLUSTER_ACTIVE_RUNNING" ] || return 0
+    local i disp st _pending=0
+    while read -r i disp _ ; do
+        [ -z "$i" ] && continue
+        st=$($OPENSTACK server show "$i" -f value -c status 2>/dev/null)
+        [ "$st" = ACTIVE ] && continue
+        [ "$st" = ERROR ] && os_nova_instance_reset "$i"
+        power_vm_restore "$i" "$disp"
+        _pending=1
+    done < "$CLUSTER_ACTIVE_RUNNING"
+    [ $_pending -eq 0 ] && rm -f "$CLUSTER_ACTIVE_RUNNING"
+}
+
 power_drain_host()
 {
     # Drain $from_host before a planned reboot. Migratable VMs are live-migrated

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -258,6 +258,89 @@ power_roll_plan()
 # Exit 0 if a roll is currently running or paused. The CLI uses this to fail fast
 # (reject a new roll before the dryrun+confirm); power_roll_start re-checks under
 # a lock as the real mutex.
+# ===================== cluster bootup status =====================
+# Full cluster power-up has no driver and cephfs is down during boot, so each node
+# self-records its boot phase to a local /run file; power_bootup_status aggregates.
+# Phases: powering_up -> bootstrapping -> finalizing -> done (anchored to kernel boot).
+BOOTUP_STATUS_FILE=/run/cube_bootup_status
+
+# Record a boot-phase transition locally. Stamps kernel boot time once, then
+# appends "<phase> <epoch>".
+power_bootup_mark()
+{
+    local phase=$1
+    [ -n "$phase" ] || return 0
+    if [ ! -e "$BOOTUP_STATUS_FILE" ] ; then
+        local btime=$(awk '/^btime/{print $2}' /proc/stat 2>/dev/null)
+        [ -n "$btime" ] && echo "boot $btime" > "$BOOTUP_STATUS_FILE"
+    fi
+    echo "$phase $(date +%s)" >> "$BOOTUP_STATUS_FILE"
+}
+
+# Aggregate every node's local bootup record into a table. Unreachable nodes are
+# still powering up (POST/early boot); flags the least-progressed node.
+power_bootup_status()
+{
+    local now=$(date +%s)
+    # Read nodes into an array (not a while-read pipe): ssh below eats stdin and
+    # would drop every node after the first. </dev/null on the ssh calls too.
+    local nodelines line ; mapfile -t nodelines < <(cubectl node list -j 2>/dev/null | jq -r '.[]|"\(.hostname)\t\(.role)\t\(.ip.management)"')
+    local rows="" minidx=3 anyactive=0 h role ip
+    for line in "${nodelines[@]}" ; do
+        IFS=$'\t' read -r h role ip <<< "$line"
+        [ -z "$h" ] && continue
+        local content="" reach=0
+        local committed=0
+        if is_sshable "$ip" </dev/null >/dev/null 2>&1 ; then
+            reach=1
+            content=$(remote_run "$ip" "cat $BOOTUP_STATUS_FILE 2>/dev/null ; [ -e /run/cube_commit_done ] && echo __COMMITTED__" </dev/null)
+            echo "$content" | grep -q __COMMITTED__ && committed=1
+            content=$(printf '%s\n' "$content" | grep -v __COMMITTED__)
+        fi
+        local bt=$(echo "$content" | awk '$1=="boot"{print $2}' | tail -1)
+        local bs=$(echo "$content" | awk '$1=="bootstrapping"{print $2}' | tail -1)
+        local fn=$(echo "$content" | awk '$1=="finalizing"{print $2}' | tail -1)
+        local dn=$(echo "$content" | awk '$1=="done"{print $2}' | tail -1)
+        # Each phase's own duration, kept separately. Running phase shows now-<start>
+        # with trailing '*'; -1 => not reached yet (printed as '-').
+        local idx phase pu bsd fnd tot pu_p=0 bs_p=0 fn_p=0 tot_p=0
+        if [ "$reach" = 0 ] ; then
+            pu=-1 ; bsd=-1 ; fnd=-1 ; tot=-1 ; phase="powering_up" ; idx=0 ; anyactive=1
+        else
+            if   [ -n "$bs" ] ; then pu=$(( bs - ${bt:-$bs} ))
+            elif [ -n "$bt" ] ; then pu=$(( now - bt )) ; pu_p=1
+            else pu=-1 ; fi
+            if   [ -n "$fn" ] ; then bsd=$(( fn - bs ))
+            elif [ -n "$bs" ] ; then bsd=$(( now - bs )) ; bs_p=1
+            else bsd=-1 ; fi
+            if   [ -n "$dn" ] ; then fnd=$(( dn - fn ))
+            elif [ -n "$fn" ] ; then fnd=$(( now - fn )) ; fn_p=1
+            else fnd=-1 ; fi
+            if   [ -n "$dn" ] ; then phase="done" ; idx=3 ; tot=$(( dn - ${bt:-$dn} ))
+            elif [ -n "$fn" ] ; then phase="finalizing" ; idx=2 ; tot=$(( now - ${bt:-$fn} )) ; tot_p=1 ; anyactive=1
+            elif [ -n "$bs" ] ; then phase="bootstrapping" ; idx=1 ; tot=$(( now - ${bt:-$bs} )) ; tot_p=1 ; anyactive=1
+            elif [ -z "$bt" ] && [ "$committed" = 1 ] ; then phase="done" ; idx=3 ; tot=-1   # up, booted pre-instrumentation (no this-boot record)
+            else phase="powering_up" ; idx=0 ; anyactive=1 ; [ -n "$bt" ] && { tot=$(( now - bt )) ; tot_p=1 ; } || tot=-1 ; fi
+        fi
+        [ "$idx" -lt "$minidx" ] && minidx=$idx
+        rows="${rows}${h}\t${pu}\t${pu_p}\t${bsd}\t${bs_p}\t${fnd}\t${fn_p}\t${tot}\t${tot_p}\t${phase}\t${idx}\t${reach}\n"
+    done
+
+    local state="complete" ; [ "$anyactive" = 1 ] && state="in progress"
+    echo "state:    $state   (* = phase still in progress)"
+    echo ""
+    printf " %-14s %-11s %-13s %-11s %-11s %-14s %s\n" "node" "powering_up" "bootstrapping" "finalizing" "total" "phase" "note"
+    printf "%b" "$rows" | while IFS=$'\t' read -r h pu pup bsd bsp fnd fnp tot totp phase idx reach ; do
+        [ -z "$h" ] && continue
+        _c() { local s=$1 p=$2 ; [ "$s" -ge 0 ] 2>/dev/null || { echo "-" ; return ; } ; local o="$(( s/60 ))m$(printf %02d $(( s%60 )))s" ; [ "$p" = 1 ] && o="${o}*" ; echo "$o" ; }
+        local note=""
+        if [ "$reach" = 0 ] ; then note="<- unreachable (POST/early boot)"
+        elif [ "$state" = "in progress" ] && [ "$idx" = "$minidx" ] && [ "$phase" != done ] ; then note="<- watch (slowest)"
+        fi
+        printf " %-14s %-11s %-13s %-11s %-11s %-14s %s\n" "$h" "$(_c "$pu" "$pup")" "$(_c "$bsd" "$bsp")" "$(_c "$fnd" "$fnp")" "$(_c "$tot" "$totp")" "$phase" "$note"
+    done
+}
+
 power_roll_active()
 {
     # A node mid-roll-recovery hasn't mounted cephfs yet, so the shared job.json


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds `cluster bootup [status|status_watch]` — per-node power-up / boot-recovery phase timing (2nd PR of the rolling-restart series).

A full cluster power-up has no driver process and cephfs is down during boot, so each node self-records its phases to a local `/run` file: `power_bootup_mark` stamps `powering_up → bootstrapping → finalizing → done` (anchored to kernel `btime`) from `bootstrap_cube_config` and `cube_cluster_start`. `power_bootup_status` aggregates over ssh into a per-phase duration table: running phase marked `*`, unreachable nodes shown as still in POST/early boot, the least-progressed node flagged as the one to watch. Nodes booted before instrumentation (committed but no this-boot record) report `done`.

This is the measurement companion to the boot-time levers — it's how the ~45 → ~20 min progress is observed per node.

#### Which issue(s) this PR fixes

Fixes #1073

#### Special notes for your reviewer

> Stack: #1058 ← status-resilience ← **this** ← vm-restore ← autorepair-robustness. The node list is read into an array (not a `while read` pipe) because the ssh calls would otherwise eat stdin and drop every node after the first — same for the `</dev/null` on the remote calls.

#### Additional documentation

```docs
Handbook: new kb note (bootup status) under kb/cubecos/architecture/.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So64xm2uahGXMhX7JLT8M1
