### PR TITLE
fix: cut steady-state log flooding on healthy clusters, phase 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 TAGS
 jail/ubi9.tar.gz
 triangle
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/core/modules/config_cubesys.cpp
+++ b/core/modules/config_cubesys.cpp
@@ -117,8 +117,11 @@ WriteSshConfig(void)
     // Multiplex repeated connections so health checks (one ssh per service per
     // node) reuse a single session instead of flooding sshd/logind/sudo.
     fprintf(fout, "ControlMaster auto\n");
+    // control socket is root-only in /run (tmpfs, cleared on reboot) on a
+    // single-tenant appliance; 120s outlives the ~40s health poll so masters
+    // don't expire between cycles.
     fprintf(fout, "ControlPath /run/cube-ssh-%%C\n");
-    fprintf(fout, "ControlPersist 30s\n");
+    fprintf(fout, "ControlPersist 120s\n");
     fclose(fout);
 
     return true;

--- a/core/modules/config_logstash.cpp
+++ b/core/modules/config_logstash.cpp
@@ -83,6 +83,13 @@ WriteConfigs(const std::string &kafkaHosts)
 
     fprintf(fout, "filebeat.inputs:\n");
     fprintf(fout, "- type: filestream\n");
+    // native (inode) identity: no 1KB fingerprint floor, so sub-1KB writes
+    // ship; safe here -- these logs rotate via copytruncate (inode-stable)
+    fprintf(fout, "  file_identity.native: ~\n");
+    fprintf(fout, "  prospector.scanner.fingerprint.enabled: false\n");
+    // horizon_access is a byte-identical duplicate of access.log (both
+    // CustomLog targets); with native identity both copies would ship
+    fprintf(fout, "  prospector.scanner.exclude_files: ['horizon_access\\.log$']\n");
     fprintf(fout, "  paths:\n");
     fprintf(fout, "    - /var/log/messages\n");
     fprintf(fout, "    - /var/log/nova/*.log\n");
@@ -123,6 +130,10 @@ WriteConfigs(const std::string &kafkaHosts)
     fprintf(fout, "  max_message_bytes: 1000000\n");
     fprintf(fout, "\n");
 
+    // keep the per-30s metrics snapshots out of syslog
+    fprintf(fout, "logging.metrics.enabled: false\n");
+    fprintf(fout, "\n");
+
     fclose(fout);
 
     fout = fopen(AB_CONF, "w");
@@ -158,6 +169,10 @@ WriteConfigs(const std::string &kafkaHosts)
     fprintf(fout, "    reachable_only: false\n");
     fprintf(fout, "  required_acks: 1\n");
     fprintf(fout, "  max_message_bytes: 1000000\n");
+    fprintf(fout, "\n");
+
+    // keep the per-30s metrics snapshots out of syslog
+    fprintf(fout, "logging.metrics.enabled: false\n");
     fprintf(fout, "\n");
 
     fclose(fout);

--- a/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ipmi_sensors.py
+++ b/core/monasca/yoga_patch/monasca_agent/collector/checks_d/ipmi_sensors.py
@@ -1,8 +1,13 @@
 # Monasca agent check: host hardware sensors via IPMI.
 # Feeds Watcher thermal_optimization / airflow_optimization / saving_energy.
+import re
 import subprocess
 
 import monasca_agent.collector.checks as checks
+
+# first numeric token in a `sensor reading` value cell ("45", "36.500",
+# or a unit-bearing "12.3 degrees C" from other firmware)
+_NUM = re.compile(r'[-+]?[0-9]*\.?[0-9]+')
 
 
 class IpmiSensors(checks.AgentCheck):
@@ -24,13 +29,27 @@ class IpmiSensors(checks.AgentCheck):
     def check(self, instance):
         dimensions = self._set_dimensions(None, instance)
         sensors = instance.get('sensors') or self.DEFAULT_SENSORS
-        for metric, sensor in sensors.items():
-            try:
-                out = subprocess.check_output(
-                    ['sudo', '-n', 'ipmitool', 'sensor', 'reading', sensor],
-                    timeout=15, stderr=subprocess.DEVNULL).decode()
-                value = float(out.split('|')[1].strip())
-            except (OSError, subprocess.SubprocessError, IndexError, ValueError) as e:
-                self.log.debug('ipmi sensor %s unavailable: %s', sensor, e)
+        # one batched ipmitool call (one sudo) per cycle; a missing sensor is
+        # omitted from output and forces exit 1 while the rest still print, so
+        # parse stdout regardless of return code (do NOT gate on it)
+        try:
+            proc = subprocess.run(
+                ['sudo', '-n', 'ipmitool', 'sensor', 'reading'] + list(sensors.values()),
+                timeout=15, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            out = proc.stdout.decode()
+        except (OSError, subprocess.SubprocessError) as e:
+            self.log.debug('ipmi sensors unavailable: %s', e)
+            return
+        readings = {}
+        for line in out.splitlines():
+            name, sep, value = line.partition('|')
+            if not sep:
                 continue
-            self.gauge(metric, value, dimensions=dimensions)
+            m = _NUM.search(value)
+            if m:
+                readings[name.strip()] = float(m.group())
+        for metric, sensor in sensors.items():
+            if sensor in readings:
+                self.gauge(metric, readings[sensor], dimensions=dimensions)
+            else:
+                self.log.debug('ipmi sensor %s unavailable', sensor)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Phase 2 of the log-noise work (phase 1 = #1030, FTS-time floods): a healthy **idle** 3-node HA control node logs ~250 lines/min of noise. This PR (plus its hex companion) takes that to ~25 lines/min — ~90% — with every source root-caused and independently verified on the sky lab cluster:

| Fix | Flood it kills | Share |
|---|---|---|
| influxdb template: `[logging] level=warn` | flux "Invalid column reader" per UI/API events query | ~42% |
| hex bump (bigstack-oss/hex#129): DumpInterface json path stops up-probing down NICs | kernel `8021q: adding VLAN 0` bursts; also un-stalls API node sync (≤8s per down NIC) | ~14% |
| monasca `ipmi_sensors`: one batched ipmitool call/cycle instead of one sudo per sensor | 75% of root session churn (5.8k sudo/12h) | ~10% |
| ssh `ControlPersist 30s→120s` | peer health-ssh re-login every ~40s poll | ~3% |
| hex bump: license probe logging → Debug (alarm states stay Notice) | license triplets every health cycle | ~5% |
| filebeat template: **native (inode) file identity** (kills the 1KB fingerprint floor — quiet copytruncate-rotated service logs warned "too small" every 10s AND sub-1KB error bursts never shipped); exclude `horizon_access.log` only (byte-identical CustomLog duplicate — with native identity both copies would ship; the small one-shot tool logs no longer need excluding since native identity has no size floor); `logging.metrics.enabled: false` for both beats | filestream scanner warnings + per-30s JSON metrics blobs + a silent observability gap | ~9% |

#### Which issue(s) this PR fixes

Fixes #1103

#### Special notes for your reviewer

> - `ipmi_sensors` batching: ipmitool exits 1 when any named sensor is missing **while still printing the rest**, so the check parses stdout regardless of return code (verified against missing-sensor hardware).
> - influxd restart briefly errors cube-cos-api health queries ("failed to get query cursor") — roll one node at a time when this lands.
> - Native-identity migration verified live on sky142: no history re-ingest (offset delta ~= baseline; modest startup catch-up), and a canary appended to a 0-byte octavia log reached kafka in 2s. Safe here because cube logs rotate via copytruncate (inode-stable).
> - Remaining known noise is deliberate and documented: octavia/masakari 0-byte service logs stay watchable (copytruncate + journald-bound request logs = empty on healthy days), cube-cos-api NIC-spec sync 30s→hourly deferred to that repo.

#### Additional documentation

```docs
Handbook: kb/cubecos/known-issues/steady-state-log-floods-corrections.md (bigstack-handbook) — full
symptom → root cause → fix → verification chain per item, incl. measurement pitfalls
(dmesg ring-buffer saturation, rsyslog out-of-order blocks).
```


