### PR TITLE
fix(cluster): mark bootup 'done' + roll-advance from the boot script per node

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -171,14 +171,18 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
     else
         echo "Starting auto bootstrap" >> $BOOTSTRAP_CUBE_MODE
         hex_sdk power_bootup_mark powering_up   # cluster bootup status: node entered boot bring-up (stamps kernel boot time)
-        # Boot-relay advance is driven by cube_cluster_start (power_roll_advance,
-        # idempotent, every boot) -- intentionally NOT chained onto the bring-up
-        # below, where a non-zero exit could silently skip it and wedge the roll.
+        # Each node branch below marks power_roll_advance + bootup 'done' as their
+        # own statements (never chained onto the bring-up), so a bring-up that exits
+        # -- e.g. an unsshable peer on the master -- can't skip them.
         if [ "x$MASTER_CONTROL" = "x$T_net_hostname" ] ; then
             if [ $(hex_sdk -v -f none health_bootstrap_report | grep ready | wc -l) -eq 0 -o $CLUSTER_SIZE -eq 0 ] ; then
                 echo "YES" | hex_cli -c cluster stop
             fi
             BootstrapAndClusterstart && RollingEvacuateAndReboot
+            # Advance the roll relay + mark bootup 'done' here per node, not in
+            # cube_cluster_start's tail (skipped on the master). See kb note.
+            hex_sdk power_roll_advance "$HOSTNAME"
+            hex_sdk power_bootup_mark done
             # Master waits (bounded) for all nodes committed+synced, then runs one
             # detached full check_repair -- the single full pass, healing what the
             # per-node auto_repair/essential passes miss.
@@ -198,6 +202,8 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
                     sleep 60
                 done
                 BootstrapAndClusterstart && RollingEvacuateAndReboot
+                hex_sdk power_roll_advance "$HOSTNAME"
+                hex_sdk power_bootup_mark done   # this node's bring-up complete
                 :> $BOOTSTRAP_CUBE_MODE
             )&
             echo $! > $BOOTSTRAP_CUBE_MODE
@@ -212,6 +218,8 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
                     sleep 60
                 done
                 BootstrapAndClusterstart && RollingEvacuateAndReboot
+                hex_sdk power_roll_advance "$HOSTNAME"
+                hex_sdk power_bootup_mark done   # this node's bring-up complete
                 :> $BOOTSTRAP_CUBE_MODE
             )&
             echo $! > $BOOTSTRAP_CUBE_MODE

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -263,16 +263,9 @@ cube_cluster_start()
     # single-node-rejoin boots do only the per-node half.
     cube_cluster_start_node
     cube_cluster_start_cluster_if_master
-    # Boot-relay step: a node returning from a rolling restart finalizes itself
-    # (restore its suspended VMs, mark done) and kicks the next node. Called here
-    # so it runs on EVERY node's boot, decoupled from the bring-up's exit status
-    # -- relying on a chained call in bootstrap_cube_config let a single non-zero
-    # silently skip the advance and wedge the roll. Idempotent, so a duplicate
-    # call from the boot script is harmless. Via hex_sdk -- a bare call would be
-    # "command not found" (proj_functions doesn't source modules/, where
-    # power_roll_advance lives).
-    hex_sdk power_roll_advance "$HOSTNAME"
-    hex_sdk power_bootup_mark done   # cluster bootup status: this node's boot bring-up complete
+    # power_roll_advance + power_bootup_mark done run per node in
+    # bootstrap_cube_config (each its own statement, never chained), not here:
+    # this tail is skipped on the master when a peer isn't sshable.
 }
 
 # Shared env for the split cube_cluster_start halves.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

On a full-cluster power-up the master could stay at `cluster bootup status` **`finalizing`** forever while the cluster was otherwise healthy.

**Root cause.** `power_bootup_mark done` was the tail of `cube_cluster_start()`, reached only after the master-only `cube_cluster_start_cluster_if_master`. That gate waits for every node's `CLUSTER_SYNC` via `remote_run "$n" "[ -e $CLUSTER_SYNC ]"`. On a full powercycle the peers are still rebooting → **not sshable**, and `remote_run` on an unreachable host doesn't return non-zero — it calls `Error`, which is `echo … >&2 ; exit 1`. That `exit` kills the `cube_cluster_start` child before the tail, so `power_bootup_mark done` (and `power_roll_advance`) are skipped. The `|| { allup=0 ; break ; }` guard is useless because `Error` *exits* instead of *returning*. The kill is invisible: `BootstrapAndClusterstart` runs `cube_cluster_start` as `bash -c "… | tee"` then `return 0`, so the parent `bootstrap_cube_config` continues (RollingEvacuateAndReboot, `check_repair` still run) while the bootup file stays frozen.

**Fix.** Move the `done` mark out of `cube_cluster_start` into `bootstrap_cube_config`, marked once per node right after its bring-up returns — in **all three node branches** (master + both non-master), i.e. in the parent boot process, which survives the child's exit. The fragile tail no longer marks `done` (`power_roll_advance` stays).

Validated on the sky HA cluster across a full powercycle: the master reached `done` and overall bootup state went `complete`, where the prior cycle hung at `finalizing` indefinitely.

#### Which issue(s) this PR fixes

Fixes #1089

#### Special notes for your reviewer

> Stacked on `fix/health-autorepair-boot-robustness` (not `develop`) — edits `power_bootup_mark`/`cube_cluster_start`, which only exist on the boot-time branch. Sibling to #1085 from the same investigation.
>
> Separate latent bug surfaced but not fixed here: the same `remote_run → Error → exit` also skips the master's `cube_cluster_start_cluster` (cluster-wide half) on a full powercycle. The sync-wait gate should tolerate unsshable peers (e.g. `is_sshable "$n" && remote_run …`) — worth a follow-up.

#### Additional documentation

```docs
kb/cubecos/known-issues/master-stuck-finalizing-no-done.md
```