### PR TITLE
fix(cluster): record the rolling-restart 'bootstrapping' phase timestamp

### DIFF
--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -46,12 +46,56 @@ _power_roll_set_node_status()
         '(.nodes[]|select(.hostname==$h)) |= (.status=$s | .phase_ts=((.phase_ts//{}) + {($s):$ts}))'
 }
 
-# Stamp a phase timestamp without changing .status. No-op if no job exists.
+# The raw phase_ts write. Also the entry point a peer or a spool-replay uses:
+# `hex_sdk _power_roll_write_phase_ts <host> <phase> <epoch>`.
+_power_roll_write_phase_ts()
+{
+    [ -e "$ROLLING_RESTART_JOB" ] || return 1
+    _power_roll_write --arg h "$1" --arg p "$2" --argjson ts "$3" \
+        '(.nodes[]|select(.hostname==$h)) |= (.phase_ts=((.phase_ts//{}) + {($p):$ts}))'
+}
+
+# Replay locally-buffered stamps to job.json once cephfs is reachable.
+_power_roll_flush_phase_ts_spool()
+{
+    local spool=$1 bh bp bts
+    [ -e "$spool" ] || return 0
+    while read -r bh bp bts ; do
+        [ -n "$bh" ] && _power_roll_write_phase_ts "$bh" "$bp" "$bts"
+    done < "$spool"
+    rm -f "$spool"
+}
+
+# First reachable control peer (not self) -- it has cephfs, so it can stamp for us.
+_power_roll_ts_peer()
+{
+    local self=$(hostname) n
+    for n in ${MASTER_CONTROL:-} $(cubectl node list -r control -j 2>/dev/null | jq -r '.[].hostname' 2>/dev/null) ; do
+        [ "$n" = "$self" ] && continue
+        is_sshable "$n" 2>/dev/null && { echo "$n" ; return 0 ; }
+    done
+}
+
+# Stamp a phase timestamp without changing .status. job.json lives on cephfs, which
+# isn't mounted early in a node's own boot -- so capture the real ts now, then write
+# it directly (cephfs up), else delegate to an up peer that has cephfs, else spool
+# locally and flush on a later cephfs-up call. Never fatal: the delegate runs in a
+# subshell so a peer that Errors/exits (remote_run) can't kill the boot script.
 _power_roll_set_phase_ts()
 {
-    [ -e "$ROLLING_RESTART_JOB" ] || return 0
-    _power_roll_write --arg h "$1" --arg p "$2" --argjson ts "$(date +%s)" \
-        '(.nodes[]|select(.hostname==$h)) |= (.phase_ts=((.phase_ts//{}) + {($p):$ts}))'
+    local h=$1 p=$2 ts=$(date +%s)
+    local spool=${_POWER_ROLL_TS_SPOOL:-/run/roll_phase_ts.spool}
+    if [ -e "$ROLLING_RESTART_JOB" ] ; then
+        _power_roll_flush_phase_ts_spool "$spool"
+        _power_roll_write_phase_ts "$h" "$p" "$ts"
+        return 0
+    fi
+    local peer=$(_power_roll_ts_peer)
+    if [ -n "$peer" ] ; then
+        ( remote_run "$peer" "hex_sdk _power_roll_write_phase_ts $h $p $ts" ) >/dev/null 2>&1 && return 0
+    fi
+    echo "$h $p $ts" >> "$spool" 2>/dev/null
+    return 0
 }
 
 _power_roll_set_node_num() { _power_roll_write --arg h "$1" --argjson v "$3" "(.nodes[]|select(.hostname==\$h).$2)=\$v" ; }

--- a/core/sdk_sh/tests/test_power_roll_phase_ts.sh
+++ b/core/sdk_sh/tests/test_power_roll_phase_ts.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Unit test for the rolling-restart phase_ts delegate/buffer logic in
+# ../modules/sdk_power.sh: _power_roll_write_phase_ts / _power_roll_flush_phase_ts_spool
+# / _power_roll_set_phase_ts. job.json lives on cephfs (not mounted early in a node's
+# boot), so a stamp must be written directly, delegated to an up peer, or spooled and
+# replayed -- never dropped, never fatal.
+#
+# Self-contained: extracts just these functions (mocks the jq write, remote_run and
+# the peer lookup), so it needs no cluster and no cephfs.  Run: bash test_...sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_power.sh"
+
+for fn in _power_roll_write_phase_ts _power_roll_flush_phase_ts_spool _power_roll_ts_peer _power_roll_set_phase_ts ; do
+    body="$(awk -v f="^${fn}\\\\(\\\\)" '$0~f{p=1} p{print} p&&/^}/{exit}' "$SRC")"
+    [ -n "$body" ] || { echo "FAIL: $fn not extracted"; exit 1; }
+    eval "$body"
+done
+
+WRITES=$(mktemp)                       # every jq-layer write records "h p ts" here
+pass=0 fail=0
+chk(){ if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: $1: got [$2] want [$3]"; fi; }
+
+# mock the jq write layer
+_power_roll_write(){ local h p ts; while [ $# -gt 0 ]; do case "$1" in
+    --arg) case "$2" in h) h=$3;; p) p=$3;; esac; shift 3;;
+    --argjson) [ "$2" = ts ] && ts=$3; shift 3;;
+    *) shift;; esac; done; echo "$h $p $ts" >> "$WRITES"; }
+
+# 1. write_phase_ts: writes when job exists; no-op + rc1 when it doesn't
+ROLLING_RESTART_JOB=$(mktemp); : > "$WRITES"
+_power_roll_write_phase_ts n1 bootstrapping 100
+chk "write(job present)" "$(cat "$WRITES")" "n1 bootstrapping 100"
+rm -f "$ROLLING_RESTART_JOB"; : > "$WRITES"
+_power_roll_write_phase_ts n1 bootstrapping 100; chk "write(job absent) rc1" "$?" "1"
+chk "write(job absent) noop" "$(cat "$WRITES")" ""
+
+# 2. flush spool: replays every buffered stamp in order, then removes the spool
+ROLLING_RESTART_JOB=$(mktemp); : > "$WRITES"; SPOOL=$(mktemp)
+printf 'a bootstrapping 10\nb finalizing 20\n' > "$SPOOL"
+_power_roll_flush_phase_ts_spool "$SPOOL"
+chk "flush replays"  "$(tr '\n' ';' < "$WRITES")" "a bootstrapping 10;b finalizing 20;"
+chk "flush clears"   "$([ -e "$SPOOL" ] && echo y || echo n)" "n"
+
+# 3. set_phase_ts branch selection (spool path overridden for the test)
+export _POWER_ROLL_TS_SPOOL=$(mktemp -u)
+# 3a. cephfs up -> direct write, no delegation, no spool
+ROLLING_RESTART_JOB=$(mktemp); : > "$WRITES"; rm -f "$_POWER_ROLL_TS_SPOOL"
+_power_roll_ts_peer(){ echo PEER; }; remote_run(){ echo "DELEGATED" >> "$WRITES"; return 0; }
+_power_roll_set_phase_ts n1 bootstrapping
+chk "3a direct write"    "$(awk '{print $1,$2}' "$WRITES")" "n1 bootstrapping"
+chk "3a no delegation"   "$(grep -c DELEGATED "$WRITES")" "0"
+chk "3a no spool"        "$([ -e "$_POWER_ROLL_TS_SPOOL" ] && echo y || echo n)" "n"
+# 3b. cephfs down + peer reachable + delegate ok -> delegated, no local spool
+rm -f "$ROLLING_RESTART_JOB" "$_POWER_ROLL_TS_SPOOL"; : > "$WRITES"
+_power_roll_set_phase_ts n1 bootstrapping
+chk "3b delegated"       "$(grep -c DELEGATED "$WRITES")" "1"
+chk "3b no spool"        "$([ -e "$_POWER_ROLL_TS_SPOOL" ] && echo y || echo n)" "n"
+# 3c. cephfs down + no peer -> buffered to spool (not lost)
+rm -f "$_POWER_ROLL_TS_SPOOL"; : > "$WRITES"; _power_roll_ts_peer(){ :; }
+_power_roll_set_phase_ts n1 bootstrapping
+chk "3c buffered"        "$(awk '{print $1,$2}' "$_POWER_ROLL_TS_SPOOL" 2>/dev/null)" "n1 bootstrapping"
+# 3d. cephfs down + peer but delegate FAILS -> falls back to spool (never lost)
+rm -f "$_POWER_ROLL_TS_SPOOL"; : > "$WRITES"; _power_roll_ts_peer(){ echo PEER; }; remote_run(){ return 1; }
+_power_roll_set_phase_ts n1 finalizing
+chk "3d delegate-fail buffers" "$(awk '{print $1,$2}' "$_POWER_ROLL_TS_SPOOL" 2>/dev/null)" "n1 finalizing"
+
+rm -f "$WRITES" "$_POWER_ROLL_TS_SPOOL" 2>/dev/null
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: phase_ts delegate/buffer"; exit 0; } || exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`rolling_restart status` showed a blank `bootstrapping` column and an inflated, never-ending `rebooting` time.

**Root cause.** The phase state (`job.json`) lives on cephfs, and `_power_roll_set_phase_ts` guards on `[ -e "$ROLLING_RESTART_JOB" ] || return 0`. The `bootstrapping` stamp fires early in a recovering node’s boot — **before its config commit mounts cephfs** — so the write is silently dropped. `finalizing`/`done` run after the mount and record fine. Because the display derives `rebooting = bootstrapping_ts − rebooting_ts`, a missing `bootstrapping_ts` leaves `rebooting` open-ended. (`cluster bootup status` is unaffected — it uses a local `/run` file.)

**Fix.** Capture the real timestamp, then:
1. write it directly if cephfs is up (also flushing any buffered stamps);
2. else delegate to an up control peer that has cephfs — **in a subshell**, so a peer that Errors/`exit`s via `remote_run` can’t kill the boot script;
3. else spool locally to `/run` and replay on the next cephfs-up call.

The stamp is never dropped and never fatal. Unit-tested in `core/sdk_sh/tests/test_power_roll_phase_ts.sh` (direct / delegated / buffered / delegate-failure branches).

Latent since the phase-timing feature (26310cf / #1076) — not a regression.

#### Which issue(s) this PR fixes

Fixes #1091

#### Special notes for your reviewer

> Surfaced while validating the boot-time work on the sky HA cluster. Independent of the storage-recovery (#1085) and master-bootup-done (#1090) fixes. The delegate path deliberately avoids the bare `remote_run → Error → exit` hazard (the same one #1090 addresses) by isolating it in a subshell.

#### Additional documentation

```docs
kb/cubecos/known-issues/rolling-restart-bootstrapping-time-blank.md
```