### PR TITLE
fix(ceph): render mon host from the live monmap on every node's boot

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -287,6 +287,8 @@ cube_cluster_start_node()
     _cube_cluster_start_env
     Quiet -n ip neigh flush all
     Quiet -n $HEX_SDK ceph_leave_maintenance # ensure storage is working before other actions
+    # re-render mon host from the live monmap (boot commit writes only the master mon IP)
+    Quiet -n /usr/sbin/hex_config sync_ceph_config
     if [ "$VERBOSE" == "1" ] ; then
         /usr/sbin/hex_config -p trigger node_start
     else

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1744,6 +1744,13 @@ SyncConfigMain(int argc, char* argv[])
     std::string monIplist = HexUtilPOpen(HEX_SDK " ceph_mon_map_iplist %s", CONF);
     std::string mdsIplist = HexUtilPOpen(HEX_SDK " ceph_mds_map_iplist %s", CONF);
     std::string adminCliPass = GetSaltKey(s_saltkey, s_adminCliPass.newValue(), s_seed.newValue());
+
+    // no usable monmap (sdk returns "1" on failure): keep the existing conf
+    if (monHosts.length() == 0 || monIplist.find('.') == std::string::npos) {
+        HexLogWarning("sync_ceph_config: no monmap available, keeping %s", CONF);
+        return EXIT_SUCCESS;
+    }
+
     UpdateConfig(fsid, ctrl, ctrlIp, sharedId, monHosts, monIplist, pubNet, clstrNet, adminCliPass, s_perfTuned, mdsIplist);
 
     return EXIT_SUCCESS;

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -296,14 +296,14 @@ ceph_mon_map_iplist()
     elif echo $iplist | grep -q 'v1' ; then
         iplist=$(monmaptool --print $MAPFILE | grep 6789 | awk -F' ' '{print $2}' | awk -F':' '{print $2}' | tr '\n' ',')
     fi
-    echo -n ${iplist:-1}
+    echo -n $iplist
 }
 
 ceph_mon_map_hosts()
 {
     ceph_mon_map_create $1
     local hosts=$(monmaptool --print $MAPFILE | grep 6789 | awk -F' ' '{print $3}' | cut -c 5- | tr '\n' ',')
-    echo -n ${hosts:-1}
+    echo -n $hosts
 }
 
 ceph_mds_map_iplist()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Every node's config commit renders `mon host = <master mon IP>` — one address. The full-monmap renderer (`sync_ceph_config`) exists, but since the rolling-restart split it is reached only via the master-only, run-once `cluster_start` trigger (or the manual `storage > sync_config` CLI), so non-master nodes never converge and every boot regresses their conf back to the single master IP.

Consequence (hit live during a host-failure test): with the master chassis off, every **new** ceph client on the survivors hangs bootstrapping against the dead IP despite healthy 2/3 mon quorum — `ceph df` blocks nova-compute's resource tracker, heartbeats stop, both survivors go scheduler-`down`, and host-failure evacuation returns `NoValidHost` cluster-wide. Running qemu processes are unaffected (they hold the learned monmap), which kept this invisible until a real host death.

Fix:
- `cube_cluster_start_node`: run `sync_ceph_config` on **every node's boot**, restoring the pre-refactor per-node convergence (the sdk falls back to extracting the local mon store when quorum is unreachable).
- `ceph_mon_map_iplist` / `ceph_mon_map_hosts`: return empty output on failure instead of the literal `1` — a bash `${var:-1}` default-expansion copied from the file's arithmetic contexts; every caller (sync, the rejoin path, `ceph_mds_map_hosts`) consumed the sentinel as real data, e.g. writing `mon host = 1`.
- `sync_ceph_config`: additionally skip the rewrite unless the monmap yields something address-shaped, so a failed monmap fetch never clobbers a working conf (defense in depth over the sdk fix).

Validated on sky141/142/143: `sync_ceph_config` renders the full v2/v1 monmap list per node and ceph clients answer instantly with a mon down; during the incident, the single-IP → full-list edit turned a ~35-minute evacuation blackout into a sub-minute evacuation.

#### Which issue(s) this PR fixes

Fixes #1099

#### Special notes for your reviewer

- First-bootstrap behavior is unchanged: the commit path still seeds the single master IP before a monmap exists; the per-node sync then converges the conf as soon as a monmap is available and keeps it converged on every boot.
- Transition note for existing clusters: the first post-upgrade boot syncs from a conf that still lists only the master — fine while the master is alive; on control nodes the local-store fallback covers the master-down case.
- The `[mds.<host>] mon host` line from `ceph_mds_map_iplist` is pre-existing, section-scoped behavior and deliberately untouched.
- The `CONTROL_REJOIN` fetch (`config_ceph.cpp:1508`) also consumed the old sentinel unvalidated; with the sdk fix it now gets empty output on failure — still a failing rejoin, but no longer writes garbage. A validation there is a possible follow-up.

#### Additional documentation

```docs
Each node re-renders ceph.conf's `mon host` from the live monmap at every boot
(cube_cluster_start_node -> hex_config sync_ceph_config); clients can reach the
mon quorum regardless of which control node is down.
```
