### PR TITLE
feat(cinder): upgrade cinder from yoga to antelope

### DIFF
--- a/core/cinder/antelope_patch/volume/drivers/nfs.py
+++ b/core/cinder/antelope_patch/volume/drivers/nfs.py
@@ -162,6 +162,16 @@ class NfsDriver(remotefs.RemoteFSSnapDriverDistributed):
             msg = _('nfs volume must be a valid raw or qcow2 image.')
             raise exception.InvalidVolume(reason=msg)
 
+        # Test if the size is accurate or if something tried to modify it
+        if info.virtual_size != volume.size * units.Gi:
+            LOG.error('The volume virtual_size does not match the size in '
+                      'cinder, aborting as we suspect an exploit. '
+                      'Virtual Size is %(vsize)s and real size is %(size)s',
+                      {'vsize': info.virtual_size, 'size': volume.size})
+            msg = _('The volume virtual_size does not match the size in '
+                    'cinder, aborting as we suspect an exploit.')
+            raise exception.InvalidVolume(reason=msg)
+
         conn_info['data']['format'] = info.file_format
         LOG.debug('NfsDriver: conn_info: %s', conn_info)
         return conn_info
@@ -475,6 +485,14 @@ class NfsDriver(remotefs.RemoteFSSnapDriverDistributed):
         This method should rename the back-end volume name(id) on the
         destination host back to its original name(id) on the source host.
 
+        Due to this renaming, inheriting drivers may need to also re-associate
+        other entities (such as backend QoS) with the new name.  Alternatively
+        they could overwrite this method and raise NotImplemented.
+
+        In any case, driver's code should always use the volume OVO's 'name_id'
+        field instead of 'id' to get the volume's real UUID, as the renaming
+        could fail.
+
         :param ctxt: The context used to run the method update_migrated_volume
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
@@ -530,13 +548,13 @@ class NfsDriver(remotefs.RemoteFSSnapDriverDistributed):
 
         self._stats = data
 
-    @coordination.synchronized('{self.driver_prefix}-{volume[id]}')
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def create_volume(self, volume):
         """Apply locking to the create volume operation."""
 
         return super(NfsDriver, self).create_volume(volume)
 
-    @coordination.synchronized('{self.driver_prefix}-{volume[id]}')
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def delete_volume(self, volume):
         """Deletes a logical volume."""
 

--- a/core/cinder/antelope_patch/volume/drivers/nfs.py.orig
+++ b/core/cinder/antelope_patch/volume/drivers/nfs.py.orig
@@ -160,6 +160,16 @@ class NfsDriver(remotefs.RemoteFSSnapDriverDistributed):
             msg = _('nfs volume must be a valid raw or qcow2 image.')
             raise exception.InvalidVolume(reason=msg)
 
+        # Test if the size is accurate or if something tried to modify it
+        if info.virtual_size != volume.size * units.Gi:
+            LOG.error('The volume virtual_size does not match the size in '
+                      'cinder, aborting as we suspect an exploit. '
+                      'Virtual Size is %(vsize)s and real size is %(size)s',
+                      {'vsize': info.virtual_size, 'size': volume.size})
+            msg = _('The volume virtual_size does not match the size in '
+                    'cinder, aborting as we suspect an exploit.')
+            raise exception.InvalidVolume(reason=msg)
+
         conn_info['data']['format'] = info.file_format
         LOG.debug('NfsDriver: conn_info: %s', conn_info)
         return conn_info
@@ -473,6 +483,14 @@ class NfsDriver(remotefs.RemoteFSSnapDriverDistributed):
         This method should rename the back-end volume name(id) on the
         destination host back to its original name(id) on the source host.
 
+        Due to this renaming, inheriting drivers may need to also re-associate
+        other entities (such as backend QoS) with the new name.  Alternatively
+        they could overwrite this method and raise NotImplemented.
+
+        In any case, driver's code should always use the volume OVO's 'name_id'
+        field instead of 'id' to get the volume's real UUID, as the renaming
+        could fail.
+
         :param ctxt: The context used to run the method update_migrated_volume
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
@@ -528,13 +546,13 @@ class NfsDriver(remotefs.RemoteFSSnapDriverDistributed):
 
         self._stats = data
 
-    @coordination.synchronized('{self.driver_prefix}-{volume[id]}')
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def create_volume(self, volume):
         """Apply locking to the create volume operation."""
 
         return super(NfsDriver, self).create_volume(volume)
 
-    @coordination.synchronized('{self.driver_prefix}-{volume[id]}')
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def delete_volume(self, volume):
         """Deletes a logical volume."""
 

--- a/core/cinder/api-paste.ini
+++ b/core/cinder/api-paste.ini
@@ -1,0 +1,68 @@
+#############
+# OpenStack #
+#############
+
+[composite:osapi_volume]
+use = call:cinder.api:root_app_factory
+/: apiversions
+/healthcheck: healthcheck
+/v3: openstack_volume_api_v3
+
+[composite:openstack_volume_api_v3]
+use = call:cinder.api.middleware.auth:pipeline_factory
+noauth = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler noauth apiv3
+noauth_include_project_id = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler noauth_include_project_id apiv3
+keystone = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler authtoken keystonecontext apiv3
+keystone_nolimit = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler authtoken keystonecontext apiv3
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = cinder
+
+[filter:faultwrap]
+paste.filter_factory = cinder.api.middleware.fault:FaultWrapper.factory
+
+[filter:osprofiler]
+paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
+
+[filter:noauth]
+paste.filter_factory = cinder.api.middleware.auth:NoAuthMiddleware.factory
+
+[filter:noauth_include_project_id]
+paste.filter_factory = cinder.api.middleware.auth:NoAuthMiddlewareIncludeProjectID.factory
+
+[filter:sizelimit]
+paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
+
+[app:apiv3]
+paste.app_factory = cinder.api.v3.router:APIRouter.factory
+
+[pipeline:apiversions]
+pipeline = request_id cors http_proxy_to_wsgi faultwrap osvolumeversionapp
+
+[app:osvolumeversionapp]
+paste.app_factory = cinder.api.versions:Versions.factory
+
+[pipeline:healthcheck]
+pipeline = request_id healthcheckapp
+
+[app:healthcheckapp]
+paste.app_factory = oslo_middleware:Healthcheck.app_factory
+backends = disable_by_file
+disable_by_file_path = /etc/cinder/healthcheck_disable
+
+##########
+# Shared #
+##########
+
+[filter:keystonecontext]
+paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:request_id]
+paste.filter_factory = cinder.api.middleware.request_id:RequestId.factory

--- a/core/cinder/cinder-config-generator.conf
+++ b/core/cinder/cinder-config-generator.conf
@@ -1,0 +1,22 @@
+[DEFAULT]
+output_file = etc/cinder/cinder.conf.sample
+wrap_width = 79
+namespace = castellan.config
+namespace = cinder
+namespace = keystonemiddleware.auth_token
+namespace = osprofiler
+namespace = oslo.config
+namespace = oslo.concurrency
+namespace = oslo.db
+namespace = oslo.log
+namespace = oslo.messaging
+namespace = oslo.middleware
+namespace = oslo.policy
+namespace = oslo.privsep
+namespace = oslo.reports
+namespace = oslo.service.periodic_task
+namespace = oslo.service.service
+namespace = oslo.service.sslutils
+namespace = oslo.service.wsgi
+namespace = oslo.versionedobjects
+namespace = os_brick

--- a/core/cinder/cinder-dist.conf
+++ b/core/cinder/cinder-dist.conf
@@ -1,0 +1,19 @@
+[DEFAULT]
+log_dir = /var/log/cinder
+use_stderr = False
+state_path = /var/lib/cinder
+volumes_dir = /etc/cinder/volumes
+rootwrap_config = /etc/cinder/rootwrap.conf
+auth_strategy = keystone
+
+[backend_defaults]
+target_helper = lioadm
+
+[database]
+connection = mysql://cinder:cinder@localhost/cinder
+
+[oslo_concurrency]
+lock_path = /var/lib/cinder/tmp
+
+[keystone_authtoken]
+auth_url = http://127.0.0.1:5000

--- a/core/cinder/cinder-sudoers
+++ b/core/cinder/cinder-sudoers
@@ -1,0 +1,4 @@
+Defaults:cinder !requiretty
+
+cinder ALL = (root) NOPASSWD: /usr/bin/cinder-rootwrap /etc/cinder/rootwrap.conf *
+cinder ALL = (root) NOPASSWD: /usr/bin/privsep-helper *

--- a/core/cinder/cinder.conf.sample
+++ b/core/cinder/cinder.conf.sample
@@ -1,0 +1,6300 @@
+[DEFAULT]
+
+#
+# From cinder
+#
+
+# The maximum number of items that a collection resource returns in a single
+# response (integer value)
+#osapi_max_limit = 1000
+
+# Json file indicating user visible filter parameters for list queries. (string
+# value)
+#resource_query_filters_file = /etc/cinder/resource_filters.json
+
+# Treat X-Forwarded-For as the canonical remote address. Only enable this if
+# you have a sanitizing proxy. (boolean value)
+#use_forwarded_for = false
+
+# The validation regex for project_ids used in urls. This defaults to
+# [0-9a-f\\-]+ if not set, which matches normal uuids created by keystone.
+# (string value)
+#project_id_regex = [0-9a-f\-]+
+
+# Public url to use for versions endpoint. The default is None, which will use
+# the request's host_url attribute to populate the URL base. If Cinder is
+# operating behind a proxy, you will want to change this to represent the
+# proxy's URL. (string value)
+#public_endpoint = <None>
+
+# Backup services use same backend. (boolean value)
+#backup_use_same_host = false
+
+# Compression algorithm for backups ('none' to disable) (string value)
+# Possible values:
+# none - Do not use compression
+# off - Same as 'none'
+# no - Same as 'none'
+# zlib - Use the Deflate compression algorithm
+# gzip - Same as 'zlib'
+# bz2 - Use Burrows-Wheeler transform compression
+# bzip2 - Same as 'bz2'
+# zstd - Use the Zstandard compression algorithm
+#backup_compression_algorithm = zlib
+
+# Backup metadata version to be used when backing up volume metadata. If this
+# number is bumped, make sure the service doing the restore supports the new
+# version. (integer value)
+#backup_metadata_version = 2
+
+# The number of chunks or objects, for which one Ceilometer notification will
+# be sent (integer value)
+#backup_object_number_per_notification = 10
+
+# Interval, in seconds, between two progress notifications reporting the backup
+# status (integer value)
+#backup_timer_interval = 120
+
+# Ceph configuration file to use. (string value)
+#backup_ceph_conf = /etc/ceph/ceph.conf
+
+# The Ceph user to connect with. Default here is to use the same user as for
+# Cinder volumes. If not using cephx this should be set to None. (string value)
+#backup_ceph_user = cinder
+
+# The chunk size, in bytes, that a backup is broken into before transfer to the
+# Ceph object store. (integer value)
+#backup_ceph_chunk_size = 134217728
+
+# The Ceph pool where volume backups are stored. (string value)
+#backup_ceph_pool = backups
+
+# RBD stripe unit to use when creating a backup image. (integer value)
+#backup_ceph_stripe_unit = 0
+
+# RBD stripe count to use when creating a backup image. (integer value)
+#backup_ceph_stripe_count = 0
+
+# If True, apply JOURNALING and EXCLUSIVE_LOCK feature bits to the backup RBD
+# objects to allow mirroring (boolean value)
+#backup_ceph_image_journals = false
+
+# If True, always discard excess bytes when restoring volumes i.e. pad with
+# zeroes. (boolean value)
+#restore_discard_excess_bytes = true
+
+# The GCS bucket to use. (string value)
+#backup_gcs_bucket = <None>
+
+# The size in bytes of GCS backup objects. (integer value)
+#backup_gcs_object_size = 52428800
+
+# The size in bytes that changes are tracked for incremental backups.
+# backup_gcs_object_size has to be multiple of backup_gcs_block_size. (integer
+# value)
+#backup_gcs_block_size = 32768
+
+# GCS object will be downloaded in chunks of bytes. (integer value)
+#backup_gcs_reader_chunk_size = 2097152
+
+# GCS object will be uploaded in chunks of bytes. Pass in a value of -1 if the
+# file is to be uploaded as a single chunk. (integer value)
+#backup_gcs_writer_chunk_size = 2097152
+
+# Number of times to retry. (integer value)
+#backup_gcs_num_retries = 3
+
+# List of GCS error codes. (list value)
+#backup_gcs_retry_error_codes = 429
+
+# Location of GCS bucket. (string value)
+#backup_gcs_bucket_location = US
+
+# Storage class of GCS bucket. (string value)
+#backup_gcs_storage_class = NEARLINE
+
+# Absolute path of GCS service account credential file. (string value)
+#backup_gcs_credential_file = <None>
+
+# Owner project id for GCS bucket. (string value)
+#backup_gcs_project_id = <None>
+
+# Http user-agent string for gcs api. (string value)
+#backup_gcs_user_agent = gcscinder
+
+# Enable or Disable the timer to send the periodic progress notifications to
+# Ceilometer when backing up the volume to the GCS backend storage. The default
+# value is True to enable the timer. (boolean value)
+#backup_gcs_enable_progress_timer = true
+
+# URL for http proxy access. (uri value)
+#backup_gcs_proxy_url = <None>
+
+# Base dir containing mount point for gluster share. (string value)
+#glusterfs_backup_mount_point = $state_path/backup_mount
+
+# GlusterFS share in <hostname|ipv4addr|ipv6addr>:<gluster_vol_name> format.
+# Eg: 1.2.3.4:backup_vol (string value)
+#glusterfs_backup_share = <None>
+
+# Base dir containing mount point for NFS share. (string value)
+#backup_mount_point_base = $state_path/backup_mount
+
+# NFS share in hostname:path, ipv4addr:path, or "[ipv6addr]:path" format.
+# (string value)
+#backup_share = <None>
+
+# Mount options passed to the NFS client. See NFS man page for details. (string
+# value)
+#backup_mount_options = <None>
+
+# The number of attempts to mount NFS shares before raising an error. (integer
+# value)
+# Minimum value: 1
+#backup_mount_attempts = 3
+
+# The maximum size in bytes of the files used to hold backups. If the volume
+# being backed up exceeds this size, then it will be backed up into multiple
+# files. backup_file_size also determines the buffer size used to build backup
+# files, so should be scaled according to available RAM and number of workers.
+# backup_file_size must be a multiple of backup_sha_block_size_bytes. (integer
+# value)
+#backup_file_size = 1999994880
+
+# The size in bytes that changes are tracked for incremental backups.
+# backup_file_size has to be multiple of backup_sha_block_size_bytes. (integer
+# value)
+#backup_sha_block_size_bytes = 32768
+
+# Enable or Disable the timer to send the periodic progress notifications to
+# Ceilometer when backing up the volume to the backend storage. The default
+# value is True to enable the timer. (boolean value)
+#backup_enable_progress_timer = true
+
+# Path specifying where to store backups. (string value)
+#backup_posix_path = $state_path/backup
+
+# Custom directory to use for backups. (string value)
+#backup_container = <None>
+
+# The url where the S3 server is listening. (string value)
+#backup_s3_endpoint_url = <None>
+
+# The S3 query token access key. (string value)
+#backup_s3_store_access_key = <None>
+
+# The S3 query token secret key. (string value)
+#backup_s3_store_secret_key = <None>
+
+# The S3 bucket to be used to store the Cinder backup data. (string value)
+#backup_s3_store_bucket = volumebackups
+
+# The size in bytes of S3 backup objects (integer value)
+#backup_s3_object_size = 52428800
+
+# The size in bytes that changes are tracked for incremental backups.
+# backup_s3_object_size has to be multiple of backup_s3_block_size. (integer
+# value)
+#backup_s3_block_size = 32768
+
+# Enable or Disable the timer to send the periodic progress notifications to
+# Ceilometer when backing up the volume to the S3 backend storage. The default
+# value is True to enable the timer. (boolean value)
+#backup_s3_enable_progress_timer = true
+
+# Address or host for the http proxy server. (string value)
+#backup_s3_http_proxy =
+
+# Address or host for the https proxy server. (string value)
+#backup_s3_https_proxy =
+
+# The time in seconds till a timeout exception is thrown. (floating point
+# value)
+#backup_s3_timeout = 60
+
+# The maximum number of connections to keep in a connection pool. (integer
+# value)
+#backup_s3_max_pool_connections = 10
+
+# An integer representing the maximum number of retry attempts that will be
+# made on a single request. (integer value)
+#backup_s3_retry_max_attempts = 4
+
+# A string representing the type of retry mode. e.g: legacy, standard, adaptive
+# (string value)
+#backup_s3_retry_mode = legacy
+
+# Enable or Disable ssl verify. (boolean value)
+#backup_s3_verify_ssl = true
+
+# path/to/cert/bundle.pem - A filename of the CA cert bundle to use. (string
+# value)
+#backup_s3_ca_cert_file = <None>
+
+# Enable or Disable md5 validation in the s3 backend. (boolean value)
+#backup_s3_md5_validation = true
+
+# The SSECustomerKey. backup_s3_sse_customer_algorithm must be set at the same
+# time to enable SSE. (string value)
+#backup_s3_sse_customer_key = <None>
+
+# The SSECustomerAlgorithm. backup_s3_sse_customer_key must be set at the same
+# time to enable SSE. (string value)
+#backup_s3_sse_customer_algorithm = <None>
+
+# The URL of the Swift endpoint (uri value)
+#backup_swift_url = <None>
+
+# The URL of the Keystone endpoint (uri value)
+#backup_swift_auth_url = <None>
+
+# Info to match when looking for swift in the service catalog. Format is:
+# separated values of the form: <service_type>:<service_name>:<endpoint_type> -
+# Only used if backup_swift_url is unset (string value)
+#swift_catalog_info = object-store:swift:publicURL
+
+# Info to match when looking for keystone in the service catalog. Format is:
+# separated values of the form: <service_type>:<service_name>:<endpoint_type> -
+# Only used if backup_swift_auth_url is unset (string value)
+#keystone_catalog_info = identity:Identity Service:publicURL
+
+# Swift authentication mechanism (per_user or single_user). (string value)
+# Possible values:
+# per_user - <No description provided>
+# single_user - <No description provided>
+#backup_swift_auth = per_user
+
+# Swift authentication version. Specify "1" for auth 1.0, or "2" for auth 2.0
+# or "3" for auth 3.0 (string value)
+#backup_swift_auth_version = 1
+
+# Swift tenant/account name. Required when connecting to an auth 2.0 system
+# (string value)
+#backup_swift_tenant = <None>
+
+# Swift user domain name. Required when connecting to an auth 3.0 system
+# (string value)
+#backup_swift_user_domain = <None>
+
+# Swift project domain name. Required when connecting to an auth 3.0 system
+# (string value)
+#backup_swift_project_domain = <None>
+
+# Swift project/account name. Required when connecting to an auth 3.0 system
+# (string value)
+#backup_swift_project = <None>
+
+# Swift user name (string value)
+#backup_swift_user = <None>
+
+# Swift key for authentication (string value)
+#backup_swift_key = <None>
+
+# The default Swift container to use (string value)
+#backup_swift_container = volumebackups
+
+# The storage policy to use when creating the Swift container. If the container
+# already exists the storage policy cannot be enforced (string value)
+#backup_swift_create_storage_policy = <None>
+
+# The size in bytes of Swift backup objects (integer value)
+#backup_swift_object_size = 52428800
+
+# The size in bytes that changes are tracked for incremental backups.
+# backup_swift_object_size has to be multiple of backup_swift_block_size.
+# (integer value)
+#backup_swift_block_size = 32768
+
+# The number of retries to make for Swift operations (integer value)
+#backup_swift_retry_attempts = 3
+
+# The backoff time in seconds between Swift retries (integer value)
+#backup_swift_retry_backoff = 2
+
+# Enable or Disable the timer to send the periodic progress notifications to
+# Ceilometer when backing up the volume to the Swift backend storage. The
+# default value is True to enable the timer. (boolean value)
+#backup_swift_enable_progress_timer = true
+
+# Location of the CA certificate file to use for swift client requests. (string
+# value)
+#backup_swift_ca_cert_file = <None>
+
+# Bypass verification of server certificate when making SSL connection to
+# Swift. (boolean value)
+#backup_swift_auth_insecure = false
+
+# Send a X-Service-Token header with service auth credentials. If enabled you
+# also must set the service_user group and enable send_service_user_token.
+# (boolean value)
+#backup_swift_service_auth = false
+
+# Driver to use for backups. (string value)
+#backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver
+
+# Time in seconds between checks to see if the backup driver has been
+# successfully initialized, any time the driver is restarted. (integer value)
+# Minimum value: 5
+#backup_driver_init_check_interval = 60
+
+# Time in seconds between checks of the backup driver status.  If does not
+# report as working, it is restarted. (integer value)
+# Minimum value: 10
+# Deprecated group/name - [DEFAULT]/backup_driver_status_check_interval
+#backup_driver_stats_polling_interval = 60
+
+# Offload pending backup delete during backup service startup. If false, the
+# backup service will remain down until all pending backups are deleted.
+# (boolean value)
+#backup_service_inithost_offload = true
+
+# Size of the native threads pool for the backups.  Most backup drivers rely
+# heavily on this, it can be decreased for specific drivers that don't.
+# (integer value)
+# Minimum value: 20
+#backup_native_threads_pool_size = 60
+
+# Number of backup processes to launch. Improves performance with concurrent
+# backups. (integer value)
+# Minimum value: 1
+# Maximum value: 20
+#backup_workers = 1
+
+# Maximum number of concurrent memory heavy operations: backup and restore.
+# Value of 0 means unlimited (integer value)
+# Minimum value: 0
+#backup_max_operations = 15
+
+# Name of this cluster. Used to group volume hosts that share the same backend
+# configurations to work in HA Active-Active mode. (string value)
+#cluster = <None>
+
+# Enables or disables rate limit of the API. (boolean value)
+#api_rate_limit = true
+
+# The full class name of the group API class (string value)
+#group_api_class = cinder.group.api.API
+
+# Specify list of extensions to load when using osapi_volume_extension option
+# with cinder.api.contrib.select_extensions (list value)
+#osapi_volume_ext_list =
+
+# osapi volume extension to load (multi valued)
+#osapi_volume_extension = cinder.api.contrib.standard_extensions
+
+# The full class name of the volume API class to use (string value)
+#volume_api_class = cinder.volume.api.API
+
+# Top-level directory for maintaining cinder's state (string value)
+#state_path = /var/lib/cinder
+
+# The strategy to use for auth. Supports noauth, noauth_include_project_id or
+# keystone. (string value)
+# Possible values:
+# noauth - Do not perform authentication
+# noauth_include_project_id - Do not perform authentication, and include a
+# project_id in API URLs
+# keystone - Authenticate using keystone
+#auth_strategy = keystone
+
+# The full class name of the volume backup API class (string value)
+#backup_api_class = cinder.backup.api.API
+
+# Full class name for the Manager for volume backup (string value)
+#backup_manager = cinder.backup.manager.BackupManager
+
+# A list of the URLs of glance API servers available to cinder
+# ([http[s]://][hostname|ip]:port). If protocol is not specified it defaults to
+# http. (list value)
+#glance_api_servers = <None>
+
+# Number retries when downloading an image from glance (integer value)
+# Minimum value: 0
+#glance_num_retries = 3
+
+# Allow to perform insecure SSL (https) requests to glance (https will be used
+# but cert validation will not be performed). (boolean value)
+#glance_api_insecure = false
+
+# Enables or disables negotiation of SSL layer compression. In some cases
+# disabling compression can improve data throughput, such as when high network
+# bandwidth is available and you use compressed image formats like qcow2.
+# (boolean value)
+#glance_api_ssl_compression = false
+
+# Location of ca certificates file to use for glance client requests. (string
+# value)
+#glance_ca_certificates_file = <None>
+
+# Location of certificate file to use for glance client requests. (string
+# value)
+#glance_certfile = <None>
+
+# Location of certificate key file to use for glance client requests. (string
+# value)
+#glance_keyfile = <None>
+
+# http/https timeout value for glance operations. If no value (None) is
+# supplied here, the glanceclient default value is used. (integer value)
+#glance_request_timeout = <None>
+
+# IP address of this host (host address value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#my_ip = <HOST_IP_ADDRESS>
+
+# Full class name for the Manager for volume (string value)
+#volume_manager = cinder.volume.manager.VolumeManager
+
+# Full class name for the Manager for scheduler (string value)
+#scheduler_manager = cinder.scheduler.manager.SchedulerManager
+
+# Name of this node.  This can be an opaque identifier. It is not necessarily a
+# host name, FQDN, or IP address. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#host = localhost
+
+# Availability zone of this node. Can be overridden per volume backend with the
+# option "backend_availability_zone". (string value)
+#storage_availability_zone = nova
+
+# Default availability zone for new volumes. If not set, the
+# storage_availability_zone option value is used as the default for new
+# volumes. (string value)
+#default_availability_zone = <None>
+
+# If the requested Cinder availability zone is unavailable, fall back to the
+# value of default_availability_zone, then storage_availability_zone, instead
+# of failing. (boolean value)
+#allow_availability_zone_fallback = false
+
+# Default volume type to use (string value)
+#default_volume_type = __DEFAULT__
+
+# Default group type to use (string value)
+#default_group_type = <None>
+
+# Time period for which to generate volume usages. The options are hour, day,
+# month, or year. (string value)
+#volume_usage_audit_period = month
+
+# Path to the rootwrap configuration file to use for running commands as root
+# (string value)
+#rootwrap_config = /etc/cinder/rootwrap.conf
+
+# Enable monkey patching (boolean value)
+#monkey_patch = false
+
+# List of modules/decorators to monkey patch (list value)
+#monkey_patch_modules =
+
+# Maximum time since last check-in for a service to be considered up (integer
+# value)
+#service_down_time = 60
+
+# A list of backend names to use. These backend names should be backed by a
+# unique [CONFIG] group with its options (list value)
+#enabled_backends = <None>
+
+# Whether snapshots sizes count against global and per volume type gigabyte
+# quotas. By default snapshots' sizes are counted. (boolean value)
+#no_snapshot_gb_quota = false
+
+# The full class name of the volume transfer API class (string value)
+#transfer_api_class = cinder.transfer.api.API
+
+# The full class name of the consistencygroup API class (string value)
+#consistencygroup_api_class = cinder.consistencygroup.api.API
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# Image compression format on image upload (string value)
+# Possible values:
+# gzip - GNUzip format
+#compression_format = gzip
+
+# The strategy to use for image compression on upload. Default is disallow
+# compression. (boolean value)
+#allow_compression_on_image_upload = false
+
+# The full class name of the compute API class to use (string value)
+#compute_api_class = cinder.compute.nova.API
+
+# ID of the project which will be used as the Cinder internal tenant. (string
+# value)
+#cinder_internal_tenant_project_id = <None>
+
+# ID of the user to be used in volume operations as the Cinder internal tenant.
+# (string value)
+#cinder_internal_tenant_user_id = <None>
+
+# Services to be added to the available pool on create (boolean value)
+#enable_new_services = true
+
+# Template string to be used to generate volume names (string value)
+#volume_name_template = volume-%s
+
+# Template string to be used to generate snapshot names (string value)
+#snapshot_name_template = snapshot-%s
+
+# Template string to be used to generate backup names (string value)
+#backup_name_template = backup-%s
+
+# A list of url schemes that can be downloaded directly via the direct_url.
+# Currently supported schemes: [file, cinder]. (list value)
+#allowed_direct_url_schemes =
+
+#
+# Enable image signature verification.
+#
+# Cinder uses the image signature metadata from Glance and
+# verifies the signature of a signed image while downloading
+# that image. There are two options here.
+#
+# 1. ``enabled``: verify when image has signature metadata.
+# 2. ``disabled``: verification is turned off.
+#
+# If the image signature cannot be verified or if the image
+# signature metadata is incomplete when required, then Cinder
+# will not create the volume and update it into an error
+# state. This provides end users with stronger assurances
+# of the integrity of the image data they are using to
+# create volumes.
+#  (string value)
+# Possible values:
+# disabled - <No description provided>
+# enabled - <No description provided>
+#verify_glance_signatures = enabled
+
+# Info to match when looking for glance in the service catalog. Format is:
+# separated values of the form: <service_type>:<service_name>:<endpoint_type> -
+# Only used if glance_api_servers are not provided. (string value)
+#glance_catalog_info = image:glance:publicURL
+
+# Default core properties of image (list value)
+#glance_core_properties = checksum,container_format,disk_format,image_name,image_id,min_disk,min_ram,name,size
+
+# Directory used for temporary storage during image conversion (string value)
+#image_conversion_dir = $state_path/conversion
+
+# When possible, compress images uploaded to the image service (boolean value)
+#image_compress_on_upload = true
+
+# CPU time limit in seconds to convert the image (integer value)
+#image_conversion_cpu_limit = 60
+
+# Address space limit in gigabytes to convert the image (integer value)
+#image_conversion_address_space_limit = 1
+
+# Disallow image conversion when creating a volume from an image and when
+# uploading a volume as an image. Image conversion consumes a large amount of
+# system resources and can cause performance problems on the cinder-volume
+# node. When set True, this option disables image conversion. (boolean value)
+#image_conversion_disable = false
+
+# A list of strings describing the VMDK createType subformats that are allowed.
+# We recommend that you only include single-file-with-sparse-header variants to
+# avoid potential host file exposure when processing named extents when an
+# image is converted to raw format as it is written to a volume.  If this list
+# is empty, no VMDK images are allowed. (list value)
+#vmdk_allowed_types = streamOptimized,monolithicSparse
+
+# List of reserved image namespaces that should be filtered out when uploading
+# a volume as an image back to Glance. When a volume is created from an image,
+# Cinder stores the image properties as volume image metadata, and if the
+# volume is later uploaded as an image, Cinder will add these properties when
+# it creates the image in Glance. This can cause problems for image metadata
+# that are in namespaces that glance reserves for itself, or when properties
+# (such as an image signature) cannot apply to the new image, or when an
+# operator has configured glance property protections to make some image
+# properties read-only. Cinder will *always* filter out image metadata in the
+# namespaces `os_glance` and `img_signature`; this configuration option allows
+# operators to specify *additional* namespaces to be excluded. (list value)
+#reserved_image_namespaces =
+
+# message minimum life in seconds. (integer value)
+#message_ttl = 2592000
+
+# interval between periodic task runs to clean expired messages in seconds.
+# (integer value)
+#message_reap_interval = 86400
+
+# Number of volumes allowed per project (integer value)
+#quota_volumes = 10
+
+# Number of volume snapshots allowed per project (integer value)
+#quota_snapshots = 10
+
+# Number of consistencygroups allowed per project (integer value)
+#quota_consistencygroups = 10
+
+# Number of groups allowed per project (integer value)
+#quota_groups = 10
+
+# Total amount of storage, in gigabytes, allowed for volumes and snapshots per
+# project (integer value)
+#quota_gigabytes = 1000
+
+# Number of volume backups allowed per project (integer value)
+#quota_backups = 10
+
+# Total amount of storage, in gigabytes, allowed for backups per project
+# (integer value)
+#quota_backup_gigabytes = 1000
+
+# Number of seconds until a reservation expires (integer value)
+#reservation_expire = 86400
+
+# Interval between periodic task runs to clean expired reservations in seconds.
+# (integer value)
+#reservation_clean_interval = $reservation_expire
+
+# Count of reservations until usage is refreshed (integer value)
+#until_refresh = 0
+
+# Number of seconds between subsequent usage refreshes (integer value)
+#max_age = 0
+
+# Default driver to use for quota checks (string value)
+#quota_driver = cinder.quota.DbQuotaDriver
+
+# Enables or disables use of default quota class with default quota. (boolean
+# value)
+#use_default_quota_class = true
+
+# Max size allowed per volume, in gigabytes (integer value)
+#per_volume_size_limit = -1
+
+# The scheduler host manager class to use (string value)
+#scheduler_host_manager = cinder.scheduler.host_manager.HostManager
+
+# Maximum number of attempts to schedule a volume (integer value)
+#scheduler_max_attempts = 3
+
+# Which filter class names to use for filtering hosts when not specified in the
+# request. (list value)
+#scheduler_default_filters = AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter
+
+# Which weigher class names to use for weighing hosts. (list value)
+#scheduler_default_weighers = CapacityWeigher
+
+# Which handler to use for selecting the host/pool after weighing (string
+# value)
+#scheduler_weight_handler = cinder.scheduler.weights.OrderedHostWeightHandler
+
+# Default scheduler driver to use (string value)
+#scheduler_driver = cinder.scheduler.filter_scheduler.FilterScheduler
+
+# Maximum time in seconds to wait for the driver to report as ready (integer
+# value)
+# Minimum value: 1
+#scheduler_driver_init_wait_time = 60
+
+# Absolute path to scheduler configuration JSON file. (string value)
+#scheduler_json_config_location =
+
+# Multiplier used for weighing free capacity. Negative numbers mean to stack vs
+# spread. (floating point value)
+#capacity_weight_multiplier = 1.0
+
+# Multiplier used for weighing allocated capacity. Positive numbers mean to
+# stack vs spread. (floating point value)
+#allocated_capacity_weight_multiplier = -1.0
+
+# Multiplier used for weighing volume number. Negative numbers mean to spread
+# vs stack. (floating point value)
+#volume_number_multiplier = -1.0
+
+# Interval, in seconds, between nodes reporting state to datastore (integer
+# value)
+#report_interval = 10
+
+# Interval, in seconds, between running periodic tasks (integer value)
+#periodic_interval = 60
+
+# Range, in seconds, to randomly delay when starting the periodic task
+# scheduler to reduce stampeding. (Disable by setting to 0) (integer value)
+#periodic_fuzzy_delay = 60
+
+# IP address on which OpenStack Volume API listens (string value)
+#osapi_volume_listen = 0.0.0.0
+
+# Port on which OpenStack Volume API listens (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#osapi_volume_listen_port = 8776
+
+# Number of workers for OpenStack Volume API service. The default is equal to
+# the number of CPUs available. (integer value)
+#osapi_volume_workers = <None>
+
+# Wraps the socket in a SSL context if True is set. A certificate file and key
+# file must be specified. (boolean value)
+#osapi_volume_use_ssl = false
+
+# Option to enable strict host key checking.  When set to "True" Cinder will
+# only connect to systems with a host key present in the configured
+# "ssh_hosts_key_file".  When set to "False" the host key will be saved upon
+# first connection and used for subsequent connections.  Default=False (boolean
+# value)
+#strict_ssh_host_key_policy = false
+
+# File containing SSH host keys for the systems with which Cinder needs to
+# communicate.  OPTIONAL: Default=$state_path/ssh_known_hosts (string value)
+#ssh_hosts_key_file = $state_path/ssh_known_hosts
+
+# The number of characters in the salt. (integer value)
+#volume_transfer_salt_length = 8
+
+# The number of characters in the autogenerated auth key. (integer value)
+#volume_transfer_key_length = 16
+
+# Enables the Force option on upload_to_image. This enables running
+# upload_volume on in-use volumes for backends that support it. (boolean value)
+#enable_force_upload = false
+
+# Create volume from snapshot at the host where snapshot resides (boolean
+# value)
+#snapshot_same_host = true
+
+# Ensure that the new volumes are the same AZ as snapshot or source volume
+# (boolean value)
+#cloned_volume_same_az = true
+
+# Cache volume availability zones in memory for the provided duration in
+# seconds (integer value)
+#az_cache_duration = 3600
+
+# Number of times to attempt to run flakey shell commands (integer value)
+#num_shell_tries = 3
+
+# The percentage of backend capacity is reserved (integer value)
+# Minimum value: 0
+# Maximum value: 100
+#reserved_percentage = 0
+
+# Prefix for iSCSI/NVMEoF volumes (string value)
+#target_prefix = iqn.2010-10.org.openstack:
+
+# The IP address that the iSCSI/NVMEoF daemon is listening on (string value)
+#target_ip_address = $my_ip
+
+# The list of secondary IP addresses of the iSCSI/NVMEoF daemon (list value)
+# Deprecated group/name - [DEFAULT]/iscsi_secondary_ip_addresses
+#target_secondary_ip_addresses =
+
+# The port that the iSCSI/NVMEoF daemon is listening on (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#target_port = 3260
+
+# The maximum number of times to rescan targets to find volume (integer value)
+#num_volume_device_scan_tries = 3
+
+# The backend name for a given driver implementation (string value)
+#volume_backend_name = <None>
+
+# Method used to wipe old volumes (string value)
+# Possible values:
+# none - <No description provided>
+# zero - <No description provided>
+#volume_clear = zero
+
+# Size in MiB to wipe at start of old volumes. 1024 MiB at max. 0 => all
+# (integer value)
+# Maximum value: 1024
+#volume_clear_size = 0
+
+# The flag to pass to ionice to alter the i/o priority of the process used to
+# zero a volume after deletion, for example "-c3" for idle only priority.
+# (string value)
+#volume_clear_ionice = <None>
+
+# Target user-land tool to use. tgtadm is default, use lioadm for LIO iSCSI
+# support, scstadmin for SCST target support, ietadm for iSCSI Enterprise
+# Target, iscsictl for Chelsio iSCSI Target, nvmet for NVMEoF support, spdk-
+# nvmeof for SPDK NVMe-oF, or fake for testing. Note: The IET driver is
+# deprecated and will be removed in the V release. (string value)
+# Possible values:
+# tgtadm - <No description provided>
+# lioadm - <No description provided>
+# scstadmin - <No description provided>
+# iscsictl - <No description provided>
+# ietadm - <No description provided>
+# nvmet - <No description provided>
+# spdk-nvmeof - <No description provided>
+# fake - <No description provided>
+#target_helper = tgtadm
+
+# Volume configuration file storage directory (string value)
+#volumes_dir = $state_path/volumes
+
+# DEPRECATED: IET configuration file (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: IET target driver is no longer supported.
+#iet_conf = /etc/iet/ietd.conf
+
+# Chiscsi (CXT) global defaults configuration file (string value)
+#chiscsi_conf = /etc/chelsio-iscsi/chiscsi.conf
+
+# Sets the behavior of the iSCSI target to either perform blockio or fileio
+# optionally, auto can be set and Cinder will autodetect type of backing device
+# (string value)
+# Possible values:
+# blockio - <No description provided>
+# fileio - <No description provided>
+# auto - <No description provided>
+#iscsi_iotype = fileio
+
+# The default block size used when copying/clearing volumes (string value)
+#volume_dd_blocksize = 1M
+
+# The blkio cgroup name to be used to limit bandwidth of volume copy (string
+# value)
+#volume_copy_blkio_cgroup_name = cinder-volume-copy
+
+# The upper limit of bandwidth of volume copy. 0 => unlimited (integer value)
+#volume_copy_bps_limit = 0
+
+# Sets the behavior of the iSCSI target to either perform write-back(on) or
+# write-through(off). This parameter is valid if target_helper is set to
+# tgtadm. (string value)
+# Possible values:
+# on - <No description provided>
+# off - <No description provided>
+#iscsi_write_cache = on
+
+# Sets the target-specific flags for the iSCSI target. Only used for tgtadm to
+# specify backing device flags using bsoflags option. The specified string is
+# passed as is to the underlying tool. (string value)
+#iscsi_target_flags =
+
+# Determines the target protocol for new volumes, created with tgtadm, lioadm
+# and nvmet target helpers. In order to enable RDMA, this parameter should be
+# set with the value "iser". The supported iSCSI protocol values are "iscsi"
+# and "iser", in case of nvmet target set to "nvmet_rdma" or "nvmet_tcp".
+# (string value)
+# Possible values:
+# iscsi - <No description provided>
+# iser - <No description provided>
+# nvmet_rdma - <No description provided>
+# nvmet_tcp - <No description provided>
+#target_protocol = iscsi
+
+# The path to the client certificate key for verification, if the driver
+# supports it. (string value)
+#driver_client_cert_key = <None>
+
+# The path to the client certificate for verification, if the driver supports
+# it. (string value)
+#driver_client_cert = <None>
+
+# Tell driver to use SSL for connection to backend storage if the driver
+# supports it. (boolean value)
+#driver_use_ssl = false
+
+# Representation of the over subscription ratio when thin provisioning is
+# enabled. Default ratio is 20.0, meaning provisioned capacity can be 20 times
+# of the total physical capacity. If the ratio is 10.5, it means provisioned
+# capacity can be 10.5 times of the total physical capacity. A ratio of 1.0
+# means provisioned capacity cannot exceed the total physical capacity. If
+# ratio is 'auto', Cinder will automatically calculate the ratio based on the
+# provisioned capacity and the used space. If not set to auto, the ratio has to
+# be a minimum of 1.0. (string value)
+#max_over_subscription_ratio = 20.0
+
+# Option to enable/disable CHAP authentication for targets. (boolean value)
+#use_chap_auth = false
+
+# CHAP user name. (string value)
+#chap_username =
+
+# Password for specified CHAP account name. (string value)
+#chap_password =
+
+# Namespace for driver private data values to be saved in. (string value)
+#driver_data_namespace = <None>
+
+# String representation for an equation that will be used to filter hosts. Only
+# used when the driver filter is set to be used by the Cinder scheduler.
+# (string value)
+#filter_function = <None>
+
+# String representation for an equation that will be used to determine the
+# goodness of a host. Only used when using the goodness weigher is set to be
+# used by the Cinder scheduler. (string value)
+#goodness_function = <None>
+
+# If set to True the http client will validate the SSL certificate of the
+# backend endpoint. (boolean value)
+#driver_ssl_cert_verify = false
+
+# Can be used to specify a non default path to a CA_BUNDLE file or directory
+# with certificates of trusted CAs, which will be used to validate the backend
+# (string value)
+#driver_ssl_cert_path = <None>
+
+# List of options that control which trace info is written to the DEBUG log
+# level to assist developers. Valid values are method and api. (list value)
+#trace_flags = <None>
+
+# Multi opt of dictionaries to represent a replication target device.  This
+# option may be specified multiple times in a single config section to specify
+# multiple replication target devices.  Each entry takes the standard dict
+# config form: replication_device =
+# target_device_id:<required>,key1:value1,key2:value2... (dict value)
+#replication_device = <None>
+
+# Report to clients of Cinder that the backend supports discard (aka.
+# trim/unmap). This will not actually change the behavior of the backend or the
+# client directly, it will only notify that it can be used. (boolean value)
+#report_discard_supported = false
+
+# Protocol for transferring data between host and storage back-end. (string
+# value)
+# Possible values:
+# iSCSI - <No description provided>
+# FC - <No description provided>
+#storage_protocol = iSCSI
+
+# Set this to True when you want to allow an unsupported driver to start.
+# Drivers that haven't maintained a working CI system and testing are marked as
+# unsupported until CI is working again.  This also marks a driver as
+# deprecated and may be removed in the next release. (boolean value)
+#enable_unsupported_driver = false
+
+# Availability zone for this volume backend. If not set, the
+# storage_availability_zone option value is used as the default for all
+# backends. (string value)
+#backend_availability_zone = <None>
+
+# The maximum number of times to rescan iSER target to find volume (integer
+# value)
+#num_iser_scan_tries = 3
+
+# Prefix for iSER volumes (string value)
+#iser_target_prefix = iqn.2010-10.org.openstack:
+
+# The IP address that the iSER daemon is listening on (string value)
+#iser_ip_address = $my_ip
+
+# The port that the iSER daemon is listening on (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#iser_port = 3260
+
+# The name of the iSER target user-land tool to use (string value)
+#iser_helper = tgtadm
+
+# NVMe os-brick connector has 2 different connection info formats, this allows
+# some NVMe-oF drivers that use the original format (version 1), such as spdk
+# and LVM-nvmet, to send the newer format. (integer value)
+# Minimum value: 1
+# Maximum value: 2
+#nvmeof_conn_info_version = 1
+
+# The id of the NVMe target port definition when not sharing targets.  The
+# starting port id value when sharing, incremented for each secondary ip
+# address. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#nvmet_port_id = 1
+
+# Namespace id for the subsystem for the LVM volume when not sharing targets.
+# The minimum id value when sharing.Maximum supported value in Linux is 8192
+# (integer value)
+#nvmet_ns_id = 10
+
+# Certain ISCSI targets have predefined target names, SCST target driver uses
+# this name. (string value)
+#scst_target_iqn_name = <None>
+
+# SCST target implementation can choose from multiple SCST target drivers.
+# (string value)
+#scst_target_driver = iscsi
+
+# If this is set to True, a temporary snapshot will be created for performing
+# non-disruptive backups. Otherwise a temporary volume will be cloned in order
+# to perform a backup. (boolean value)
+#backup_use_temp_snapshot = false
+
+# If set to True, upload-to-image in raw format will create a cloned volume and
+# register its location to the image service, instead of uploading the volume
+# content. The cinder backend and locations support must be enabled in the
+# image service. (boolean value)
+#image_upload_use_cinder_backend = false
+
+# If set to True, the image volume created by upload-to-image will be placed in
+# the internal tenant. Otherwise, the image volume is created in the current
+# context's tenant. (boolean value)
+#image_upload_use_internal_tenant = false
+
+# Enable the image volume cache for this backend. (boolean value)
+#image_volume_cache_enabled = false
+
+# Max size of the image volume cache for this backend in GB. 0 => unlimited.
+# (integer value)
+#image_volume_cache_max_size_gb = 0
+
+# Max number of entries allowed in the image volume cache. 0 => unlimited.
+# (integer value)
+#image_volume_cache_max_count = 0
+
+# Do we attach/detach volumes in cinder using multipath for volume to image and
+# image to volume transfers? This parameter needs to be configured for each
+# backend section or in [backend_defaults] section as a common configuration
+# for all backends. (boolean value)
+#use_multipath_for_image_xfer = false
+
+# If this is set to True, attachment of volumes for image transfer will be
+# aborted when multipathd is not running. Otherwise, it will fallback to single
+# path. This parameter needs to be configured for each backend section or in
+# [backend_defaults] section as a common configuration for all backends.
+# (boolean value)
+#enforce_multipath_for_image_xfer = false
+
+# DEPRECATED: Datera API port. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#datera_api_port = 7717
+
+# DEPRECATED: Datera API version. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#datera_api_version = 2.2
+
+# LDAP authentication server (string value)
+#datera_ldap_server = <None>
+
+# Timeout for HTTP 503 retry messages (integer value)
+#datera_503_timeout = 120
+
+# Interval between 503 retries (integer value)
+#datera_503_interval = 5
+
+# True to set function arg and return logging (boolean value)
+#datera_debug = false
+
+# ONLY FOR DEBUG/TESTING PURPOSES
+# True to set replica_count to 1 (boolean value)
+#datera_debug_replica_count_override = false
+
+# If set to 'Map' --> OpenStack project ID will be mapped implicitly to Datera
+# tenant ID
+# If set to None --> Datera tenant ID will not be used during volume
+# provisioning
+# If set to anything else --> Datera tenant ID will be the provided value
+# (string value)
+#datera_tenant_id = <None>
+
+# Set to True to enable Datera backend image caching (boolean value)
+#datera_enable_image_cache = false
+
+# Cinder volume type id to use for cached volumes (string value)
+#datera_image_cache_volume_type_id = <None>
+
+# Set to True to disable profiling in the Datera driver (boolean value)
+#datera_disable_profiler = false
+
+# Set to True to disable sending additional metadata to the Datera backend
+# (boolean value)
+#datera_disable_extended_metadata = false
+
+# Set to True to disable automatic template override of the size attribute when
+# creating from a template (boolean value)
+#datera_disable_template_override = false
+
+# Settings here will be used as volume-type defaults if the volume-type setting
+# is not provided.  This can be used, for example, to set a very low
+# total_iops_max value if none is specified in the volume-type to prevent
+# accidental overusage.  Options are specified via the following format,
+# WITHOUT ANY 'DF:' PREFIX:
+# 'datera_volume_type_defaults=iops_per_gb:100,bandwidth_per_gb:200...etc'.
+# (dict value)
+#datera_volume_type_defaults =
+
+# The port number to be used when doing nvme connect from host (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#nvme_connect_port = 4420
+
+# Specify whether to use SSL or not when accessing the composer APIs (boolean
+# value)
+#api_enable_ssl = true
+
+# Maximum read IOPS that volume can get when reading data from the volume
+# during host assisted migration (integer value)
+#iops_for_image_migration = 250000
+
+# Create clone volume timeout in seconds (integer value)
+#fsc_clone_volume_timeout = 1800
+
+# DEPRECATED: The flag of thin storage allocation. (boolean value)
+# This option is deprecated for removal since 14.0.0.
+# Its value may be silently ignored in the future.
+# Reason: FusionStorage cinder driver refactored the code with Restful method
+# and the old CLI mode has been abandon. So those configuration items are no
+# longer used.
+#dsware_isthin = false
+
+# DEPRECATED: Fusionstorage manager ip addr for cinder-volume. (string value)
+# This option is deprecated for removal since 14.0.0.
+# Its value may be silently ignored in the future.
+# Reason: FusionStorage cinder driver refactored the code with Restful method
+# and the old CLI mode has been abandon. So those configuration items are no
+# longer used.
+#dsware_manager =
+
+# DEPRECATED: Fusionstorage agent ip addr range (string value)
+# This option is deprecated for removal since 14.0.0.
+# Its value may be silently ignored in the future.
+# Reason: FusionStorage cinder driver refactored the code with Restful method
+# and the old CLI mode has been abandon. So those configuration items are no
+# longer used.
+#fusionstorageagent =
+
+# DEPRECATED: Pool type, like sata-2copy (string value)
+# This option is deprecated for removal since 14.0.0.
+# Its value may be silently ignored in the future.
+# Reason: FusionStorage cinder driver refactored the code with Restful method
+# and the old CLI mode has been abandon. So those configuration items are no
+# longer used.
+#pool_type = default
+
+# DEPRECATED: Pool id permit to use (list value)
+# This option is deprecated for removal since 14.0.0.
+# Its value may be silently ignored in the future.
+# Reason: FusionStorage cinder driver refactored the code with Restful method
+# and the old CLI mode has been abandon. So those configuration items are no
+# longer used.
+#pool_id_filter =
+
+# DEPRECATED: Create clone volume timeout (integer value)
+# This option is deprecated for removal since 14.0.0.
+# Its value may be silently ignored in the future.
+# Reason: FusionStorage cinder driver refactored the code with Restful method
+# and the old CLI mode has been abandon. So those configuration items are no
+# longer used.
+#clone_volume_timeout = 680
+
+# This option is to support the FSA to mount across the different nodes. The
+# parameters takes the standard dict config form, manager_ips = host1:ip1,
+# host2:ip2... (dict value)
+#manager_ips =
+
+# The address of FusionStorage array. For example, "dsware_rest_url=xxx"
+# (string value)
+#dsware_rest_url =
+
+# The list of pools on the FusionStorage array, the semicolon(;) was used to
+# split the storage pools, "dsware_storage_pools = xxx1; xxx2; xxx3" (string
+# value)
+#dsware_storage_pools =
+
+# Initial interval at which remote replication pair status is checked (integer
+# value)
+#hitachi_replication_status_check_short_interval = 5
+
+# Interval at which remote replication pair status is checked. This parameter
+# is applied if the status has not changed to the expected status after the
+# time indicated by this parameter has elapsed. (integer value)
+#hitachi_replication_status_check_long_interval = 600
+
+# Maximum wait time before the remote replication pair status changes to the
+# expected status (integer value)
+#hitachi_replication_status_check_timeout = 86400
+
+# Path group ID assigned to the remote connection for remote replication
+# (integer value)
+# Minimum value: 0
+# Maximum value: 255
+#hitachi_path_group_id = 0
+
+# ID of the Quorum disk used for global-active device (integer value)
+# Minimum value: 0
+# Maximum value: 31
+#hitachi_quorum_disk_id = <None>
+
+# Remote copy speed of storage system. 1 or 2 indicates low speed, 3 indicates
+# middle speed, and a value between 4 and 15 indicates high speed. (integer
+# value)
+# Minimum value: 1
+# Maximum value: 15
+#hitachi_replication_copy_speed = 3
+
+# Whether or not to set the mirror reserve attribute (boolean value)
+#hitachi_set_mirror_reserve_attribute = true
+
+# Instance number for REST API (integer value)
+# Minimum value: 0
+# Maximum value: 255
+#hitachi_replication_number = 0
+
+# ID of secondary storage system (string value)
+#hitachi_mirror_storage_id = <None>
+
+# Pool of secondary storage system (string value)
+#hitachi_mirror_pool = <None>
+
+# Thin pool of secondary storage system (string value)
+#hitachi_mirror_snap_pool = <None>
+
+# Logical device range of secondary storage system (string value)
+#hitachi_mirror_ldev_range = <None>
+
+# Target port names for host group or iSCSI target (list value)
+#hitachi_mirror_target_ports =
+
+# Target port names of compute node for host group or iSCSI target (list value)
+#hitachi_mirror_compute_target_ports =
+
+# Pair target name of the host group or iSCSI target (integer value)
+# Minimum value: 0
+# Maximum value: 99
+#hitachi_mirror_pair_target_number = 0
+
+# Whether or not to use iSCSI authentication (boolean value)
+#hitachi_mirror_use_chap_auth = false
+
+# iSCSI authentication username (string value)
+#hitachi_mirror_auth_user = <None>
+
+# iSCSI authentication password (string value)
+#hitachi_mirror_auth_password = <None>
+
+# Target port names for pair of the host group or iSCSI target (list value)
+#hitachi_mirror_rest_pair_target_ports =
+
+# Username of secondary storage system for REST API (string value)
+#hitachi_mirror_rest_user = <None>
+
+# Password of secondary storage system for REST API (string value)
+#hitachi_mirror_rest_password = <None>
+
+# IP address of REST API server (string value)
+#hitachi_mirror_rest_api_ip = <None>
+
+# Port number of REST API server (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#hitachi_mirror_rest_api_port = 443
+
+# If set to True the http client will validate the SSL certificate of the
+# backend endpoint. (boolean value)
+#hitachi_mirror_ssl_cert_verify = false
+
+# Can be used to specify a non default path to a CA_BUNDLE file or directory
+# with certificates of trusted CAs, which will be used to validate the backend
+# (string value)
+#hitachi_mirror_ssl_cert_path = <None>
+
+# The Infortrend logical volumes name list. It is separated with comma. (list
+# value)
+#infortrend_pools_name =
+
+# The Infortrend CLI absolute path. (string value)
+#infortrend_cli_path = /opt/bin/Infortrend/raidcmd_ESDS10.jar
+
+# The maximum retry times if a command fails. (integer value)
+#infortrend_cli_max_retries = 5
+
+# The timeout for CLI in seconds. (integer value)
+#infortrend_cli_timeout = 60
+
+# Infortrend raid channel ID list on Slot A for OpenStack usage. It is
+# separated with comma. (list value)
+#infortrend_slots_a_channels_id =
+
+# Infortrend raid channel ID list on Slot B for OpenStack usage. It is
+# separated with comma. (list value)
+#infortrend_slots_b_channels_id =
+
+# Infortrend iqn prefix for iSCSI. (string value)
+#infortrend_iqn_prefix = iqn.2002-10.com.infortrend
+
+# The Infortrend CLI cache. While set True, the RAID status report will use
+# cache stored in the CLI. Never enable this unless the RAID is managed only by
+# Openstack and only by one infortrend cinder-volume backend. Otherwise, CLI
+# might report out-dated status to cinder and thus there might be some race
+# condition among all backend/CLIs. (boolean value)
+#infortrend_cli_cache = false
+
+# The Java absolute path. (string value)
+#java_path = /usr/bin/java
+
+# The Storage Pools Cinder should use, a comma separated list. (list value)
+#as13000_ipsan_pools = Pool0
+
+# The effective time of token validity in seconds. (integer value)
+# Minimum value: 600
+# Maximum value: 3600
+#as13000_token_available_time = 3300
+
+# The pool which is used as a meta pool when creating a volume, and it should
+# be a replication pool at present. If not set, the driver will choose a
+# replication pool from the value of as13000_ipsan_pools. (string value)
+#as13000_meta_pool = <None>
+
+# Storage system autoexpand parameter for volumes (True/False) (boolean value)
+#instorage_mcs_vol_autoexpand = true
+
+# Storage system compression option for volumes (boolean value)
+#instorage_mcs_vol_compression = false
+
+# Enable InTier for volumes (boolean value)
+#instorage_mcs_vol_intier = true
+
+# Allow tenants to specify QOS on create (boolean value)
+#instorage_mcs_allow_tenant_qos = false
+
+# Storage system grain size parameter for volumes (32/64/128/256) (integer
+# value)
+# Minimum value: 32
+# Maximum value: 256
+#instorage_mcs_vol_grainsize = 256
+
+# Storage system space-efficiency parameter for volumes (percentage) (integer
+# value)
+# Minimum value: -1
+# Maximum value: 100
+#instorage_mcs_vol_rsize = 2
+
+# Storage system threshold for volume capacity warnings (percentage) (integer
+# value)
+# Minimum value: -1
+# Maximum value: 100
+#instorage_mcs_vol_warning = 0
+
+# Maximum number of seconds to wait for LocalCopy to be prepared. (integer
+# value)
+# Minimum value: 1
+# Maximum value: 600
+#instorage_mcs_localcopy_timeout = 120
+
+# Specifies the InStorage LocalCopy copy rate to be used when creating a full
+# volume copy. The default rate is 50, and the valid rates are 1-100. (integer
+# value)
+# Minimum value: 1
+# Maximum value: 100
+#instorage_mcs_localcopy_rate = 50
+
+# The I/O group in which to allocate volumes. It can be a comma-separated list
+# in which case the driver will select an io_group based on least number of
+# volumes associated with the io_group. (string value)
+#instorage_mcs_vol_iogrp = 0
+
+# Specifies secondary management IP or hostname to be used if san_ip is invalid
+# or becomes inaccessible. (string value)
+#instorage_san_secondary_ip = <None>
+
+# Comma separated list of storage system storage pools for volumes. (list
+# value)
+#instorage_mcs_volpool_name = volpool
+
+# Configure CHAP authentication for iSCSI connections (Default: Enabled)
+# (boolean value)
+#instorage_mcs_iscsi_chap_enabled = true
+
+# KumoScale provisioner REST API URL (string value)
+#kioxia_url = <None>
+
+# Cert for provisioner REST API SSL (string value)
+#kioxia_cafile = <None>
+
+# KumoScale Provisioner auth token. (string value)
+#kioxia_token = <None>
+
+# Number of volume replicas. (integer value)
+#kioxia_num_replicas = 1
+
+# Upper limit for IOPS/GB. (integer value)
+#kioxia_max_iops_per_gb = 0
+
+# Desired IOPS/GB. (integer value)
+#kioxia_desired_iops_per_gb = 0
+
+# Upper limit for bandwidth in B/s per GB. (integer value)
+#kioxia_max_bw_per_gb = 0
+
+# Desired bandwidth in B/s per GB. (integer value)
+#kioxia_desired_bw_per_gb = 0
+
+# Can more than one replica be allocated to same rack. (boolean value)
+#kioxia_same_rack_allowed = false
+
+# Volume block size in bytes - 512 or 4096 (Default). (integer value)
+#kioxia_block_size = 4096
+
+# Volumes from snapshot writeable or not. (boolean value)
+#kioxia_writable = false
+
+# Thin or thick volume, Default thick. (string value)
+# Possible values:
+# THICK - Thick provisioning
+# THIN - Thin provisioning
+#kioxia_provisioning_type = THICK
+
+# Thin volume reserved capacity allocation percentage. (integer value)
+#kioxia_vol_reserved_space_percentage = 0
+
+# Percentage of the parent volume to be used for log. (integer value)
+#kioxia_snap_reserved_space_percentage = 0
+
+# Writable snapshot percentage of parent volume used for log. (integer value)
+#kioxia_snap_vol_reserved_space_percentage = 0
+
+# Replicated volume max downtime for replica in minutes. (integer value)
+#kioxia_max_replica_down_time = 0
+
+# Allow span - Default True. (boolean value)
+#kioxia_span_allowed = true
+
+# Allow span in snapshot volume - Default True. (boolean value)
+#kioxia_snap_vol_span_allowed = true
+
+# IP address of Open-E JovianDSS SA (list value)
+#san_hosts =
+
+# Time before HA cluster failure. (integer value)
+#jovian_recovery_delay = 60
+
+# List of multipath ip addresses to ignore. (list value)
+#jovian_ignore_tpath =
+
+# Length of the random string for CHAP password. (integer value)
+#chap_password_len = 12
+
+# JovianDSS pool that holds all cinder volumes (string value)
+#jovian_pool = Pool-0
+
+# Block size for new volume (string value)
+# Possible values:
+# 16K - Use 16K block size
+# 32K - Use 32K block size
+# 64K - Use 64K block size
+# 128K - Use 128K block size
+# 256K - Use 256K block size
+# 512K - Use 512K block size
+# 1M - Use 1M block size
+#jovian_block_size = 64K
+
+# SandStone default target ip. (list value)
+#default_sandstone_target_ips =
+
+# SandStone storage pool resource name. (string value)
+#sandstone_pool =
+
+# Support initiator assign target with assign ip. (dict value)
+#initiator_assign_sandstone_target_ip =
+
+# Comma separated list of storage system storage pools for volumes. (list
+# value)
+#acs5000_volpool_name = pool01
+
+# When volume copy task is going on,refresh volume status interval (integer
+# value)
+# Minimum value: 3
+# Maximum value: 100
+#acs5000_copy_interval = 5
+
+# Enable to allow volumes attaching to multiple hosts with no limit. (boolean
+# value)
+#acs5000_multiattach = false
+
+# Create sparse Lun. (boolean value)
+#vrts_lun_sparse = true
+
+# VA config file. (string value)
+#vrts_target_config = /etc/cinder/vrts_target.xml
+
+# Timeout for creating the volume to migrate to when performing volume
+# migration (seconds) (integer value)
+#migration_create_volume_timeout_secs = 300
+
+# Offload pending volume delete during volume service startup (boolean value)
+#volume_service_inithost_offload = false
+
+# FC Zoning mode configured, only 'fabric' is supported now. (string value)
+#zoning_mode = <None>
+
+# Maximum times to reintialize the driver if volume initialization fails. The
+# interval of retry is exponentially backoff, and will be 1s, 2s, 4s etc.
+# (integer value)
+#reinit_driver_count = 3
+
+# Max number of volumes and snapshots to be retrieved per batch during volume
+# manager host initialization. Query results will be obtained in batches from
+# the database and not in one shot to avoid extreme memory usage. Set 0 to turn
+# off this functionality. (integer value)
+#init_host_max_objects_retrieval = 0
+
+# Time in seconds between requests for usage statistics from the backend.  Be
+# aware that generating usage statistics is expensive for some backends, so
+# setting this value too low may adversely affect performance. (integer value)
+# Minimum value: 3
+#backend_stats_polling_interval = 60
+
+# Sets the value of TCP_KEEPALIVE (True/False) for each server socket. (boolean
+# value)
+#tcp_keepalive = true
+
+# Sets the value of TCP_KEEPINTVL in seconds for each server socket. Not
+# supported on OS X. (integer value)
+#tcp_keepalive_interval = <None>
+
+# Sets the value of TCP_KEEPCNT for each server socket. Not supported on OS X.
+# (integer value)
+#tcp_keepalive_count = <None>
+
+#
+# From oslo.config
+#
+
+# Path to a config file to use. Multiple config files can be specified, with
+# values in later files taking precedence. Defaults to %(default)s. This option
+# must be set from the command-line. (unknown value)
+#config_file = ['~/.project/project.conf', '~/project.conf', '/etc/project/project.conf', '/etc/project.conf']
+
+# Path to a config directory to pull `*.conf` files from. This file set is
+# sorted, so as to provide a predictable parse order if individual options are
+# over-ridden. The set is parsed after the file(s) specified via previous
+# --config-file, arguments hence over-ridden options in the directory take
+# precedence. This option must be set from the command-line. (list value)
+#config_dir = ~/.project/project.conf.d/,~/project.conf.d/,/etc/project/project.conf.d/,/etc/project.conf.d/
+
+# Lists configuration groups that provide more details for accessing
+# configuration settings from locations other than local files. (list value)
+#config_source =
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, log-date-format). (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Enable journald for logging. If running in a systemd environment you may wish
+# to enable journal support. Doing so will use the journal native protocol
+# which includes structured metadata in addition to log messages.This option is
+# ignored if log_config_append is set. (boolean value)
+#use_journal = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Use JSON formatting for logging. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_json = false
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = false
+
+# Log output to Windows Event Log. (boolean value)
+#use_eventlog = false
+
+# The amount of time before the log files are rotated. This option is ignored
+# unless log_rotation_type is set to "interval". (integer value)
+#log_rotate_interval = 1
+
+# Rotation interval type. The time of the last file change (or the time when
+# the service was started) is used when scheduling the next rotation. (string
+# value)
+# Possible values:
+# Seconds - <No description provided>
+# Minutes - <No description provided>
+# Hours - <No description provided>
+# Days - <No description provided>
+# Weekday - <No description provided>
+# Midnight - <No description provided>
+#log_rotate_interval_type = days
+
+# Maximum number of rotated log files. (integer value)
+#max_logfile_count = 30
+
+# Log file maximum size in MB. This option is ignored if "log_rotation_type" is
+# not set to "size". (integer value)
+#max_logfile_size_mb = 200
+
+# Log rotation type. (string value)
+# Possible values:
+# interval - Rotate logs at predefined time intervals.
+# size - Rotate logs once they reach a predefined size.
+# none - Do not rotate log files.
+#log_rotation_type = none
+
+# Format string to use for log messages with context. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(global_request_id)s %(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. Used by oslo_log.formatters.ContextFormatter (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. Used by oslo_log.formatters.ContextFormatter
+# (string value)
+#logging_user_identity_format = %(user)s %(project)s %(domain)s %(system_scope)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo_policy=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval. (integer value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO, WARNING, DEBUG
+# or empty string. Logs with level greater or equal to rate_limit_except_level
+# are not filtered. An empty string means that all levels are filtered. (string
+# value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+#
+# From oslo.messaging
+#
+
+# Size of RPC connection pool. (integer value)
+# Minimum value: 1
+#rpc_conn_pool_size = 30
+
+# The pool size limit for connections expiration policy (integer value)
+#conn_pool_min_size = 2
+
+# The time-to-live in sec of idle connections in the pool (integer value)
+#conn_pool_ttl = 1200
+
+# Size of executor thread pool when executor is threading or eventlet. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/rpc_thread_pool_size
+#executor_thread_pool_size = 64
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout = 60
+
+# The network address and optional user credentials for connecting to the
+# messaging backend, in URL format. The expected format is:
+#
+# driver://[user:pass@]host:port[,[userN:passN@]hostN:portN]/virtual_host?query
+#
+# Example: rabbit://rabbitmq:password@127.0.0.1:5672//
+#
+# For full details on the fields in the URL see the documentation of
+# oslo_messaging.TransportURL at
+# https://docs.openstack.org/oslo.messaging/latest/reference/transport.html
+# (string value)
+#transport_url = rabbit://
+
+# The default exchange under which topics are scoped. May be overridden by an
+# exchange name specified in the transport_url option. (string value)
+#control_exchange = openstack
+
+# Add an endpoint to answer to ping calls. Endpoint is named
+# oslo_rpc_server_ping (boolean value)
+#rpc_ping_enabled = false
+
+#
+# From oslo.service.periodic_task
+#
+
+# Some periodic tasks can be run in a separate process. Should we run them
+# here? (boolean value)
+#run_external_periodic_tasks = true
+
+#
+# From oslo.service.service
+#
+
+# Enable eventlet backdoor.  Acceptable values are 0, <port>, and
+# <start>:<end>, where 0 results in listening on a random tcp port number;
+# <port> results in listening on the specified port number (and not enabling
+# backdoor if that port is in use); and <start>:<end> results in listening on
+# the smallest unused port number within the specified range of port numbers.
+# The chosen port is displayed in the service's log file. (string value)
+#backdoor_port = <None>
+
+# Enable eventlet backdoor, using the provided path as a unix socket that can
+# receive connections. This option is mutually exclusive with 'backdoor_port'
+# in that only one should be provided. If both are provided then the existence
+# of this option overrides the usage of that option. Inside the path {pid} will
+# be replaced with the PID of the current process. (string value)
+#backdoor_socket = <None>
+
+# Enables or disables logging values of all registered options when starting a
+# service (at DEBUG level). (boolean value)
+#log_options = true
+
+# Specify a timeout after which a gracefully shutdown server will exit. Zero
+# value means endless wait. (integer value)
+#graceful_shutdown_timeout = 60
+
+#
+# From oslo.service.wsgi
+#
+
+# File name for the paste.deploy config for api service (string value)
+#api_paste_config = api-paste.ini
+
+# A python format string that is used as the template to generate log lines.
+# The following values can beformatted into it: client_ip, date_time,
+# request_line, status_code, body_length, wall_seconds. (string value)
+#wsgi_log_format = %(client_ip)s "%(request_line)s" status: %(status_code)s  len: %(body_length)s time: %(wall_seconds).7f
+
+# Sets the value of TCP_KEEPIDLE in seconds for each server socket. Not
+# supported on OS X. (integer value)
+#tcp_keepidle = 600
+
+# Size of the pool of greenthreads used by wsgi (integer value)
+#wsgi_default_pool_size = 100
+
+# Maximum line size of message headers to be accepted. max_header_line may need
+# to be increased when using large tokens (typically those generated when
+# keystone is configured to use PKI tokens with big service catalogs). (integer
+# value)
+#max_header_line = 16384
+
+# If False, closes the client socket connection explicitly. (boolean value)
+#wsgi_keep_alive = true
+
+# Timeout for client connections' socket operations. If an incoming connection
+# is idle for this number of seconds it will be closed. A value of '0' means
+# wait forever. (integer value)
+#client_socket_timeout = 900
+
+# True if the server should send exception tracebacks to the clients on 500
+# errors. If False, the server will respond with empty bodies. (boolean value)
+#wsgi_server_debug = false
+
+
+[backend]
+
+#
+# From cinder
+#
+
+# Backend override of host value. (string value)
+#backend_host = <None>
+
+
+[backend_defaults]
+
+#
+# From cinder
+#
+
+# Number of times to attempt to run flakey shell commands (integer value)
+#num_shell_tries = 3
+
+# The percentage of backend capacity is reserved (integer value)
+# Minimum value: 0
+# Maximum value: 100
+#reserved_percentage = 0
+
+# Prefix for iSCSI/NVMEoF volumes (string value)
+#target_prefix = iqn.2010-10.org.openstack:
+
+# The IP address that the iSCSI/NVMEoF daemon is listening on (string value)
+#target_ip_address = $my_ip
+
+# The list of secondary IP addresses of the iSCSI/NVMEoF daemon (list value)
+# Deprecated group/name - [backend_defaults]/iscsi_secondary_ip_addresses
+#target_secondary_ip_addresses =
+
+# The port that the iSCSI/NVMEoF daemon is listening on (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#target_port = 3260
+
+# The maximum number of times to rescan targets to find volume (integer value)
+#num_volume_device_scan_tries = 3
+
+# The backend name for a given driver implementation (string value)
+#volume_backend_name = <None>
+
+# Method used to wipe old volumes (string value)
+# Possible values:
+# none - <No description provided>
+# zero - <No description provided>
+#volume_clear = zero
+
+# Size in MiB to wipe at start of old volumes. 1024 MiB at max. 0 => all
+# (integer value)
+# Maximum value: 1024
+#volume_clear_size = 0
+
+# The flag to pass to ionice to alter the i/o priority of the process used to
+# zero a volume after deletion, for example "-c3" for idle only priority.
+# (string value)
+#volume_clear_ionice = <None>
+
+# Target user-land tool to use. tgtadm is default, use lioadm for LIO iSCSI
+# support, scstadmin for SCST target support, ietadm for iSCSI Enterprise
+# Target, iscsictl for Chelsio iSCSI Target, nvmet for NVMEoF support, spdk-
+# nvmeof for SPDK NVMe-oF, or fake for testing. Note: The IET driver is
+# deprecated and will be removed in the V release. (string value)
+# Possible values:
+# tgtadm - <No description provided>
+# lioadm - <No description provided>
+# scstadmin - <No description provided>
+# iscsictl - <No description provided>
+# ietadm - <No description provided>
+# nvmet - <No description provided>
+# spdk-nvmeof - <No description provided>
+# fake - <No description provided>
+#target_helper = tgtadm
+
+# Volume configuration file storage directory (string value)
+#volumes_dir = $state_path/volumes
+
+# DEPRECATED: IET configuration file (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: IET target driver is no longer supported.
+#iet_conf = /etc/iet/ietd.conf
+
+# Chiscsi (CXT) global defaults configuration file (string value)
+#chiscsi_conf = /etc/chelsio-iscsi/chiscsi.conf
+
+# Sets the behavior of the iSCSI target to either perform blockio or fileio
+# optionally, auto can be set and Cinder will autodetect type of backing device
+# (string value)
+# Possible values:
+# blockio - <No description provided>
+# fileio - <No description provided>
+# auto - <No description provided>
+#iscsi_iotype = fileio
+
+# The default block size used when copying/clearing volumes (string value)
+#volume_dd_blocksize = 1M
+
+# The blkio cgroup name to be used to limit bandwidth of volume copy (string
+# value)
+#volume_copy_blkio_cgroup_name = cinder-volume-copy
+
+# The upper limit of bandwidth of volume copy. 0 => unlimited (integer value)
+#volume_copy_bps_limit = 0
+
+# Sets the behavior of the iSCSI target to either perform write-back(on) or
+# write-through(off). This parameter is valid if target_helper is set to
+# tgtadm. (string value)
+# Possible values:
+# on - <No description provided>
+# off - <No description provided>
+#iscsi_write_cache = on
+
+# Sets the target-specific flags for the iSCSI target. Only used for tgtadm to
+# specify backing device flags using bsoflags option. The specified string is
+# passed as is to the underlying tool. (string value)
+#iscsi_target_flags =
+
+# Determines the target protocol for new volumes, created with tgtadm, lioadm
+# and nvmet target helpers. In order to enable RDMA, this parameter should be
+# set with the value "iser". The supported iSCSI protocol values are "iscsi"
+# and "iser", in case of nvmet target set to "nvmet_rdma" or "nvmet_tcp".
+# (string value)
+# Possible values:
+# iscsi - <No description provided>
+# iser - <No description provided>
+# nvmet_rdma - <No description provided>
+# nvmet_tcp - <No description provided>
+#target_protocol = iscsi
+
+# The path to the client certificate key for verification, if the driver
+# supports it. (string value)
+#driver_client_cert_key = <None>
+
+# The path to the client certificate for verification, if the driver supports
+# it. (string value)
+#driver_client_cert = <None>
+
+# Tell driver to use SSL for connection to backend storage if the driver
+# supports it. (boolean value)
+#driver_use_ssl = false
+
+# Representation of the over subscription ratio when thin provisioning is
+# enabled. Default ratio is 20.0, meaning provisioned capacity can be 20 times
+# of the total physical capacity. If the ratio is 10.5, it means provisioned
+# capacity can be 10.5 times of the total physical capacity. A ratio of 1.0
+# means provisioned capacity cannot exceed the total physical capacity. If
+# ratio is 'auto', Cinder will automatically calculate the ratio based on the
+# provisioned capacity and the used space. If not set to auto, the ratio has to
+# be a minimum of 1.0. (string value)
+#max_over_subscription_ratio = 20.0
+
+# Option to enable/disable CHAP authentication for targets. (boolean value)
+#use_chap_auth = false
+
+# CHAP user name. (string value)
+#chap_username =
+
+# Password for specified CHAP account name. (string value)
+#chap_password =
+
+# Namespace for driver private data values to be saved in. (string value)
+#driver_data_namespace = <None>
+
+# String representation for an equation that will be used to filter hosts. Only
+# used when the driver filter is set to be used by the Cinder scheduler.
+# (string value)
+#filter_function = <None>
+
+# String representation for an equation that will be used to determine the
+# goodness of a host. Only used when using the goodness weigher is set to be
+# used by the Cinder scheduler. (string value)
+#goodness_function = <None>
+
+# If set to True the http client will validate the SSL certificate of the
+# backend endpoint. (boolean value)
+#driver_ssl_cert_verify = false
+
+# Can be used to specify a non default path to a CA_BUNDLE file or directory
+# with certificates of trusted CAs, which will be used to validate the backend
+# (string value)
+#driver_ssl_cert_path = <None>
+
+# List of options that control which trace info is written to the DEBUG log
+# level to assist developers. Valid values are method and api. (list value)
+#trace_flags = <None>
+
+# Multi opt of dictionaries to represent a replication target device.  This
+# option may be specified multiple times in a single config section to specify
+# multiple replication target devices.  Each entry takes the standard dict
+# config form: replication_device =
+# target_device_id:<required>,key1:value1,key2:value2... (dict value)
+#replication_device = <None>
+
+# Report to clients of Cinder that the backend supports discard (aka.
+# trim/unmap). This will not actually change the behavior of the backend or the
+# client directly, it will only notify that it can be used. (boolean value)
+#report_discard_supported = false
+
+# Protocol for transferring data between host and storage back-end. (string
+# value)
+# Possible values:
+# iSCSI - <No description provided>
+# FC - <No description provided>
+#storage_protocol = iSCSI
+
+# Set this to True when you want to allow an unsupported driver to start.
+# Drivers that haven't maintained a working CI system and testing are marked as
+# unsupported until CI is working again.  This also marks a driver as
+# deprecated and may be removed in the next release. (boolean value)
+#enable_unsupported_driver = false
+
+# Availability zone for this volume backend. If not set, the
+# storage_availability_zone option value is used as the default for all
+# backends. (string value)
+#backend_availability_zone = <None>
+
+# The maximum number of times to rescan iSER target to find volume (integer
+# value)
+#num_iser_scan_tries = 3
+
+# Prefix for iSER volumes (string value)
+#iser_target_prefix = iqn.2010-10.org.openstack:
+
+# The IP address that the iSER daemon is listening on (string value)
+#iser_ip_address = $my_ip
+
+# The port that the iSER daemon is listening on (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#iser_port = 3260
+
+# The name of the iSER target user-land tool to use (string value)
+#iser_helper = tgtadm
+
+# NVMe os-brick connector has 2 different connection info formats, this allows
+# some NVMe-oF drivers that use the original format (version 1), such as spdk
+# and LVM-nvmet, to send the newer format. (integer value)
+# Minimum value: 1
+# Maximum value: 2
+#nvmeof_conn_info_version = 1
+
+# The id of the NVMe target port definition when not sharing targets.  The
+# starting port id value when sharing, incremented for each secondary ip
+# address. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#nvmet_port_id = 1
+
+# Namespace id for the subsystem for the LVM volume when not sharing targets.
+# The minimum id value when sharing.Maximum supported value in Linux is 8192
+# (integer value)
+#nvmet_ns_id = 10
+
+# Certain ISCSI targets have predefined target names, SCST target driver uses
+# this name. (string value)
+#scst_target_iqn_name = <None>
+
+# SCST target implementation can choose from multiple SCST target drivers.
+# (string value)
+#scst_target_driver = iscsi
+
+# If set to True, upload-to-image in raw format will create a cloned volume and
+# register its location to the image service, instead of uploading the volume
+# content. The cinder backend and locations support must be enabled in the
+# image service. (boolean value)
+#image_upload_use_cinder_backend = false
+
+# If set to True, the image volume created by upload-to-image will be placed in
+# the internal tenant. Otherwise, the image volume is created in the current
+# context's tenant. (boolean value)
+#image_upload_use_internal_tenant = false
+
+# Enable the image volume cache for this backend. (boolean value)
+#image_volume_cache_enabled = false
+
+# Max size of the image volume cache for this backend in GB. 0 => unlimited.
+# (integer value)
+#image_volume_cache_max_size_gb = 0
+
+# Max number of entries allowed in the image volume cache. 0 => unlimited.
+# (integer value)
+#image_volume_cache_max_count = 0
+
+# Do we attach/detach volumes in cinder using multipath for volume to image and
+# image to volume transfers? This parameter needs to be configured for each
+# backend section or in [backend_defaults] section as a common configuration
+# for all backends. (boolean value)
+#use_multipath_for_image_xfer = false
+
+# If this is set to True, attachment of volumes for image transfer will be
+# aborted when multipathd is not running. Otherwise, it will fallback to single
+# path. This parameter needs to be configured for each backend section or in
+# [backend_defaults] section as a common configuration for all backends.
+# (boolean value)
+#enforce_multipath_for_image_xfer = false
+
+# Whether or not our private network has unique FQDN on each initiator or not.
+# For example networks with QA systems usually have multiple servers/VMs with
+# the same FQDN. When true this will create host entries on 3PAR using the
+# FQDN, when false it will use the reversed IQN/WWNN. (boolean value)
+#unique_fqdn_network = true
+
+# The username for the rbd_target_api service (string value)
+#rbd_iscsi_api_user =
+
+# The username for the rbd_target_api service (string value)
+#rbd_iscsi_api_password =
+
+# The url to the rbd_target_api service (string value)
+#rbd_iscsi_api_url =
+
+# Enable client request debugging. (boolean value)
+#rbd_iscsi_api_debug = false
+
+# The preconfigured target_iqn on the iscsi gateway. (string value)
+#rbd_iscsi_target_iqn = <None>
+
+# DataCore virtual disk type (single/mirrored). Mirrored virtual disks require
+# two storage servers in the server group. (string value)
+# Possible values:
+# single - <No description provided>
+# mirrored - <No description provided>
+#datacore_disk_type = single
+
+# DataCore virtual disk storage profile. (string value)
+#datacore_storage_profile = <None>
+
+# List of DataCore disk pools that can be used by volume driver. (list value)
+#datacore_disk_pools =
+
+# Seconds to wait for a response from a DataCore API call. (integer value)
+# Minimum value: 1
+#datacore_api_timeout = 300
+
+# Seconds to wait for DataCore virtual disk to come out of the "Failed" state.
+# (integer value)
+# Minimum value: 0
+#datacore_disk_failed_delay = 300
+
+# List of FC targets that cannot be used to attach volume. To prevent the
+# DataCore FibreChannel volume driver from using some front-end targets in
+# volume attachment, specify this option and list the iqn and target machine
+# for each target as the value, such as <wwpns:target name>, <wwpns:target
+# name>, <wwpns:target name>. (list value)
+#datacore_fc_unallowed_targets =
+
+# List of iSCSI targets that cannot be used to attach volume. To prevent the
+# DataCore iSCSI volume driver from using some front-end targets in volume
+# attachment, specify this option and list the iqn and target machine for each
+# target as the value, such as <iqn:target name>, <iqn:target name>,
+# <iqn:target name>. (list value)
+#datacore_iscsi_unallowed_targets =
+
+# Fully qualified file name where dynamically generated iSCSI CHAP secrets are
+# stored.  This must be changed to a unique per-backend value if deploying
+# multiple DataCore backends on the same host. (string value)
+#datacore_iscsi_chap_storage = $state_path/.datacore_chap
+
+# DEPRECATED: renamed to powerflex_rest_server_port. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_rest_server_port.
+#vxflexos_rest_server_port = 443
+
+# DEPRECATED: renamed to powerflex_round_volume_capacity. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_round_volume_capacity.
+#vxflexos_round_volume_capacity = true
+
+# DEPRECATED: renamed to powerflex_round_volume_capacity. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_round_volume_capacity.
+#vxflexos_unmap_volume_before_deletion = false
+
+# DEPRECATED: renamed to powerflex_storage_pools. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_storage_pools.
+#vxflexos_storage_pools = <None>
+
+# DEPRECATED: renamed to powerflex_server_api_version. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_server_api_version.
+#vxflexos_server_api_version = <None>
+
+# DEPRECATED: renamed to powerflex_max_over_subscription_ratio. (floating point
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_max_over_subscription_ratio.
+#vxflexos_max_over_subscription_ratio = 10.0
+
+# DEPRECATED: renamed to powerflex_allow_non_padded_volumes. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_allow_non_padded_volumes.
+#vxflexos_allow_non_padded_volumes = false
+
+# DEPRECATED: renamed to powerflex_allow_migration_during_rebuild. (boolean
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by powerflex_allow_migration_during_rebuild.
+#vxflexos_allow_migration_during_rebuild = false
+
+# Gateway REST server port. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# Deprecated group/name - [backend_defaults]/vxflexos_rest_server_port
+#powerflex_rest_server_port = 443
+
+# Round volume sizes up to 8GB boundaries. PowerFlex/VxFlex OS requires volumes
+# to be sized in multiples of 8GB. If set to False, volume creation will fail
+# for volumes not sized properly (boolean value)
+# Deprecated group/name - [backend_defaults]/vxflexos_round_volume_capacity
+#powerflex_round_volume_capacity = true
+
+# Unmap volumes before deletion. (boolean value)
+# Deprecated group/name - [backend_defaults]/vxflexos_unmap_volume_before_deletion
+#powerflex_unmap_volume_before_deletion = false
+
+# Storage Pools. Comma separated list of storage pools used to provide volumes.
+# Each pool should be specified as a protection_domain_name:storage_pool_name
+# value (string value)
+# Deprecated group/name - [backend_defaults]/vxflexos_storage_pools
+#powerflex_storage_pools = <None>
+
+# PowerFlex/ScaleIO API version. This value should be left as the default value
+# unless otherwise instructed by technical support. (string value)
+# Deprecated group/name - [backend_defaults]/vxflexos_server_api_version
+#powerflex_server_api_version = <None>
+
+# max_over_subscription_ratio setting for the driver. Maximum value allowed is
+# 10.0. (floating point value)
+# Deprecated group/name - [backend_defaults]/vxflexos_max_over_subscription_ratio
+#powerflex_max_over_subscription_ratio = 10.0
+
+# Allow volumes to be created in Storage Pools when zero padding is disabled.
+# This option should not be enabled if multiple tenants will utilize volumes
+# from a shared Storage Pool. (boolean value)
+# Deprecated group/name - [backend_defaults]/vxflexos_allow_non_padded_volumes
+#powerflex_allow_non_padded_volumes = false
+
+# Allow volume migration during rebuild. (boolean value)
+# Deprecated group/name - [backend_defaults]/vxflexos_allow_migration_during_rebuild
+#powerflex_allow_migration_during_rebuild = false
+
+# Use this value to specify length of the interval in seconds. (integer value)
+#interval = 3
+
+# Use this value to specify number of retries. (integer value)
+#retries = 200
+
+# Use this value to enable the initiator_check. (boolean value)
+#initiator_check = false
+
+# Workload, setting this as an extra spec in pool_name is preferable. (string
+# value)
+#vmax_workload = <None>
+
+# How long to wait for the server to send data before giving up. (integer
+# value)
+#u4p_failover_timeout = 20.0
+
+# The maximum number of retries each connection should attempt. Note, this
+# applies only to failed DNS lookups, socket connections and connection
+# timeouts, never to requests where data has made it to the server. (integer
+# value)
+#u4p_failover_retries = 3
+
+# A backoff factor to apply between attempts after the second try (most errors
+# are resolved immediately by a second try without a delay). Retries will sleep
+# for: {backoff factor} * (2 ^ ({number of total retries} - 1)) seconds.
+# (integer value)
+#u4p_failover_backoff_factor = 1
+
+# If the driver should automatically failback to the primary instance of
+# Unisphere when a successful connection is re-established. (boolean value)
+#u4p_failover_autofailback = true
+
+# Dictionary of Unisphere failover target info. (dict value)
+#u4p_failover_target = <None>
+
+# Serial number of the array to connect to. (string value)
+#powermax_array = <None>
+
+# Storage resource pool on array to use for provisioning. (string value)
+#powermax_srp = <None>
+
+# Service level to use for provisioning storage. Setting this as an extra spec
+# in pool_name is preferable. (string value)
+#powermax_service_level = <None>
+
+# List of port groups containing frontend ports configured prior for server
+# connection. (list value)
+#powermax_port_groups = <None>
+
+# List of user assigned name for storage array. (list value)
+#powermax_array_tag_list = <None>
+
+# User defined override for short host name. (string value)
+#powermax_short_host_name_template = shortHostName
+
+# User defined override for port group name. (string value)
+#powermax_port_group_name_template = portGroupName
+
+# Enable/disable load balancing for a PowerMax backend. (boolean value)
+#load_balance = false
+
+# Enable/disable real-time performance metrics for Port level load balancing
+# for a PowerMax backend. (boolean value)
+#load_balance_real_time = false
+
+# Performance data format, not applicable for real-time metrics. Available
+# options are "avg" and "max". (string value)
+#load_data_format = Avg
+
+# How far in minutes to look back for diagnostic performance metrics in load
+# calculation, minimum of 0 maximum of 1440 (24 hours). (integer value)
+#load_look_back = 60
+
+# How far in minutes to look back for real-time performance metrics in load
+# calculation, minimum of 1 maximum of 10. (integer value)
+#load_look_back_real_time = 1
+
+# Metric used for port group load calculation. (string value)
+#port_group_load_metric = PercentBusy
+
+# Metric used for port load calculation. (string value)
+#port_load_metric = PercentBusy
+
+# DEPRECATED: Appliances names. Comma separated list of PowerStore appliances
+# names used to provision volumes. (list value)
+# This option is deprecated for removal since Wallaby.
+# Its value may be silently ignored in the future.
+# Reason: Is not used anymore. PowerStore Load Balancer is used to provision
+# volumes instead.
+#powerstore_appliances =
+
+# Allowed ports. Comma separated list of PowerStore iSCSI IPs or FC WWNs (ex.
+# 58:cc:f0:98:49:22:07:02) to be used. If option is not set all ports are
+# allowed. (list value)
+#powerstore_ports =
+
+# Connect PowerStore volumes using NVMe-OF. (boolean value)
+#powerstore_nvme = false
+
+# File with the list of available NFS shares. (string value)
+#nfs_shares_config = /etc/cinder/nfs_shares
+
+# Create volumes as sparsed files which take no space. If set to False volume
+# is created as regular file. In such case volume creation takes a lot of time.
+# (boolean value)
+#nfs_sparsed_volumes = true
+
+# Create volumes as QCOW2 files rather than raw files. (boolean value)
+#nfs_qcow2_volumes = false
+
+# Base dir containing mount points for NFS shares. (string value)
+#nfs_mount_point_base = $state_path/mnt
+
+# Mount options passed to the NFS client. See the NFS(5) man page for details.
+# (string value)
+#nfs_mount_options = <None>
+
+# The number of attempts to mount NFS shares before raising an error.  At least
+# one attempt will be made to mount an NFS share, regardless of the value
+# specified. (integer value)
+#nfs_mount_attempts = 3
+
+# Enable support for snapshots on the NFS driver. Platforms using libvirt
+# <1.2.7 will encounter issues with this feature. (boolean value)
+#nfs_snapshot_support = false
+
+# Pool or Vdisk name to use for volume creation. (string value)
+#pvme_pool_name = A
+
+# List of comma-separated target iSCSI IP addresses. (list value)
+#pvme_iscsi_ips =
+
+# Storage Center System Serial Number (integer value)
+#dell_sc_ssn = 64702
+
+# Dell API port (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#dell_sc_api_port = 3033
+
+# Name of the server folder to use on the Storage Center (string value)
+#dell_sc_server_folder = openstack
+
+# Name of the volume folder to use on the Storage Center (string value)
+#dell_sc_volume_folder = openstack
+
+# Enable HTTPS SC certificate verification (boolean value)
+#dell_sc_verify_cert = false
+
+# IP address of secondary DSM controller (string value)
+#secondary_san_ip =
+
+# Secondary DSM user name (string value)
+#secondary_san_login = Admin
+
+# Secondary DSM user password name (string value)
+#secondary_san_password =
+
+# Secondary Dell API port (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#secondary_sc_api_port = 3033
+
+# Dell SC API async call default timeout in seconds. (integer value)
+#dell_api_async_rest_timeout = 15
+
+# Dell SC API sync call default timeout in seconds. (integer value)
+#dell_api_sync_rest_timeout = 30
+
+# DEPRECATED: Fault Domain IP to be excluded from iSCSI returns. (IP address
+# value)
+# This option is deprecated for removal since Stein.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by excluded_domain_ips option
+#excluded_domain_ip = <None>
+
+# Comma separated Fault Domain IPs to be excluded from iSCSI returns. (list
+# value)
+#excluded_domain_ips =
+
+# Comma separated Fault Domain IPs to be included from iSCSI returns. (list
+# value)
+#included_domain_ips =
+
+# Server OS type to use when creating a new server on the Storage Center.
+# (string value)
+#dell_server_os = Red Hat Linux 6.x
+
+# A comma-separated list of storage pool names to be used. (list value)
+#unity_storage_pool_names =
+
+# A comma-separated list of iSCSI or FC ports to be used. Each port can be
+# Unix-style glob expressions. (list value)
+#unity_io_ports =
+
+# To remove the host from Unity when the last LUN is detached from it. By
+# default, it is False. (boolean value)
+#remove_empty_host = false
+
+# VNX authentication scope type. By default, the value is global. (string
+# value)
+#storage_vnx_authentication_type = global
+
+# Directory path that contains the VNX security file. Make sure the security
+# file is generated first. (string value)
+#storage_vnx_security_file_dir = <None>
+
+# Naviseccli Path. (string value)
+#naviseccli_path = <None>
+
+# Comma-separated list of storage pool names to be used. (list value)
+#storage_vnx_pool_names = <None>
+
+# Default timeout for CLI operations in minutes. For example, LUN migration is
+# a typical long running operation, which depends on the LUN size and the load
+# of the array. An upper bound in the specific deployment can be set to avoid
+# unnecessary long wait. By default, it is 365 days long. (integer value)
+#default_timeout = 31536000
+
+# Default max number of LUNs in a storage group. By default, the value is 255.
+# (integer value)
+#max_luns_per_storage_group = 255
+
+# To destroy storage group when the last LUN is removed from it. By default,
+# the value is False. (boolean value)
+#destroy_empty_storage_group = false
+
+# Mapping between hostname and its iSCSI initiator IP addresses. (string value)
+#iscsi_initiators = <None>
+
+# Comma separated iSCSI or FC ports to be used in Nova or Cinder. (list value)
+#io_port_list = <None>
+
+# Automatically register initiators. By default, the value is False. (boolean
+# value)
+#initiator_auto_registration = false
+
+# Automatically deregister initiators after the related storage group is
+# destroyed. By default, the value is False. (boolean value)
+#initiator_auto_deregistration = false
+
+# DEPRECATED: Report free_capacity_gb as 0 when the limit to maximum number of
+# pool LUNs is reached. By default, the value is False. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#check_max_pool_luns_threshold = false
+
+# Delete a LUN even if it is in Storage Groups. (boolean value)
+#force_delete_lun_in_storagegroup = true
+
+# Force LUN creation even if the full threshold of pool is reached. By default,
+# the value is False. (boolean value)
+#ignore_pool_full_threshold = false
+
+# Always use asynchronous migration during volume cloning and creating from
+# snapshot. As described in configuration doc, async migration has some
+# constraints. Besides using metadata, customers could use this option to
+# disable async migration. Be aware that `async_migrate` in metadata overrides
+# this option when both are set. By default, the value is True. (boolean value)
+#vnx_async_migrate = true
+
+# XMS cluster id in multi-cluster environment (string value)
+#xtremio_cluster_name =
+
+# Number of retries in case array is busy (integer value)
+#xtremio_array_busy_retry_count = 5
+
+# Interval between retries in case array is busy (integer value)
+#xtremio_array_busy_retry_interval = 5
+
+# Number of volumes created from each cached glance image (integer value)
+#xtremio_volumes_per_glance_cache = 100
+
+# Should the driver remove initiator groups with no volumes after the last
+# connection was terminated. Since the behavior till now was to leave the IG
+# be, we default to False (not deleting IGs without connected volumes); setting
+# this parameter to True will remove any IG after terminating its connection to
+# the last volume. (boolean value)
+#xtremio_clean_unused_ig = false
+
+# Allowed ports. Comma separated list of XtremIO iSCSI IPs or FC WWNs (ex.
+# 58:cc:f0:98:49:22:07:02) to be used. If option is not set all ports are
+# allowed. (list value)
+#xtremio_ports =
+
+# Config file for cinder eternus_dx volume driver. (string value)
+#cinder_eternus_config_file = /etc/cinder/cinder_fujitsu_eternus_dx.xml
+
+# Product number of the storage system. (string value)
+#hitachi_storage_id = <None>
+
+# Pool number[s] or pool name[s] of the DP pool. (list value)
+# Deprecated group/name - [backend_defaults]/hitachi_pool
+#hitachi_pools =
+
+# Pool number or pool name of the snapshot pool. (string value)
+#hitachi_snap_pool = <None>
+
+# Range of the LDEV numbers in the format of 'xxxx-yyyy' that can be used by
+# the driver. Values can be in decimal format (e.g. 1000) or in colon-separated
+# hexadecimal format (e.g. 00:03:E8). (string value)
+#hitachi_ldev_range = <None>
+
+# IDs of the storage ports used to attach volumes to the controller node. To
+# specify multiple ports, connect them by commas (e.g. CL1-A,CL2-A). (list
+# value)
+#hitachi_target_ports =
+
+# IDs of the storage ports used to attach volumes to compute nodes. To specify
+# multiple ports, connect them by commas (e.g. CL1-A,CL2-A). (list value)
+#hitachi_compute_target_ports =
+
+# If True, the driver will create host groups or iSCSI targets on storage ports
+# as needed. (boolean value)
+#hitachi_group_create = false
+
+# If True, the driver will delete host groups or iSCSI targets on storage ports
+# as needed. (boolean value)
+#hitachi_group_delete = false
+
+# Copy speed of storage system. 1 or 2 indicates low speed, 3 indicates middle
+# speed, and a value between 4 and 15 indicates high speed. (integer value)
+# Minimum value: 1
+# Maximum value: 15
+#hitachi_copy_speed = 3
+
+# Interval in seconds to check copying status during a volume copy. (integer
+# value)
+# Minimum value: 1
+# Maximum value: 600
+#hitachi_copy_check_interval = 3
+
+# Interval in seconds to check asynchronous copying status during a copy pair
+# deletion or data restoration. (integer value)
+# Minimum value: 1
+# Maximum value: 600
+#hitachi_async_copy_check_interval = 10
+
+# Enable port scheduling of WWNs to the configured ports so that WWNs are
+# registered to ports in a round-robin fashion. (boolean value)
+#hitachi_port_scheduler = false
+
+# Pair target name of the host group or iSCSI target (integer value)
+# Minimum value: 0
+# Maximum value: 99
+#hitachi_pair_target_number = 0
+
+# Format of host groups, iSCSI targets, and server objects. (string value)
+#hitachi_group_name_format = <None>
+
+# This option will allow detaching volume immediately. If set False, storage
+# may take few minutes to detach volume after I/O. (boolean value)
+#hitachi_rest_disable_io_wait = true
+
+# Enables or disables use of REST API tcp keepalive (boolean value)
+#hitachi_rest_tcp_keepalive = true
+
+# Enable or disable zero page reclamation in a DP-VOL. (boolean value)
+#hitachi_discard_zero_page = true
+
+# Maximum wait time in seconds for adding a LUN mapping to the server. (integer
+# value)
+#hitachi_lun_timeout = 50
+
+# Retry interval in seconds for REST API adding a LUN mapping to the server.
+# (integer value)
+#hitachi_lun_retry_interval = 1
+
+# Maximum wait time in seconds for the restore operation to complete. (integer
+# value)
+#hitachi_restore_timeout = 86400
+
+# Maximum wait time in seconds for a volume transition to complete. (integer
+# value)
+#hitachi_state_transition_timeout = 900
+
+# Maximum wait time in seconds for storage to be logined or unlocked. (integer
+# value)
+#hitachi_lock_timeout = 7200
+
+# Maximum wait time in seconds for each REST API request. (integer value)
+#hitachi_rest_timeout = 30
+
+# Maximum wait time in seconds for a volume extention to complete. (integer
+# value)
+#hitachi_extend_timeout = 600
+
+# Retry interval in seconds for REST API execution. (integer value)
+#hitachi_exec_retry_interval = 5
+
+# Maximum wait time in seconds for connecting to REST API session. (integer
+# value)
+#hitachi_rest_connect_timeout = 30
+
+# Maximum wait time in seconds for a response against async methods from REST
+# API, for example PUT and DELETE. (integer value)
+#hitachi_rest_job_api_response_timeout = 1800
+
+# Maximum wait time in seconds for a response against sync methods, for example
+# GET (integer value)
+#hitachi_rest_get_api_response_timeout = 1800
+
+# Maximum wait time in seconds when REST API returns busy. (integer value)
+#hitachi_rest_server_busy_timeout = 7200
+
+# Loop interval in seconds for keeping REST API session. (integer value)
+#hitachi_rest_keep_session_loop_interval = 180
+
+# Retry time in seconds when new LUN allocation request fails. (integer value)
+#hitachi_rest_another_ldev_mapped_retry_timeout = 600
+
+# Wait time in seconds for sending a first TCP keepalive packet. (integer
+# value)
+#hitachi_rest_tcp_keepidle = 60
+
+# Interval of transmissions in seconds for TCP keepalive packet. (integer
+# value)
+#hitachi_rest_tcp_keepintvl = 15
+
+# Maximum number of transmissions for TCP keepalive packet. (integer value)
+#hitachi_rest_tcp_keepcnt = 4
+
+# Host mode option for host group or iSCSI target. (list value)
+#hitachi_host_mode_options =
+
+# Target port names for pair of the host group or iSCSI target (list value)
+#hitachi_rest_pair_target_ports =
+
+# If True, the driver will configure FC zoning between the server and the
+# storage system provided that FC zoning manager is enabled. (boolean value)
+#hitachi_zoning_request = false
+
+# WSAPI Server URL. This setting applies to: 3PAR, Primera and Alletra 9k
+#        Example 1: for 3PAR, URL is:
+#        https://<3par ip>:8080/api/v1
+#        Example 2: for Primera/Alletra 9k, URL is:
+#        https://<primera ip>:443/api/v1 (string value)
+#hpe3par_api_url =
+
+# 3PAR/Primera/Alletra 9k username with the 'edit' role (string value)
+#hpe3par_username =
+
+# 3PAR/Primera/Alletra 9k password for the user specified in hpe3par_username
+# (string value)
+#hpe3par_password =
+
+# List of the 3PAR/Primera/Alletra 9k CPG(s) to use for volume creation (list
+# value)
+#hpe3par_cpg = OpenStack
+
+# The 3PAR/Primera/Alletra 9k CPG to use for snapshots of volumes. If empty the
+# userCPG will be used. (string value)
+#hpe3par_cpg_snap =
+
+# The time in hours to retain a snapshot.  You can't delete it before this
+# expires. (string value)
+#hpe3par_snapshot_retention =
+
+# The time in hours when a snapshot expires  and is deleted.  This must be
+# larger than expiration (string value)
+#hpe3par_snapshot_expiration =
+
+# Enable HTTP debugging to 3PAR/Primera/Alletra 9k (boolean value)
+#hpe3par_debug = false
+
+# List of target iSCSI addresses to use. (list value)
+#hpe3par_iscsi_ips =
+
+# Enable CHAP authentication for iSCSI connections. (boolean value)
+#hpe3par_iscsi_chap_enabled = false
+
+# The nsp of 3PAR/Primera/Alletra 9k backend to be used when: (1) multipath is
+# not enabled in cinder.conf. (2) Fiber Channel Zone Manager is not used. (3)
+# the backend is prezoned with this specific nsp only. For example if nsp is 2
+# 1 2, the format of the option's value is 2:1:2 (string value)
+#hpe3par_target_nsp =
+
+# Nimble Controller pool name (string value)
+#nimble_pool_name = default
+
+# Nimble Subnet Label (string value)
+#nimble_subnet_label = *
+
+# Whether to verify Nimble SSL Certificate (boolean value)
+#nimble_verify_certificate = false
+
+# Path to Nimble Array SSL certificate (string value)
+#nimble_verify_cert_path = <None>
+
+# Product number of the storage system. (string value)
+#hpexp_storage_id = <None>
+
+# Pool number[s] or pool name[s] of the THP pool. (list value)
+# Deprecated group/name - [backend_defaults]/hpexp_pool
+#hpexp_pools =
+
+# Pool number or pool name of the snapshot pool. (string value)
+#hpexp_snap_pool = <None>
+
+# Range of the LDEV numbers in the format of 'xxxx-yyyy' that can be used by
+# the driver. Values can be in decimal format (e.g. 1000) or in colon-separated
+# hexadecimal format (e.g. 00:03:E8). (string value)
+#hpexp_ldev_range = <None>
+
+# IDs of the storage ports used to attach volumes to the controller node. To
+# specify multiple ports, connect them by commas (e.g. CL1-A,CL2-A). (list
+# value)
+#hpexp_target_ports =
+
+# IDs of the storage ports used to attach volumes to compute nodes. To specify
+# multiple ports, connect them by commas (e.g. CL1-A,CL2-A). (list value)
+#hpexp_compute_target_ports =
+
+# If True, the driver will create host groups or iSCSI targets on storage ports
+# as needed. (boolean value)
+#hpexp_group_create = false
+
+# If True, the driver will delete host groups or iSCSI targets on storage ports
+# as needed. (boolean value)
+#hpexp_group_delete = false
+
+# Copy speed of storage system. 1 or 2 indicates low speed, 3 indicates middle
+# speed, and a value between 4 and 15 indicates high speed. (integer value)
+# Minimum value: 1
+# Maximum value: 15
+#hpexp_copy_speed = 3
+
+# Interval in seconds to check copy (integer value)
+# Minimum value: 1
+# Maximum value: 600
+#hpexp_copy_check_interval = 3
+
+# Interval in seconds to check copy asynchronously (integer value)
+# Minimum value: 1
+# Maximum value: 600
+#hpexp_async_copy_check_interval = 10
+
+# It may take some time to detach volume after I/O. This option will allow
+# detaching volume to complete immediately. (boolean value)
+#hpexp_rest_disable_io_wait = true
+
+# Enables or disables use of REST API tcp keepalive (boolean value)
+#hpexp_rest_tcp_keepalive = true
+
+# Enable or disable zero page reclamation in a THP V-VOL. (boolean value)
+#hpexp_discard_zero_page = true
+
+# Maximum wait time in seconds for adding a LUN to complete. (integer value)
+#hpexp_lun_timeout = 50
+
+# Retry interval in seconds for REST API adding a LUN. (integer value)
+#hpexp_lun_retry_interval = 1
+
+# Maximum wait time in seconds for the restore operation to complete. (integer
+# value)
+#hpexp_restore_timeout = 86400
+
+# Maximum wait time in seconds for a volume transition to complete. (integer
+# value)
+#hpexp_state_transition_timeout = 900
+
+# Maximum wait time in seconds for storage to be unlocked. (integer value)
+#hpexp_lock_timeout = 7200
+
+# Maximum wait time in seconds for REST API execution to complete. (integer
+# value)
+#hpexp_rest_timeout = 30
+
+# Maximum wait time in seconds for a volume extention to complete. (integer
+# value)
+#hpexp_extend_timeout = 600
+
+# Retry interval in seconds for REST API execution. (integer value)
+#hpexp_exec_retry_interval = 5
+
+# Maximum wait time in seconds for REST API connection to complete. (integer
+# value)
+#hpexp_rest_connect_timeout = 30
+
+# Maximum wait time in seconds for a response from REST API. (integer value)
+#hpexp_rest_job_api_response_timeout = 1800
+
+# Maximum wait time in seconds for a response against GET method of REST API.
+# (integer value)
+#hpexp_rest_get_api_response_timeout = 1800
+
+# Maximum wait time in seconds when REST API returns busy. (integer value)
+#hpexp_rest_server_busy_timeout = 7200
+
+# Loop interval in seconds for keeping REST API session. (integer value)
+#hpexp_rest_keep_session_loop_interval = 180
+
+# Retry time in seconds when new LUN allocation request fails. (integer value)
+#hpexp_rest_another_ldev_mapped_retry_timeout = 600
+
+# Wait time in seconds for sending a first TCP keepalive packet. (integer
+# value)
+#hpexp_rest_tcp_keepidle = 60
+
+# Interval of transmissions in seconds for TCP keepalive packet. (integer
+# value)
+#hpexp_rest_tcp_keepintvl = 15
+
+# Maximum number of transmissions for TCP keepalive packet. (integer value)
+#hpexp_rest_tcp_keepcnt = 4
+
+# Host mode option for host group or iSCSI target. (list value)
+#hpexp_host_mode_options =
+
+# If True, the driver will configure FC zoning between the server and the
+# storage system provided that FC zoning manager is enabled. (boolean value)
+#hpexp_zoning_request = false
+
+# The configuration file for the Cinder Huawei driver. (string value)
+#cinder_huawei_conf_file = /etc/cinder/cinder_huawei_conf.xml
+
+# The remote device hypermetro will use. (string value)
+#hypermetro_devices = <None>
+
+# The remote metro device san user. (string value)
+#metro_san_user = <None>
+
+# The remote metro device san password. (string value)
+#metro_san_password = <None>
+
+# The remote metro device domain name. (string value)
+#metro_domain_name = <None>
+
+# The remote metro device request url. (string value)
+#metro_san_address = <None>
+
+# The remote metro device pool names. (string value)
+#metro_storage_pools = <None>
+
+# Connection protocol should be FC. (Default is FC.) (string value)
+#flashsystem_connection_protocol = FC
+
+# Allows vdisk to multi host mapping. (Default is True) (boolean value)
+#flashsystem_multihostmap_enabled = true
+
+# Default iSCSI Port ID of FlashSystem. (Default port is 0.) (integer value)
+#flashsystem_iscsi_portid = 0
+
+# Specifies the path of the GPFS directory where Block Storage volume and
+# snapshot files are stored. (string value)
+#gpfs_mount_point_base = <None>
+
+# Specifies the path of the Image service repository in GPFS.  Leave undefined
+# if not storing images in GPFS. (string value)
+#gpfs_images_dir = <None>
+
+# Specifies the type of image copy to be used.  Set this when the Image service
+# repository also uses GPFS so that image files can be transferred efficiently
+# from the Image service to the Block Storage service. There are two valid
+# values: "copy" specifies that a full copy of the image is made;
+# "copy_on_write" specifies that copy-on-write optimization strategy is used
+# and unmodified blocks of the image file are shared efficiently. (string
+# value)
+# Possible values:
+# copy - <No description provided>
+# copy_on_write - <No description provided>
+# <None> - <No description provided>
+#gpfs_images_share_mode = <None>
+
+# Specifies an upper limit on the number of indirections required to reach a
+# specific block due to snapshots or clones.  A lengthy chain of copy-on-write
+# snapshots or clones can have a negative impact on performance, but improves
+# space utilization.  0 indicates unlimited clone depth. (integer value)
+#gpfs_max_clone_depth = 0
+
+# Specifies that volumes are created as sparse files which initially consume no
+# space. If set to False, the volume is created as a fully allocated file, in
+# which case, creation may take a significantly longer time. (boolean value)
+#gpfs_sparse_volumes = true
+
+# Specifies the storage pool that volumes are assigned to. By default, the
+# system storage pool is used. (string value)
+#gpfs_storage_pool = system
+
+# Comma-separated list of IP address or hostnames of GPFS nodes. (list value)
+#gpfs_hosts =
+
+# Username for GPFS nodes. (string value)
+#gpfs_user_login = root
+
+# Password for GPFS node user. (string value)
+#gpfs_user_password =
+
+# Filename of private key to use for SSH authentication. (string value)
+#gpfs_private_key =
+
+# SSH port to use. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#gpfs_ssh_port = 22
+
+# File containing SSH host keys for the gpfs nodes with which driver needs to
+# communicate. Default=$state_path/ssh_known_hosts (string value)
+#gpfs_hosts_key_file = $state_path/ssh_known_hosts
+
+# Option to enable strict gpfs host key checking while connecting to gpfs
+# nodes. Default=False (boolean value)
+#gpfs_strict_host_key_policy = false
+
+# Mapping between IODevice address and unit address. (string value)
+#ds8k_devadd_unitadd_mapping =
+
+# Set the first two digits of SSID. (string value)
+#ds8k_ssid_prefix = FF
+
+# Reserve LSSs for consistency group. (string value)
+#lss_range_for_cg =
+
+# Set to zLinux if your OpenStack version is prior to Liberty and you're
+# connecting to zLinux systems. Otherwise set to auto. Valid values for this
+# parameter are: 'auto', 'AMDLinuxRHEL', 'AMDLinuxSuse', 'AppleOSX', 'Fujitsu',
+# 'Hp', 'HpTru64', 'HpVms', 'LinuxDT', 'LinuxRF', 'LinuxRHEL', 'LinuxSuse',
+# 'Novell', 'SGI', 'SVC', 'SanFsAIX', 'SanFsLinux', 'Sun', 'VMWare', 'Win2000',
+# 'Win2003', 'Win2008', 'Win2012', 'iLinux', 'nSeries', 'pLinux', 'pSeries',
+# 'pSeriesPowerswap', 'zLinux', 'iSeries'. (string value)
+#ds8k_host_type = auto
+
+# Proxy driver that connects to the IBM Storage Array (string value)
+#proxy = cinder.volume.drivers.ibm.ibm_storage.proxy.IBMStorageProxy
+
+# Connection type to the IBM Storage Array (string value)
+# Possible values:
+# fibre_channel - <No description provided>
+# iscsi - <No description provided>
+#connection_type = iscsi
+
+# CHAP authentication mode, effective only for iscsi (disabled|enabled) (string
+# value)
+# Possible values:
+# disabled - <No description provided>
+# enabled - <No description provided>
+#chap = disabled
+
+# List of Management IP addresses (separated by commas) (string value)
+#management_ips =
+
+# Comma separated list of storage system storage pools for volumes. (list
+# value)
+#storwize_svc_volpool_name = volpool
+
+# Storage system space-efficiency parameter for volumes (percentage) (integer
+# value)
+# Minimum value: -1
+# Maximum value: 100
+#storwize_svc_vol_rsize = 2
+
+# Storage system threshold for volume capacity warnings (percentage) (integer
+# value)
+# Minimum value: -1
+# Maximum value: 100
+#storwize_svc_vol_warning = 0
+
+# Storage system autoexpand parameter for volumes (True/False) (boolean value)
+#storwize_svc_vol_autoexpand = true
+
+# Storage system grain size parameter for volumes (8/32/64/128/256) (integer
+# value)
+#storwize_svc_vol_grainsize = 256
+
+# Storage system compression option for volumes (boolean value)
+#storwize_svc_vol_compression = false
+
+# Enable Easy Tier for volumes (boolean value)
+#storwize_svc_vol_easytier = true
+
+# The I/O group in which to allocate volumes. It can be a comma-separated list
+# in which case the driver will select an io_group based on least number of
+# volumes associated with the io_group. (string value)
+#storwize_svc_vol_iogrp = 0
+
+# Maximum number of seconds to wait for FlashCopy to be prepared. (integer
+# value)
+# Minimum value: 1
+# Maximum value: 600
+#storwize_svc_flashcopy_timeout = 120
+
+# DEPRECATED: This option no longer has any affect. It is deprecated and will
+# be removed in the next release. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#storwize_svc_multihostmap_enabled = true
+
+# Allow tenants to specify QOS on create (boolean value)
+#storwize_svc_allow_tenant_qos = false
+
+# If operating in stretched cluster mode, specify the name of the pool in which
+# mirrored copies are stored.Example: "pool2" (string value)
+#storwize_svc_stretched_cluster_partner = <None>
+
+# Specifies secondary management IP or hostname to be used if san_ip is invalid
+# or becomes inaccessible. (string value)
+#storwize_san_secondary_ip = <None>
+
+# Specifies that the volume not be formatted during creation. (boolean value)
+#storwize_svc_vol_nofmtdisk = false
+
+# Specifies the Storwize FlashCopy copy rate to be used when creating a full
+# volume copy. The default is rate is 50, and the valid rates are 1-150.
+# (integer value)
+# Minimum value: 1
+# Maximum value: 150
+#storwize_svc_flashcopy_rate = 50
+
+# Specifies the Storwize cleaning rate for the mapping. The default rate is 50,
+# and the valid rates are 0-150. (integer value)
+# Minimum value: 0
+# Maximum value: 150
+#storwize_svc_clean_rate = 50
+
+# Specifies the name of the pool in which mirrored copy is stored. Example:
+# "pool2" (string value)
+#storwize_svc_mirror_pool = <None>
+
+# Specifies the name of the portset in which the host is to be created. (string
+# value)
+#storwize_portset = <None>
+
+# Specifies the name of the source child pool in which global mirror source
+# change volume is stored. (string value)
+#storwize_svc_src_child_pool = <None>
+
+# Specifies the name of the target child pool in which global mirror auxiliary
+# change volume is stored. (string value)
+#storwize_svc_target_child_pool = <None>
+
+# Specifies the name of the peer pool for hyperswap volume, the peer pool must
+# exist on the other site. (string value)
+#storwize_peer_pool = <None>
+
+# Specifies the site information for host. One WWPN or multi WWPNs used in the
+# host can be specified. For example:
+# storwize_preferred_host_site=site1:wwpn1,site2:wwpn2&wwpn3 or
+# storwize_preferred_host_site=site1:iqn1,site2:iqn2 (dict value)
+#storwize_preferred_host_site =
+
+# This defines an optional cycle period that applies to Global Mirror
+# relationships with a cycling mode of multi. A Global Mirror relationship
+# using the multi cycling_mode performs a complete cycle at most once each
+# period. The default is 300 seconds, and the valid seconds are 60-86400.
+# (integer value)
+# Minimum value: 60
+# Maximum value: 86400
+#cycle_period_seconds = 300
+
+# Enable or disable retaining of aux volume on secondary storage during delete
+# of the volume on primary storage or moving the primary volume from mirror to
+# non-mirror with replication enabled. This option is valid for Storage
+# Virtualize Family. (boolean value)
+#storwize_svc_retain_aux_volume = false
+
+# Parameter to enable or disable Volume Group(True/False) (boolean value)
+#storwize_volume_group = false
+
+# Connect with multipath (FC only; iSCSI multipath is controlled by Nova)
+# (boolean value)
+#storwize_svc_multipath_enabled = false
+
+# Configure CHAP authentication for iSCSI connections (Default: Enabled)
+# (boolean value)
+#storwize_svc_iscsi_chap_enabled = true
+
+# Name of the pool from which volumes are allocated (string value)
+#infinidat_pool_name = <None>
+
+# Protocol for transferring data between host and storage back-end. (string
+# value)
+# Possible values:
+# iscsi - <No description provided>
+# fc - <No description provided>
+#infinidat_storage_protocol = fc
+
+# List of names of network spaces to use for iSCSI connectivity (list value)
+#infinidat_iscsi_netspaces =
+
+# Specifies whether to turn on compression for newly created volumes. (boolean
+# value)
+#infinidat_use_compression = false
+
+# K2 driver will calculate max_oversubscription_ratio on setting this option as
+# True. (boolean value)
+#auto_calc_max_oversubscription_ratio = false
+
+# Disabling iSCSI discovery (sendtargets) for multipath connections on K2
+# driver. (boolean value)
+#disable_discovery = false
+
+# Pool or Vdisk name to use for volume creation. (string value)
+# Deprecated group/name - [backend_defaults]/lenovo_backend_name
+#lenovo_pool_name = A
+
+# linear (for VDisk) or virtual (for Pool). (string value)
+# Possible values:
+# linear - <No description provided>
+# virtual - <No description provided>
+# Deprecated group/name - [backend_defaults]/lenovo_backend_type
+#lenovo_pool_type = virtual
+
+# DEPRECATED: Lenovo api interface protocol. (string value)
+# Possible values:
+# http - <No description provided>
+# https - <No description provided>
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: driver_use_ssl should be used instead.
+#lenovo_api_protocol = https
+
+# DEPRECATED: Whether to verify Lenovo array SSL certificate. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use driver_ssl_cert_verify instead.
+#lenovo_verify_certificate = false
+
+# DEPRECATED: Lenovo array SSL certificate path. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use driver_ssl_cert_path instead.
+#lenovo_verify_certificate_path = <None>
+
+# List of comma-separated target iSCSI IP addresses. (list value)
+#lenovo_iscsi_ips =
+
+# The IP addresses of the LightOS API servers separated by commas. (list value)
+#lightos_api_address = <None>
+
+# The TCP/IP port at which the LightOS API endpoints listen. Port 443 is used
+# for HTTPS and other values are used for HTTP. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#lightos_api_port = 443
+
+# JWT to be used for volume and snapshot operations with the LightOS cluster.
+# Do not set this parameter if the cluster is installed with multi-tenancy
+# disabled. (string value)
+#lightos_jwt = <None>
+
+# The default number of replicas to create for each volume. (integer value)
+# Minimum value: 1
+# Maximum value: 3
+#lightos_default_num_replicas = 3
+
+# Set to True to create  new volumes compressed assuming no other compression
+# setting is specified via the volumes type. (boolean value)
+#lightos_default_compression_enabled = false
+
+# The default amount of time (in seconds) to wait for an API endpoint response.
+# (integer value)
+#lightos_api_service_timeout = 30
+
+# Default Volume Group name for LINSTOR. Not Cinder Volume. (string value)
+#linstor_default_volume_group_name = drbd-vg
+
+# Default storage URI for LINSTOR. (string value)
+#linstor_default_uri = linstor://localhost
+
+# Default Storage Pool name for LINSTOR. (string value)
+#linstor_default_storage_pool_name = DfltStorPool
+
+# Default volume downscale size in KiB = 4 MiB. (floating point value)
+#linstor_volume_downsize_factor = 4096
+
+# Default Block size for Image restoration. When using iSCSI transport, this
+# option specifies the block size. (integer value)
+#linstor_default_blocksize = 4096
+
+# Autoplace replication count on volume deployment. 0 = Full cluster
+# replication without autoplace, 1 = Single node deployment without
+# replication, 2 or greater = Replicated deployment with autoplace. (integer
+# value)
+#linstor_autoplace_count = 0
+
+# True means Cinder node is a diskless LINSTOR node. (boolean value)
+#linstor_controller_diskless = true
+
+# Name for the VG that will contain exported volumes (string value)
+#volume_group = cinder-volumes
+
+# If >0, create LVs with multiple mirrors. Note that this requires lvm_mirrors
+# + 2 PVs with available space (integer value)
+#lvm_mirrors = 0
+
+# Type of LVM volumes to deploy; (default, thin, or auto). Auto defaults to
+# thin if thin is supported. (string value)
+# Possible values:
+# default - Thick-provisioned LVM.
+# thin - Thin-provisioned LVM.
+# auto - Defaults to thin when supported.
+#lvm_type = auto
+
+# LVM conf file to use for the LVM driver in Cinder; this setting is ignored if
+# the specified file does not exist (You can also specify 'None' to not use a
+# conf file even if one exists). (string value)
+#lvm_conf_file = /etc/cinder/lvm.conf
+
+# Suppress leaked file descriptor warnings in LVM commands. (boolean value)
+#lvm_suppress_fd_warnings = false
+
+# Whether to share the same target for all LUNs or not (currently only
+# supported by nvmet. (boolean value)
+#lvm_share_target = false
+
+# MacroSAN sdas devices' ip addresses (list value)
+#macrosan_sdas_ipaddrs = <None>
+
+# MacroSAN sdas devices' username (string value)
+#macrosan_sdas_username = <None>
+
+# MacroSAN sdas devices' password (string value)
+#macrosan_sdas_password = <None>
+
+# MacroSAN replication devices' ip addresses (list value)
+#macrosan_replication_ipaddrs = <None>
+
+# MacroSAN replication devices' username (string value)
+#macrosan_replication_username = <None>
+
+# MacroSAN replication devices' password (string value)
+#macrosan_replication_password = <None>
+
+# Slave device (list value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#macrosan_replication_destination_ports = eth-1:0/eth-1:1, eth-2:0/eth-2:1
+
+# Pool to use for volume creation (string value)
+#macrosan_pool = <None>
+
+# Set the thin lun's extent size (integer value)
+#macrosan_thin_lun_extent_size = 8
+
+# Set the thin lun's low watermark (integer value)
+#macrosan_thin_lun_low_watermark = 5
+
+# Set the thin lun's high watermark (integer value)
+#macrosan_thin_lun_high_watermark = 20
+
+# Force disconnect while deleting volume (boolean value)
+#macrosan_force_unmap_itl = true
+
+# Set snapshot's resource ratio (floating point value)
+#macrosan_snapshot_resource_ratio = 1.0
+
+# Whether enable log timing (boolean value)
+#macrosan_log_timing = true
+
+# The use_sp_port_nr parameter is the number of online FC ports used by the
+# single-ended memory when the FC connection is established in the switch non-
+# all-pass mode. The maximum is 4 (integer value)
+# Maximum value: 4
+#macrosan_fc_use_sp_port_nr = 1
+
+# In the case of an FC connection, the configuration item associated with the
+# port is maintained. (boolean value)
+#macrosan_fc_keep_mapped_ports = true
+
+# Macrosan iscsi_clients list.
+#                 You can configure multiple clients.
+#                 You can configure it in this format:
+#                 (host; client_name; sp1_iscsi_port; sp2_iscsi_port),
+#                 (host; client_name; sp1_iscsi_port; sp2_iscsi_port)
+#                 Important warning, Client_name has the following
+# requirements:
+#                     [a-zA-Z0-9.-_:], the maximum number of characters is 31
+#                 E.g:
+#                 (controller1; device1; eth-1:0; eth-2:0),
+#                 (controller2; device2; eth-1:0/eth-1:1; eth-2:0/eth-2:1),
+#                  (list value)
+#macrosan_client = <None>
+
+# This is the default connection ports' name for iscsi. This default
+# configuration is used when no host related information is obtained.E.g:
+# eth-1:0/eth-1:1; eth-2:0/eth-2:1 (string value)
+#macrosan_client_default = <None>
+
+# Product number of the storage system. (string value)
+#nec_v_storage_id = <None>
+
+# Pool number[s] or pool name[s] of the DP pool. (list value)
+# Deprecated group/name - [backend_defaults]/nec_v_pool
+#nec_v_pools =
+
+# Pool number or pool name of the snapshot pool. (string value)
+#nec_v_snap_pool = <None>
+
+# Range of the LDEV numbers in the format of 'xxxx-yyyy' that can be used by
+# the driver. Values can be in decimal format (e.g. 1000) or in colon-separated
+# hexadecimal format (e.g. 00:03:E8). (string value)
+#nec_v_ldev_range = <None>
+
+# IDs of the storage ports used to attach volumes to the controller node. To
+# specify multiple ports, connect them by commas (e.g. CL1-A,CL2-A). (list
+# value)
+#nec_v_target_ports =
+
+# IDs of the storage ports used to attach volumes to compute nodes. To specify
+# multiple ports, connect them by commas (e.g. CL1-A,CL2-A). (list value)
+#nec_v_compute_target_ports =
+
+# If True, the driver will create host groups or iSCSI targets on storage ports
+# as needed. (boolean value)
+#nec_v_group_create = false
+
+# If True, the driver will delete host groups or iSCSI targets on storage ports
+# as needed. (boolean value)
+#nec_v_group_delete = false
+
+# Copy speed of storage system. 1 or 2 indicates low speed, 3 indicates middle
+# speed, and a value between 4 and 15 indicates high speed. (integer value)
+# Minimum value: 1
+# Maximum value: 15
+#nec_v_copy_speed = 3
+
+# Interval in seconds to check copying status during a volume copy. (integer
+# value)
+# Minimum value: 1
+# Maximum value: 600
+#nec_v_copy_check_interval = 3
+
+# Interval in seconds to check asynchronous copying status during a copy pair
+# deletion or data restoration. (integer value)
+# Minimum value: 1
+# Maximum value: 600
+#nec_v_async_copy_check_interval = 10
+
+# It may take some time to detach volume after I/O. This option will allow
+# detaching volume to complete immediately. (boolean value)
+#nec_v_rest_disable_io_wait = true
+
+# Enables or disables use of REST API tcp keepalive (boolean value)
+#nec_v_rest_tcp_keepalive = true
+
+# Enable or disable zero page reclamation in a DP-VOL. (boolean value)
+#nec_v_discard_zero_page = true
+
+# Maximum wait time in seconds for adding a LUN to complete. (integer value)
+#nec_v_lun_timeout = 50
+
+# Retry interval in seconds for REST API adding a LUN. (integer value)
+#nec_v_lun_retry_interval = 1
+
+# Maximum wait time in seconds for the restore operation to complete. (integer
+# value)
+#nec_v_restore_timeout = 86400
+
+# Maximum wait time in seconds for a volume transition to complete. (integer
+# value)
+#nec_v_state_transition_timeout = 900
+
+# Maximum wait time in seconds for storage to be unlocked. (integer value)
+#nec_v_lock_timeout = 7200
+
+# Maximum wait time in seconds for REST API execution to complete. (integer
+# value)
+#nec_v_rest_timeout = 30
+
+# Maximum wait time in seconds for a volume extention to complete. (integer
+# value)
+#nec_v_extend_timeout = 600
+
+# Retry interval in seconds for REST API execution. (integer value)
+#nec_v_exec_retry_interval = 5
+
+# Maximum wait time in seconds for REST API connection to complete. (integer
+# value)
+#nec_v_rest_connect_timeout = 30
+
+# Maximum wait time in seconds for a response from REST API. (integer value)
+#nec_v_rest_job_api_response_timeout = 1800
+
+# Maximum wait time in seconds for a response against GET method of REST API.
+# (integer value)
+#nec_v_rest_get_api_response_timeout = 1800
+
+# Maximum wait time in seconds when REST API returns busy. (integer value)
+#nec_v_rest_server_busy_timeout = 7200
+
+# Loop interval in seconds for keeping REST API session. (integer value)
+#nec_v_rest_keep_session_loop_interval = 180
+
+# Retry time in seconds when new LUN allocation request fails. (integer value)
+#nec_v_rest_another_ldev_mapped_retry_timeout = 600
+
+# Wait time in seconds for sending a first TCP keepalive packet. (integer
+# value)
+#nec_v_rest_tcp_keepidle = 60
+
+# Interval of transmissions in seconds for TCP keepalive packet. (integer
+# value)
+#nec_v_rest_tcp_keepintvl = 15
+
+# Maximum number of transmissions for TCP keepalive packet. (integer value)
+#nec_v_rest_tcp_keepcnt = 4
+
+# Host mode option for host group or iSCSI target (list value)
+#nec_v_host_mode_options =
+
+# If True, the driver will configure FC zoning between the server and the
+# storage system provided that FC zoning manager is enabled. (boolean value)
+#nec_v_zoning_request = false
+
+# The storage family type used on the storage system; the only valid value is
+# ontap_cluster for using clustered Data ONTAP. (string value)
+# Possible values:
+# ontap_cluster - <No description provided>
+#netapp_storage_family = ontap_cluster
+
+# The storage protocol to be used on the data path with the storage system.
+# (string value)
+# Possible values:
+# iscsi - <No description provided>
+# fc - <No description provided>
+# nfs - <No description provided>
+# nvme - <No description provided>
+#netapp_storage_protocol = <None>
+
+# The hostname (or IP address) for the storage system or proxy server. (string
+# value)
+#netapp_server_hostname = <None>
+
+# The TCP port to use for communication with the storage system or proxy
+# server. If not specified, Data ONTAP drivers will use 80 for HTTP and 443 for
+# HTTPS. (integer value)
+#netapp_server_port = <None>
+
+# Select which ONTAP client to use for retrieving and modifying data on the
+# storage. The legacy client relies on ZAPI calls. If set to False, the new
+# REST client is used, which runs REST calls if supported, otherwise falls back
+# to the equivalent ZAPI call. (boolean value)
+#netapp_use_legacy_client = true
+
+# The maximum time in seconds to wait for completing a REST asynchronous
+# operation. (integer value)
+# Minimum value: 60
+#netapp_async_rest_timeout = 60
+
+# The transport protocol used when communicating with the storage system or
+# proxy server. (string value)
+# Possible values:
+# http - <No description provided>
+# https - <No description provided>
+#netapp_transport_type = http
+
+# The path to a CA_BUNDLE file or directory with certificates of trusted CA. If
+# set to a directory, it must have been processed using the c_rehash utility
+# supplied with OpenSSL. If not informed, it will use the Mozilla's carefully
+# curated collection of Root Certificates for validating the trustworthiness of
+# SSL certificates. Only applies with new REST client. (string value)
+#netapp_ssl_cert_path = <None>
+
+# Administrative user account name used to access the storage system or proxy
+# server. (string value)
+#netapp_login = <None>
+
+# Password for the administrative user account specified in the netapp_login
+# option. (string value)
+#netapp_password = <None>
+
+# This option specifies the virtual storage server (Vserver) name on the
+# storage cluster on which provisioning of block storage volumes should occur.
+# (string value)
+#netapp_vserver = <None>
+
+# The quantity to be multiplied by the requested volume size to ensure enough
+# space is available on the virtual storage server (Vserver) to fulfill the
+# volume creation request.  Note: this option is deprecated and will be removed
+# in favor of "reserved_percentage" in the Mitaka release. (floating point
+# value)
+#netapp_size_multiplier = 1.2
+
+# This option determines if storage space is reserved for LUN allocation. If
+# enabled, LUNs are thick provisioned. If space reservation is disabled,
+# storage space is allocated on demand. (string value)
+# Possible values:
+# enabled - <No description provided>
+# disabled - <No description provided>
+#netapp_lun_space_reservation = enabled
+
+# Set to True for Cinder to query the storage system in order to calculate
+# volumes provisioned size, otherwise provisioned_capacity_gb will corresponds
+# to the value of allocated_capacity_gb (calculated by Cinder Core code).
+# Enabling this feature increases the number of API calls to the storage and
+# requires more processing on host, which may impact volume report overall
+# performance. (boolean value)
+#netapp_driver_reports_provisioned_capacity = false
+
+# Sets time in seconds between NFS image cache cleanup tasks. (integer value)
+# Minimum value: 60
+#netapp_nfs_image_cache_cleanup_interval = 600
+
+# If the percentage of available space for an NFS share has dropped below the
+# value specified by this option, the NFS image cache will be cleaned. (integer
+# value)
+#thres_avl_size_perc_start = 20
+
+# When the percentage of available space on an NFS share has reached the
+# percentage specified by this option, the driver will stop clearing files from
+# the NFS image cache that have not been accessed in the last M minutes, where
+# M is the value of the expiry_thres_minutes configuration option. (integer
+# value)
+#thres_avl_size_perc_stop = 60
+
+# This option specifies the threshold for last access time for images in the
+# NFS image cache. When a cache cleaning cycle begins, images in the cache that
+# have not been accessed in the last M minutes, where M is the value of this
+# parameter, will be deleted from the cache to create free space on the NFS
+# share. (integer value)
+#expiry_thres_minutes = 720
+
+# DEPRECATED: This option specifies the path of the NetApp copy offload tool
+# binary. Ensure that the binary has execute permissions set which allow the
+# effective user of the cinder-volume process to execute the file. (string
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: The CopyOfflload tool is no longer available for downloading.
+#netapp_copyoffload_tool_path = <None>
+
+# This option defines the type of operating system that will access a LUN
+# exported from Data ONTAP; it is assigned to the LUN at the time it is
+# created. (string value)
+#netapp_lun_ostype = <None>
+
+# This option defines the type of operating system that will access a namespace
+# exported from Data ONTAP; it is assigned to the namespace at the time it is
+# created. (string value)
+#netapp_namespace_ostype = <None>
+
+# This option defines the type of operating system for all initiators that can
+# access a LUN. This information is used when mapping LUNs to individual hosts
+# or groups of hosts. (string value)
+#netapp_host_type = <None>
+
+# This option is used to restrict provisioning to the specified pools. Specify
+# the value of this option to be a regular expression which will be applied to
+# the names of objects from the storage backend which represent pools in
+# Cinder. This option is only utilized when the storage protocol is configured
+# to use iSCSI or FC. (string value)
+# Deprecated group/name - [backend_defaults]/netapp_volume_list
+# Deprecated group/name - [backend_defaults]/netapp_storage_pools
+#netapp_pool_name_search_pattern = (.+)
+
+# Multi opt of dictionaries to represent the aggregate mapping between source
+# and destination back ends when using whole back end replication. For every
+# source aggregate associated with a cinder pool (NetApp FlexVol/FlexGroup),
+# you would need to specify the destination aggregate on the replication target
+# device. A replication target device is configured with the configuration
+# option replication_device. Specify this option as many times as you have
+# replication devices. Each entry takes the standard dict config form:
+# netapp_replication_aggregate_map =
+# backend_id:<name_of_replication_device_section>,src_aggr_name1:dest_aggr_name1,src_aggr_name2:dest_aggr_name2,...
+# (dict value)
+#netapp_replication_aggregate_map = <None>
+
+# The maximum time in seconds to wait for existing SnapMirror transfers to
+# complete before aborting during a failover. (integer value)
+# Minimum value: 0
+#netapp_snapmirror_quiesce_timeout = 3600
+
+# Sets time in seconds to wait for a replication volume create to complete and
+# go online. (integer value)
+# Minimum value: 60
+#netapp_replication_volume_online_timeout = 360
+
+# A regular expression to limit the API tracing. This option is honored only if
+# enabling ``api`` tracing with the ``trace_flags`` option. By default, all
+# APIs will be traced. (string value)
+#netapp_api_trace_pattern = (.*)
+
+# Sets time in seconds to wait for storage assisted volume migration to
+# complete. (integer value)
+# Minimum value: 30
+#netapp_migrate_volume_timeout = 3600
+
+# IP address of NexentaStor Appliance (string value)
+#nexenta_host =
+
+# DEPRECATED: IP address of NexentaStor management REST API endpoint (string
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Rest address should now be set using the common param depending on
+# driver type, san_ip or nas_host
+#nexenta_rest_address =
+
+# DEPRECATED: HTTP(S) port to connect to NexentaStor management REST API
+# server. If it is equal zero, 8443 for HTTPS and 8080 for HTTP is used
+# (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Rest address should now be set using the common param san_api_port.
+#nexenta_rest_port = 0
+
+# Use http or https for NexentaStor management REST API connection (default
+# auto) (string value)
+# Possible values:
+# http - <No description provided>
+# https - <No description provided>
+# auto - <No description provided>
+#nexenta_rest_protocol = auto
+
+# Specifies the time limit (in seconds), within which the connection to
+# NexentaStor management REST API server must be established (floating point
+# value)
+#nexenta_rest_connect_timeout = 30
+
+# Specifies the time limit (in seconds), within which NexentaStor management
+# REST API server must send a response (floating point value)
+#nexenta_rest_read_timeout = 300
+
+# Specifies the backoff factor to apply between connection attempts to
+# NexentaStor management REST API server (floating point value)
+#nexenta_rest_backoff_factor = 0.5
+
+# Specifies the number of times to repeat NexentaStor management REST API call
+# in case of connection errors and NexentaStor appliance EBUSY or ENOENT errors
+# (integer value)
+#nexenta_rest_retry_count = 3
+
+# Use HTTP secure protocol for NexentaStor management REST API connections
+# (boolean value)
+#nexenta_use_https = true
+
+# Postponed write to backing store or not (boolean value)
+#nexenta_lu_writebackcache_disabled = false
+
+# DEPRECATED: User name to connect to NexentaStor management REST API server
+# (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Common user parameters should be used depending on the driver type:
+# san_login or nas_login
+#nexenta_user = admin
+
+# DEPRECATED: Password to connect to NexentaStor management REST API server
+# (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Common password parameters should be used depending on the driver
+# type: san_password or nas_password
+#nexenta_password = nexenta
+
+# NexentaStor target portal groups (string value)
+#nexenta_iscsi_target_portal_groups =
+
+# Comma separated list of portals for NexentaStor5, in format of
+# IP1:port1,IP2:port2. Port is optional, default=3260. Example:
+# 10.10.10.1:3267,10.10.1.2 (string value)
+#nexenta_iscsi_target_portals =
+
+# Group of hosts which are allowed to access volumes (string value)
+#nexenta_iscsi_target_host_group = all
+
+# Nexenta appliance iSCSI target portal port (integer value)
+#nexenta_iscsi_target_portal_port = 3260
+
+# Amount of LUNs per iSCSI target (integer value)
+#nexenta_luns_per_target = 100
+
+# NexentaStor pool name that holds all volumes (string value)
+#nexenta_volume = cinder
+
+# iqn prefix for NexentaStor iSCSI targets (string value)
+#nexenta_target_prefix = iqn.1986-03.com.sun:02:cinder
+
+# Prefix for iSCSI target groups on NexentaStor (string value)
+#nexenta_target_group_prefix = cinder
+
+# Prefix for iSCSI host groups on NexentaStor (string value)
+#nexenta_host_group_prefix = cinder
+
+# Volume group for NexentaStor5 iSCSI (string value)
+#nexenta_volume_group = iscsi
+
+# Compression value for new ZFS folders. (string value)
+# Possible values:
+# on - <No description provided>
+# off - <No description provided>
+# gzip - <No description provided>
+# gzip-1 - <No description provided>
+# gzip-2 - <No description provided>
+# gzip-3 - <No description provided>
+# gzip-4 - <No description provided>
+# gzip-5 - <No description provided>
+# gzip-6 - <No description provided>
+# gzip-7 - <No description provided>
+# gzip-8 - <No description provided>
+# gzip-9 - <No description provided>
+# lzjb - <No description provided>
+# zle - <No description provided>
+# lz4 - <No description provided>
+#nexenta_dataset_compression = on
+
+# Deduplication value for new ZFS folders. (string value)
+# Possible values:
+# on - <No description provided>
+# off - <No description provided>
+# sha256 - <No description provided>
+# verify - <No description provided>
+# sha256, verify - <No description provided>
+#nexenta_dataset_dedup = off
+
+# A folder where cinder created datasets will reside. (string value)
+#nexenta_folder =
+
+# Human-readable description for the folder. (string value)
+#nexenta_dataset_description =
+
+# Block size for datasets (integer value)
+#nexenta_blocksize = 4096
+
+# Block size for datasets (integer value)
+#nexenta_ns5_blocksize = 32
+
+# Enables or disables the creation of sparse datasets (boolean value)
+#nexenta_sparse = false
+
+# Template string to generate origin name of clone (string value)
+#nexenta_origin_snapshot_template = origin-snapshot-%s
+
+# Template string to generate group snapshot name (string value)
+#nexenta_group_snapshot_template = group-snapshot-%s
+
+# File with the list of available nfs shares (string value)
+#nexenta_shares_config = /etc/cinder/nfs_shares
+
+# Base directory that contains NFS share mount points (string value)
+#nexenta_mount_point_base = $state_path/mnt
+
+# Enables or disables the creation of volumes as sparsed files that take no
+# space. If disabled (False), volume is created as a regular file, which takes
+# a long time. (boolean value)
+#nexenta_sparsed_volumes = true
+
+# Create volumes as QCOW2 files rather than raw files (boolean value)
+#nexenta_qcow2_volumes = false
+
+# If set True cache NexentaStor appliance volroot option value. (boolean value)
+#nexenta_nms_cache_volroot = true
+
+# Enable stream compression, level 1..9. 1 - gives best speed; 9 - gives best
+# compression. (integer value)
+#nexenta_rrmgr_compression = 0
+
+# TCP Buffer size in KiloBytes. (integer value)
+#nexenta_rrmgr_tcp_buf_size = 4096
+
+# Number of TCP connections. (integer value)
+#nexenta_rrmgr_connections = 2
+
+# NexentaEdge logical path of directory to store symbolic links to NBDs (string
+# value)
+#nexenta_nbd_symlinks_dir = /dev/disk/by-path
+
+# User name to connect to NexentaEdge. (string value)
+#nexenta_rest_user = admin
+
+# Password to connect to NexentaEdge. (string value)
+#nexenta_rest_password = nexenta
+
+# NexentaEdge logical path of bucket for LUNs (string value)
+#nexenta_lun_container =
+
+# NexentaEdge iSCSI service name (string value)
+#nexenta_iscsi_service =
+
+# DEPRECATED: NexentaEdge iSCSI Gateway client address for non-VIP service
+# (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: iSCSI target address should now be set using the common param
+# target_ip_address.
+#nexenta_client_address =
+
+# NexentaEdge iSCSI LUN object IOPS limit (integer value)
+#nexenta_iops_limit = 0
+
+# NexentaEdge iSCSI LUN object chunk size (integer value)
+#nexenta_chunksize = 32768
+
+# NexentaEdge iSCSI LUN object replication count. (integer value)
+#nexenta_replication_count = 3
+
+# Defines whether NexentaEdge iSCSI LUN object has encryption enabled. (boolean
+# value)
+#nexenta_encryption = false
+
+# DPL pool uuid in which DPL volumes are stored. (string value)
+#dpl_pool =
+
+# DPL port number. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#dpl_port = 8357
+
+# REST API authorization token. (string value)
+#pure_api_token = <None>
+
+# Automatically determine an oversubscription ratio based on the current total
+# data reduction values. If used this calculated value will override the
+# max_over_subscription_ratio config option. (boolean value)
+#pure_automatic_max_oversubscription_ratio = true
+
+# Determines how the Purity system tunes the protocol used between the array
+# and the initiator. (string value)
+# Possible values:
+# aix - <No description provided>
+# esxi - <No description provided>
+# hitachi-vsp - <No description provided>
+# hpux - <No description provided>
+# oracle-vm-server - <No description provided>
+# solaris - <No description provided>
+# vms - <No description provided>
+# <None> - <No description provided>
+#pure_host_personality = <None>
+
+# Snapshot replication interval in seconds. (integer value)
+#pure_replica_interval_default = 3600
+
+# Retain all snapshots on target for this time (in seconds.) (integer value)
+#pure_replica_retention_short_term_default = 14400
+
+# Retain how many snapshots for each day. (integer value)
+#pure_replica_retention_long_term_per_day_default = 3
+
+# Retain snapshots per day on target for this time (in days.) (integer value)
+#pure_replica_retention_long_term_default = 7
+
+# Pure Protection Group name to use for async replication (will be created if
+# it does not exist). (string value)
+#pure_replication_pg_name = cinder-group
+
+# Pure Protection Group name to use for trisync replication leg inside the sync
+# replication pod (will be created if it does not exist). (string value)
+#pure_trisync_pg_name = cinder-trisync
+
+# Pure Pod name to use for sync replication (will be created if it does not
+# exist). (string value)
+#pure_replication_pod_name = cinder-pod
+
+# CIDR of FlashArray iSCSI targets hosts are allowed to connect to. Default
+# will allow connection to any IPv4 address. This parameter now supports IPv6
+# subnets. Ignored when pure_iscsi_cidr_list is set. (string value)
+#pure_iscsi_cidr = 0.0.0.0/0
+
+# Comma-separated list of CIDR of FlashArray iSCSI targets hosts are allowed to
+# connect to. It supports IPv4 and IPv6 subnets. This parameter supersedes
+# pure_iscsi_cidr. (list value)
+#pure_iscsi_cidr_list = <None>
+
+# CIDR of FlashArray NVMe targets hosts are allowed to connect to. Default will
+# allow connection to any IPv4 address. This parameter now supports IPv6
+# subnets. Ignored when pure_nvme_cidr_list is set. (string value)
+#pure_nvme_cidr = 0.0.0.0/0
+
+# Comma-separated list of CIDR of FlashArray NVMe targets hosts are allowed to
+# connect to. It supports IPv4 and IPv6 subnets. This parameter supersedes
+# pure_nvme_cidr. (list value)
+#pure_nvme_cidr_list = <None>
+
+# The NVMe transport layer to be used by the NVMe driver. This only supports
+# RoCE at this time. (string value)
+# Possible values:
+# roce - <No description provided>
+#pure_nvme_transport = roce
+
+# When enabled, all Pure volumes, snapshots, and protection groups will be
+# eradicated at the time of deletion in Cinder. Data will NOT be recoverable
+# after a delete with this set to True! When disabled, volumes and snapshots
+# will go into pending eradication state and can be recovered. (boolean value)
+#pure_eradicate_on_delete = false
+
+# When enabled and two replication devices are provided, one each of types sync
+# and async, this will enable the ability to create a volume that is sync
+# replicated to one array and async replicated to a separate array. (boolean
+# value)
+#pure_trisync_enabled = false
+
+# The URL to management QNAP Storage. Driver does not support IPv6 address in
+# URL. (uri value)
+#qnap_management_url = <None>
+
+# The pool name in the QNAP Storage (string value)
+#qnap_poolname = <None>
+
+# Communication protocol to access QNAP storage (string value)
+#qnap_storage_protocol = iSCSI
+
+# Quobyte URL to the Quobyte volume using e.g. a DNS SRV record (preferred) or
+# a host list (alternatively) like quobyte://<DIR host1>, <DIR host2>/<volume
+# name> (string value)
+#quobyte_volume_url = <None>
+
+# Path to a Quobyte Client configuration file. (string value)
+#quobyte_client_cfg = <None>
+
+# Create volumes as sparse files which take no space. If set to False, volume
+# is created as regular file. (boolean value)
+#quobyte_sparsed_volumes = true
+
+# Create volumes as QCOW2 files rather than raw files. (boolean value)
+#quobyte_qcow2_volumes = true
+
+# Base dir containing the mount point for the Quobyte volume. (string value)
+#quobyte_mount_point_base = $state_path/mnt
+
+# Create a cache of volumes from merged snapshots to speed up creation of
+# multiple volumes from a single snapshot. (boolean value)
+#quobyte_volume_from_snapshot_cache = false
+
+# Create new volumes from the volume_from_snapshot_cache by creating overlay
+# files instead of full copies. This speeds up the creation of volumes from
+# this cache. This feature requires the options quobyte_qcow2_volumes and
+# quobyte_volume_from_snapshot_cache to be set to True. If one of these is set
+# to False this option is ignored. (boolean value)
+#quobyte_overlay_volumes = false
+
+# The name of ceph cluster (string value)
+#rbd_cluster_name = ceph
+
+# The RADOS pool where rbd volumes are stored (string value)
+#rbd_pool = rbd
+
+# The RADOS client name for accessing rbd volumes - only set when using cephx
+# authentication (string value)
+#rbd_user = <None>
+
+# Path to the ceph configuration file (string value)
+#rbd_ceph_conf =
+
+# Flatten volumes created from snapshots to remove dependency from volume to
+# snapshot (boolean value)
+#rbd_flatten_volume_from_snapshot = false
+
+# The libvirt uuid of the secret for the rbd_user volumes. Defaults to the
+# cluster FSID. (string value)
+#rbd_secret_uuid = <None>
+
+# Maximum number of nested volume clones that are taken before a flatten
+# occurs. Set to 0 to disable cloning. Note: lowering this value will not
+# affect existing volumes whose clone depth exceeds the new value. (integer
+# value)
+#rbd_max_clone_depth = 5
+
+# Volumes will be chunked into objects of this size (in megabytes). (integer
+# value)
+#rbd_store_chunk_size = 4
+
+# Timeout value (in seconds) used when connecting to ceph cluster. If value <
+# 0, no timeout is set and default librados value is used. (integer value)
+#rados_connect_timeout = -1
+
+# Number of retries if connection to ceph cluster failed. (integer value)
+#rados_connection_retries = 3
+
+# Interval value (in seconds) between connection retries to ceph cluster.
+# (integer value)
+#rados_connection_interval = 5
+
+# Timeout value (in seconds) used when connecting to ceph cluster to do a
+# demotion/promotion of volumes. If value < 0, no timeout is set and default
+# librados value is used. (integer value)
+#replication_connect_timeout = 5
+
+# Set to True for driver to report total capacity as a dynamic value (used +
+# current free) and to False to report a static value (quota max bytes if
+# defined and global size of cluster if not). (boolean value)
+#report_dynamic_total_capacity = true
+
+# Set to False if the pool is shared with other usages. On exclusive use driver
+# won't query images' provisioned size as they will match the value calculated
+# by the Cinder core code for allocated_capacity_gb. This reduces the load on
+# the Ceph cluster as well as on the volume service. On non exclusive use
+# driver will query the Ceph cluster for per image used disk, this is an
+# intensive operation having an independent request for each image. (boolean
+# value)
+#rbd_exclusive_cinder_pool = true
+
+# Enable deferred deletion. Upon deletion, volumes are tagged for deletion but
+# will only be removed asynchronously at a later time. (boolean value)
+#enable_deferred_deletion = false
+
+# Time delay in seconds before a volume is eligible for permanent removal after
+# being tagged for deferred deletion. (integer value)
+#deferred_deletion_delay = 0
+
+# Number of seconds between runs of the periodic task to purge volumes tagged
+# for deletion. (integer value)
+#deferred_deletion_purge_interval = 60
+
+# Number of flatten operations that will run concurrently on this volume
+# service. (integer value)
+# Minimum value: 0
+#rbd_concurrent_flatten_operations = 3
+
+# IP address or Hostname of NAS system. (string value)
+#nas_host =
+
+# User name to connect to NAS system. (string value)
+#nas_login = admin
+
+# Password to connect to NAS system. (string value)
+#nas_password =
+
+# SSH port to use to connect to NAS system. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#nas_ssh_port = 22
+
+# Filename of private key to use for SSH authentication. (string value)
+#nas_private_key =
+
+# Allow network-attached storage systems to operate in a secure environment
+# where root level access is not permitted. If set to False, access is as the
+# root user and insecure. If set to True, access is not as root. If set to
+# auto, a check is done to determine if this is a new installation: True is
+# used if so, otherwise False. Default is auto. (string value)
+#nas_secure_file_operations = auto
+
+# Set more secure file permissions on network-attached storage volume files to
+# restrict broad other/world access. If set to False, volumes are created with
+# open permissions. If set to True, volumes are created with permissions for
+# the cinder user and group (660). If set to auto, a check is done to determine
+# if this is a new installation: True is used if so, otherwise False. Default
+# is auto. (string value)
+#nas_secure_file_permissions = auto
+
+# Path to the share to use for storing Cinder volumes. For example:
+# "/srv/export1" for an NFS server export available at 10.0.5.10:/srv/export1 .
+# (string value)
+#nas_share_path =
+
+# Options used to mount the storage backend file system where Cinder volumes
+# are stored. (string value)
+#nas_mount_options = <None>
+
+# Provisioning type that will be used when creating volumes. (string value)
+# Possible values:
+# thin - <No description provided>
+# thick - <No description provided>
+#nas_volume_prov_type = thin
+
+# Pool or Vdisk name to use for volume creation. (string value)
+# Deprecated group/name - [backend_defaults]/hpmsa_backend_name
+#hpmsa_pool_name = A
+
+# linear (for Vdisk) or virtual (for Pool). (string value)
+# Possible values:
+# linear - <No description provided>
+# virtual - <No description provided>
+# Deprecated group/name - [backend_defaults]/hpmsa_backend_type
+#hpmsa_pool_type = virtual
+
+# DEPRECATED: HPMSA API interface protocol. (string value)
+# Possible values:
+# http - <No description provided>
+# https - <No description provided>
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: driver_use_ssl should be used instead.
+#hpmsa_api_protocol = https
+
+# DEPRECATED: Whether to verify HPMSA array SSL certificate. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use driver_ssl_cert_verify instead.
+#hpmsa_verify_certificate = false
+
+# DEPRECATED: HPMSA array SSL certificate path. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use driver_ssl_cert_path instead.
+#hpmsa_verify_certificate_path = <None>
+
+# List of comma-separated target iSCSI IP addresses. (list value)
+#hpmsa_iscsi_ips =
+
+# Use thin provisioning for SAN volumes? (boolean value)
+#san_thin_provision = true
+
+# IP address of SAN controller (string value)
+#san_ip =
+
+# Username for SAN controller (string value)
+#san_login = admin
+
+# Password for SAN controller (string value)
+#san_password =
+
+# Filename of private key to use for SSH authentication (string value)
+#san_private_key =
+
+# Cluster name to use for creating volumes (string value)
+#san_clustername =
+
+# SSH port to use with SAN (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#san_ssh_port = 22
+
+# Port to use to access the SAN API (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#san_api_port = <None>
+
+# Execute commands locally instead of over SSH; use if the volume service is
+# running on the SAN device (boolean value)
+#san_is_local = false
+
+# SSH connection timeout in seconds (integer value)
+#ssh_conn_timeout = 30
+
+# Minimum ssh connections in the pool (integer value)
+#ssh_min_pool_conn = 1
+
+# Maximum ssh connections in the pool (integer value)
+#ssh_max_pool_conn = 5
+
+# Set 512 byte emulation on volume creation;  (boolean value)
+#sf_emulate_512 = true
+
+# Allow tenants to specify QOS on create (boolean value)
+#sf_allow_tenant_qos = false
+
+# Create SolidFire accounts with this prefix. Any string can be used here, but
+# the string "hostname" is special and will create a prefix using the cinder
+# node hostname (previous default behavior).  The default is NO prefix. (string
+# value)
+#sf_account_prefix = <None>
+
+# Create SolidFire volumes with this prefix. Volume names are of the form
+# <sf_volume_prefix><cinder-volume-id>.  The default is to use a prefix of
+# 'UUID-'. (string value)
+#sf_volume_prefix = UUID-
+
+# Overrides default cluster SVIP with the one specified. This is required or
+# deployments that have implemented the use of VLANs for iSCSI networks in
+# their cloud. (string value)
+#sf_svip = <None>
+
+# SolidFire API port. Useful if the device api is behind a proxy on a different
+# port. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#sf_api_port = 443
+
+# Utilize volume access groups on a per-tenant basis. (boolean value)
+#sf_enable_vag = false
+
+# Change how SolidFire reports used space and provisioning calculations. If
+# this parameter is set to 'usedSpace', the  driver will report correct values
+# as expected by Cinder thin provisioning. (string value)
+# Possible values:
+# maxProvisionedSpace - <No description provided>
+# usedSpace - <No description provided>
+#sf_provisioning_calc = maxProvisionedSpace
+
+# Sets time in seconds to wait for clusters to complete pairing. (integer
+# value)
+# Minimum value: 3
+#sf_cluster_pairing_timeout = 60
+
+# Sets time in seconds to wait for a migrating volume to complete pairing and
+# sync. (integer value)
+# Minimum value: 30
+#sf_volume_pairing_timeout = 3600
+
+# Sets time in seconds to wait for an api request to complete. (integer value)
+# Minimum value: 30
+#sf_api_request_timeout = 30
+
+# Sets time in seconds to wait for a clone of a volume or snapshot to complete.
+# (integer value)
+# Minimum value: 60
+#sf_volume_clone_timeout = 600
+
+# Sets time in seconds to wait for a create volume operation to complete.
+# (integer value)
+# Minimum value: 30
+#sf_volume_create_timeout = 60
+
+# The StorPool template for volumes with no type. (string value)
+#storpool_template = <None>
+
+# The default StorPool chain replication value.  Used when creating a volume
+# with no specified type if storpool_template is not set.  Also used for
+# calculating the apparent free space reported in the stats. (integer value)
+#storpool_replication = 3
+
+# Pool or vdisk name to use for volume creation. (string value)
+#seagate_pool_name = A
+
+# linear (for vdisk) or virtual (for virtual pool). (string value)
+# Possible values:
+# linear - <No description provided>
+# virtual - <No description provided>
+#seagate_pool_type = virtual
+
+# List of comma-separated target iSCSI IP addresses. (list value)
+#seagate_iscsi_ips =
+
+# Volume on Synology storage to be used for creating lun. (string value)
+#synology_pool_name =
+
+# Management port for Synology storage. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#synology_admin_port = 5000
+
+# Administrator of Synology storage. (string value)
+#synology_username = admin
+
+# Password of administrator for logging in Synology storage. (string value)
+#synology_password =
+
+# Do certificate validation or not if $driver_use_ssl is True (boolean value)
+#synology_ssl_verify = true
+
+# One time password of administrator for logging in Synology storage if OTP is
+# enabled. (string value)
+#synology_one_time_pass = <None>
+
+# Device id for skip one time password check for logging in Synology storage if
+# OTP is enabled. (string value)
+#synology_device_id = <None>
+
+# IP address for connecting to VMware vCenter server. (string value)
+#vmware_host_ip = <None>
+
+# Port number for connecting to VMware vCenter server. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#vmware_host_port = 443
+
+# Username for authenticating with VMware vCenter server. (string value)
+#vmware_host_username = <None>
+
+# Password for authenticating with VMware vCenter server. (string value)
+#vmware_host_password = <None>
+
+# Optional VIM service WSDL Location e.g http://<server>/vimService.wsdl.
+# Optional over-ride to default location for bug work-arounds. (string value)
+#vmware_wsdl_location = <None>
+
+# Number of times VMware vCenter server API must be retried upon connection
+# related issues. (integer value)
+#vmware_api_retry_count = 10
+
+# The interval (in seconds) for polling remote tasks invoked on VMware vCenter
+# server. (floating point value)
+#vmware_task_poll_interval = 2.0
+
+# Name of the vCenter inventory folder that will contain Cinder volumes. This
+# folder will be created under "OpenStack/<project_folder>", where
+# project_folder is of format "Project (<volume_project_id>)". (string value)
+#vmware_volume_folder = Volumes
+
+# Timeout in seconds for VMDK volume transfer between Cinder and Glance.
+# (integer value)
+#vmware_image_transfer_timeout_secs = 7200
+
+# Max number of objects to be retrieved per batch. Query results will be
+# obtained in batches from the server and not in one shot. Server may still
+# limit the count to something less than the configured value. (integer value)
+#vmware_max_objects_retrieval = 100
+
+# Optional string specifying the VMware vCenter server version. The driver
+# attempts to retrieve the version from VMware vCenter server. Set this
+# configuration only if you want to override the vCenter server version.
+# (string value)
+#vmware_host_version = <None>
+
+# Directory where virtual disks are stored during volume backup and restore.
+# (string value)
+#vmware_tmp_dir = /tmp
+
+# CA bundle file to use in verifying the vCenter server certificate. (string
+# value)
+#vmware_ca_file = <None>
+
+# If true, the vCenter server certificate is not verified. If false, then the
+# default CA truststore is used for verification. This option is ignored if
+# "vmware_ca_file" is set. (boolean value)
+#vmware_insecure = false
+
+# Name of a vCenter compute cluster where volumes should be created. (multi
+# valued)
+#vmware_cluster_name =
+
+# Names of storage profiles to be monitored. Only used when
+# vmware_enable_volume_stats is True. (multi valued)
+#vmware_storage_profile =
+
+# Maximum number of connections in http connection pool. (integer value)
+#vmware_connection_pool_size = 10
+
+# Default adapter type to be used for attaching volumes. (string value)
+# Possible values:
+# lsiLogic - <No description provided>
+# busLogic - <No description provided>
+# lsiLogicsas - <No description provided>
+# paraVirtual - <No description provided>
+# ide - <No description provided>
+#vmware_adapter_type = lsiLogic
+
+# Volume snapshot format in vCenter server. (string value)
+# Possible values:
+# template - <No description provided>
+# COW - <No description provided>
+#vmware_snapshot_format = template
+
+# If true, the backend volume in vCenter server is created lazily when the
+# volume is created without any source. The backend volume is created when the
+# volume is attached, uploaded to image service or during backup. (boolean
+# value)
+#vmware_lazy_create = true
+
+# Regular expression pattern to match the name of datastores where backend
+# volumes are created. (string value)
+#vmware_datastore_regex = <None>
+
+# If true, this enables the fetching of the volume stats from the backend.
+# This has potential performance issues at scale.  When False, the driver will
+# not collect ANY stats about the backend. (boolean value)
+#vmware_enable_volume_stats = false
+
+# File with the list of available vzstorage shares. (string value)
+#vzstorage_shares_config = /etc/cinder/vzstorage_shares
+
+# Create volumes as sparsed files which take no space rather than regular files
+# when using raw format, in which case volume creation takes lot of time.
+# (boolean value)
+#vzstorage_sparsed_volumes = true
+
+# Percent of ACTUAL usage of the underlying volume before no new volumes can be
+# allocated to the volume destination. (floating point value)
+#vzstorage_used_ratio = 0.95
+
+# Base dir containing mount points for vzstorage shares. (string value)
+#vzstorage_mount_point_base = $state_path/mnt
+
+# Mount options passed to the vzstorage client. See section of the pstorage-
+# mount man page for details. (list value)
+#vzstorage_mount_options = <None>
+
+# Default format that will be used when creating volumes if no volume format is
+# specified. (string value)
+#vzstorage_default_volume_format = raw
+
+# Path to store VHD backed volumes (string value)
+#windows_iscsi_lun_path = C:\iSCSIVirtualDisks
+
+# File with the list of available smbfs shares. (string value)
+#smbfs_shares_config = C:\OpenStack\smbfs_shares.txt
+
+# Default format that will be used when creating volumes if no volume format is
+# specified. (string value)
+# Possible values:
+# vhd - <No description provided>
+# vhdx - <No description provided>
+#smbfs_default_volume_format = vhd
+
+# Base dir containing mount points for smbfs shares. (string value)
+#smbfs_mount_point_base = C:\OpenStack\_mnt
+
+# Mappings between share locations and pool names. If not specified, the share
+# names will be used as pool names. Example:
+# //addr/share:pool_name,//addr/share2:pool_name2 (dict value)
+#smbfs_pool_mappings =
+
+# storage pool name (string value)
+#pool_name =
+
+# Port to use to access the Tatlin API (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#api_port = 443
+
+# Ports to export Tatlin resource through (string value)
+#export_ports =
+
+# Tatlin host group name (string value)
+#host_group =
+
+# Max resource count allowed for Tatlin (integer value)
+#max_resource_count = 500
+
+# Max resource count allowed for single pool (integer value)
+#pool_max_resource_count = 250
+
+# Number of retry on Tatlin API (integer value)
+#tat_api_retry_count = 10
+
+# Authentication method for iSCSI (CHAP) (string value)
+#auth_method = CHAP
+
+# LBA Format for new volume (string value)
+#lba_format = 512e
+
+# Number of checks for a lengthy operation to finish (integer value)
+#wait_retry_count = 15
+
+# Wait number of seconds before re-checking (integer value)
+#wait_interval = 30
+
+# VPSA - Management Host name or IP address (host address value)
+#zadara_vpsa_host = <None>
+
+# VPSA - Port number (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#zadara_vpsa_port = <None>
+
+# VPSA - Use SSL connection (boolean value)
+#zadara_vpsa_use_ssl = false
+
+# If set to True the http client will validate the SSL certificate of the VPSA
+# endpoint. (boolean value)
+#zadara_ssl_cert_verify = true
+
+# VPSA access key (string value)
+#zadara_access_key = <None>
+
+# VPSA - Storage Pool assigned for volumes (string value)
+#zadara_vpsa_poolname = <None>
+
+# VPSA - Default encryption policy for volumes. If the option is neither
+# configured nor provided as metadata, the VPSA will inherit the default value.
+# (boolean value)
+#zadara_vol_encrypt = false
+
+# VPSA - Enable deduplication for volumes. If the option is neither configured
+# nor provided as metadata, the VPSA will inherit the default value. (boolean
+# value)
+#zadara_gen3_vol_dedupe = false
+
+# VPSA - Enable compression for volumes. If the option is neither configured
+# nor provided as metadata, the VPSA will inherit the default value. (boolean
+# value)
+#zadara_gen3_vol_compress = false
+
+# VPSA - Attach snapshot policy for volumes. If the option is neither
+# configured nor provided as metadata, the VPSA will inherit the default value.
+# (boolean value)
+#zadara_default_snap_policy = false
+
+# Driver to use for volume creation (string value)
+#volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver
+
+# User defined capabilities, a JSON formatted string specifying key/value
+# pairs. The key/value pairs can be used by the CapabilitiesFilter to select
+# between backends when requests specify volume types. For example, specifying
+# a service level or the geographical location of a backend, then creating a
+# volume type to allow the user to select by these different properties.
+# (string value)
+#extra_capabilities = {}
+
+# Suppress requests library SSL certificate warnings. (boolean value)
+#suppress_requests_ssl_warnings = false
+
+# Size of the native threads pool for the backend.  Increase for backends that
+# heavily rely on this, like the RBD driver. (integer value)
+# Minimum value: 20
+#backend_native_threads_pool_size = 20
+
+# The NVMe target remote configuration IP address. (string value)
+#spdk_rpc_ip = <None>
+
+# The NVMe target remote configuration port. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#spdk_rpc_port = 8000
+
+# The NVMe target remote configuration username. (string value)
+#spdk_rpc_username = <None>
+
+# The NVMe target remote configuration password. (string value)
+#spdk_rpc_password = <None>
+
+# Protocol to be used with SPDK RPC proxy (string value)
+# Possible values:
+# http - <No description provided>
+# https - <No description provided>
+#spdk_rpc_protocol = http
+
+# Queue depth for rdma transport. (integer value)
+# Minimum value: 1
+# Maximum value: 128
+#spdk_max_queue_depth = 64
+
+
+[barbican]
+
+#
+# From castellan.config
+#
+
+# Use this endpoint to connect to Barbican, for example:
+# "http://localhost:9311/" (string value)
+#barbican_endpoint = <None>
+
+# Version of the Barbican API, for example: "v1" (string value)
+#barbican_api_version = <None>
+
+# Use this endpoint to connect to Keystone (string value)
+# Deprecated group/name - [key_manager]/auth_url
+#auth_endpoint = http://localhost/identity/v3
+
+# Number of seconds to wait before retrying poll for key creation completion
+# (integer value)
+#retry_delay = 1
+
+# Number of times to retry poll for key creation completion (integer value)
+#number_of_retries = 60
+
+# Specifies if insecure TLS (https) requests. If False, the server's
+# certificate will not be validated, if True, we can set the verify_ssl_path
+# config meanwhile. (boolean value)
+#verify_ssl = true
+
+# A path to a bundle or CA certs to check against, or None for requests to
+# attempt to locate and use certificates which verify_ssh is True. If
+# verify_ssl is False, this is ignored. (string value)
+#verify_ssl_path = <None>
+
+# Specifies the type of endpoint.  Allowed values are: public, private, and
+# admin (string value)
+# Possible values:
+# public - <No description provided>
+# internal - <No description provided>
+# admin - <No description provided>
+#barbican_endpoint_type = public
+
+# Specifies the region of the chosen endpoint. (string value)
+#barbican_region_name = <None>
+
+#
+# When True, if sending a user token to a REST API, also send a service token.
+#
+# Nova often reuses the user token provided to the nova-api to talk to other
+# REST
+# APIs, such as Cinder, Glance and Neutron. It is possible that while the user
+# token was valid when the request was made to Nova, the token may expire
+# before
+# it reaches the other service. To avoid any failures, and to make it clear it
+# is
+# Nova calling the service on the user's behalf, we include a service token
+# along
+# with the user token. Should the user's token have expired, a valid service
+# token ensures the REST API request will still be accepted by the keystone
+# middleware.
+#  (boolean value)
+#send_service_user_token = false
+
+
+[barbican_service_user]
+
+#
+# From castellan.config
+#
+
+# PEM encoded Certificate Authority to use when verifying HTTPs connections.
+# (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# Authentication type to load (string value)
+# Deprecated group/name - [barbican_service_user]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string value)
+#auth_section = <None>
+
+
+[brcd_fabric_example]
+
+#
+# From cinder
+#
+
+# South bound connector for the fabric. (string value)
+# Possible values:
+# SSH - <No description provided>
+# HTTP - <No description provided>
+# HTTPS - <No description provided>
+# REST_HTTP - <No description provided>
+# REST_HTTPS - <No description provided>
+#fc_southbound_protocol = REST_HTTP
+
+# Management IP of fabric. (string value)
+#fc_fabric_address =
+
+# Fabric user ID. (string value)
+#fc_fabric_user =
+
+# Password for user. (string value)
+#fc_fabric_password =
+
+# Connecting port (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#fc_fabric_port = 22
+
+# Local SSH certificate Path. (string value)
+#fc_fabric_ssh_cert_path =
+
+# Overridden zoning policy. (string value)
+#zoning_policy = initiator-target
+
+# Overridden zoning activation state. (boolean value)
+#zone_activate = true
+
+# Overridden zone name prefix. (string value)
+#zone_name_prefix = openstack
+
+# Virtual Fabric ID. (string value)
+#fc_virtual_fabric_id = <None>
+
+
+[cisco_fabric_example]
+
+#
+# From cinder
+#
+
+# Management IP of fabric (string value)
+#cisco_fc_fabric_address =
+
+# Fabric user ID (string value)
+#cisco_fc_fabric_user =
+
+# Password for user (string value)
+#cisco_fc_fabric_password =
+
+# Connecting port (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#cisco_fc_fabric_port = 22
+
+# overridden zoning policy (string value)
+#cisco_zoning_policy = initiator-target
+
+# overridden zoning activation state (boolean value)
+#cisco_zone_activate = true
+
+# overridden zone name prefix (string value)
+#cisco_zone_name_prefix = <None>
+
+# VSAN of the Fabric (string value)
+#cisco_zoning_vsan = <None>
+
+
+[coordination]
+
+#
+# From cinder
+#
+
+# The backend URL to use for distributed coordination. (string value)
+#backend_url = file://$state_path
+
+
+[cors]
+
+#
+# From oslo.middleware
+#
+
+# Indicate whether this resource may be shared with the domain received in the
+# requests "origin" header. Format: "<protocol>://<host>[:<port>]", no trailing
+# slash. Example: https://horizon.example.com (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to HTTP Simple
+# Headers. (list value)
+#expose_headers = X-Auth-Token,X-Subject-Token,X-Service-Token,X-OpenStack-Request-ID,OpenStack-API-Version
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list value)
+#allow_methods = GET,PUT,POST,DELETE,PATCH,HEAD
+
+# Indicate which header field names may be used during the actual request.
+# (list value)
+#allow_headers = X-Auth-Token,X-Identity-Status,X-Roles,X-Service-Catalog,X-User-Id,X-Tenant-Id,X-OpenStack-Request-ID,X-Trace-Info,X-Trace-HMAC,OpenStack-API-Version
+
+
+[database]
+
+#
+# From oslo.db
+#
+
+# If True, SQLite uses synchronous mode. (boolean value)
+#sqlite_synchronous = true
+
+# The back end to use for the database. (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend = sqlalchemy
+
+# The SQLAlchemy connection string to use to connect to the database. (string
+# value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+#connection = <None>
+
+# The SQLAlchemy connection string to use to connect to the slave database.
+# (string value)
+#slave_connection = <None>
+
+# The SQL mode to be used for MySQL sessions. This option, including the
+# default, overrides any server-set SQL mode. To use whatever SQL mode is set
+# by the server configuration, set this to no value. Example: mysql_sql_mode=
+# (string value)
+#mysql_sql_mode = TRADITIONAL
+
+# For Galera only, configure wsrep_sync_wait causality checks on new
+# connections.  Default is None, meaning don't configure any setting. (integer
+# value)
+#mysql_wsrep_sync_wait = <None>
+
+# DEPRECATED: If True, transparently enables support for handling MySQL Cluster
+# (NDB). (boolean value)
+# This option is deprecated for removal since 12.1.0.
+# Its value may be silently ignored in the future.
+# Reason: Support for the MySQL NDB Cluster storage engine has been deprecated
+# and will be removed in a future release.
+#mysql_enable_ndb = false
+
+# Connections which have been present in the connection pool longer than this
+# number of seconds will be replaced with a new one the next time they are
+# checked out from the pool. (integer value)
+#connection_recycle_time = 3600
+
+# Maximum number of SQL connections to keep open in a pool. Setting a value of
+# 0 indicates no limit. (integer value)
+#max_pool_size = 5
+
+# Maximum number of database connection retries during startup. Set to -1 to
+# specify an infinite retry count. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries = 10
+
+# Interval between retries of opening a SQL connection. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval = 10
+
+# If set, use this value for max_overflow with SQLAlchemy. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow = 50
+
+# Verbosity of SQL debugging information: 0=None, 100=Everything. (integer
+# value)
+# Minimum value: 0
+# Maximum value: 100
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug = 0
+
+# Add Python stack traces to SQL as comment strings. (boolean value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace = false
+
+# If set, use this value for pool_timeout with SQLAlchemy. (integer value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout = <None>
+
+# Enable the experimental use of database reconnect on connection lost.
+# (boolean value)
+#use_db_reconnect = false
+
+# Seconds between retries of a database transaction. (integer value)
+#db_retry_interval = 1
+
+# If True, increases the interval between retries of a database operation up to
+# db_max_retry_interval. (boolean value)
+#db_inc_retry_interval = true
+
+# If db_inc_retry_interval is set, the maximum seconds between retries of a
+# database operation. (integer value)
+#db_max_retry_interval = 10
+
+# Maximum retries in case of connection error or deadlock error before error is
+# raised. Set to -1 to specify an infinite retry count. (integer value)
+#db_max_retries = 20
+
+# Optional URL parameters to append onto the connection URL at connect time;
+# specify as param1=value1&param2=value2&... (string value)
+#connection_parameters =
+
+
+[fc-zone-manager]
+
+#
+# From cinder
+#
+
+# South bound connector for zoning operation (string value)
+#brcd_sb_connector = HTTP
+
+# Southbound connector for zoning operation (string value)
+#cisco_sb_connector = cinder.zonemanager.drivers.cisco.cisco_fc_zone_client_cli.CiscoFCZoneClientCLI
+
+# FC Zone Driver responsible for zone management (string value)
+#zone_driver = cinder.zonemanager.drivers.brocade.brcd_fc_zone_driver.BrcdFCZoneDriver
+
+# Zoning policy configured by user; valid values include "initiator-target" or
+# "initiator" (string value)
+#zoning_policy = initiator-target
+
+# Comma separated list of Fibre Channel fabric names. This list of names is
+# used to retrieve other SAN credentials for connecting to each SAN fabric
+# (string value)
+#fc_fabric_names = <None>
+
+# FC SAN Lookup Service (string value)
+#fc_san_lookup_service = cinder.zonemanager.drivers.brocade.brcd_fc_san_lookup_service.BrcdFCSanLookupService
+
+# Set this to True when you want to allow an unsupported zone manager driver to
+# start.  Drivers that haven't maintained a working CI system and testing are
+# marked as unsupported until CI is working again.  This also marks a driver as
+# deprecated and may be removed in the next release. (boolean value)
+#enable_unsupported_driver = false
+
+
+[healthcheck]
+
+#
+# From oslo.middleware
+#
+
+# DEPRECATED: The path to respond to healtcheck requests on. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#path = /healthcheck
+
+# Show more detailed information as part of the response. Security note:
+# Enabling this option may expose sensitive details about the service being
+# monitored. Be sure to verify that it will not violate your security policies.
+# (boolean value)
+#detailed = false
+
+# Additional backends that can perform health checks and report that
+# information back as part of a request. (list value)
+#backends =
+
+# Check the presence of a file to determine if an application is running on a
+# port. Used by DisableByFileHealthcheck plugin. (string value)
+#disable_by_file_path = <None>
+
+# Check the presence of a file based on a port to determine if an application
+# is running on a port. Expects a "port:path" list of strings. Used by
+# DisableByFilesPortsHealthcheck plugin. (list value)
+#disable_by_file_paths =
+
+
+[key_manager]
+
+#
+# From castellan.config
+#
+
+# Specify the key manager implementation. Options are "barbican" and "vault".
+# Default is  "barbican". Will support the  values earlier set using
+# [key_manager]/api_class for some time. (string value)
+# Deprecated group/name - [key_manager]/api_class
+#backend = barbican
+
+# The type of authentication credential to create. Possible values are 'token',
+# 'password', 'keystone_token', and 'keystone_password'. Required if no context
+# is passed to the credential factory. (string value)
+#auth_type = <None>
+
+# Token for authentication. Required for 'token' and 'keystone_token' auth_type
+# if no context is passed to the credential factory. (string value)
+#token = <None>
+
+# Username for authentication. Required for 'password' auth_type. Optional for
+# the 'keystone_password' auth_type. (string value)
+#username = <None>
+
+# Password for authentication. Required for 'password' and 'keystone_password'
+# auth_type. (string value)
+#password = <None>
+
+# Use this endpoint to connect to Keystone. (string value)
+#auth_url = <None>
+
+# User ID for authentication. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#user_id = <None>
+
+# User's domain ID for authentication. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#user_domain_id = <None>
+
+# User's domain name for authentication. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#user_domain_name = <None>
+
+# Trust ID for trust scoping. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#trust_id = <None>
+
+# Domain ID for domain scoping. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#domain_id = <None>
+
+# Domain name for domain scoping. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#domain_name = <None>
+
+# Project ID for project scoping. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#project_id = <None>
+
+# Project name for project scoping. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#project_name = <None>
+
+# Project's domain ID for project. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#project_domain_id = <None>
+
+# Project's domain name for project. Optional for 'keystone_token' and
+# 'keystone_password' auth_type. (string value)
+#project_domain_name = <None>
+
+# Allow fetching a new token if the current one is going to expire. Optional
+# for 'keystone_token' and 'keystone_password' auth_type. (boolean value)
+#reauthenticate = true
+
+#
+# From cinder
+#
+
+# Fixed key returned by key manager, specified in hex (string value)
+#fixed_key = <None>
+
+
+[keystone_authtoken]
+
+#
+# From keystonemiddleware.auth_token
+#
+
+# Complete "public" Identity API endpoint. This endpoint should not be an
+# "admin" endpoint, as it should be accessible by all end users.
+# Unauthenticated clients are redirected to this endpoint to authenticate.
+# Although this endpoint should ideally be unversioned, client support in the
+# wild varies. If you're using a versioned v2 endpoint here, then this should
+# *not* be the same endpoint the service user utilizes for validating tokens,
+# because normal end users may not be able to reach that endpoint. (string
+# value)
+# Deprecated group/name - [keystone_authtoken]/auth_uri
+#www_authenticate_uri = <None>
+
+# DEPRECATED: Complete "public" Identity API endpoint. This endpoint should not
+# be an "admin" endpoint, as it should be accessible by all end users.
+# Unauthenticated clients are redirected to this endpoint to authenticate.
+# Although this endpoint should ideally be unversioned, client support in the
+# wild varies. If you're using a versioned v2 endpoint here, then this should
+# *not* be the same endpoint the service user utilizes for validating tokens,
+# because normal end users may not be able to reach that endpoint. This option
+# is deprecated in favor of www_authenticate_uri and will be removed in the S
+# release. (string value)
+# This option is deprecated for removal since Queens.
+# Its value may be silently ignored in the future.
+# Reason: The auth_uri option is deprecated in favor of www_authenticate_uri
+# and will be removed in the S  release.
+#auth_uri = <None>
+
+# API version of the Identity API endpoint. (string value)
+#auth_version = <None>
+
+# Interface to use for the Identity API endpoint. Valid values are "public",
+# "internal" (default) or "admin". (string value)
+#interface = internal
+
+# Do not handle authorization requests within the middleware, but delegate the
+# authorization decision to downstream WSGI components. (boolean value)
+#delay_auth_decision = false
+
+# Request timeout value for communicating with Identity API server. (integer
+# value)
+#http_connect_timeout = <None>
+
+# How many times are we trying to reconnect when communicating with Identity
+# API Server. (integer value)
+#http_request_max_retries = 3
+
+# Request environment key where the Swift cache object is stored. When
+# auth_token middleware is deployed with a Swift cache, use this option to have
+# the middleware share a caching backend with swift. Otherwise, use the
+# ``memcached_servers`` option instead. (string value)
+#cache = <None>
+
+# Required if identity server requires client certificate (string value)
+#certfile = <None>
+
+# Required if identity server requires client certificate (string value)
+#keyfile = <None>
+
+# A PEM encoded Certificate Authority to use when verifying HTTPs connections.
+# Defaults to system CAs. (string value)
+#cafile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# The region in which the identity server can be found. (string value)
+#region_name = <None>
+
+# Optionally specify a list of memcached server(s) to use for caching. If left
+# undefined, tokens will instead be cached in-process. (list value)
+# Deprecated group/name - [keystone_authtoken]/memcache_servers
+#memcached_servers = <None>
+
+# In order to prevent excessive effort spent validating tokens, the middleware
+# caches previously-seen tokens for a configurable duration (in seconds). Set
+# to -1 to disable caching completely. (integer value)
+#token_cache_time = 300
+
+# (Optional) If defined, indicate whether token data should be authenticated or
+# authenticated and encrypted. If MAC, token data is authenticated (with HMAC)
+# in the cache. If ENCRYPT, token data is encrypted and authenticated in the
+# cache. If the value is not one of these options or empty, auth_token will
+# raise an exception on initialization. (string value)
+# Possible values:
+# None - <No description provided>
+# MAC - <No description provided>
+# ENCRYPT - <No description provided>
+#memcache_security_strategy = None
+
+# (Optional, mandatory if memcache_security_strategy is defined) This string is
+# used for key derivation. (string value)
+#memcache_secret_key = <None>
+
+# (Optional) Number of seconds memcached server is considered dead before it is
+# tried again. (integer value)
+#memcache_pool_dead_retry = 300
+
+# (Optional) Maximum total number of open connections to every memcached
+# server. (integer value)
+#memcache_pool_maxsize = 10
+
+# (Optional) Socket timeout in seconds for communicating with a memcached
+# server. (integer value)
+#memcache_pool_socket_timeout = 3
+
+# (Optional) Number of seconds a connection to memcached is held unused in the
+# pool before it is closed. (integer value)
+#memcache_pool_unused_timeout = 60
+
+# (Optional) Number of seconds that an operation will wait to get a memcached
+# client connection from the pool. (integer value)
+#memcache_pool_conn_get_timeout = 10
+
+# (Optional) Use the advanced (eventlet safe) memcached client pool. (boolean
+# value)
+#memcache_use_advanced_pool = true
+
+# (Optional) Indicate whether to set the X-Service-Catalog header. If False,
+# middleware will not ask for service catalog on token validation and will not
+# set the X-Service-Catalog header. (boolean value)
+#include_service_catalog = true
+
+# Used to control the use and type of token binding. Can be set to: "disabled"
+# to not check token binding. "permissive" (default) to validate binding
+# information if the bind type is of a form known to the server and ignore it
+# if not. "strict" like "permissive" but if the bind type is unknown the token
+# will be rejected. "required" any form of token binding is needed to be
+# allowed. Finally the name of a binding method that must be present in tokens.
+# (string value)
+#enforce_token_bind = permissive
+
+# A choice of roles that must be present in a service token. Service tokens are
+# allowed to request that an expired token can be used and so this check should
+# tightly control that only actual services should be sending this token. Roles
+# here are applied as an ANY check so any role in this list must be present.
+# For backwards compatibility reasons this currently only affects the
+# allow_expired check. (list value)
+#service_token_roles = service
+
+# For backwards compatibility reasons we must let valid service tokens pass
+# that don't pass the service_token_roles check as valid. Setting this true
+# will become the default in a future release and should be enabled if
+# possible. (boolean value)
+#service_token_roles_required = false
+
+# The name or type of the service as it appears in the service catalog. This is
+# used to validate tokens that have restricted access rules. (string value)
+#service_type = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [keystone_authtoken]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string value)
+#auth_section = <None>
+
+
+[nova]
+
+#
+# From cinder
+#
+
+# Name of nova region to use. Useful if keystone manages more than one region.
+# (string value)
+#region_name = <None>
+
+# Type of the nova endpoint to use.  This endpoint will be looked up in the
+# keystone catalog and should be one of public, internal or admin. (string
+# value)
+# Possible values:
+# public - <No description provided>
+# admin - <No description provided>
+# internal - <No description provided>
+#interface = public
+
+# The authentication URL for the nova connection when using the current users
+# token (string value)
+#token_auth_url = <None>
+
+# PEM encoded Certificate Authority to use when verifying HTTPs connections.
+# (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# Authentication type to load (string value)
+# Deprecated group/name - [nova]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string value)
+#auth_section = <None>
+
+
+[os_brick]
+
+#
+# From os_brick
+#
+
+# Directory to use for os-brick lock files. Defaults to
+# oslo_concurrency.lock_path which is a sensible default for compute nodes, but
+# not for HCI deployments or controllers where Glance uses Cinder as a backend,
+# as locks should use the same directory. (string value)
+#lock_path = <None>
+
+# Number of attempts for the multipath device to be ready for I/O after it was
+# created. Readiness is checked with ``multipath -C``. See related
+# ``wait_mpath_device_interval`` config option. Default value is 4. (integer
+# value)
+# Minimum value: 1
+#wait_mpath_device_attempts = 4
+
+# Interval value to wait for multipath device to be ready for I/O. Max number
+# of attempts is set in ``wait_mpath_device_attempts``. Time in seconds to wait
+# for each retry is ``base ^ attempt * interval``, so for 4 attempts (1 attempt
+# 3 retries) and 1 second interval will yield: 2, 4 and 8 seconds. Note that
+# there is no wait before first attempt. Default value is 1. (integer value)
+# Minimum value: 1
+#wait_mpath_device_interval = 1
+
+
+[oslo_concurrency]
+
+#
+# From oslo.concurrency
+#
+
+# Enables or disables inter-process locks. (boolean value)
+#disable_process_locking = false
+
+# Directory to use for lock files.  For security, the specified directory
+# should only be writable by the user running the processes that need locking.
+# Defaults to environment variable OSLO_LOCK_PATH. If external locks are used,
+# a lock path must be set. (string value)
+#lock_path = <None>
+
+
+[oslo_messaging_amqp]
+
+#
+# From oslo.messaging
+#
+
+# Name for the AMQP container. must be globally unique. Defaults to a generated
+# UUID (string value)
+#container_name = <None>
+
+# Timeout for inactive connections (in seconds) (integer value)
+#idle_timeout = 0
+
+# Debug: dump AMQP frames to stdout (boolean value)
+#trace = false
+
+# Attempt to connect via SSL. If no other ssl-related parameters are given, it
+# will use the system's CA-bundle to verify the server's certificate. (boolean
+# value)
+#ssl = false
+
+# CA certificate PEM file used to verify the server's certificate (string
+# value)
+#ssl_ca_file =
+
+# Self-identifying certificate PEM file for client authentication (string
+# value)
+#ssl_cert_file =
+
+# Private key PEM file used to sign ssl_cert_file certificate (optional)
+# (string value)
+#ssl_key_file =
+
+# Password for decrypting ssl_key_file (if encrypted) (string value)
+#ssl_key_password = <None>
+
+# By default SSL checks that the name in the server's certificate matches the
+# hostname in the transport_url. In some configurations it may be preferable to
+# use the virtual hostname instead, for example if the server uses the Server
+# Name Indication TLS extension (rfc6066) to provide a certificate per virtual
+# host. Set ssl_verify_vhost to True if the server's SSL certificate uses the
+# virtual host name instead of the DNS name. (boolean value)
+#ssl_verify_vhost = false
+
+# Space separated list of acceptable SASL mechanisms (string value)
+#sasl_mechanisms =
+
+# Path to directory that contains the SASL configuration (string value)
+#sasl_config_dir =
+
+# Name of configuration file (without .conf suffix) (string value)
+#sasl_config_name =
+
+# SASL realm to use if no realm present in username (string value)
+#sasl_default_realm =
+
+# Seconds to pause before attempting to re-connect. (integer value)
+# Minimum value: 1
+#connection_retry_interval = 1
+
+# Increase the connection_retry_interval by this many seconds after each
+# unsuccessful failover attempt. (integer value)
+# Minimum value: 0
+#connection_retry_backoff = 2
+
+# Maximum limit for connection_retry_interval + connection_retry_backoff
+# (integer value)
+# Minimum value: 1
+#connection_retry_interval_max = 30
+
+# Time to pause between re-connecting an AMQP 1.0 link that failed due to a
+# recoverable error. (integer value)
+# Minimum value: 1
+#link_retry_delay = 10
+
+# The maximum number of attempts to re-send a reply message which failed due to
+# a recoverable error. (integer value)
+# Minimum value: -1
+#default_reply_retry = 0
+
+# The deadline for an rpc reply message delivery. (integer value)
+# Minimum value: 5
+#default_reply_timeout = 30
+
+# The deadline for an rpc cast or call message delivery. Only used when caller
+# does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_send_timeout = 30
+
+# The deadline for a sent notification message delivery. Only used when caller
+# does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_notify_timeout = 30
+
+# The duration to schedule a purge of idle sender links. Detach link after
+# expiry. (integer value)
+# Minimum value: 1
+#default_sender_link_timeout = 600
+
+# Indicates the addressing mode used by the driver.
+# Permitted values:
+# 'legacy'   - use legacy non-routable addressing
+# 'routable' - use routable addresses
+# 'dynamic'  - use legacy addresses if the message bus does not support routing
+# otherwise use routable addressing (string value)
+#addressing_mode = dynamic
+
+# Enable virtual host support for those message buses that do not natively
+# support virtual hosting (such as qpidd). When set to true the virtual host
+# name will be added to all message bus addresses, effectively creating a
+# private 'subnet' per virtual host. Set to False if the message bus supports
+# virtual hosting using the 'hostname' field in the AMQP 1.0 Open performative
+# as the name of the virtual host. (boolean value)
+#pseudo_vhost = true
+
+# address prefix used when sending to a specific server (string value)
+#server_request_prefix = exclusive
+
+# address prefix used when broadcasting to all servers (string value)
+#broadcast_prefix = broadcast
+
+# address prefix when sending to any server in group (string value)
+#group_request_prefix = unicast
+
+# Address prefix for all generated RPC addresses (string value)
+#rpc_address_prefix = openstack.org/om/rpc
+
+# Address prefix for all generated Notification addresses (string value)
+#notify_address_prefix = openstack.org/om/notify
+
+# Appended to the address prefix when sending a fanout message. Used by the
+# message bus to identify fanout messages. (string value)
+#multicast_address = multicast
+
+# Appended to the address prefix when sending to a particular RPC/Notification
+# server. Used by the message bus to identify messages sent to a single
+# destination. (string value)
+#unicast_address = unicast
+
+# Appended to the address prefix when sending to a group of consumers. Used by
+# the message bus to identify messages that should be delivered in a round-
+# robin fashion across consumers. (string value)
+#anycast_address = anycast
+
+# Exchange name used in notification addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_notification_exchange if set
+# else control_exchange if set
+# else 'notify' (string value)
+#default_notification_exchange = <None>
+
+# Exchange name used in RPC addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_rpc_exchange if set
+# else control_exchange if set
+# else 'rpc' (string value)
+#default_rpc_exchange = <None>
+
+# Window size for incoming RPC Reply messages. (integer value)
+# Minimum value: 1
+#reply_link_credit = 200
+
+# Window size for incoming RPC Request messages (integer value)
+# Minimum value: 1
+#rpc_server_credit = 100
+
+# Window size for incoming Notification messages (integer value)
+# Minimum value: 1
+#notify_server_credit = 100
+
+# Send messages of this type pre-settled.
+# Pre-settled messages will not receive acknowledgement
+# from the peer. Note well: pre-settled messages may be
+# silently discarded if the delivery fails.
+# Permitted values:
+# 'rpc-call' - send RPC Calls pre-settled
+# 'rpc-reply'- send RPC Replies pre-settled
+# 'rpc-cast' - Send RPC Casts pre-settled
+# 'notify'   - Send Notifications pre-settled
+#  (multi valued)
+#pre_settled = rpc-cast
+#pre_settled = rpc-reply
+
+
+[oslo_messaging_kafka]
+
+#
+# From oslo.messaging
+#
+
+# Max fetch bytes of Kafka consumer (integer value)
+#kafka_max_fetch_bytes = 1048576
+
+# Default timeout(s) for Kafka consumers (floating point value)
+#kafka_consumer_timeout = 1.0
+
+# DEPRECATED: Pool Size for Kafka Consumers (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#pool_size = 10
+
+# DEPRECATED: The pool size limit for connections expiration policy (integer
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_min_size = 2
+
+# DEPRECATED: The time-to-live in sec of idle connections in the pool (integer
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_ttl = 1200
+
+# Group id for Kafka consumer. Consumers in one group will coordinate message
+# consumption (string value)
+#consumer_group = oslo_messaging_consumer
+
+# Upper bound on the delay for KafkaProducer batching in seconds (floating
+# point value)
+#producer_batch_timeout = 0.0
+
+# Size of batch for the producer async send (integer value)
+#producer_batch_size = 16384
+
+# The compression codec for all data generated by the producer. If not set,
+# compression will not be used. Note that the allowed values of this depend on
+# the kafka version (string value)
+# Possible values:
+# none - <No description provided>
+# gzip - <No description provided>
+# snappy - <No description provided>
+# lz4 - <No description provided>
+# zstd - <No description provided>
+#compression_codec = none
+
+# Enable asynchronous consumer commits (boolean value)
+#enable_auto_commit = false
+
+# The maximum number of records returned in a poll call (integer value)
+#max_poll_records = 500
+
+# Protocol used to communicate with brokers (string value)
+# Possible values:
+# PLAINTEXT - <No description provided>
+# SASL_PLAINTEXT - <No description provided>
+# SSL - <No description provided>
+# SASL_SSL - <No description provided>
+#security_protocol = PLAINTEXT
+
+# Mechanism when security protocol is SASL (string value)
+#sasl_mechanism = PLAIN
+
+# CA certificate PEM file used to verify the server certificate (string value)
+#ssl_cafile =
+
+# Client certificate PEM file used for authentication. (string value)
+#ssl_client_cert_file =
+
+# Client key PEM file used for authentication. (string value)
+#ssl_client_key_file =
+
+# Client key password file used for authentication. (string value)
+#ssl_client_key_password =
+
+
+[oslo_messaging_notifications]
+
+#
+# From oslo.messaging
+#
+
+# The Drivers(s) to handle sending notifications. Possible values are
+# messaging, messagingv2, routing, log, test, noop (multi valued)
+# Deprecated group/name - [DEFAULT]/notification_driver
+#driver =
+
+# A URL representing the messaging driver to use for notifications. If not set,
+# we fall back to the same configuration used for RPC. (string value)
+# Deprecated group/name - [DEFAULT]/notification_transport_url
+#transport_url = <None>
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+# Deprecated group/name - [DEFAULT]/notification_topics
+#topics = notifications
+
+# The maximum number of attempts to re-send a notification message which failed
+# to be delivered due to a recoverable error. 0 - No retry, -1 - indefinite
+# (integer value)
+#retry = -1
+
+
+[oslo_messaging_rabbit]
+
+#
+# From oslo.messaging
+#
+
+# Use durable queues in AMQP. If rabbit_quorum_queue is enabled, queues will be
+# durable and this value will be ignored. (boolean value)
+#amqp_durable_queues = false
+
+# Auto-delete queues in AMQP. (boolean value)
+#amqp_auto_delete = false
+
+# Connect over SSL. (boolean value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_use_ssl
+#ssl = false
+
+# SSL version to use (valid only if SSL enabled). Valid values are TLSv1 and
+# SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be available on some
+# distributions. (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_version
+#ssl_version =
+
+# SSL key file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_keyfile
+#ssl_key_file =
+
+# SSL cert file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_certfile
+#ssl_cert_file =
+
+# SSL certification authority file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_ca_certs
+#ssl_ca_file =
+
+# Global toggle for enforcing the OpenSSL FIPS mode. This feature requires
+# Python support. This is available in Python 3.9 in all environments and may
+# have been backported to older Python versions on select environments. If the
+# Python executable used does not support OpenSSL FIPS mode, an exception will
+# be raised. (boolean value)
+#ssl_enforce_fips_mode = false
+
+# Run the health check heartbeat thread through a native python thread by
+# default. If this option is equal to False then the health check heartbeat
+# will inherit the execution model from the parent process. For example if the
+# parent process has monkey patched the stdlib by using eventlet/greenlet then
+# the heartbeat will be run through a green thread. This option should be set
+# to True only for the wsgi services. (boolean value)
+#heartbeat_in_pthread = false
+
+# How long to wait (in seconds) before reconnecting in response to an AMQP
+# consumer cancel notification. (floating point value)
+# Minimum value: 0.0
+# Maximum value: 4.5
+#kombu_reconnect_delay = 1.0
+
+# EXPERIMENTAL: Possible values are: gzip, bz2. If not set compression will not
+# be used. This option may not be available in future versions. (string value)
+#kombu_compression = <None>
+
+# How long to wait a missing client before abandoning to send it its replies.
+# This value should not be longer than rpc_response_timeout. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_reconnect_timeout
+#kombu_missing_consumer_retry_timeout = 60
+
+# Determines how the next RabbitMQ node is chosen in case the one we are
+# currently connected to becomes unavailable. Takes effect only if more than
+# one RabbitMQ node is provided in config. (string value)
+# Possible values:
+# round-robin - <No description provided>
+# shuffle - <No description provided>
+#kombu_failover_strategy = round-robin
+
+# The RabbitMQ login method. (string value)
+# Possible values:
+# PLAIN - <No description provided>
+# AMQPLAIN - <No description provided>
+# EXTERNAL - <No description provided>
+# RABBIT-CR-DEMO - <No description provided>
+#rabbit_login_method = AMQPLAIN
+
+# How frequently to retry connecting with RabbitMQ. (integer value)
+#rabbit_retry_interval = 1
+
+# How long to backoff for between retries when connecting to RabbitMQ. (integer
+# value)
+#rabbit_retry_backoff = 2
+
+# Maximum interval of RabbitMQ connection retries. Default is 30 seconds.
+# (integer value)
+#rabbit_interval_max = 30
+
+# Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
+# option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring
+# is no longer controlled by the x-ha-policy argument when declaring a queue.
+# If you just want to make sure that all queues (except those with auto-
+# generated names) are mirrored across all nodes, run: "rabbitmqctl set_policy
+# HA '^(?!amq\.).*' '{"ha-mode": "all"}' " (boolean value)
+#rabbit_ha_queues = false
+
+# Use quorum queues in RabbitMQ (x-queue-type: quorum). The quorum queue is a
+# modern queue type for RabbitMQ implementing a durable, replicated FIFO queue
+# based on the Raft consensus algorithm. It is available as of RabbitMQ 3.8.0.
+# If set this option will conflict with the HA queues (``rabbit_ha_queues``)
+# aka mirrored queues, in other words the HA queues should be disabled, quorum
+# queues durable by default so the amqp_durable_queues opion is ignored when
+# this option enabled. (boolean value)
+#rabbit_quorum_queue = false
+
+# Each time a message is redelivered to a consumer, a counter is incremented.
+# Once the redelivery count exceeds the delivery limit the message gets dropped
+# or dead-lettered (if a DLX exchange has been configured) Used only when
+# rabbit_quorum_queue is enabled, Default 0 which means dont set a limit.
+# (integer value)
+#rabbit_quorum_delivery_limit = 0
+
+# By default all messages are maintained in memory if a quorum queue grows in
+# length it can put memory pressure on a cluster. This option can limit the
+# number of messages in the quorum queue. Used only when rabbit_quorum_queue is
+# enabled, Default 0 which means dont set a limit. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_length
+#rabbit_quorum_max_memory_length = 0
+
+# By default all messages are maintained in memory if a quorum queue grows in
+# length it can put memory pressure on a cluster. This option can limit the
+# number of memory bytes used by the quorum queue. Used only when
+# rabbit_quorum_queue is enabled, Default 0 which means dont set a limit.
+# (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_bytes
+#rabbit_quorum_max_memory_bytes = 0
+
+# Positive integer representing duration in seconds for queue TTL (x-expires).
+# Queues which are unused for the duration of the TTL are automatically
+# deleted. The parameter affects only reply and fanout queues. (integer value)
+# Minimum value: 1
+#rabbit_transient_queues_ttl = 1800
+
+# Specifies the number of messages to prefetch. Setting to zero allows
+# unlimited messages. (integer value)
+#rabbit_qos_prefetch_count = 0
+
+# Number of seconds after which the Rabbit broker is considered down if
+# heartbeat's keep-alive fails (0 disables heartbeat). (integer value)
+#heartbeat_timeout_threshold = 60
+
+# How often times during the heartbeat_timeout_threshold we check the
+# heartbeat. (integer value)
+#heartbeat_rate = 2
+
+# DEPRECATED: (DEPRECATED) Enable/Disable the RabbitMQ mandatory flag for
+# direct send. The direct send is used as reply, so the MessageUndeliverable
+# exception is raised in case the client queue does not
+# exist.MessageUndeliverable exception will be used to loop for a timeout to
+# lets a chance to sender to recover.This flag is deprecated and it will not be
+# possible to deactivate this functionality anymore (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Mandatory flag no longer deactivable.
+#direct_mandatory_flag = true
+
+# Enable x-cancel-on-ha-failover flag so that rabbitmq server will cancel and
+# notify consumerswhen queue is down (boolean value)
+#enable_cancel_on_failover = false
+
+
+[oslo_middleware]
+
+#
+# From oslo.middleware
+#
+
+# The maximum body size for each  request, in bytes. (integer value)
+# Deprecated group/name - [DEFAULT]/osapi_max_request_body_size
+# Deprecated group/name - [DEFAULT]/max_request_body_size
+#max_request_body_size = 114688
+
+# DEPRECATED: The HTTP Header that will be used to determine what the original
+# request protocol scheme was, even if it was hidden by a SSL termination
+# proxy. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#secure_proxy_ssl_header = X-Forwarded-Proto
+
+# Whether the application is behind a proxy or not. This determines if the
+# middleware should parse the headers or not. (boolean value)
+#enable_proxy_headers_parsing = false
+
+# HTTP basic auth password file. (string value)
+#http_basic_auth_user_file = /etc/htpasswd
+
+
+[oslo_policy]
+
+#
+# From oslo.policy
+#
+
+# This option controls whether or not to enforce scope when evaluating
+# policies. If ``True``, the scope of the token used in the request is compared
+# to the ``scope_types`` of the policy being enforced. If the scopes do not
+# match, an ``InvalidScope`` exception will be raised. If ``False``, a message
+# will be logged informing operators that policies are being invoked with
+# mismatching scope. (boolean value)
+#enforce_scope = false
+
+# This option controls whether or not to use old deprecated defaults when
+# evaluating policies. If ``True``, the old deprecated defaults are not going
+# to be evaluated. This means if any existing token is allowed for old defaults
+# but is disallowed for new defaults, it will be disallowed. It is encouraged
+# to enable this flag along with the ``enforce_scope`` flag so that you can get
+# the benefits of new defaults and ``scope_type`` together. If ``False``, the
+# deprecated policy check string is logically OR'd with the new policy check
+# string, allowing for a graceful upgrade experience between releases with new
+# policies, which is the default behavior. (boolean value)
+#enforce_new_defaults = false
+
+# The relative or absolute path of a file that maps roles to permissions for a
+# given service. Relative paths must be specified in relation to the
+# configuration file setting this option. (string value)
+#policy_file = policy.yaml
+
+# Default rule. Enforced when a requested rule is not found. (string value)
+#policy_default_rule = default
+
+# Directories where policy configuration files are stored. They can be relative
+# to any directory in the search path defined by the config_dir option, or
+# absolute paths. The file defined by policy_file must exist for these
+# directories to be searched.  Missing or empty directories are ignored. (multi
+# valued)
+#policy_dirs = policy.d
+
+# Content Type to send and receive data for REST based policy check (string
+# value)
+# Possible values:
+# application/x-www-form-urlencoded - <No description provided>
+# application/json - <No description provided>
+#remote_content_type = application/x-www-form-urlencoded
+
+# server identity verification for REST based policy check (boolean value)
+#remote_ssl_verify_server_crt = false
+
+# Absolute path to ca cert file for REST based policy check (string value)
+#remote_ssl_ca_crt_file = <None>
+
+# Absolute path to client cert for REST based policy check (string value)
+#remote_ssl_client_crt_file = <None>
+
+# Absolute path client key file REST based policy check (string value)
+#remote_ssl_client_key_file = <None>
+
+
+[oslo_reports]
+
+#
+# From oslo.reports
+#
+
+# Path to a log directory where to create a file (string value)
+#log_dir = <None>
+
+# The path to a file to watch for changes to trigger the reports, instead of
+# signals. Setting this option disables the signal trigger for the reports. If
+# application is running as a WSGI application it is recommended to use this
+# instead of signals. (string value)
+#file_event_handler = <None>
+
+# How many seconds to wait between polls when file_event_handler is set
+# (integer value)
+#file_event_handler_interval = 1
+
+
+[oslo_versionedobjects]
+
+#
+# From oslo.versionedobjects
+#
+
+# Make exception message format errors fatal (boolean value)
+#fatal_exception_format_errors = false
+
+
+[privsep]
+# Configuration options for the oslo.privsep daemon. Note that this group name
+# can be changed by the consuming service. Check the service's docs to see if
+# this is the case.
+
+#
+# From oslo.privsep
+#
+
+# User that the privsep daemon should run as. (string value)
+#user = <None>
+
+# Group that the privsep daemon should run as. (string value)
+#group = <None>
+
+# List of Linux capabilities retained by the privsep daemon. (list value)
+#capabilities =
+
+# The number of threads available for privsep to concurrently run processes.
+# Defaults to the number of CPU cores in the system. (integer value)
+# Minimum value: 1
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#thread_pool_size = multiprocessing.cpu_count()
+
+# Command to invoke to start the privsep daemon if not using the "fork" method.
+# If not specified, a default is generated using "sudo privsep-helper" and
+# arguments designed to recreate the current configuration. This command must
+# accept suitable --privsep_context and --privsep_sock_path arguments. (string
+# value)
+#helper_command = <None>
+
+# Logger name to use for this privsep context.  By default all contexts log
+# with oslo_privsep.daemon. (string value)
+#logger_name = oslo_privsep.daemon
+
+
+[profiler]
+
+#
+# From osprofiler
+#
+
+#
+# Enable the profiling for all services on this node.
+#
+# Default value is False (fully disable the profiling feature).
+#
+# Possible values:
+#
+# * True: Enables the feature
+# * False: Disables the feature. The profiling cannot be started via this
+# project
+#   operations. If the profiling is triggered by another project, this project
+#   part will be empty.
+#  (boolean value)
+# Deprecated group/name - [profiler]/profiler_enabled
+#enabled = false
+
+#
+# Enable SQL requests profiling in services.
+#
+# Default value is False (SQL requests won't be traced).
+#
+# Possible values:
+#
+# * True: Enables SQL requests profiling. Each SQL query will be part of the
+#   trace and can the be analyzed by how much time was spent for that.
+# * False: Disables SQL requests profiling. The spent time is only shown on a
+#   higher level of operations. Single SQL queries cannot be analyzed this way.
+#  (boolean value)
+#trace_sqlalchemy = false
+
+#
+# Secret key(s) to use for encrypting context data for performance profiling.
+#
+# This string value should have the following format:
+# <key1>[,<key2>,...<keyn>],
+# where each key is some random string. A user who triggers the profiling via
+# the REST API has to set one of these keys in the headers of the REST API call
+# to include profiling results of this node for this particular project.
+#
+# Both "enabled" flag and "hmac_keys" config options should be set to enable
+# profiling. Also, to generate correct profiling information across all
+# services
+# at least one key needs to be consistent between OpenStack projects. This
+# ensures it can be used from client side to generate the trace, containing
+# information from all possible resources.
+#  (string value)
+#hmac_keys = SECRET_KEY
+
+#
+# Connection string for a notifier backend.
+#
+# Default value is ``messaging://`` which sets the notifier to oslo_messaging.
+#
+# Examples of possible values:
+#
+# * ``messaging://`` - use oslo_messaging driver for sending spans.
+# * ``redis://127.0.0.1:6379`` - use redis driver for sending spans.
+# * ``mongodb://127.0.0.1:27017`` - use mongodb driver for sending spans.
+# * ``elasticsearch://127.0.0.1:9200`` - use elasticsearch driver for sending
+#   spans.
+# * ``jaeger://127.0.0.1:6831`` - use jaeger tracing as driver for sending
+# spans.
+#  (string value)
+#connection_string = messaging://
+
+#
+# Document type for notification indexing in elasticsearch.
+#  (string value)
+#es_doc_type = notification
+
+#
+# This parameter is a time value parameter (for example: es_scroll_time=2m),
+# indicating for how long the nodes that participate in the search will
+# maintain
+# relevant resources in order to continue and support it.
+#  (string value)
+#es_scroll_time = 2m
+
+#
+# Elasticsearch splits large requests in batches. This parameter defines
+# maximum size of each batch (for example: es_scroll_size=10000).
+#  (integer value)
+#es_scroll_size = 10000
+
+#
+# Redissentinel provides a timeout option on the connections.
+# This parameter defines that timeout (for example: socket_timeout=0.1).
+#  (floating point value)
+#socket_timeout = 0.1
+
+#
+# Redissentinel uses a service name to identify a master redis service.
+# This parameter defines the name (for example:
+# ``sentinal_service_name=mymaster``).
+#  (string value)
+#sentinel_service_name = mymaster
+
+#
+# Enable filter traces that contain error/exception to a separated place.
+#
+# Default value is set to False.
+#
+# Possible values:
+#
+# * True: Enable filter traces that contain error/exception.
+# * False: Disable the filter.
+#  (boolean value)
+#filter_error_trace = false
+
+
+[sample_castellan_source]
+# Example of using a castellan source
+#
+# castellan: A backend driver for configuration values served through
+# castellan.
+#
+# Required options:
+#   - config_file: The castellan configuration file.
+#
+#   - mapping_file: A configuration/castellan_id mapping file. This file
+#                   creates connections between configuration options and
+#                   castellan ids. The group and option name remains the
+#                   same, while the value gets stored a secret manager behind
+#                   castellan and is replaced by its castellan id. The ids
+#                   will be used to fetch the values through castellan.
+
+#
+# From oslo.config
+#
+
+# The name of the driver that can load this configuration source. (string
+# value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#driver = castellan
+
+# The path to a castellan configuration file. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#config_file = etc/castellan/castellan.conf
+
+# The path to a configuration/castellan_id mapping file. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#mapping_file = etc/castellan/secrets_mapping.conf
+
+
+[sample_remote_file_source]
+# Example of using a remote_file source
+#
+# remote_file: A backend driver for remote files served through http[s].
+#
+# Required options:
+#   - uri: URI containing the file location.
+#
+# Non-required options:
+#   - ca_path: The path to a CA_BUNDLE file or directory with
+#              certificates of trusted CAs.
+#
+#   - client_cert: Client side certificate, as a single file path
+#                  containing either the certificate only or the
+#                  private key and the certificate.
+#
+#   - client_key: Client side private key, in case client_cert is
+#                 specified but does not includes the private key.
+
+#
+# From oslo.config
+#
+
+# The name of the driver that can load this configuration source. (string
+# value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#driver = remote_file
+
+# Required option with the URI of the extra configuration file's location. (uri
+# value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#uri = https://example.com/my-configuration.ini
+
+# The path to a CA_BUNDLE file or directory with certificates of trusted CAs.
+# (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#ca_path = /etc/ca-certificates
+
+# Client side certificate, as a single file path containing either the
+# certificate only or the private key and the certificate. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#client_cert = /etc/ca-certificates/service-client-keystore
+
+# Client side private key, in case client_cert is specified but does not
+# includes the private key. (string value)
+#client_key = <None>
+
+
+[service_user]
+
+#
+# From cinder
+#
+
+#
+# When True, if sending a user token to an REST API, also send a service token.
+#  (boolean value)
+#send_service_user_token = false
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Project ID to scope to (string value)
+#project_id = <None>
+
+# Project name to scope to (string value)
+#project_name = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User ID (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [service_user]/user_name
+#username = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User's password (string value)
+#password = <None>
+
+# PEM encoded Certificate Authority to use when verifying HTTPs connections.
+# (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+
+[ssl]
+
+#
+# From oslo.service.sslutils
+#
+
+# CA certificate file to use to verify connecting clients. (string value)
+# Deprecated group/name - [DEFAULT]/ssl_ca_file
+#ca_file = <None>
+
+# Certificate file to use when starting the server securely. (string value)
+# Deprecated group/name - [DEFAULT]/ssl_cert_file
+#cert_file = <None>
+
+# Private key file to use when starting the server securely. (string value)
+# Deprecated group/name - [DEFAULT]/ssl_key_file
+#key_file = <None>
+
+# SSL version to use (valid only if SSL enabled). Valid values are TLSv1 and
+# SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be available on some
+# distributions. (string value)
+#version = <None>
+
+# Sets the list of available ciphers. value should be a string in the OpenSSL
+# cipher list format. (string value)
+#ciphers = <None>
+
+
+[vault]
+
+#
+# From castellan.config
+#
+
+# root token for vault (string value)
+#root_token_id = <None>
+
+# AppRole role_id for authentication with vault (string value)
+#approle_role_id = <None>
+
+# AppRole secret_id for authentication with vault (string value)
+#approle_secret_id = <None>
+
+# Mountpoint of KV store in Vault to use, for example: secret (string value)
+#kv_mountpoint = secret
+
+# Version of KV store in Vault to use, for example: 2 (integer value)
+#kv_version = 2
+
+# Use this endpoint to connect to Vault, for example: "http://127.0.0.1:8200"
+# (string value)
+#vault_url = http://127.0.0.1:8200
+
+# Absolute path to ca cert file (string value)
+#ssl_ca_crt_file = <None>
+
+# SSL Enabled/Disabled (boolean value)
+#use_ssl = false
+
+# Vault Namespace to use for all requests to Vault. Vault Namespaces feature is
+# available only in Vault Enterprise (string value)
+#namespace = <None>

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -48,7 +48,6 @@ rootfs_install::
 	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-scheduler.service $(ROOTDIR)/tmp/cinder/
 	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-volume.service $(ROOTDIR)/tmp/cinder/
 	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-backup.service $(ROOTDIR)/tmp/cinder/
-	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder.logrotate $(ROOTDIR)/tmp/cinder/
 
 # install system directories and production files
 rootfs_install::
@@ -64,8 +63,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/api-paste.ini /etc/cinder/api-paste.ini
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/rootwrap.conf /etc/cinder/rootwrap.conf
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/resource_filters.json /etc/cinder/resource_filters.json
-	$(Q)# install logrotate and security configurations
-	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder.logrotate /etc/logrotate.d/openstack-cinder
+	$(Q)# install security configurations
 	$(Q)chroot $(ROOTDIR) install -p -D -m 440 /tmp/cinder/cinder-sudoers /etc/sudoers.d/cinder
 	$(Q)# install systemd unit files
 	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder-api.service /usr/lib/systemd/system/openstack-cinder-api.service

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -109,6 +109,13 @@ rootfs_install::
 	$(Q)[ -d $(CINDER_PATCHDIR) ] && cp -rf $(CINDER_PATCHDIR)/* $(CINDER_SRCDIR)/ || /bin/true
 
 rootfs_install::
+	$(Q)chroot $(ROOTDIR) mkdir -p /var/lock/os_brick
+	$(Q)# give full read-write-execute permissions to both service users
+	$(Q)chroot $(ROOTDIR) setfacl -m u:cinder:rwx /var/lock/os_brick
+	$(Q)chroot $(ROOTDIR) setfacl -m u:glance:rwx /var/lock/os_brick
+	$(Q)# ensure any future lock files created inside automatically inherit these permissions
+	$(Q)chroot $(ROOTDIR) setfacl -d -m u:cinder:rwx /var/lock/os_brick
+	$(Q)chroot $(ROOTDIR) setfacl -d -m u:glance:rwx /var/lock/os_brick
 	$(Q)cp -f $(CINDER_CONFDIR)/cinder.conf $(CINDER_CONFDIR)/cinder.conf.org
 	$(Q)touch $(CINDER_CONFDIR)/cinder.conf.def
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/cinder/cinder.d

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -1,8 +1,8 @@
 # Cube SDK
 # cinder installation
 
-ROOTFS_DNF += qemu-img cryptsetup lvm2 iscsi-initiator-utils device-mapper-multipath nvmetcli sudo sshpass
-ROOTFS_DNF_NOARCH += targetcli
+ROOTFS_DNF += qemu-img cryptsetup lvm2 iscsi-initiator-utils device-mapper-multipath sudo sshpass
+ROOTFS_DNF_NOARCH += nvmetcli targetcli
 
 CINDER_SRCDIR := $(ROOTDIR)/opt/openstack-antelope/lib/python3.10/site-packages/cinder
 CINDER_PATCHDIR := $(COREDIR)/cinder/$(NEXT_OPENSTACK_RELEASE)_patch

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -4,8 +4,8 @@
 ROOTFS_DNF += qemu-img cryptsetup lvm2 iscsi-initiator-utils device-mapper-multipath nvmetcli sudo sshpass
 ROOTFS_DNF_NOARCH += targetcli
 
-CINDER_SRCDIR := $(ROOTDIR)/usr/lib/python3.9/site-packages/cinder
-CINDER_PATCHDIR := $(COREDIR)/cinder/$(OPENSTACK_RELEASE)_patch
+CINDER_SRCDIR := $(ROOTDIR)/opt/openstack-antelope/lib/python3.10/site-packages/cinder
+CINDER_PATCHDIR := $(COREDIR)/cinder/$(NEXT_OPENSTACK_RELEASE)_patch
 
 CINDER_CONFDIR := $(ROOTDIR)/etc/cinder
 

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -47,6 +47,7 @@ rootfs_install::
 
 # generate default configurations using oslo-config-generator
 rootfs_install::
+	$(Q)cp -f $(COREDIR)/cinder/cinder-dist.conf $(ROOTDIR)/tmp/cinder/
 	$(Q)cp -f $(COREDIR)/cinder/cinder-config-generator.conf $(ROOTDIR)/tmp/cinder/
 	$(Q)cp -f $(COREDIR)/cinder/cinder.conf.sample $(ROOTDIR)/tmp/cinder/
 	$(Q)# copy statutory configuration templates from core directory
@@ -71,6 +72,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -d -m 755 /etc/cinder/rootwrap.d
 	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/run/cinder
 	$(Q)# install configurations
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/cinder-dist.conf /usr/share/cinder/cinder-dist.conf
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/cinder.conf.sample /etc/cinder/cinder.conf
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/api-paste.ini /etc/cinder/api-paste.ini
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/rootwrap.conf /etc/cinder/rootwrap.conf
@@ -87,6 +89,7 @@ rootfs_install::
 
 # adjust file ownerships and permissions
 rootfs_install::
+	$(Q)chroot $(ROOTDIR) chown root:cinder /usr/share/cinder/cinder-dist.conf
 	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/cinder.conf
 	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/api-paste.ini
 	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/rootwrap.conf

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -27,6 +27,18 @@ rootfs_install::
 			pywbem"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder /usr/bin/cinder
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-3 /usr/bin/cinder-3
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-api /usr/bin/cinder-api
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-backup /usr/bin/cinder-backup
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-manage /usr/bin/cinder-manage
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-rootwrap /usr/bin/cinder-rootwrap
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-rtstool /usr/bin/cinder-rtstool
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-scheduler /usr/bin/cinder-scheduler
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-status /usr/bin/cinder-status
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-volume /usr/bin/cinder-volume
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-volume-usage-audit /usr/bin/cinder-volume-usage-audit
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/cinder-wsgi /usr/bin/cinder-wsgi
 
 # prepare the build directory
 rootfs_install::

--- a/core/cinder/cinder.mk
+++ b/core/cinder/cinder.mk
@@ -1,18 +1,100 @@
 # Cube SDK
 # cinder installation
 
-ROOTFS_DNF += iscsi-initiator-utils sshpass
-ROOTFS_DNF_NOARCH += openstack-cinder targetcli python3-keystone
-# support other storage backends
-ROOTFS_PIP += purestorage
-# support Fujitsu Eternus DX
-ROOTFS_DNF_NOARCH += python3-pywbem
+ROOTFS_DNF += qemu-img cryptsetup lvm2 iscsi-initiator-utils device-mapper-multipath nvmetcli sudo sshpass
+ROOTFS_DNF_NOARCH += targetcli
 
 CINDER_SRCDIR := $(ROOTDIR)/usr/lib/python3.9/site-packages/cinder
 CINDER_PATCHDIR := $(COREDIR)/cinder/$(OPENSTACK_RELEASE)_patch
 
 CINDER_CONFDIR := $(ROOTDIR)/etc/cinder
 
+# install cinder inside the python 3.10 virtual environment
+# purestorage: support Pure Storage
+# pywbem: support Fujitsu Eternus DX
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			cinder==22.3.0 \
+			python-cinderclient \
+			python-keystoneclient \
+			uwsgi \
+			etcd3gw \
+			websocket-client \
+			purestorage \
+			pywbem"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+
+# prepare the build directory
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rm -rf /tmp/cinder
+	$(Q)chroot $(ROOTDIR) mkdir -p /tmp/cinder
+
+# generate default configurations using oslo-config-generator
+rootfs_install::
+	$(Q)cp -f $(COREDIR)/cinder/cinder-config-generator.conf $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/cinder.conf.sample $(ROOTDIR)/tmp/cinder/
+	$(Q)# copy statutory configuration templates from core directory
+	$(Q)cp -f $(COREDIR)/cinder/api-paste.ini $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/rootwrap.conf $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/resource_filters.json $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/cinder-sudoers $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/volume.filters $(ROOTDIR)/tmp/cinder/
+	$(Q)# copy systemd unit file templates
+	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-api.service $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-scheduler.service $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-volume.service $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder-backup.service $(ROOTDIR)/tmp/cinder/
+	$(Q)cp -f $(COREDIR)/cinder/openstack-cinder.logrotate $(ROOTDIR)/tmp/cinder/
+
+# install system directories and production files
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/lib/cinder
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/lib/cinder/tmp
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/log/cinder
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /etc/cinder
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /etc/cinder/volumes
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /etc/cinder/rootwrap.d
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/run/cinder
+	$(Q)# install configurations
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/cinder.conf.sample /etc/cinder/cinder.conf
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/api-paste.ini /etc/cinder/api-paste.ini
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/rootwrap.conf /etc/cinder/rootwrap.conf
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/cinder/resource_filters.json /etc/cinder/resource_filters.json
+	$(Q)# install logrotate and security configurations
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder.logrotate /etc/logrotate.d/openstack-cinder
+	$(Q)chroot $(ROOTDIR) install -p -D -m 440 /tmp/cinder/cinder-sudoers /etc/sudoers.d/cinder
+	$(Q)# install systemd unit files
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder-api.service /usr/lib/systemd/system/openstack-cinder-api.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder-scheduler.service /usr/lib/systemd/system/openstack-cinder-scheduler.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder-volume.service /usr/lib/systemd/system/openstack-cinder-volume.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/openstack-cinder-backup.service /usr/lib/systemd/system/openstack-cinder-backup.service
+	$(Q)# install rootwrap filters into system cinder deployment configuration
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/cinder/volume.filters /etc/cinder/rootwrap.d/
+
+# adjust file ownerships and permissions
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/cinder.conf
+	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/api-paste.ini
+	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/rootwrap.conf
+	$(Q)chroot $(ROOTDIR) chown root:cinder /etc/cinder/resource_filters.json
+	$(Q)chroot $(ROOTDIR) chown cinder:root /var/log/cinder
+	$(Q)chroot $(ROOTDIR) chmod 0750 /var/log/cinder
+	$(Q)chroot $(ROOTDIR) chown cinder:root /var/run/cinder
+	$(Q)chroot $(ROOTDIR) chmod 0755 /var/run/cinder
+	$(Q)chroot $(ROOTDIR) chown cinder:root /etc/cinder/volumes
+	$(Q)chroot $(ROOTDIR) chmod 0755 /etc/cinder/volumes
+	$(Q)chroot $(ROOTDIR) chown -R cinder:cinder /var/lib/cinder
+	$(Q)chroot $(ROOTDIR) chown -R cinder:cinder /var/lib/cinder/tmp
+
+# clean up the build directory
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rm -rf /tmp/cinder
+
+# install custom files
 rootfs_install::
 	$(Q)[ -d $(CINDER_PATCHDIR) ] && cp -rf $(CINDER_PATCHDIR)/* $(CINDER_SRCDIR)/ || /bin/true
 

--- a/core/cinder/resource_filters.json
+++ b/core/cinder/resource_filters.json
@@ -1,0 +1,16 @@
+{
+    "volume": ["name", "status", "metadata",
+               "bootable", "migration_status", "availability_zone",
+               "group_id", "size", "created_at", "updated_at",
+               "consumes_quota"],
+    "backup": ["name", "status", "volume_id"],
+    "snapshot": ["name", "status", "volume_id", "metadata",
+                 "availability_zone", "consumes_quota"],
+    "group": ["name"],
+    "group_snapshot": ["name", "status", "group_id"],
+    "attachment": ["volume_id", "status", "instance_id", "attach_status"],
+    "message": ["resource_uuid", "resource_type", "event_id",
+                "request_id", "message_level"],
+    "pool": ["name", "volume_type"],
+    "volume_type": ["is_public", "extra_specs"]
+}

--- a/core/cinder/rootwrap.conf
+++ b/core/cinder/rootwrap.conf
@@ -1,0 +1,33 @@
+# Configuration for cinder-rootwrap
+# This file should be owned by (and only-writeable by) the root user
+
+[DEFAULT]
+# List of directories to load filter definitions from (separated by ',').
+# These directories MUST all be only writeable by root !
+filters_path=/etc/cinder/rootwrap.d,/usr/share/cinder/rootwrap
+
+# List of directories to search executables in, in case filters do not
+# explicitely specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writeable by root !
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/usr/lpp/mmfs/bin
+
+# Enable logging to syslog
+# Default value is False
+use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, local0, local1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
+syslog_log_level=ERROR
+
+# Rootwrap daemon exits after this seconds of inactivity
+daemon_timeout=600
+
+# Rootwrap daemon limits itself to that many file descriptors (Linux only)
+rlimit_nofile=1024

--- a/core/cinder/volume.filters
+++ b/core/cinder/volume.filters
@@ -1,0 +1,143 @@
+# cinder-rootwrap command filters for volume nodes
+# This file should be owned by (and only-writeable by) the root user
+
+[Filters]
+# cinder/volume/targets/iscsi.py: target_helper '--op' ...
+iscsictl: CommandFilter, iscsictl, root
+cinder-rtstool: CommandFilter, cinder-rtstool, root
+
+# LVM related show commands
+pvs: EnvFilter, env, root, LC_ALL=C, pvs
+vgs: EnvFilter, env, root, LC_ALL=C, vgs
+lvs: EnvFilter, env, root, LC_ALL=C, lvs
+lvdisplay: EnvFilter, env, root, LC_ALL=C, lvdisplay
+
+# -LVM related show commands with suppress fd warnings
+pvs2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, pvs
+vgs2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, vgs
+lvs2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvs
+lvdisplay2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvdisplay
+
+
+# -LVM related show commands conf var
+pvs3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, pvs
+vgs3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, vgs
+lvs3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, lvs
+lvdisplay3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, lvdisplay
+
+# -LVM conf var with suppress fd_warnings
+pvs4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, pvs
+vgs4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, vgs
+lvs4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, lvs
+lvdisplay4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, lvdisplay
+
+# os-brick library commands
+# os_brick.privileged.run_as_root oslo.privsep context
+# This line ties the superuser privs with the config files, context name,
+# and (implicitly) the actual python code invoked.
+privsep-rootwrap: RegExpFilter, privsep-helper, root, privsep-helper, --config-file, /etc/(?!\.\.).*, --privsep_context, os_brick.privileged.default, --privsep_sock_path, /tmp/.*
+
+# Privsep calls within cinder iteself
+privsep-rootwrap-sys_admin: RegExpFilter, privsep-helper, root, privsep-helper, --config-file, /etc/(?!\.\.).*, --privsep_context, cinder.privsep.sys_admin_pctxt, --privsep_sock_path, /tmp/.*
+
+# cinder/brick/local_dev/lvm.py: 'lvcreate', '-L', sizestr, '-n', volume_name,..
+# cinder/brick/local_dev/lvm.py: 'lvcreate', '-L', ...
+lvcreate: EnvFilter, env, root, LC_ALL=C, lvcreate
+lvcreate_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, lvcreate
+lvcreate_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvcreate
+lvcreate_lvmconf_fdwarn: EnvFilter, env, root, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, LC_ALL=C, lvcreate
+
+# cinder/volume/driver.py: 'dd', 'if=%s' % srcstr, 'of=%s' % deststr,...
+dd: CommandFilter, dd, root
+
+# cinder/volume/driver.py: 'lvremove', '-f', %s/%s % ...
+lvremove: CommandFilter, lvremove, root
+
+# cinder/brick/local_dev/lvm.py: 'lvextend', '-L' '%(new_size)s', '%(lv_name)s' ...
+# cinder/brick/local_dev/lvm.py: 'lvextend', '-L' '%(new_size)s', '%(thin_pool)s' ...
+lvextend: EnvFilter, env, root, LC_ALL=C, lvextend
+lvextend_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, lvextend
+lvextend_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvextend
+lvextend_lvmconf_fdwarn: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvextend
+
+# cinder/brick/local_dev/lvm.py: 'lvchange -a y -K <lv>'
+lvchange: CommandFilter, lvchange, root
+
+# cinder/volume/driver.py: 'iscsiadm', '-m', 'discovery', '-t',...
+# cinder/volume/driver.py: 'iscsiadm', '-m', 'node', '-T', ...
+iscsiadm: CommandFilter, iscsiadm, root
+
+# cinder/volume/utils.py: utils.temporary_chown(path, 0)
+chown: CommandFilter, chown, root
+
+# cinder/volume/utils.py: copy_volume(..., ionice='...')
+ionice_1: ChainingRegExpFilter, ionice, root, ionice, -c[0-3], -n[0-7]
+ionice_2: ChainingRegExpFilter, ionice, root, ionice, -c[0-3]
+
+# cinder/volume/utils.py: setup_blkio_cgroup()
+cgexec: ChainingRegExpFilter, cgexec, root, cgexec, -g, blkio:\S+
+
+# cinder/image/image_utils.py
+qemu-img: EnvFilter, env, root, LC_ALL=C, qemu-img
+qemu-img_convert: CommandFilter, qemu-img, root
+qzip: CommandFilter, qzip, root
+gzip: CommandFilter, gzip, root
+
+# cinder/volume/nfs.py
+stat: CommandFilter, stat, root
+mount: CommandFilter, mount, root
+df: CommandFilter, df, root
+du: CommandFilter, du, root
+truncate: CommandFilter, truncate, root
+chmod: CommandFilter, chmod, root
+rm: CommandFilter, rm, root
+
+# cinder/volume/drivers/netapp/dataontap/nfs_base.py:
+netapp_nfs_find: RegExpFilter, find, root, find, ^[/]*([^/\0]+(/+)?)*$, -maxdepth, \d+, -name, img-cache.*, -amin, \+\d+
+
+# cinder/backup/drivers/nfs.py
+# cinder/backup/drivers/glusterfs.py
+chgrp: CommandFilter, chgrp, root
+
+# cinder/brick/initiator/connector.py:
+ls: CommandFilter, ls, root
+multipath: CommandFilter, multipath, root
+multipathd: CommandFilter, multipathd, root
+
+# cinder/volume/drivers/ibm/gpfs.py
+# cinder/volume/drivers/netapp/dataontap/nfs_base.py
+mv: CommandFilter, mv, root
+
+# cinder/volume/drivers/ibm/gpfs.py
+cp: CommandFilter, cp, root
+mmgetstate: CommandFilter, mmgetstate, root
+mmclone: CommandFilter, mmclone, root
+mmlsattr: CommandFilter, mmlsattr, root
+mmchattr: CommandFilter, mmchattr, root
+mmlsconfig: CommandFilter, mmlsconfig, root
+mmlsfs: CommandFilter, mmlsfs, root
+mmlspool: CommandFilter, mmlspool, root
+mkfs: CommandFilter, mkfs, root
+mmcrfileset: CommandFilter, mmcrfileset, root
+mmlsfileset: CommandFilter, mmlsfileset, root
+mmlinkfileset: CommandFilter, mmlinkfileset, root
+mmunlinkfileset: CommandFilter, mmunlinkfileset, root
+mmdelfileset: CommandFilter, mmdelfileset, root
+
+# cinder/volume/drivers/ibm/gpfs.py
+# cinder/volume/drivers/ibm/ibmnas.py
+find_maxdepth_inum: RegExpFilter, find, root, find, ^[/]*([^/\0]+(/+)?)*$, -maxdepth, \d+, -ignore_readdir_race, -inum, \d+, -print0, -quit
+
+# cinder/volume/drivers/vzstorage.py
+pstorage-mount: CommandFilter, pstorage-mount, root
+pstorage: CommandFilter, pstorage, root
+ploop: CommandFilter, ploop, root
+
+# cinder/volume/drivers/quobyte.py
+mount.quobyte: CommandFilter, mount.quobyte, root
+umount.quobyte: CommandFilter, umount.quobyte, root
+
+# cinder/volume/drivers/dell_emc/powerstore/nfs.py
+dellfcopy: CommandFilter, dellfcopy, root
+
+cryptsetup: CommandFilter, cryptsetup, root

--- a/core/glance/glance.mk
+++ b/core/glance/glance.mk
@@ -17,7 +17,21 @@ rootfs_install::
 			pysendfile"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance /usr/bin/glance
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-3 /usr/bin/glance-3
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-api /usr/bin/glance-api
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-cache-cleaner /usr/bin/glance-cache-cleaner
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-cache-manage /usr/bin/glance-cache-manage
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-cache-prefetcher /usr/bin/glance-cache-prefetcher
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-cache-pruner /usr/bin/glance-cache-pruner
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-control /usr/bin/glance-control
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-manage /usr/bin/glance-manage
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-replicator /usr/bin/glance-replicator
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-rootwrap /usr/bin/glance-rootwrap
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-rootwrap-3 /usr/bin/glance-rootwrap-3
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-scrubber /usr/bin/glance-scrubber
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-status /usr/bin/glance-status
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/glance-wsgi-api /usr/bin/glance-wsgi-api
 
 # prepare the build directory
 rootfs_install::

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -568,6 +568,7 @@ SetCeph(
     config[BUILTIN_STORAGE_BACKEND]["rados_connect_timeout"] = "-1";
     config[BUILTIN_STORAGE_BACKEND]["rbd_store_chunk_size"] = "4";
     config[BUILTIN_STORAGE_BACKEND]["rbd_max_clone_depth"] = "5";
+    config[BUILTIN_STORAGE_BACKEND]["enable_deferred_deletion"] = "true";
     config[BUILTIN_STORAGE_BACKEND]["rbd_flatten_volume_from_snapshot"] = "false";
     config[BUILTIN_STORAGE_BACKEND]["image_upload_use_cinder_backend"] = "true";
 }

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -437,7 +437,7 @@ SetDefaults(
     config["DEFAULT"]["enable_force_upload"] = "true";
     config["DEFAULT"]["allow_availability_zone_fallback"] = "true";
 
-    config["oslo_concurrency"]["lock_path"] = "/var/lib/cinder/tmp";
+    config["os_brick"]["lock_path"] = "/var/lock/os_brick";
     config["oslo_reports"]["log_dir"] = "/var/log/cinder";
 }
 

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -525,6 +525,16 @@ SetAuth(
     config["keystone_authtoken"]["password"] = cinderPass;
     config["keystone_authtoken"]["service_token_roles"] = "service";
     config["keystone_authtoken"]["service_token_roles_required"] = "true";
+
+    config["service_user"]["auth_type"] = "password";
+    config["service_user"]["auth_url"] = "http://" + sharedId + ":5000";
+    config["service_user"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
+    config["service_user"]["username"] = "cinder";
+    config["service_user"]["password"] = cinderPass;
+    config["service_user"]["project_name"] = "service";
+    config["service_user"]["project_domain_name"] = domain;
+    config["service_user"]["user_domain_name"] = domain;
+    config["service_user"]["send_service_user_token"] = "true";
 }
 
 /**

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -461,6 +461,7 @@ SetDatabaseConnection(
     uri << "mysql+pymysql://cinder:" << dbPass << "@" << sharedId << "/cinder";
 
     config["database"]["connection"] = uri.str();
+    config["database"]["mysql_wsrep_sync_wait"] = "1";
 }
 
 /**

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -14,10 +14,13 @@
 #include <hex/exec.hpp>
 #include <hex/filesystem.h>
 #include <hex/log.h>
+#include <hex/logrotate.h>
 #include <hex/pidfile.h>
 #include <hex/process.h>
 #include <hex/process_util.h>
 #include <mysql_util.h>
+
+static LogRotateConf log_conf("cinder", "/var/log/cinder/*.log", DAILY, 128, 0, true);
 
 static const char USER[] = "cinder";
 static const char GROUP[] = "cinder";
@@ -920,6 +923,7 @@ Commit(bool modified, int dryLevel)
 
     // start services
     StartCinderService(s_enabled, s_ha, IsBootstrap());
+    WriteLogRotateConf(log_conf);
     // wait for services to be up
     std::stringstream enabledHostLine;
     enabledHostLine << BUILTIN_STORAGE_HOST << "@" << BUILTIN_STORAGE_BACKEND;

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -314,7 +314,7 @@ SetDefaults(Configs& config)
     config["DEFAULT"]["image_size_cap"] = TwoTiB;
     config["DEFAULT"]["node_staging_uri"] = "file:///mnt/cephfs/glance_tmp_transition";
 
-    config["oslo_concurrency"]["lock_path"] = "/var/lib/glance/locks";
+    config["os_brick"]["lock_path"] = "/var/lock/os_brick";
 
     // should be oslo_reports.log_dir, however, the current version does not support it
     config["DEFAULT"]["log_dir"] = "/var/log/glance";


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Upgrade Cinder from OpenStack Yoga to Antelope

#### Which issue(s) this PR fixes

- Close #604 

#### Special notes for your reviewer

- This PR is after #1080 

#### Additional documentation

For the requirement "Ensure volume creation and deletion work",

```bash
[cc1 ~]# openstack volume service list
+------------------+-----------+------+---------+-------+----------------------------+
| Binary           | Host      | Zone | Status  | State | Updated At                 |
+------------------+-----------+------+---------+-------+----------------------------+
| cinder-backup    | cc1       | nova | enabled | up    | 2026-07-07T08:38:42.000000 |
| cinder-volume    | cube@ceph | nova | enabled | up    | 2026-07-07T08:38:42.000000 |
| cinder-scheduler | cc1       | nova | enabled | up    | 2026-07-07T08:38:43.000000 |
+------------------+-----------+------+---------+-------+----------------------------+
[cc1 ~]# openstack volume type list
+--------------------------------------+-------------+-----------+
| ID                                   | Name        | Is Public |
+--------------------------------------+-------------+-----------+
| 7bfb3798-ae8b-43a9-b7cf-96d779b17cff | CubeStorage | True      |
| 5f220a8b-fb4f-4fdd-b74a-00ffc0178bf5 | __DEFAULT__ | True      |
+--------------------------------------+-------------+-----------+
[cc1 ~]# openstack volume create --size 1 --type "CubeStorage" --description "volume for testing storage CubeStorage" "test-volume"
+---------------------+----------------------------------------+
| Field               | Value                                  |
+---------------------+----------------------------------------+
| attachments         | []                                     |
| availability_zone   | nova                                   |
| bootable            | false                                  |
| consistencygroup_id | None                                   |
| created_at          | 2026-07-07T08:42:05.401325             |
| description         | volume for testing storage CubeStorage |
| encrypted           | False                                  |
| id                  | c021df46-2ef8-4840-b46d-7adf908b2647   |
| migration_status    | None                                   |
| multiattach         | False                                  |
| name                | test-volume                            |
| properties          |                                        |
| replication_status  | None                                   |
| size                | 1                                      |
| snapshot_id         | None                                   |
| source_volid        | None                                   |
| status              | creating                               |
| type                | CubeStorage                            |
| updated_at          | None                                   |
| user_id             | db43aa46b9dc4f3cb07ee80e36a8640b       |
+---------------------+----------------------------------------+
[cc1 ~]# openstack volume list
+--------------------------------------+-------------+-----------+------+-------------+
| ID                                   | Name        | Status    | Size | Attached to |
+--------------------------------------+-------------+-----------+------+-------------+
| c021df46-2ef8-4840-b46d-7adf908b2647 | test-volume | available |    1 |             |
+--------------------------------------+-------------+-----------+------+-------------+
[cc1 ~]# rbd ls -p cinder-volumes | grep c021df46-2ef8-4840-b46d-7adf908b2647
volume-c021df46-2ef8-4840-b46d-7adf908b2647
[cc1 ~]# rbd info cinder-volumes/volume-c021df46-2ef8-4840-b46d-7adf908b2647
rbd image 'volume-c021df46-2ef8-4840-b46d-7adf908b2647':
	size 1 GiB in 256 objects
	order 22 (4 MiB objects)
	snapshot_count: 0
	id: 4d2f3b105b80
	block_name_prefix: rbd_data.4d2f3b105b80
	format: 2
	features: layering, exclusive-lock, object-map, fast-diff, deep-flatten
	op_features: 
	flags: 
	create_timestamp: Tue Jul  7 16:42:07 2026
	access_timestamp: Tue Jul  7 16:42:07 2026
	modify_timestamp: Tue Jul  7 16:42:07 2026
[cc1 ~]# openstack volume delete c021df46-2ef8-4840-b46d-7adf908b2647
[cc1 ~]# openstack volume list

[cc1 ~]# rbd ls -p cinder-volumes | grep c021df46-2ef8-4840-b46d-7adf908b2647
[cc1 ~]# rbd info cinder-volumes/volume-c021df46-2ef8-4840-b46d-7adf908b2647
rbd: error opening image volume-c021df46-2ef8-4840-b46d-7adf908b2647: (2) No such file or directory
```

For the requirement "health check",

```bash
[cc1 ~]# hex_cli -v -c boot_mode status
two phase boot... [yes]
standalone services... [ready]
cube services... [ready]
cluster data... [synced]
applying policy... [no]
[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
            Image      ok  [ glance(v) ]
           IaasDb      ok  [ mysql(v) ]
       InstanceHa      ok  [ masakari(v) ]
        HaCluster      ok  [ hacluster(v) ]
            LBaaS      ok  [ octavia(v) ]
        Baremetal      ok  [ ironic(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
         FileStor      ok  [ manila(v) ]
           K8SaaS      ok  [ rancher(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
        BlockStor      ok  [ cinder(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
    Orchestration      ok  [ heat(v) ]
       ObjectStor      ok  [ swift(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
           DNSaaS      ok  [ designate(v) ]
    BusinessLogic      ok  [ watcher(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
          Network      ok  [ neutron(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) ]
```
