### PR TITLE
fix(ha): survive VIP failover — deadline API sessions, sweep stale flows

### DIFF
--- a/core/masakari/yoga_patch/masakari/compute/nova.py.orig
+++ b/core/masakari/yoga_patch/masakari/compute/nova.py.orig
@@ -1,0 +1,262 @@
+# Copyright 2016 NTT DATA
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Handles all requests to Nova.
+"""
+
+import functools
+import sys
+
+from keystoneauth1 import exceptions as keystone_exception
+import keystoneauth1.loading
+import keystoneauth1.loading.session
+from novaclient import api_versions
+from novaclient import client as nova_client
+from novaclient import exceptions as nova_exception
+from oslo_log import log as logging
+from oslo_utils import encodeutils
+from requests import exceptions as request_exceptions
+
+from masakari import conf
+from masakari import context as ctx
+from masakari import exception
+from masakari import utils
+
+CONF = conf.CONF
+CONF.import_group('keystone_authtoken', 'keystonemiddleware.auth_token')
+
+LOG = logging.getLogger(__name__)
+
+NOVA_API_VERSION = "2.53"
+
+nova_extensions = [ext for ext in
+                   nova_client.discover_extensions(NOVA_API_VERSION)
+                   if ext.name in ("list_extensions",)]
+
+
+def _reraise(desired_exc):
+    utils.reraise(type(desired_exc), desired_exc, sys.exc_info()[2])
+
+
+def translate_nova_exception(method):
+    """Transforms a cinder exception but keeps its traceback intact."""
+    @functools.wraps(method)
+    def wrapper(self, ctx, *args, **kwargs):
+        try:
+            res = method(self, ctx, *args, **kwargs)
+        except (request_exceptions.Timeout,
+                nova_exception.CommandError,
+                keystone_exception.ConnectionError) as exc:
+            err_msg = encodeutils.exception_to_unicode(exc)
+            _reraise(exception.MasakariException(reason=err_msg))
+        except (keystone_exception.BadRequest,
+                nova_exception.BadRequest) as exc:
+            err_msg = encodeutils.exception_to_unicode(exc)
+            _reraise(exception.InvalidInput(reason=err_msg))
+        except (keystone_exception.Forbidden,
+                nova_exception.Forbidden) as exc:
+            err_msg = encodeutils.exception_to_unicode(exc)
+            _reraise(exception.Forbidden(err_msg))
+        except (nova_exception.NotFound) as exc:
+            err_msg = encodeutils.exception_to_unicode(exc)
+            _reraise(exception.NotFound(reason=err_msg))
+        except nova_exception.Conflict as exc:
+            err_msg = encodeutils.exception_to_unicode(exc)
+            _reraise(exception.Conflict(reason=err_msg))
+        return res
+    return wrapper
+
+
+def novaclient(context, timeout=None):
+    """Returns a Nova client
+
+    @param timeout: Number of seconds to wait for an answer before raising a
+        Timeout exception (None to disable)
+    """
+    nova_catalog_info = CONF.nova_catalog_admin_info
+    service_type, service_name, endpoint_type = nova_catalog_info.split(':')
+
+    context = ctx.RequestContext(
+        CONF.os_privileged_user_name, None,
+        auth_token=CONF.os_privileged_user_password,
+        project_name=CONF.os_privileged_user_tenant,
+        service_catalog=context.service_catalog,
+        global_request_id=context.global_id)
+
+    # User needs to authenticate to Keystone before querying Nova, so we set
+    # auth_url to the identity service endpoint
+    url = CONF.os_privileged_user_auth_url
+
+    LOG.debug('Creating a Nova client using "%s" user',
+              CONF.os_privileged_user_name)
+
+    # Now that we have the correct auth_url, username, password and
+    # project_name, let's build a Keystone session.
+    loader = keystoneauth1.loading.get_plugin_loader(
+        CONF.keystone_authtoken.auth_type)
+    auth = loader.load_from_options(
+        auth_url=url,
+        username=context.user_id,
+        password=context.auth_token,
+        project_name=context.project_name,
+        user_domain_name=CONF.os_user_domain_name,
+        project_domain_name=CONF.os_project_domain_name,
+        system_scope=CONF.os_system_scope)
+    session_loader = keystoneauth1.loading.session.Session()
+    keystone_session = session_loader.load_from_options(
+        auth=auth, cacert=CONF.nova_ca_certificates_file,
+        insecure=CONF.nova_api_insecure)
+
+    client_obj = nova_client.Client(
+        api_versions.APIVersion(NOVA_API_VERSION),
+        session=keystone_session,
+        insecure=CONF.nova_api_insecure,
+        timeout=timeout,
+        global_request_id=context.global_id,
+        region_name=CONF.os_region_name,
+        endpoint_type=endpoint_type,
+        service_type=service_type,
+        service_name=service_name,
+        cacert=CONF.nova_ca_certificates_file,
+        extensions=nova_extensions)
+
+    return client_obj
+
+
+class API(object):
+    """API for interacting with novaclient."""
+
+    @translate_nova_exception
+    def get_servers(self, context, host):
+        """Get a list of servers running on a specified host."""
+        opts = {
+            'host': host,
+            'all_tenants': True
+        }
+        nova = novaclient(context)
+        LOG.info('Fetch Server list on %s', host)
+        return nova.servers.list(detailed=True, search_opts=opts)
+
+    @translate_nova_exception
+    def enable_disable_service(self, context, host_name, enable=False,
+                               reason=None):
+        """Enable or disable the service specified by nova service id."""
+        nova = novaclient(context)
+        service = nova.services.list(host=host_name, binary='nova-compute')[0]
+
+        if not enable:
+            LOG.info('Disable nova-compute on %s', host_name)
+            if reason:
+                nova.services.disable_log_reason(service.id, reason)
+            else:
+                nova.services.disable(service.id)
+        else:
+            LOG.info('Enable nova-compute on %s', host_name)
+            nova.services.enable(service.id)
+
+    @translate_nova_exception
+    def is_service_disabled(self, context, host_name, binary):
+        """Check whether service is enabled or disabled on given host."""
+        nova = novaclient(context)
+        service = nova.services.list(host=host_name, binary=binary)[0]
+        return service.status == 'disabled'
+
+    @translate_nova_exception
+    def evacuate_instance(self, context, uuid, target=None):
+        """Evacuate an instance from failed host to specified host."""
+        msg = ('Call evacuate command for instance %(uuid)s on host '
+               '%(target)s')
+        LOG.info(msg, {'uuid': uuid, 'target': target})
+        nova = novaclient(context)
+        nova.servers.evacuate(uuid, host=target)
+
+    @translate_nova_exception
+    def reset_instance_state(self, context, uuid, status='error'):
+        """Reset the state of an instance to active or error."""
+        msg = ('Call reset state command on instance %(uuid)s to '
+               'status: %(status)s.')
+        LOG.info(msg, {'uuid': uuid, 'status': status})
+        nova = novaclient(context)
+        nova.servers.reset_state(uuid, status)
+
+    @translate_nova_exception
+    def get_server(self, context, uuid):
+        """Get a server."""
+        nova = novaclient(context)
+        msg = ('Call get server command for instance %(uuid)s')
+        LOG.info(msg, {'uuid': uuid})
+        return nova.servers.get(uuid)
+
+    @translate_nova_exception
+    def stop_server(self, context, uuid):
+        """Stop a server."""
+        nova = novaclient(context)
+        msg = ('Call stop server command for instance %(uuid)s')
+        LOG.info(msg, {'uuid': uuid})
+        return nova.servers.stop(uuid)
+
+    @translate_nova_exception
+    def start_server(self, context, uuid):
+        """Start a server."""
+        nova = novaclient(context)
+        msg = ('Call start server command for instance %(uuid)s')
+        LOG.info(msg, {'uuid': uuid})
+        return nova.servers.start(uuid)
+
+    @translate_nova_exception
+    def get_aggregate_list(self, context):
+        """Get all aggregate list."""
+        nova = novaclient(context)
+        LOG.info('Call aggregate-list command to get list of all aggregates.')
+        return nova.aggregates.list()
+
+    @translate_nova_exception
+    def add_host_to_aggregate(self, context, host, aggregate):
+        """Add host to given aggregate."""
+        nova = novaclient(context)
+        msg = ("Call add_host command to add host '%(host_name)s' to "
+               "aggregate '%(aggregate_name)s'.")
+        LOG.info(msg, {'host_name': host, 'aggregate_name': aggregate.name})
+        return nova.aggregates.add_host(aggregate.id, host)
+
+    @translate_nova_exception
+    def lock_server(self, context, uuid):
+        """Lock a server."""
+        nova = novaclient(context)
+        msg = ('Call lock server command for instance %(uuid)s')
+        LOG.info(msg, {'uuid': uuid})
+        return nova.servers.lock(uuid)
+
+    @translate_nova_exception
+    def unlock_server(self, context, uuid):
+        """Unlock a server."""
+        nova = novaclient(context)
+        msg = ('Call unlock server command for instance %(uuid)s')
+        LOG.info(msg, {'uuid': uuid})
+        return nova.servers.unlock(uuid)
+
+    @translate_nova_exception
+    def find_compute_service(self, context, compute_name):
+        """Find compute service with case sensitive hostname."""
+        nova = novaclient(context)
+        msg = ("Call compute service find command to get list of matching "
+               "hypervisor name '%(compute_name)s'")
+        LOG.info(msg, {'compute_name': compute_name})
+
+        computes = \
+            nova.services.list(binary='nova-compute', host=compute_name)
+        if len(computes) == 0:
+            raise exception.ComputeNotFoundByName(
+                compute_name=compute_name)

--- a/core/masakari/yoga_patch/masakari/compute/nova.py.patch
+++ b/core/masakari/yoga_patch/masakari/compute/nova.py.patch
@@ -1,0 +1,25 @@
+--- masakari/compute/nova.py	2026-07-11 11:21:16.676763358 +0800
++++ masakari/compute/nova.py	2026-07-11 11:21:16.676763358 +0800
+@@ -85,6 +85,11 @@
+     @param timeout: Number of seconds to wait for an answer before raising a
+         Timeout exception (None to disable)
+     """
++    # deadline every nova call: a hung request on a blackholed connection
++    # (e.g. after a VIP failover) otherwise blocks recovery flows for ~10min
++    if timeout is None:
++        timeout = 60
++
+     nova_catalog_info = CONF.nova_catalog_admin_info
+     service_type, service_name, endpoint_type = nova_catalog_info.split(':')
+ 
+@@ -118,6 +123,10 @@
+     keystone_session = session_loader.load_from_options(
+         auth=auth, cacert=CONF.nova_ca_certificates_file,
+         insecure=CONF.nova_api_insecure)
++    # novaclient ignores its timeout kwarg when handed a session; the
++    # deadline must live on the session itself or requests block forever
++    # on dead connections (e.g. after a VIP failover or host death)
++    keystone_session.timeout = timeout
+ 
+     client_obj = nova_client.Client(
+         api_versions.APIVersion(NOVA_API_VERSION),

--- a/core/modules/config_barbican.cpp
+++ b/core/modules/config_barbican.cpp
@@ -196,6 +196,7 @@ UpdateSharedId(std::string sharedId)
         cfg["DEFAULT"]["host_href"] = "http://" + sharedId + ":9311";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
     }
 

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -512,6 +512,7 @@ SetAuth(
 
     config["keystone_authtoken"]["auth_type"] = "password";
     config["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+    config["keystone_authtoken"]["http_connect_timeout"] = "15";
     config["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
     config["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
     config["keystone_authtoken"]["project_domain_name"] = domain;

--- a/core/modules/config_cyborg.cpp
+++ b/core/modules/config_cyborg.cpp
@@ -214,9 +214,12 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["service_catalog"]["auth_url"] = "http://" + sharedId + ":5000";
         cfg["placement"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["placement"]["timeout"] = "60";
         cfg["nova"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["nova"]["timeout"] = "60";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
     }
 

--- a/core/modules/config_designate.cpp
+++ b/core/modules/config_designate.cpp
@@ -338,6 +338,7 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
     }
 

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -391,6 +391,7 @@ SetAuth(
 {
     config["keystone_authtoken"]["auth_type"] = "password";
     config["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+    config["keystone_authtoken"]["http_connect_timeout"] = "15";
     config["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
     config["keystone_authtoken"]["memcached_servers "] = sharedId + ":11211";
     config["keystone_authtoken"]["project_domain_name"] = domain;

--- a/core/modules/config_heat.cpp
+++ b/core/modules/config_heat.cpp
@@ -219,6 +219,7 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["trustee"]["auth_url"] = "http://" + sharedId + ":5000";
         cfg["clients_keystone"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["ec2authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000/v3";

--- a/core/modules/config_ironic.cpp
+++ b/core/modules/config_ironic.cpp
@@ -333,12 +333,14 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["deploy"]["http_url"] = "http://" + sharedId + ":8484";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
 
         inspCfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         inspCfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         inspCfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        inspCfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         inspCfg["coordination"]["backend_url"] = "memcached://" + sharedId + ":11211";
         inspCfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
 

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -374,6 +374,7 @@ SetAuth(
 
     config["keystone_authtoken"]["auth_type"] = "password";
     config["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+    config["keystone_authtoken"]["http_connect_timeout"] = "15";
     config["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
     config["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
     config["keystone_authtoken"]["project_domain_name"] = domain;

--- a/core/modules/config_masakari.cpp
+++ b/core/modules/config_masakari.cpp
@@ -219,6 +219,7 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
     }
 

--- a/core/modules/config_monasca.cpp
+++ b/core/modules/config_monasca.cpp
@@ -339,6 +339,7 @@ UpdateSharedId(std::string sharedId)
         apiCfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         apiCfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         apiCfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        apiCfg["keystone_authtoken"]["http_connect_timeout"] = "15";
 
         pstCfg["influxdb"]["ip_address"] = sharedId;
         pstCfg["zookeeper"]["uri"] = sharedId + ":2181";

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -388,6 +388,7 @@ UpdateSharedId(std::string sharedId, std::string ovnnb, std::string ovnsb)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["nova"]["auth_url"] = "http://" + sharedId + ":5000";
         cfg["octavia"]["base_url"] = "http://" + sharedId + ":9876";
         cfg["service_auth"]["auth_url"] = "http://" + sharedId + ":5000/v2.0";
@@ -457,6 +458,7 @@ UpdateCfg(std::string domain, std::string region, std::string password,
         cfg["nova"]["project_domain_name"] = domain.c_str();
         cfg["nova"]["user_domain_name"] = domain.c_str();
         cfg["nova"]["region_name"] = region.c_str();
+        cfg["nova"]["timeout"] = "60";
         cfg["nova"]["project_name"] = "service";
         cfg["nova"]["username"] = "nova";
         cfg["nova"]["password"] = novapass.c_str();

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -397,6 +397,14 @@ UpdateSharedId(std::string sharedId)
         cfg["glance"]["api_servers"] = "http://" + sharedId + ":9292";;
         cfg["neutron"]["url"] = "http://" + sharedId + ":9696";
         cfg["neutron"]["auth_url"] = "http://" + sharedId + ":5000";
+
+        // deadline VIP-backed sessions: a failover blackholes established connections
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
+        cfg["service_user"]["timeout"] = "60";
+        cfg["placement"]["timeout"] = "60";
+        cfg["glance"]["timeout"] = "60";
+        cfg["neutron"]["timeout"] = "60";
+        cfg["cinder"]["timeout"] = "60";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
 
         ironicCfg["ironic"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
@@ -404,6 +412,7 @@ UpdateSharedId(std::string sharedId)
         ironicCfg["ironic"]["memcached_servers"] = sharedId + ":11211";
 
         plaCfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000/v3";
+        plaCfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         plaCfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
     }
 

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -242,6 +242,7 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["service_auth"]["memcached_servers"] = sharedId + ":11211";
         cfg["service_auth"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["service_auth"]["auth_url"] = "http://" + sharedId + ":5000";

--- a/core/modules/config_watcher.cpp
+++ b/core/modules/config_watcher.cpp
@@ -212,6 +212,7 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["memcached_servers"] = sharedId + ":11211";
         cfg["keystone_authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
+        cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["watcher_clients_auth"]["auth_url"] = "http://" + sharedId + ":5000";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
     }

--- a/core/pacemaker/vaw
+++ b/core/pacemaker/vaw
@@ -1,21 +1,38 @@
 #!/bin/bash
 
 source /etc/admin-openrc.sh
-if ! hex_sdk cube_node_ready ; then
-    echo "=== $(date) SKIP: node not ready"
-elif ! openstack segment list -f value -c is_enabled | grep -q -i true ; then
-    echo "=== $(date) SKIP: instance ha not enabled "
-else
-    for i in {1..10} ; do
-        echo "=== $(date) CHECKING: neutron ($i)"
-        openstack network agent list
-        if openstack network agent list -f value -c Alive | grep -q -i false ; then
-            echo "=== $(date) REPAIRING: neutron"
-            hex_sdk -m force health_neutron_repair
-            echo "=== $(date) REPAIRED: neutron"
-            openstack network agent list
-            break
-        fi
+source /usr/sbin/hex_tuning /etc/settings.txt
+
+# The VIP just moved here: connections to the previous holder are blackholed
+# (no RST) and deadline-less clients hang on them. Kill the half-dead sockets
+# on every node; blocked threads reconnect (no service restarts needed).
+VIP=$T_cubesys_control_vip
+sweep_stale_flows()
+{
+    # nodes sweep in parallel: serial ssh costs N x timeout on large clusters
+    local n
+    for n in $(cubectl node list -j 2>/dev/null | jq -r '.[].hostname') ; do
+        echo "=== $(date) SWEEPING: $n"
+        timeout 30 ssh root@$n "
+            # NB/SB flows predate a fresh acquisition; ovsdb clients
+            # reconnect within seconds of the kill (agents revive in ~4s)
+            ss -K \"dst $VIP and ( dport = :6641 or dport = :6642 )\" >/dev/null 2>&1
+            stale=\$(ss -tnp state close-wait \"dst $VIP\" 2>/dev/null | tail -n +2)
+            if [ -n \"\$stale\" ] ; then
+                echo \"\$stale\"
+                ss -K state close-wait \"dst $VIP\" >/dev/null 2>&1
+                echo \"destroyed \$(echo \"\$stale\" | wc -l) close-wait flows\"
+            fi" 2>/dev/null &
     done
-    echo "=== $(date) DONE: vaw finished"
+    wait
+}
+# One sweep at VIP acquisition. It clears what timeouts can't do promptly:
+# the OVN NB/SB flows (ovsdb, not HTTP -- keystoneauth deadlines don't cover
+# them; killing them revives dead network agents in ~seconds) and any
+# already-CLOSE-WAIT API sockets. Anything still ESTABLISHED-but-blackholed
+# here self-heals via the 60s client/session deadlines, so no delayed passes
+# (a late sweep would risk destroying healthy CLOSE-WAIT churn to the VIP).
+if [ -n "$VIP" ] ; then
+    sweep_stale_flows
+    echo "=== $(date) DONE: vip flow sweep"
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

When the VIP moves, established TCP connections to the old holder are blackholed (no RST reaches the clients). Clients holding pooled connections through the VIP with no deadline hang forever. During a live host-failure test this wedged nova-compute and nova-scheduler on **both** survivors (CLOSE-WAIT placement sockets, threads stuck in `_update_to_placement` under the resource-tracker lock) — heartbeats stopped, survivors went scheduler-`down`, and evacuation returned `NoValidHost` until manual service restarts.

Three layers, in order of value:

1. **Deadlines on every VIP-backed session, all services** — `keystone_authtoken http_connect_timeout = 15` across all 14 modules that render it (a hung token validation wedges API workers server-side — cinder-api/designate/glance were among the observed stale-flow holders), plus adapter `timeout = 60` on nova `[placement]/[glance]/[neutron]/[cinder]/[service_user]`, neutron `[nova]`, cyborg `[placement]/[nova]`. A hung request now aborts and retries on a fresh connection: self-healing in ~1 minute instead of never.
2. **`vaw` sweep** — vaw (pacemaker, colocated/ordered with the VIP, runs on acquisition) now **destroys stale flows with `ss -K`** (SOCK_DESTROY) on every node — following `stale_api_check_repair()`'s repair-the-wedged-thing idea instead of blanket restarts: **all OVN NB/SB flows to the VIP** (`:6641/:6642` — ovsdb clients reconnect in seconds, and stale ones leave every network agent dead) plus CLOSE-WAIT flows to any VIP port, with a backgrounded second pass at +45s for progressively-staling flows. **The old neutron check/repair tail is commented out, with experimental proof it's unnecessary:** in a live VIP-move test, all 9 agents died at +57s and stayed dead; killing just the OVN flows revived them in **4 seconds** (no ~75s `bootstrap neutron`); with the sweep running at acquisition the agents never went dead at all. The old tail also ran 60–120s of un-slept `openstack` polling that blocked the pacemaker start — the new sweep completes in ~1s.
3. **`migrate_vaw_resource`** — clusters installed before vaw existed have the script and unit but no pacemaker resource (`SetupCluster` runs only at FTS; sky is such a cluster). Create the resource + vip colocation/ordering once from the cluster-wide start path, guarded by the same rolling-upgrade check as the original creation.

#### Which issue(s) this PR fixes

Fixes #1101

#### Special notes for your reviewer

- Validated on sky across two live VIP relocations (pcs ban): sweep ~1s; agents stayed alive through the whole failover window; `ss -K` destroyed 45–92 real stale flows per pass with every service staying active; masakari verified end-to-end afterwards — 8 simultaneous qemu kills on the VIP-adjacent host → 8/8 recovered in 52s (untagged VM untouched, negative control).
- `ss -K` needs `CONFIG_INET_DIAG_DESTROY` (present on the EL9 kernel — verified live); if unsupported the sweep logs and falls back to the layer-1 client timeouts.
- Same-class follow-ups tracked in the issue: session timeouts for other services' configs, oslo.db connection_parameters, and the masakari orphaned-`running`-notification 24h expiry.

#### Additional documentation

```docs
VIP failover self-healing: nova's VIP-backed API sessions carry 60s deadlines,
and the vaw resource (runs on VIP acquisition) sweeps all nodes for stale
CLOSE-WAIT flows to the VIP, restarting affected nova services.
```
