### PR TITLE
fix: nfs-ganesha, cinder-backup & telegraf auto-recover after a maintenance cycle

### DIFF
--- a/core/ceph/ceph.mk
+++ b/core/ceph/ceph.mk
@@ -40,6 +40,8 @@ rootfs_install::
 	#$(Q)mv $(ROOTDIR)/lib/udev/rules.d/95-ceph-osd.rules $(ROOTDIR)/lib/udev/disabled/.
 	$(Q)rm -f $(ROOTDIR)/etc/ganesha/*
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/ceph/ganesha.conf ./etc/ganesha/
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/systemd/system/nfs-ganesha.service.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/ceph/nfs-ganesha-sigkill.conf ./etc/systemd/system/nfs-ganesha.service.d/
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/cron
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cube/cos/ceph
 

--- a/core/ceph/nfs-ganesha-sigkill.conf
+++ b/core/ceph/nfs-ganesha-sigkill.conf
@@ -1,0 +1,10 @@
+# Upstream nfs-ganesha 5.9 SEGVs on the SIGTERM systemd sends to stop it, which
+# leaves the unit core-dumped/failed and flaps ganesha on every maintenance cycle
+# -- burning the health auto-repair maxerr budget so ceph_mds stays NG. Hard-kill
+# on stop (no catchable SIGTERM -> no crashing shutdown handler) and treat the
+# kill as a clean stop, so ganesha stops cleanly and the ~63s auto-repair recovers
+# it. See kb/cubecos/known-issues/nfs-ganesha-segv-on-stop.md.
+[Service]
+ExecStop=
+KillSignal=SIGKILL
+SuccessExitStatus=SIGKILL

--- a/core/ceph/nfs-ganesha-sigkill.conf
+++ b/core/ceph/nfs-ganesha-sigkill.conf
@@ -1,9 +1,5 @@
-# Upstream nfs-ganesha 5.9 SEGVs on the SIGTERM systemd sends to stop it, which
-# leaves the unit core-dumped/failed and flaps ganesha on every maintenance cycle
-# -- burning the health auto-repair maxerr budget so ceph_mds stays NG. Hard-kill
-# on stop (no catchable SIGTERM -> no crashing shutdown handler) and treat the
-# kill as a clean stop, so ganesha stops cleanly and the ~63s auto-repair recovers
-# it. See kb/cubecos/known-issues/nfs-ganesha-segv-on-stop.md.
+# Hard-kill on stop: nfs-ganesha 5.9 SEGVs on SIGTERM, flapping it and burning the
+# health auto-repair budget. See kb/cubecos/known-issues/nfs-ganesha-segv-on-stop.md.
 [Service]
 ExecStop=
 KillSignal=SIGKILL

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -75,6 +75,14 @@ EOF
     fi
 }
 
+# Auto_repair gate: repair every round below maxerr, then back off to every Nth
+# round instead of giving up forever. Args: <count> <maxerr> <backoff>.
+_health_repair_due()
+{
+    local count=$1 maxerr=$2 backoff=$3
+    [ "$count" -lt "$maxerr" ] || [ $(( (count - maxerr) % backoff )) -eq 0 ]
+}
+
 _health_fail_log()
 {
     local srv=$(caller 0 | cut -d" " -f2 | sed -e "s/^health_//" -e "s/_check$//")
@@ -93,6 +101,9 @@ _health_fail_log()
     if [ ${_OVERRIDE_MAX_ERR:-0} -gt 0 ] ; then
         maxerr=$_OVERRIDE_MAX_ERR
     fi
+
+    # backoff cadence past maxerr (see _health_repair_due)
+    local backoff=${_HEALTH_REPAIR_BACKOFF:-10}
 
     local count=0
     if [ -f /tmp/health_${srv}_error.count ] ; then
@@ -122,7 +133,7 @@ _health_fail_log()
             let "count = $count + 1"
             echo "failed count: $count" >> /var/log/health_${srv}_error.log
             echo $count > /tmp/health_${srv}_error.count
-            if [ $count -lt $maxerr ] ; then
+            if _health_repair_due "$count" "$maxerr" "$backoff" ; then
                 local auto_repair_func="_health_${srv}_auto_repair"
                 if Quiet type $auto_repair_func 2>/dev/null ; then
                     query="insert health,component=$srv,node=$HOSTNAME,code=$ERR_CODE description=\"fixing\""

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2406,7 +2406,7 @@ health_cinder_check()
     stale_api_check_repair openstack-cinder-api 8776 cinder-api python3
 
     local http_stats=$(influx -host $(shared_id) -database monasca -format json -execute "select last(value) from http_status where service = 'block-storage'" | jq .results[0].series[0].values[0][1])
-    local service_stats="$($OPENSTACK volume service list -f value -c Binary -c Status -c State 2>/dev/null)"
+    local service_stats="$($OPENSTACK volume service list -f value -c Binary -c Host -c Status -c State 2>/dev/null)"
     local scheduler_up=$(echo "$service_stats" | grep scheduler | grep -i enabled | grep -i up | wc -l )
     local scheduler_down=$(echo "$service_stats" | grep scheduler | grep -i enabled | grep -i down | wc -l )
     local volume_up=$(echo "$service_stats" | grep volume | grep -i enabled | grep -i up | wc -l )
@@ -2431,6 +2431,9 @@ health_cinder_check()
         ERR_CODE=5
     fi
 
+    # feed _health_cinder_auto_repair the down services ("Binary Host ... enabled
+    # down") so it can restart them; ceph health detail alone has no such lines.
+    ERR_MSG+=$'\n'"$(echo "$service_stats" | grep -iE 'enabled.*down')"
     ERR_MSG+="`$CEPH health detail`"
     _health_fail_log
 }

--- a/core/sdk_sh/tests/test_sdk_health_repair_backoff.sh
+++ b/core/sdk_sh/tests/test_sdk_health_repair_backoff.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Unit test for _health_repair_due() in ../modules/sdk_health.sh -- the maxerr
+# backoff gate: auto_repair runs every round below maxerr, then backs off to
+# every Nth round instead of giving up forever (so a service whose dependency
+# later recovers still gets fixed).
+#
+# Self-contained: extracts ONLY the predicate, so it needs none of
+# sdk_health.sh's runtime prerequisites (PROG / SDK_DIR / errcodes).
+# Run:  bash test_sdk_health_repair_backoff.sh   (exit 0 = pass)
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_health.sh"
+
+fn="$(awk '/^_health_repair_due\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+[ -n "$fn" ] || { echo "FAIL: _health_repair_due not found in $SRC"; exit 1; }
+eval "$fn"
+
+pass=0 fail=0
+# assert <want: due|no> <count> <maxerr> <backoff>
+assert() {
+    local want=$1 count=$2 maxerr=$3 backoff=$4 got
+    if _health_repair_due "$count" "$maxerr" "$backoff"; then got=due; else got=no; fi
+    if [ "$got" = "$want" ]; then pass=$((pass+1))
+    else fail=$((fail+1)); echo "FAIL: count=$count maxerr=$maxerr backoff=$backoff -> $got (want $want)"; fi
+}
+
+# maxerr=6 backoff=10: repair every round below 6, then only rounds 6,16,26,...
+for c in 0 1 2 3 4 5; do assert due "$c" 6 10; done          # below maxerr: always repair
+assert due 6 6 10                                            # at maxerr: retry (not give up)
+for c in 7 8 9 10 11 12 13 14 15; do assert no "$c" 6 10; done  # cooldown: skip
+assert due 16 6 10                                          # +backoff: retry
+for c in 17 18 25; do assert no "$c" 6 10; done
+assert due 26 6 10                                         # +2*backoff: retry
+
+# tunable knobs: maxerr=6 backoff=3 -> retry at 6,9,12; skip 7,8,10,11
+assert due 6 6 3; assert no 7 6 3; assert no 8 6 3; assert due 9 6 3; assert no 10 6 3; assert due 12 6 3
+
+# key property: never a permanent give-up -- some round in any window is due
+found=no
+for c in $(seq 100 109); do _health_repair_due "$c" 6 10 && { found=yes; break; }; done
+if [ "$found" = yes ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: permanent give-up (no retry in 10 rounds past maxerr)"; fi
+
+echo "----"
+echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: _health_repair_due"; exit 0; } || exit 1

--- a/core/telegraf/telegraf-restart.conf
+++ b/core/telegraf/telegraf-restart.conf
@@ -1,0 +1,11 @@
+# telegraf's kafka output fails at agent init if kafka's brokers aren't reachable
+# yet -- at boot its node_start commit can run before kafka, so it exits 1. Keep
+# retrying in the background until kafka comes back instead of tripping
+# StartLimitBurst (which then strands it -- the health auto-repair burns its
+# maxerr budget and gives up). Type=simple => start returns at once, so the
+# node_start commit is not blocked. See
+# kb/cubecos/known-issues/telegraf-crashloop-kafka-not-ready.md
+[Unit]
+StartLimitIntervalSec=0
+[Service]
+RestartSec=15

--- a/core/telegraf/telegraf-restart.conf
+++ b/core/telegraf/telegraf-restart.conf
@@ -1,10 +1,6 @@
-# telegraf's kafka output fails at agent init if kafka's brokers aren't reachable
-# yet -- at boot its node_start commit can run before kafka, so it exits 1. Keep
-# retrying in the background until kafka comes back instead of tripping
-# StartLimitBurst (which then strands it -- the health auto-repair burns its
-# maxerr budget and gives up). Type=simple => start returns at once, so the
-# node_start commit is not blocked. See
-# kb/cubecos/known-issues/telegraf-crashloop-kafka-not-ready.md
+# Keep retrying until kafka is reachable instead of tripping the start-limit when
+# telegraf boots before kafka. Type=simple so the node_start commit isn't blocked.
+# See kb/cubecos/known-issues/telegraf-crashloop-kafka-not-ready.md.
 [Unit]
 StartLimitIntervalSec=0
 [Service]

--- a/core/telegraf/telegraf.mk
+++ b/core/telegraf/telegraf.mk
@@ -16,3 +16,5 @@ rootfs_install::
 	$(Q)cp -f $(COREDIR)/telegraf/telegraf-device-linux.conf.in $(ROOTDIR)/etc/telegraf/telegraf-device-linux.conf.in
 	$(Q)cp -f $(COREDIR)/telegraf/telegraf-device-win.conf.in $(ROOTDIR)/etc/telegraf/telegraf-device-win.conf.in
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/telegraf/telegraf_sudoers ./etc/sudoers.d/
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/systemd/system/telegraf.service.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/telegraf/telegraf-restart.conf ./etc/systemd/system/telegraf.service.d/


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

After a `cluster powercycle`/reboot, several services stayed NG and needed a manual restart instead of self-healing via the periodic health auto-repair. Four fixes so they recover on their own — three per-service *triggers* plus the systemic *trap* behind them:

**1. nfs-ganesha SIGKILL drop-in** (`core/ceph/nfs-ganesha-sigkill.conf` + `ceph.mk`)
ganesha 5.9 SEGVs on the SIGTERM stop, flapping it until it burns the auto-repair `maxerr` budget → `ceph_mds` stays NG. Hard-kill on stop → clean stop, no flap.

**2. cinder-backup auto-repair** (`sdk_health.sh`)
`health_cinder_check` fed `_health_cinder_auto_repair` `ceph health detail` (no `enabled … down` lines) instead of the down-service list, so it never restarted the down service. Feed it the service list (+ `Host` column).

**3. telegraf restart drop-in** (`core/telegraf/telegraf-restart.conf` + `telegraf.mk`)
telegraf's kafka output `Connect()` fails at init when it boots before kafka → exits 1 → trips `StartLimitBurst` → burns `maxerr`. A restart drop-in (`StartLimitIntervalSec=0`, `RestartSec=15`) retries in the background until kafka is up. `Type=simple`, so it does **not** block the `node_start` commit (an `ExecStartPre` wait would have).

**4. maxerr backoff — the systemic fix** (`sdk_health.sh` + unit test)
`_health_fail_log` gave up auto-repair permanently once `count ≥ maxerr` (the count only resets on a passing check, impossible while the service is down). So anything transiently down at boot stayed stranded even after its dependency recovered. Now it **backs off** past `maxerr` (retry every Nth round via the new `_health_repair_due` predicate, tunable `_HEALTH_REPAIR_BACKOFF`) instead of stopping. Unit-tested in `core/sdk_sh/tests/`.

Verified end-to-end on the sky HA cluster across two full powercycles: with all fixes, every service group returns to `ok` (bar an unrelated `fc_link` hardware baseline).

#### Which issue(s) this PR fixes

Fixes #1084

#### Special notes for your reviewer

> Fixes 1–3 remove the per-service triggers; fix 4 removes the trap itself, so a service transiently down at boot recovers regardless of what stranded it. A **fifth** fix from the same investigation — the master never marking bootup `done` (`fix/master-bootup-done`) — is **not** in this PR: it edits `power_bootup_mark`/`cluster_check_repair_async`, which exist only on the boot-time branch, not `develop`. It ships with the boot-time work.

#### Additional documentation

```docs
kb/cubecos/known-issues/nfs-ganesha-segv-on-stop.md
kb/cubecos/known-issues/cinder-backup-auto-repair-fed-wrong-errmsg.md
kb/cubecos/known-issues/telegraf-crashloop-kafka-not-ready.md
kb/cubecos/known-issues/health-autorepair-gives-up-at-maxerr.md
```