### PR TITLE
fix(health): check node clock time differences in parallel

### DIFF
--- a/core/sdk_sh/modules.pre/sdk_cmd.sh
+++ b/core/sdk_sh/modules.pre/sdk_cmd.sh
@@ -88,13 +88,18 @@ cmd()
     fi
     if [ "x$onebyone" = "xfalse" ] ; then
         for _cmd_node in "${_cmd_nodes[@]}" ; do
-            _cmd_nodes_logs[$_cmd_node]="$(mktemp -u /tmp/cmd_${node}.XXXX)"
+            # Minor fix: changed ${node} to ${_cmd_node} to correctly map the loop variable
+            _cmd_nodes_logs[$_cmd_node]="$(mktemp -u /tmp/cmd_${_cmd_node}.XXXX)"
+
             if [ "x$dryrun" = "xfalse" ] ; then
-                if is_sshable $_cmd_node ; then
-                    timeout $_ssh_to ssh $_ssh_opts $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@" >${_cmd_nodes_logs[$_cmd_node]} 2>&1 &
-                else
-                    false &
-                fi
+                # Wrapping is_sshable into the backgrounded execution block
+                {
+                    if is_sshable $_cmd_node ; then
+                        timeout $_ssh_to ssh $_ssh_opts $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@"
+                    else
+                        false
+                    fi
+                } >"${_cmd_nodes_logs[$_cmd_node]}" 2>&1 &
             else
                 echo "ssh -o LogLevel=quiet $_cmd_node $@" &
             fi
@@ -122,7 +127,8 @@ cmd()
         local cnt=0
         for _cmd_node in "${_cmd_nodes[@]}" ; do
             ((cnt++))
-            _cmd_node_log="$(mktemp -u /tmp/cmd_${node}.XXXX)"
+            # Minor fix here as well for onebyone mode
+            local _cmd_node_log="$(mktemp -u /tmp/cmd_${_cmd_node}.XXXX)"
             if [ "x$dryrun" = "xfalse" ] ; then
                 if is_sshable $_cmd_node ; then
                     timeout $_ssh_to ssh $_ssh_opts $_cmd_node "$(typeset -f ${1%% *} || echo true ); VERBOSE=$VERBOSE; $@" >$_cmd_node_log 2>&1

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -276,7 +276,9 @@ health_clock_report()
 
 health_clock_check()
 {
-    local times=$(cmd -v "date +%s" | cut -d"|" -f3 | sed "/^$/d" | sort)
+    # this is a temporary fix since we are moving away cubectl in favor of cmd()
+    # however, we do not have real parallelism in cmd()
+    local times=$(cubectl node exec -np date "+%s" | sort)
     local timea=$(echo "$times" | head -1)
     local timeb=$(echo "$times" | tail -1)
     local delta=$(expr ${timeb:-0} - ${timea:-0})

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -276,9 +276,7 @@ health_clock_report()
 
 health_clock_check()
 {
-    # this is a temporary fix since we are moving away cubectl in favor of cmd()
-    # however, we do not have real parallelism in cmd()
-    local times=$(cubectl node exec -np date "+%s" | sort)
+    local times=$(cmd -v "date +%s" | cut -d"|" -f3 | sed "/^$/d" | sort)
     local timea=$(echo "$times" | head -1)
     local timeb=$(echo "$times" | tail -1)
     local delta=$(expr ${timeb:-0} - ${timea:-0})


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Check node clock time differences in parallel
  - The original implementation leveraged `cmd()`. However, the underlying SSH handshakes for calling to each remote node took around 1 second. This could pile up and exceed the threshold 10 seconds if we have more than 10 nodes in a cluster.

#### Which issue(s) this PR fixes

- Fixes #1086 

#### Special notes for your reviewer

#### Additional documentation
