### PR TITLE
fix(health): repair OVN metadata by nb_cfg progress, not the Alive flag

### DIFF
--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -757,8 +757,11 @@ ClusterStartMain(int argc, const char** argv)
     CliPrintf("Starting cluster");
     HexSpawn(0, HEX_SDK, "cmd", HEX_SDK, "-v", "cube_cluster_start", ZEROCHAR_PTR);
 
-    // FIXME: workaround neutron services that aren't always in ready state
-    HexUtilSystemF(0, 0, HEX_SDK " health_neutron_repair");
+    // FIXME: workaround neutron services that aren't always in ready state.
+    // Disabled to verify it's still needed -- health_neutron_repair now waits for OVN
+    // metadata nb_cfg catch-up (#1094), and ClusterCheckRepairMain below repairs neutron
+    // anyway, so this pre-emptive call may be redundant.
+    // HexUtilSystemF(0, 0, HEX_SDK " health_neutron_repair");
 
     ClusterCheckRepairMain(1, &ACTION);
 
@@ -847,7 +850,9 @@ ClusterReadyMain(int argc, const char** argv)
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run " HEX_SDK " ceph_pool_replicate_init");
 
     CliPrintf("[2/6] Checking SDN services");
-    HexUtilSystemF(0, 0,  HEX_SDK " host_local_run " HEX_SDK " health_neutron_repair");
+    // Disabled to verify it's still needed (#1094): health_neutron_repair now waits for OVN
+    // metadata nb_cfg catch-up, and [6/6] cluster_check_repair_async repairs neutron anyway.
+    // HexUtilSystemF(0, 0,  HEX_SDK " host_local_run " HEX_SDK " health_neutron_repair");
 
     CliPrintf("[3/6] Configuring modules");
     if (cfgFlatExt)
@@ -863,7 +868,9 @@ ClusterReadyMain(int argc, const char** argv)
 
     CliPrintf("[6/6] Cluster check and repair started in the background.");
     CliPrintf("      The box is ready to use now; the result will pop up here when it completes.");
-    HexSpawn(0, HEX_SDK, "host_local_run", "hex_sdk", "-m force",  "health_neutron_repair", ZEROCHAR_PTR);
+    // Disabled to verify it's still needed (#1094): cluster_check_repair_async below already
+    // repairs neutron via check_repair, which now waits for OVN metadata nb_cfg catch-up.
+    // HexSpawn(0, HEX_SDK, "host_local_run", "hex_sdk", "-m force",  "health_neutron_repair", ZEROCHAR_PTR);
     HexSpawn(0, HEX_SDK, "cmd", "rm -f /tmp/health_*_error.count", ZEROCHAR_PTR);
     HexSystemF(0, HEX_SDK " cluster_check_repair_async");
 

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -7,6 +7,7 @@ if [ -z "$PROG" ] ; then
 fi
 
 source ${SDK_DIR}/modules/errcodes
+source ${SDK_DIR}/modules/sdk_ovn.sh   # _ovn_metadata_* helpers used by health_neutron_check/repair
 # _check is invoked by lmi which lacks persmissions to run
 # ssh commands like is_remote_running. Wrap it with /usr/sbin/hex_config sdk_run
 ERR_CODE=${ERR_CODE:-0}         # health_check error code
@@ -2285,7 +2286,8 @@ health_neutron_check()
         ERR_CODE=1
     elif [ -z "$service_stats" ] ; then
         ERR_CODE=2
-    elif [ "$metadata_up" == "0" -o "$metadata_down" != "0" ] ; then
+    elif _ovn_metadata_stuck_hosts "$service_stats" ; then
+        # only stuck agents; catching-up ones self-heal (hosts in OVN_META_STUCK)
         ERR_CODE=3
     elif [ "$vpn_up" == "0" -o "$vpn_down" != "0" ] ; then
         ERR_CODE=4
@@ -2326,6 +2328,12 @@ _health_neutron_auto_repair()
             $CEPH mgr module enable dashboard
         elif [ $ERR_CODE -eq 6 ] ; then
             Quiet -n cmd -c -- $HEX_SDK os_neutron_worker_scale
+        elif [ $ERR_CODE -eq 3 ] ; then
+            # restart only stuck agents; catching-up ones self-heal (no db_sync -- the
+            # agent re-syncs nb_cfg itself; a resource resync is irrelevant here).
+            for host in $OVN_META_STUCK ; do
+                remote_systemd_restart $host neutron-ovn-metadata-agent
+            done
         else
             $HEX_SDK ovn_neutron_db_sync
             readarray entry_array <<<"$(echo -n "$ERR_MSG" | awk '/False/{print $1" "$3}' | sort)"
@@ -2343,6 +2351,11 @@ _health_neutron_auto_repair()
 
 health_neutron_repair()
 {
+    # Wait for catching-up metadata agents to converge before escalating: the manual path
+    # must return a healthy agent, and the bootstrap/delete below would reset a still-
+    # catching-up agent's sync. (auto_repair just leaves it to self-heal.)
+    _ovn_metadata_wait_caught_up 120
+
     # A full neutron bootstrap is expensive (~75s) and set_ready invokes this
     # twice; only re-bootstrap when the OVN/neutron agents aren't already healthy.
     local agent_alive="$($OPENSTACK network agent list -f value -c Alive 2>/dev/null)"

--- a/core/sdk_sh/modules/sdk_ovn.sh
+++ b/core/sdk_sh/modules/sdk_ovn.sh
@@ -265,3 +265,79 @@ ovn_bridge_sflow_disable()
 
     rm -f /etc/appliance/state/sflow_enabled
 }
+
+# --- OVN metadata liveness (nb_cfg progress) --------------------------------
+# Alive=False just means the agent's sb-cfg lags nb_cfg (normal while it re-syncs after a
+# reconnect). Track progress toward nb_cfg: catching-up self-heals, only a stuck (frozen)
+# sb-cfg needs a restart. All OVN reads are bulk -- a fixed 3 calls per pass regardless of
+# node count, since metadata runs on every compute. Mechanism/rationale in PR #1094.
+_ovn_nb_cfg() { ovn-nbctl --timeout=5 get NB_Global . nb_cfg 2>/dev/null ; }
+
+# One bulk snapshot of every chassis' metadata sb-cfg: "<hostname> <sbcfg>" per line.
+# Joins Chassis (name->hostname) with Chassis_Private (name->external_ids) on chassis name
+# -- two ovn-sbctl reads total, independent of node count. Empty if OVN can't be read.
+_ovn_metadata_sbcfg_all()
+{
+    local chassis priv
+    chassis=$(ovn-sbctl --timeout=5 -f csv --no-headings --columns=name,hostname list Chassis 2>/dev/null | tr -d '"')
+    priv=$(ovn-sbctl --timeout=5 -f csv --no-headings --columns=name,external_ids list Chassis_Private 2>/dev/null | tr -d '"')
+    [ -n "$chassis" ] && [ -n "$priv" ] || return 1
+    awk '
+        FNR==NR { i=index($0,","); host[substr($0,1,i-1)]=substr($0,i+1); next }
+        { i=index($0,","); nm=substr($0,1,i-1)
+          if (match($0,/neutron:ovn-metadata-sb-cfg=[0-9]+/)) {
+              s=substr($0,RSTART,RLENGTH); sub(/.*=/,"",s)
+              if (nm in host) print host[nm], s
+          }
+        }
+    ' <(printf '%s\n' "$chassis") <(printf '%s\n' "$priv")
+}
+
+# Classify the given metadata hosts from ONE bulk snapshot (3 ovn calls total, not per host).
+# Sets OVN_META_STUCK (frozen/unreadable -> restart) and OVN_META_CATCHING (advancing -> leave
+# alone). A per-host state file holds the last sb-cfg, to tell advancing from frozen.
+_ovn_metadata_classify()   # <hosts>
+{
+    OVN_META_STUCK=""; OVN_META_CATCHING=""
+    local target snap h cur last statef
+    declare -A _sb
+    target=$(_ovn_nb_cfg)
+    snap=$(_ovn_metadata_sbcfg_all)
+    while read -r h cur ; do [ -n "$h" ] && _sb[$h]=$cur ; done <<< "$snap"
+    for h in $1 ; do
+        cur=${_sb[$h]:-} ; statef=${_OVN_SBCFG_DIR:-/run}/health_neutron_sbcfg_$h
+        last=$(cat "$statef" 2>/dev/null)
+        [ -n "$cur" ] && echo "$cur" > "$statef"
+        if [ -z "$target" ] || [ -z "$cur" ] ; then OVN_META_STUCK+="$h "                    # can't tell -> repairable
+        elif [ "$cur" -ge "$target" ] 2>/dev/null ; then :                                    # caught up
+        elif [ -n "$last" ] && [ "$cur" -le "$last" ] 2>/dev/null ; then OVN_META_STUCK+="$h " # frozen
+        else OVN_META_CATCHING+="$h "                                                         # advancing / first-seen
+        fi
+    done
+}
+
+# Alive=False metadata agents that are stuck (frozen sb-cfg); records them in OVN_META_STUCK.
+_ovn_metadata_stuck_hosts()   # <service_stats>
+{
+    local hosts=$(echo "$1" | grep neutron-ovn-metadata-agent | grep -i False | awk '{print $3}')
+    _ovn_metadata_classify "$hosts"
+    [ -n "$OVN_META_STUCK" ]
+}
+
+# Wait only while progress is observable, capped by an absolute deadline. Each pass is a fixed
+# 3 bulk ovn calls, so it scales to 100+ metadata agents; a failed/timed-out read yields stuck
+# (not catching), so we bail instead of burning the budget. Manual repair() path only.
+_ovn_metadata_wait_caught_up()   # <timeout-secs, default 120>
+{
+    local timeout=${1:-120} deadline hosts
+    hosts=$($OPENSTACK network agent list -f value -c Binary -c Alive -c Host 2>/dev/null \
+            | grep neutron-ovn-metadata-agent | grep -i False | awk '{print $3}')
+    [ -n "$hosts" ] || return 0
+    deadline=$(( $(date +%s) + timeout ))
+    while [ "$(date +%s)" -lt "$deadline" ] ; do
+        _ovn_metadata_classify "$hosts"
+        [ -z "$OVN_META_CATCHING" ] && return 0
+        sleep 10
+    done
+    return 0
+}

--- a/core/sdk_sh/tests/test_ovn_metadata_classify.sh
+++ b/core/sdk_sh/tests/test_ovn_metadata_classify.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Unit test for the bulk OVN metadata liveness logic in ../modules/sdk_ovn.sh:
+#   _ovn_metadata_classify  -- partitions lagging agents into stuck vs catching-up from a
+#                              single nb_cfg + one bulk sb-cfg snapshot (O(1) ovn calls).
+#   _ovn_metadata_sbcfg_all -- the Chassis / Chassis_Private join parser (real csv format).
+#
+# Self-contained: extracts just those two functions, mocks the OVN getters, so it needs no
+# cluster/OVN.  Run: bash test_ovn_metadata_classify.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_ovn.sh"
+eval "$(awk '/^_ovn_metadata_classify\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+eval "$(awk '/^_ovn_metadata_sbcfg_all\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+[ "$(type -t _ovn_metadata_classify)" = function ] || { echo "FAIL: classify not extracted"; exit 1; }
+
+export _OVN_SBCFG_DIR=$(mktemp -d)
+pass=0 fail=0
+ck(){ [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+
+# ---- classify: mock nb_cfg + the bulk snapshot ----
+MOCK_NB=""; MOCK_SNAP=""
+_ovn_nb_cfg(){ echo "$MOCK_NB"; }
+_ovn_metadata_sbcfg_all(){ printf '%s' "$MOCK_SNAP"; }   # "<host> <sbcfg>" lines
+bucket(){ case " $OVN_META_STUCK " in *" $1 "*) echo stuck; return;; esac
+          case " $OVN_META_CATCHING " in *" $1 "*) echo catching; return;; esac; echo clear; }
+run1(){  # <host> <nb> <cur|''> <last|''>
+    MOCK_NB="$2"; { [ -n "$3" ] && MOCK_SNAP="$1 $3"; } || MOCK_SNAP=""
+    { [ -n "$4" ] && echo "$4" > "$_OVN_SBCFG_DIR/health_neutron_sbcfg_$1"; } || rm -f "$_OVN_SBCFG_DIR/health_neutron_sbcfg_$1"
+    _ovn_metadata_classify "$1"
+}
+run1 h1 100 100 '' ; ck "$(bucket h1)" clear    "caught_up (cur==nb)"
+run1 h1 100 105 '' ; ck "$(bucket h1)" clear    "ahead (cur>nb)"
+run1 h2 100 90  80 ; ck "$(bucket h2)" catching "advancing (90>80)"
+run1 h3 100 90  '' ; ck "$(bucket h3)" catching "first-seen while lagging"
+run1 h4 100 90  90 ; ck "$(bucket h4)" stuck    "frozen (90==90)"
+run1 h5 100 90  95 ; ck "$(bucket h5)" stuck    "backwards (90<95)"
+run1 h6 ""  90  '' ; ck "$(bucket h6)" stuck    "empty nb_cfg -> fail-safe"
+run1 h7 100 ''  '' ; ck "$(bucket h7)" stuck    "host absent from snapshot -> fail-safe"
+run1 h8 100 70  '' ; ck "$(cat "$_OVN_SBCFG_DIR/health_neutron_sbcfg_h8")" 70 "state file updated to cur"
+
+# bulk: one classify call partitions many hosts at once
+MOCK_NB=100; MOCK_SNAP=$'a 100\nb 90\nc 90'
+echo 88 > "$_OVN_SBCFG_DIR/health_neutron_sbcfg_b"   # b advancing 88->90
+echo 90 > "$_OVN_SBCFG_DIR/health_neutron_sbcfg_c"   # c frozen 90->90
+_ovn_metadata_classify "a b c"
+ck "$(bucket a)" clear    "bulk: a caught_up"
+ck "$(bucket b)" catching "bulk: b advancing"
+ck "$(bucket c)" stuck    "bulk: c frozen"
+
+# ---- parser: _ovn_metadata_sbcfg_all via an ovn-sbctl PATH shim (real csv format) ----
+# restore the real parser (it was mocked above for the classify tests)
+eval "$(awk '/^_ovn_metadata_sbcfg_all\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+shim=$(mktemp -d)
+cat > "$shim/chassis.csv" <<'EOF'
+"""cd8bd37f-72d3-44a5-9d7a-b8198641c842""",sky142
+"""ada4ccfe-d238-42b2-ad85-96a2de41bc1a""",sky143
+"""fcf50a31-d9c0-4779-be93-a6beaa1e2807""",sky141
+EOF
+cat > "$shim/priv.csv" <<'EOF'
+"""ada4ccfe-d238-42b2-ad85-96a2de41bc1a""","{""neutron:ovn-metadata-id""=""x"", ""neutron:ovn-metadata-sb-cfg""=""42140"", ""neutron:ovn-vpnagent-sb-cfg""=""42147""}"
+"""fcf50a31-d9c0-4779-be93-a6beaa1e2807""","{""neutron:ovn-metadata-sb-cfg""=""42147"", ""neutron:ovn-vpnagent-sb-cfg""=""42147""}"
+EOF
+cat > "$shim/ovn-sbctl" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"list Chassis_Private"*) cat "$shim/priv.csv" ;;
+  *"list Chassis"*)         cat "$shim/chassis.csv" ;;
+esac
+EOF
+chmod +x "$shim/ovn-sbctl"
+# sky142 present in Chassis but absent from Chassis_Private -> correctly omitted.
+# must pick metadata-sb-cfg (42140/42147), never vpnagent-sb-cfg.
+out=$(PATH="$shim:$PATH" _ovn_metadata_sbcfg_all | sort | tr '\n' ';')
+ck "$out" "sky141 42147;sky143 42140;" "parser join: metadata sb-cfg only, missing-priv host omitted"
+
+rm -rf "$_OVN_SBCFG_DIR" "$shim"
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: _ovn_metadata_classify + _ovn_metadata_sbcfg_all"; exit 0; } || exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

After a rolling restart, `neutron(N metadata not all up)` could stay NG for ~10-15 min, with the auto-repair *prolonging* it.

**Root cause.** OVN metadata "Alive" is an nb_cfg sequence: neutron-server bumps `NB_Global.nb_cfg`, ovn-northd copies it to SB, each agent writes the value it processed into its `Chassis_Private`. `Alive=False` only means the agent's `sb-cfg` **lags** `nb_cfg` — normal while it re-syncs after reconnecting. `health_neutron_check` flagged `ERR_CODE=3` on *any* `Alive=False` agent and the repair restarted it — but restarting a catching-up agent **drops its SB connection and resets the sync**, so the repair (every cycle) kept throwing away the agent's progress. Observed: 3 restarts over ~15 min, each interrupting re-sync; healed only once a restart was left alone.

**Fix — classify by nb_cfg progress:**
- `caught_up` — `sb-cfg >= nb_cfg`
- `catching_up` — `sb-cfg` advancing since last check (or first-seen)
- `stuck` — `sb-cfg` frozen

Then split by caller, because the two repair paths have different contracts:

- **`auto_repair`** (periodic, backgrounded, must not block): flag + restart **only stuck** agents; leave catching-up ones entirely — they self-heal within a check cycle.
- **`repair()` = `health_neutron_repair`** (explicit: operator `check_repair`, `set_ready`): its contract is to return a *converged* service, so it now **waits (bounded 120 s)** for catching-up agents before escalating. Previously any `Alive=False` triggered a full `hex_config bootstrap neutron` (~75 s) and **deleted the agent record** — resetting the very sync that was about to complete. The wait is self-limiting (only while a read is advancing) and capped by an absolute wall-clock deadline.

**Scale.** Metadata agents run on **every compute** (target: 100+ nodes), so the OVN reads are **bulk**: one `nb_cfg` read plus a single `Chassis`/`Chassis_Private` snapshot (joined on chassis name) classify *every* agent at once — a fixed **~3 ovn calls per pass regardless of node count**, not 3 per host. A timed-out/unreadable read → `stuck` (fail-safe), so a hung OVN never holds the wait; the per-pass cost is bounded even at 100+ nodes, in both `check()` and `repair()`.

**Fail-safe:** if OVN can't be queried, treat as stuck so a genuine failure still repairs. Unit-tested (`core/sdk_sh/tests/test_ovn_metadata_classify.sh`) — classification logic + the Chassis/Chassis_Private join parser against real csv. Bulk join validated live on the sky HA cluster.

#### Which issue(s) this PR fixes

Fixes #1093

#### Special notes for your reviewer

> Found while validating the boot-time work on the sky HA cluster (post rolling-restart). Independent of #1085/#1090/#1092. Helpers live in `core/sdk_sh/modules/sdk_ovn.sh` under the `_ovn_*` convention (resolved by the neutron health check/repair via the all-modules fallback); stuck hosts recorded in `OVN_META_STUCK`. vpn/control agents (same nb_cfg mechanism) left as-is for now.

#### Additional documentation

\`\`\`docs
kb/cubecos/known-issues/neutron-metadata-restart-prolongs-outage.md
\`\`\`