### PR TITLE
feat(upgrade): mixed-version rolling-upgrade safety (gcache, live-migration gate, version-uniformity gates)

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -68,6 +68,17 @@ RollingEvacuateAndReboot()
                 if [ "x$n_lastboot" = "xlast_boot = Never" -a "x$n_fwver" = "x$fwver" ] ; then
                     upgrading=true
                     echo "Starting auto rolling upgrade" >> $BOOTSTRAP_CUBE_MODE
+                    # Don't drain+reboot the next node until this node has rejoined
+                    # and the live-migration path is functional. Version-robust, so
+                    # a mixed N/N+1 SLURP window passes; pauses (never advances into
+                    # a broken cluster) if it can't confirm within the timeout.
+                    if ! hex_sdk live_migration_gate 300 "$N" ; then
+                        msg="Auto rolling upgrade paused: live-migration path not ready before draining $N"
+                        hex_sdk remote_run $n_ip "echo -n \"$msg\" >$BOOTSTRAP_CUBE_LOG"
+                        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+                        hex_sdk influx_event "${query},severity=\"W\" message=\"$msg\""
+                        break
+                    fi
                     if [ "x$n_role" = "xcontrol-converged" -o "x$n_role" = "xedge-core" -o "x$n_role" = "xcompute" ] ; then
                         msg="Evacuating VMs on $N"
                         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
@@ -139,11 +150,22 @@ RollingEvacuateAndReboot()
                 rsync -ar /var/lib/ceph /store/
             fi
             if [ "$ROLLING_RECOVER" = "1" ] ; then
-                # Rolling restart only needs the live-migration path verified --
-                # run the focused essential check+repair (fast, ~tens of seconds)
-                # instead of the full 28-group safe-net sweep.
-                hex_sdk cluster_check_repair_essential 1
-                msg="Cluster ready; live-migration essential services checked"
+                # Rolling restart only needs the live-migration path verified before
+                # this node releases the relay to drain the next one (same gate the
+                # rolling-upgrade relay uses). Gate FIRST: on a healthy roll it passes
+                # in seconds and we skip the essential check+repair entirely. Only if
+                # it can't confirm do we spend time repairing, then re-gate; still not
+                # ready -> pause (state=paused makes the later power_roll_advance a
+                # no-op). Emit the duration + whether repair was needed for tuning.
+                lmg_t0=$SECONDS ; lmg_repaired=0
+                if ! hex_sdk live_migration_gate 60 ; then
+                    lmg_repaired=1
+                    hex_sdk cluster_check_repair_essential 1
+                    hex_sdk live_migration_gate 120 \
+                        || hex_sdk _power_roll_pause "live-migration path not ready before releasing the next node"
+                fi
+                hex_sdk influx_event "${query},severity=\"I\" message=\"live-migration gate ${lmg_repaired:+with repair }verified in $((SECONDS-lmg_t0))s\""
+                msg="Cluster ready; live-migration path verified"
             else
                 # Normal boot: 'cluster check' above kicks per-service auto_repair;
                 # master runs full check_repair centrally once all nodes ready.

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -72,7 +72,10 @@ RollingEvacuateAndReboot()
                     # and the live-migration path is functional. Version-robust, so
                     # a mixed N/N+1 SLURP window passes; pauses (never advances into
                     # a broken cluster) if it can't confirm within the timeout.
-                    if ! hex_sdk live_migration_gate 300 "$N" ; then
+                    # repair mode = the surgical pre-drain repairs (formerly
+                    # _os_pre_failure_host_evacuation); run on the master control
+                    # so it gates even when the booting node is a compute node.
+                    if ! hex_sdk remote_run $MASTER_CONTROL "hex_sdk live_migration_gate 300 $N repair" ; then
                         msg="Auto rolling upgrade paused: live-migration path not ready before draining $N"
                         hex_sdk remote_run $n_ip "echo -n \"$msg\" >$BOOTSTRAP_CUBE_LOG"
                         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
@@ -159,19 +162,18 @@ RollingEvacuateAndReboot()
             if [ "$ROLLING_RECOVER" = "1" ] ; then
                 # Rolling restart only needs the live-migration path verified before
                 # this node releases the relay to drain the next one (same gate the
-                # rolling-upgrade relay uses). Gate FIRST: on a healthy roll it passes
-                # in seconds and we skip the essential check+repair entirely. Only if
-                # it can't confirm do we spend time repairing, then re-gate; still not
-                # ready -> pause (state=paused makes the later power_roll_advance a
-                # no-op). Emit the duration + whether repair was needed for tuning.
-                lmg_t0=$SECONDS ; lmg_repaired=0
-                if ! hex_sdk live_migration_gate 60 ; then
-                    lmg_repaired=1
-                    hex_sdk cluster_check_repair_essential 1
-                    hex_sdk live_migration_gate 120 \
-                        || hex_sdk _power_roll_pause "live-migration path not ready before releasing the next node"
+                # rolling-upgrade relay uses). Checks always run first, so a healthy
+                # roll passes in seconds with zero side effects; a failed check
+                # triggers its surgical repair inside the gate (which emits a health
+                # event per repaired cause -- the duration below completes the tuning
+                # picture). Still not ready -> pause (state=paused makes the later
+                # power_roll_advance a no-op).
+                lmg_t0=$SECONDS
+                if hex_sdk live_migration_gate 180 "" repair ; then
+                    hex_sdk influx_event "${query},severity=\"I\" message=\"live-migration gate verified in $((SECONDS-lmg_t0))s\""
+                else
+                    hex_sdk _power_roll_pause "live-migration path not ready before releasing the next node"
                 fi
-                hex_sdk influx_event "${query},severity=\"I\" message=\"live-migration gate ${lmg_repaired:+with repair }verified in $((SECONDS-lmg_t0))s\""
                 msg="Cluster ready; live-migration path verified"
             else
                 # Normal boot: 'cluster check' above kicks per-service auto_repair;

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -53,11 +53,6 @@ RollingEvacuateAndReboot()
     local query="insert system,category=RUG,severity=I,key=RUG00001I,service=rolling_upgrade,host=$HOSTNAME,metadata\"rolling upgrade to $(hex_cli -c firmware list | grep -i active | cut -d' ' -f2)\""
     if [ -e "$cluster_info" -a "x$inst_type" = "xPPU" ] ; then
         for N in $(cat $cluster_info | jq -r .[].hostname) ; do
-            # Cube dashboard topN misses partial info after rolling upgrades
-            if [ "x$last_n" = "x$T_net_hostname" ] ; then
-                hex_cli -c cluster repair kafka
-            fi
-
             if [ "x$prev_n" = "x$T_net_hostname" ] ; then
                 n_role=$(cat $cluster_info | jq -r ".[] | select(.hostname == \"$N\") | .role")
                 n_ip=$(cat $cluster_info | jq -r ".[] | select(.hostname == \"$N\") | .ip.management")
@@ -68,6 +63,11 @@ RollingEvacuateAndReboot()
                 if [ "x$n_lastboot" = "xlast_boot = Never" -a "x$n_fwver" = "x$fwver" ] ; then
                     upgrading=true
                     echo "Starting auto rolling upgrade" >> $BOOTSTRAP_CUBE_MODE
+                    # Guard ceph for the roll: keep the rebooting node's OSDs from
+                    # being marked out (no re-replication churn) without pausing I/O.
+                    # Idempotent -- re-set each relay step; cleared when the last
+                    # node completes below.
+                    hex_sdk remote_run $MASTER_CONTROL "hex_sdk ceph_enter_rolling"
                     # Don't drain+reboot the next node until this node has rejoined
                     # and the live-migration path is functional. Version-robust, so
                     # a mixed N/N+1 SLURP window passes; pauses (never advances into
@@ -77,6 +77,7 @@ RollingEvacuateAndReboot()
                         hex_sdk remote_run $n_ip "echo -n \"$msg\" >$BOOTSTRAP_CUBE_LOG"
                         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
                         hex_sdk influx_event "${query},severity=\"W\" message=\"$msg\""
+                        hex_sdk remote_run $MASTER_CONTROL "hex_sdk ceph_leave_rolling"
                         break
                     fi
                     if [ "x$n_role" = "xcontrol-converged" -o "x$n_role" = "xedge-core" -o "x$n_role" = "xcompute" ] ; then
@@ -88,6 +89,7 @@ RollingEvacuateAndReboot()
                             hex_sdk remote_run $n_ip "echo -n \"$msg\" >$BOOTSTRAP_CUBE_LOG"
                             echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg on $N" $'\r' | $(hex_sdk GetKernelConsoleDevices)
                             hex_sdk influx_event "${query},severity=\"W\" message=\"$msg\""
+                            hex_sdk remote_run $MASTER_CONTROL "hex_sdk ceph_leave_rolling"
                             break
                         fi
                     fi
@@ -100,6 +102,11 @@ RollingEvacuateAndReboot()
             fi
             prev_n=$N
         done
+        # Roll complete once the last node has booted -- lift the ceph rolling
+        # guard (unset noout, once every OSD is back up).
+        if [ "x$last_n" = "x$T_net_hostname" ] ; then
+            hex_sdk remote_run $MASTER_CONTROL "hex_sdk ceph_leave_rolling"
+        fi
         # While next node (in case of having VIP) is being rebooted, we are unable to establish connection to http://${vip}:5000
         # hex_sdk os_nova_instance_hardreboot $(hex_sdk os_nova_list ID STATUS POWERSTATE | grep -i -e error -e nostate | cut -d" " -f1)
     fi

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -1086,7 +1086,7 @@ _essential_check_one()
     return 1
 }
 
-# live_migration_gate [timeout_secs] [drain_host]
+# live_migration_gate [timeout_secs] [drain_host] [repair]
 #
 # Block until the live-migration drain path is FUNCTIONAL, so the rolling relay
 # can safely take the next node down. Same precondition for rolling restart and
@@ -1098,11 +1098,17 @@ _essential_check_one()
 # node from migration-target counts. keystone/haproxy/vip/memcached are covered
 # transitively by the authenticated $OPENSTACK calls; glance/cyborg are not on the
 # live-migration path. Returns 0 when a live migration can run; 1 on timeout.
+#
+# With 'repair' as $3 (absorbs the old _os_pre_failure_host_evacuation prep):
+# checks ALWAYS run first; a failed check triggers its matching surgical,
+# version-tolerant repair ONCE, then re-checks -- a healthy pass has zero side
+# effects. Heavier same-version repairs stay in cluster_check_repair_essential
+# (rolling restart only).
 live_migration_gate()
 {
     is_control_node || return 0
     source /etc/admin-openrc.sh 2>/dev/null
-    local deadline=$((SECONDS + ${1:-300})) drain=${2:-__none__} why=
+    local deadline=$((SECONDS + ${1:-300})) drain=${2:-__none__} repair=${3:-} why= repaired=
 
     while [ $SECONDS -lt $deadline ] ; do
         why=
@@ -1131,6 +1137,42 @@ live_migration_gate()
         [ -z "$why" ] && { $OPENSTACK network agent list -f value -c Alive 2>/dev/null | grep -qi true || why=neutron ; }
 
         [ -z "$why" ] && return 0
+        # repair mode: fix what the failed check names, once per cause, then
+        # re-check immediately. ceph/ceph-osd-down get no repair -- OSD rejoin
+        # is time-based and the rolling noout guard already prevents churn.
+        if [ "$repair" = "repair" ] ; then
+            case " $repaired " in
+                *" $why "*) : ;;    # already repaired this cause; just wait
+                *)
+                    repaired="$repaired $why"
+                    Quiet -n influx_event "insert health,component=live_migration_gate,node=$HOSTNAME,code=0 description=\"repairing\",detail=\"$why\""
+                    case $why in
+                        galera)   Quiet -n $HEX_SDK -m force health_mysql_repair ;;
+                        rabbitmq) Quiet -n $HEX_CLI -c cluster check_repair MsgQueue ;;
+                        nova-conductor|nova-scheduler|no-migration-target|cinder-volume)
+                            # wedged API workers (backed-up recv-Q) and
+                            # enabled-down services are what an authenticated
+                            # $OPENSTACK probe fails on
+                            cmd -c $HEX_SDK stale_api_check_repair openstack-nova-api 8774 nova-api python3 0
+                            cmd -c $HEX_SDK stale_api_check_repair openstack-cinder-api 8776 cinder-api python3 0
+                            if [ $($OPENSTACK compute service list -f value -c Status -c State 2>/dev/null | grep -ci "enabled down") -ge 1 ] ; then
+                                cmd -c systemctl restart openstack-nova-scheduler
+                                cmd -c systemctl restart openstack-nova-conductor
+                                cmd -p systemctl restart openstack-nova-compute
+                            fi
+                            ;;
+                        neutron)
+                            cmd -c $HEX_SDK stale_api_check_repair neutron-server 9696 neutron-server server 0
+                            if [ $($OPENSTACK network agent list -f value -c ID -c Alive 2>/dev/null | grep -v -i true | wc -l) -ge 1 ] ; then
+                                $OPENSTACK network agent list -f json -c ID -c Alive | jq -r ".[] | select(.Alive == false).ID" | xargs -i $OPENSTACK network agent delete {}
+                                cmd -c "timeout $SRVLTO systemctl restart neutron-server neutron-ovn-metadata-agent neutron-ovn-vpn-agent"
+                            fi
+                            ;;
+                    esac
+                    continue
+                    ;;
+            esac
+        fi
         sleep 5
     done
     echo "live_migration_gate: live-migration path not ready ($why)" >&2

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -1086,6 +1086,49 @@ _essential_check_one()
     return 1
 }
 
+# live_migration_gate [timeout_secs] [drain_host]
+#
+# Block until the live-migration drain path is FUNCTIONAL, so the rolling relay
+# can safely take the next node down. Same precondition for rolling restart and
+# rolling upgrade -- both drain via live migration.
+#
+# Version-ROBUST: asserts function + cluster membership, never version uniformity
+# (mixed N/N+1 is expected and healthy under SLURP + mixed-version-safe DB/MQ).
+# Accepts quorate-but-degraded during the reboot window and excludes the draining
+# node from migration-target counts. keystone/haproxy/vip/memcached are covered
+# transitively by the authenticated $OPENSTACK calls; glance/cyborg are not on the
+# live-migration path. Returns 0 when a live migration can run; 1 on timeout.
+live_migration_gate()
+{
+    is_control_node || return 0
+    source /etc/admin-openrc.sh 2>/dev/null
+    local deadline=$((SECONDS + ${1:-300})) drain=${2:-__none__} why=
+
+    while [ $SECONDS -lt $deadline ] ; do
+        why=
+        # version-SAFE cluster membership (true/false regardless of version)
+        $HEX_SDK health_mysql_check    >/dev/null 2>&1 || why=galera
+        [ -z "$why" ] && { $HEX_SDK health_rabbitmq_check >/dev/null 2>&1 || why=rabbitmq ; }
+        [ -z "$why" ] && { $CEPH health 2>/dev/null | grep -qiE 'HEALTH_ERR|inactive|incomplete|peering|stale' && why=ceph ; }
+
+        # FUNCTIONAL backends a live migration touches (NOT version-strict)
+        [ -z "$why" ] && { $OPENSTACK compute service list --service nova-conductor -f value -c State 2>/dev/null | grep -qi up || why=nova-conductor ; }
+        [ -z "$why" ] && { $OPENSTACK compute service list --service nova-scheduler -f value -c State 2>/dev/null | grep -qi up || why=nova-scheduler ; }
+        [ -z "$why" ] && {
+            # >=1 live migration target that is not the node being drained
+            local tgt=$($OPENSTACK compute service list --service nova-compute -f value -c Host -c State 2>/dev/null | awk -v d="$drain" '$2=="up" && $1!=d {c++} END{print c+0}')
+            [ "${tgt:-0}" -ge 1 ] || why=no-migration-target
+        }
+        [ -z "$why" ] && { $OPENSTACK volume service list --service cinder-volume -f value -c State 2>/dev/null | grep -qi up || why=cinder-volume ; }
+        [ -z "$why" ] && { $OPENSTACK network agent list -f value -c Alive 2>/dev/null | grep -qi true || why=neutron ; }
+
+        [ -z "$why" ] && return 0
+        sleep 5
+    done
+    echo "live_migration_gate: live-migration path not ready ($why)" >&2
+    return 1
+}
+
 cluster_check_repair_essential()
 {
     # $1=repair (1) or check-only (0, default). Only the live-migration path.

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -1110,6 +1110,14 @@ live_migration_gate()
         $HEX_SDK health_mysql_check    >/dev/null 2>&1 || why=galera
         [ -z "$why" ] && { $HEX_SDK health_rabbitmq_check >/dev/null 2>&1 || why=rabbitmq ; }
         [ -z "$why" ] && { $CEPH health 2>/dev/null | grep -qiE 'HEALTH_ERR|inactive|incomplete|peering|stale' && why=ceph ; }
+        # Wait for the just-rebooted node's OSDs to rejoin before draining the
+        # next one -- an in-but-down OSD (num_in > num_up) means the prior node
+        # hasn't fully returned. Tolerates degraded/recovering (so ceph can
+        # upgrade); does NOT require active+clean.
+        [ -z "$why" ] && {
+            local _ndown=$($CEPH status -f json 2>/dev/null | jq -r '.osdmap | (.num_in_osds // 0) - (.num_up_osds // 0)' 2>/dev/null)
+            [ "${_ndown:-0}" -gt 0 ] 2>/dev/null && why=ceph-osd-down
+        }
 
         # FUNCTIONAL backends a live migration touches (NOT version-strict)
         [ -z "$why" ] && { $OPENSTACK compute service list --service nova-conductor -f value -c State 2>/dev/null | grep -qi up || why=nova-conductor ; }

--- a/core/main/update.sh
+++ b/core/main/update.sh
@@ -12,6 +12,10 @@ cp /etc/libvirt/secrets/* /store/ppu/libvirt/secrets/
 if [ "$FIRST_CTRLHOST" == "$(hostname)" ]; then
     # Backup mysql
     hex_sdk support_mysql_backup_create
+    # Guard ceph for the whole rolling upgrade BEFORE any node reboots (covers the
+    # first node too); the relay re-sets it per step and clears it on
+    # completion/pause/abort.
+    hex_sdk ceph_enter_rolling
 fi
 
 

--- a/core/modules/config_mysql.cpp
+++ b/core/modules/config_mysql.cpp
@@ -190,7 +190,8 @@ WriteConfig(const bool ha, const std::string& ctrl, const std::string& ctrlIp, c
         fprintf(fout, "wsrep_slave_threads = 32\n");
         fprintf(fout, "wsrep_slave_FK_checks = OFF\n");
         fprintf(fout, "wsrep_provider = /usr/lib64/galera/libgalera_smm.so\n");
-        fprintf(fout, "wsrep_provider_options = \"pc.recovery=TRUE;gcache.size=300M;pc.ignore_sb=TRUE\"\n");
+        // 4G keeps a rejoin on IST across a firmware-reboot-length outage (SST breaks on 10.6->10.11)
+        fprintf(fout, "wsrep_provider_options = \"pc.recovery=TRUE;gcache.size=4G;pc.ignore_sb=TRUE\"\n");
         fprintf(fout, "wsrep_cluster_name = \"cube_galera_cluster\"\n");
         fprintf(fout, "wsrep_cluster_address = \"gcomm://%s\"\n", ctrlAddrs.c_str());
         fprintf(fout, "wsrep_sst_method = rsync\n");

--- a/core/modules/config_mysql.cpp
+++ b/core/modules/config_mysql.cpp
@@ -121,26 +121,34 @@ UpdateCheck()
     if (!IsControl(s_eCubeRole))
         return true;
 
-    if (access(BACKDIR, F_OK) == 0) {
-        std::vector<const char*> command;
-        command.push_back("/usr/bin/mysql_upgrade");
-        command.push_back("-u");
-        command.push_back("root");
-        command.push_back("--skip-write-binlog");
-        command.push_back(0);
+    // No pending upgrade: BACKDIR is created only by the migrate hook and removed
+    // after a successful mysql_upgrade, so a missing BACKDIR means FTS or a normal
+    // reconfig -- nothing to do, and skip the version-uniformity probe entirely.
+    if (access(BACKDIR, F_OK) != 0)
+        return true;
 
-        if (HexSpawnVQ(0, NO_STDOUT | NO_STDERR, (char* const*)&command[0]) == 0) {
-            HexSpawn(0, "/bin/rm", "-rf", BACKDIR, NULL);
-            HexLogInfo("upgrade database successfully");
-            return true;
-        }
-        else {
-            HexLogError("failed to upgrade database");
-            return false;
-        }
+    // Defer the system-table upgrade while the Galera cluster is mixed-version:
+    // mysql_upgrade DDL replicates to not-yet-upgraded peers. Run it only once
+    // every control node is on the same MariaDB version. Version uniformity, not
+    // firmware, is the correct gate for web-scale.
+    if (HexSystemF(0, HEX_SDK " os_mariadb_version_uniform") != 0)
+        return true;
+
+    std::vector<const char*> command;
+    command.push_back("/usr/bin/mysql_upgrade");
+    command.push_back("-u");
+    command.push_back("root");
+    command.push_back("--skip-write-binlog");
+    command.push_back(0);
+
+    if (HexSpawnVQ(0, NO_STDOUT | NO_STDERR, (char* const*)&command[0]) == 0) {
+        HexSpawn(0, "/bin/rm", "-rf", BACKDIR, NULL);
+        HexLogInfo("upgrade database successfully");
+        return true;
     }
 
-    return true;
+    HexLogError("failed to upgrade database");
+    return false;
 }
 
 static bool

--- a/core/modules/config_pacemaker.cpp
+++ b/core/modules/config_pacemaker.cpp
@@ -80,11 +80,9 @@ SetupCluster(const bool enabled, const bool ha, std::string sharedId, const std:
 
         HexUtilSystemF(0, 0, "pcs resource create vip ocf:heartbeat:IPaddr2 "
                        "ip=\"%s\" op monitor interval=\"30s\"", sharedId.c_str());
-        if ( HexSystemF(0, "hex_sdk is_node_rolling_upgrade") != 0 ) {
-            HexUtilSystemF(0, 0, "pcs resource create vaw systemd:vaw op monitor interval=\"0\" op start timeout=\"600s\" op stop timeout=\"600s\"");
-            HexUtilSystemF(0, 0, "pcs constraint colocation add vaw with vip INFINITY");
-            HexUtilSystemF(0, 0, "pcs constraint order vip then vaw");
-        }
+        HexUtilSystemF(0, 0, "pcs resource create vaw systemd:vaw op monitor interval=\"0\" op start timeout=\"600s\" on-fail=\"ignore\" op stop timeout=\"600s\" meta failure-timeout=\"60s\"");
+        HexUtilSystemF(0, 0, "pcs constraint colocation add vaw with vip INFINITY");
+        HexUtilSystemF(0, 0, "pcs constraint order vip then vaw");
         HexUtilSystemF(0, 0, "pcs resource create haproxy systemd:haproxy-ha op monitor interval=\"1s\"");
         HexUtilSystemF(0, 0, "pcs constraint colocation add haproxy with vip score=INFINITY");
         HexUtilSystemF(0, 0, "pcs constraint order vip then haproxy");
@@ -98,6 +96,7 @@ SetupCluster(const bool enabled, const bool ha, std::string sharedId, const std:
 
         for (auto host : hosts) {
             HexUtilSystemF(0, 0, "pcs constraint location vip prefers %s --force", host.c_str());
+            HexUtilSystemF(0, 0, "pcs constraint location vaw prefers %s --force", host.c_str());
             HexUtilSystemF(0, 0, "pcs constraint location haproxy prefers %s --force", host.c_str());
             HexUtilSystemF(0, 0, "pcs constraint location cinder-volume prefers %s --force", host.c_str());
             HexUtilSystemF(0, 0, "pcs constraint location ovndb_servers-clone prefers %s --force", host.c_str());

--- a/core/modules/config_rabbitmq.cpp
+++ b/core/modules/config_rabbitmq.cpp
@@ -229,6 +229,13 @@ CommitRabbitMQ(const bool enabled, const bool ha, const std::string& hostname, c
         }
     }
 
+    // Feature-flag enable is IRREVERSIBLE and makes the cluster reject nodes that
+    // don't support a newly-enabled flag. Only enable when the RabbitMQ cluster is
+    // version-uniform (never mid-roll): all-old (pre-roll) enables the current
+    // stable flags = correct prep; all-new (post-roll) graduates the new flags.
+    if (enabled && ha && HexSystemF(0, HEX_SDK " os_rabbitmq_version_uniform") == 0)
+        HexUtilSystemF(0, 0, CONTROL_FMT "enable_feature_flag all", hostname.c_str());
+
     return true;
 }
 

--- a/core/modules/config_rabbitmq.cpp
+++ b/core/modules/config_rabbitmq.cpp
@@ -230,10 +230,13 @@ CommitRabbitMQ(const bool enabled, const bool ha, const std::string& hostname, c
     }
 
     // Feature-flag enable is IRREVERSIBLE and makes the cluster reject nodes that
-    // don't support a newly-enabled flag. Only enable when the RabbitMQ cluster is
-    // version-uniform (never mid-roll): all-old (pre-roll) enables the current
-    // stable flags = correct prep; all-new (post-roll) graduates the new flags.
-    if (enabled && ha && HexSystemF(0, HEX_SDK " os_rabbitmq_version_uniform") == 0)
+    // don't support a newly-enabled flag. During an UPGRADE only (migration
+    // marker present), enable once the cluster is version-uniform -- i.e. the
+    // last node has reached the new version -- never mid-roll. FTS enables via
+    // the cluster_ready trigger (ClusterReadyMain), where the cluster is fully
+    // formed, so this branch stays out of first-time setup and normal reconfig.
+    if (enabled && ha && access(CUBE_MIGRATE, F_OK) == 0 &&
+        HexSystemF(0, HEX_SDK " os_rabbitmq_version_uniform") == 0)
         HexUtilSystemF(0, 0, CONTROL_FMT "enable_feature_flag all", hostname.c_str());
 
     return true;
@@ -410,6 +413,21 @@ GPassMain(int argc, char* argv[])
     return EXIT_SUCCESS;
 }
 
+static int
+ClusterReadyMain(int argc, char **argv)
+{
+    // FTS set_ready: enable all stable feature flags explicitly (belt-and-braces
+    // over RabbitMQ's fresh-cluster auto-enable). Guard on version-uniform so a
+    // manual set_ready re-run mid-roll can never enable flags on a mixed cluster.
+    // The upgrade path enables from Commit under the migration marker instead.
+    if (s_ha && IsControl(s_eCubeRole) &&
+        HexSystemF(0, HEX_SDK " os_rabbitmq_version_uniform") == 0)
+        HexUtilSystemF(0, 0, CONTROL_FMT "enable_feature_flag all",
+                       s_hostname.newValue().c_str());
+
+    return EXIT_SUCCESS;
+}
+
 CONFIG_COMMAND_WITH_SETTINGS(rabbitmq_guest_password, GPassMain, GPassUsage);
 CONFIG_COMMAND(status_rabbitmq, StatusMain, StatusUsage);
 CONFIG_COMMAND_WITH_SETTINGS(restart_rabbitmq, RestartMain, RestartUsage);
@@ -420,6 +438,7 @@ CONFIG_REQUIRES(rabbitmq, cluster);
 // extra tunings
 CONFIG_OBSERVES(rabbitmq, net, ParseNet, NotifyNet);
 CONFIG_OBSERVES(rabbitmq, cubesys, ParseCube, NotifyCube);
+CONFIG_TRIGGER_WITH_SETTINGS(rabbitmq, "cluster_ready", ClusterReadyMain);
 
 CONFIG_MIGRATE(rabbitmq, SETUP_MARK);
 CONFIG_MIGRATE(rabbitmq, "/var/lib/rabbitmq");

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -388,6 +388,27 @@ ceph_leave_maintenance()
     nohup bash -c "$HEX_SDK ceph_finish_maintenance" >/dev/null 2>&1 &
 }
 
+# Guard for a ROLLING op (upgrade/restart), distinct from the whole-cluster
+# maintenance above. Give a rebooting node's OSDs a long grace before ceph marks
+# them 'out' and re-replicates their PGs during the fragile degraded window.
+# Uses mon_osd_down_out_interval (a persistent config value) rather than the
+# 'noout' flag on purpose: cube_cluster_start_node runs ceph_leave_maintenance on
+# EVERY node's boot and would clear noout mid-roll, whereas this config survives.
+# A genuinely-dead OSD is still marked out after the grace (self-limiting), and
+# client I/O is never paused. Idempotent -- safe to (re)set each relay step.
+ceph_enter_rolling()
+{
+    Quiet $CEPH config set global mon_osd_down_out_interval 3600
+}
+
+# Lift the rolling guard -- revert to the ceph default (600s). Instant (no wait),
+# so it's safe to call on completion, pause or abort; the relay re-sets it on
+# resume.
+ceph_leave_rolling()
+{
+    Quiet $CEPH config rm global mon_osd_down_out_interval
+}
+
 ceph_maintenance_status()
 {
     if $($CEPH osd stat | grep -q noout) ; then

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -423,9 +423,35 @@ health_etcd_check()
 
 health_etcd_repair()
 {
+    # Cluster view: a reseed is only safe for a MINORITY member while the rest keep
+    # quorum. online = members reporting healthy (the down one is excluded).
+    local total online
+    total=$($ETCDCTL member list 2>/dev/null | wc -l)
+    online=$($ETCDCTL endpoint health --cluster 2>/dev/null | grep -c healthy)
+
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        if ! is_remote_running $node etcd ; then
-            remote_systemd_restart $node etcd
+        local cntf=/tmp/health_etcd_${node}_reseed.count
+        if is_remote_running $node etcd ; then
+            rm -f "$cntf"
+            continue
+        fi
+
+        # etcd is down on $node -- try a plain restart first.
+        remote_systemd_restart $node etcd
+
+        # Escalate after repeated failures: a member down long enough falls outside
+        # the leader's compacted raft log and can NEVER catch up via restart -- it
+        # must be wiped and re-added. 'cubectl this-node reset' clears the local etcd
+        # data/config; 'join' does etcd member add + start (initial-cluster-state=
+        # existing). Guard hard: only a minority member, with quorum intact WITHOUT
+        # it, and only if the node is reachable.
+        local cnt=$(( $(cat "$cntf" 2>/dev/null || echo 0) + 1 ))
+        echo "$cnt" > "$cntf"
+        if [ "$cnt" -ge 3 ] && [ "$total" -ge 3 ] && [ "$online" -ge $(( total / 2 + 1 )) ] \
+           && remote_run $node true >/dev/null 2>&1 ; then
+            echo "health_etcd_repair: reseeding etcd member $node (restart failed x$cnt, quorum $online/$total holds)" >&2
+            Quiet -n remote_run $node "cubectl this-node reset && cubectl this-node join"
+            rm -f "$cntf"
         fi
     done
 }
@@ -541,6 +567,16 @@ health_hacluster_repair()
     local master=$CUBE_NODE_CONTROL_HOSTNAMES
     local num_ctrl=${#CUBE_NODE_CONTROL_HOSTNAMES[@]}
     local last_ctrl=${CUBE_NODE_CONTROL_HOSTNAMES[$((num_ctrl - 1))]}
+
+    # Self-heal: an older repair path created a REVERSED 'vip with vaw' colocation
+    # (colocation-vip-vaw-INFINITY) that pins the VIP onto vaw and can strand it on
+    # every node. Remove it so the VIP places independently; 'vaw with vip' keeps
+    # vaw following the VIP.
+    if pcs constraint --full 2>/dev/null | grep -q "colocation-vip-vaw-INFINITY" ; then
+        pcs constraint delete colocation-vip-vaw-INFINITY >/dev/null 2>&1
+        pcs resource cleanup vip >/dev/null 2>&1
+    fi
+
     for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
         if remote_run $node "[ -e /etc/pacemaker/authkey ]" ; then
             Quiet -n remote_run $node "timeout $SRVSTO cubectl node rsync -r compute /etc/pacemaker/authkey"
@@ -554,9 +590,12 @@ health_hacluster_repair()
         for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
             if [ "x$node" = "x$HOSTNAME" -a "x$node" = "x$last_ctrl" ] ; then
                 $HEX_SDK pacemaker_node_start $node
-                cmd -co "pcs resource create vaw systemd:vaw op monitor interval=\"30s\""
-                cmd -co "pcs constraint colocation add vip with vaw score=INFINITY"
+                cmd -co "pcs resource create vaw systemd:vaw op monitor interval=\"30s\" op start on-fail=\"ignore\" meta failure-timeout=\"60s\""
+                cmd -co "pcs constraint colocation add vaw with vip score=INFINITY"
                 cmd -co "pcs constraint order vip then vaw"
+                for ctrl in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+                    cmd -co "pcs constraint location vaw prefers $ctrl --force"
+                done
             elif [ "x$node" = "x$HOSTNAME" -a "x$node" = "x$master" ] ; then
                 $HEX_SDK pacemaker_node_stop $node
             else

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1334,37 +1334,6 @@ os_evac_upgrade_prepare()
     fi
 }
 
-_os_pre_failure_host_evacuation()
-{
-    if [ "$1" == "upgrade" ] ; then
-        # os_evac_upgrade_prepare
-        $HEX_CLI -c cluster check_repair MsgQueue >/tmp/upgrade_rabbitmq.log 2>&1
-        $HEX_SDK health_mysql_check || $HEX_SDK -m force health_mysql_repair
-
-        if $HEX_SDK health_rabbitmq_check ; then
-            # clear stale api for nova, neutron, and cinder
-            cmd -c $HEX_SDK stale_api_check_repair openstack-nova-api 8774 nova-api python3 0
-            cmd -c $HEX_SDK stale_api_check_repair neutron-server 9696 neutron-server server 0
-            cmd -c $HEX_SDK stale_api_check_repair openstack-cinder-api 8776 cinder-api python3 0
-
-            # restart only "enabled down" services; leave "disabled" (drained/maintenance) hosts alone.
-            if [ $($OPENSTACK compute service list -f value -c Status -c State | grep -ci "enabled down") -ge 1 ] ; then
-                cmd -c systemctl restart openstack-nova-scheduler
-                cmd -c systemctl restart openstack-nova-conductor
-                cmd -p systemctl restart openstack-nova-compute
-            fi
-
-            if [ $($OPENSTACK network agent list -f value -c ID -c Alive | grep -v -i true | wc -l) -ge 1 ] ; then
-                $OPENSTACK network agent list -f json -c ID -c Alive | jq -r ".[] | select(.Alive == false).ID" | xargs -i $OPENSTACK network agent delete {}
-                cmd -c "$SRVLTO systemctl restart neutron-server neutron-ovn-metadata-agent neutron-ovn-vpn-agent"
-            fi
-            $HEX_SDK health_neutron_check || Error "neutron is not Ok"
-        else
-            Error "rabbitmq is not Ok"
-        fi
-    fi
-}
-
 os_pre_failure_host_evacuation()
 {
     local host=$1
@@ -1374,13 +1343,9 @@ os_pre_failure_host_evacuation()
     # hostmonitor won't cold-evacuate (rebuild) it while it's deliberately down
     os_segment_host_maintenance "$host" True
 
-    for i in 1 2 3 ; do
-        if _os_pre_failure_host_evacuation $env ; then
-            break
-        else
-            sleep 30
-        fi
-    done
+    # repair+verify the live-migration path (self-gating, fast no-op when
+    # healthy); best-effort -- the drain proceeds regardless
+    [ "$env" == "upgrade" ] && $HEX_SDK live_migration_gate 120 "$host" repair
     nova host-evacuate-live $host
 }
 
@@ -1399,13 +1364,9 @@ os_pre_failure_host_evacuation_sequential()
     local srv_cnt=${#server_list_array[@]}
     local cnt=0
 
-    for i in 1 2 3 ; do
-        if _os_pre_failure_host_evacuation $env ; then
-            break
-        else
-            sleep 10
-        fi
-    done
+    # live-migration path readiness/repair is the caller's job: the rolling
+    # relay runs 'live_migration_gate <t> <host> repair' on the master control
+    # right before this drain
     for sid in ${server_list_array[@]} ; do
         to_host=${host_array[$((cnt++ % $num_host))]}
         old_state_json=$($OPENSTACK server show $sid -f json)

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1370,6 +1370,10 @@ os_pre_failure_host_evacuation()
     local host=$1
     local env=${2:-default}
 
+    # planned reboot: mark the host in masakari maintenance BEFORE draining so
+    # hostmonitor won't cold-evacuate (rebuild) it while it's deliberately down
+    os_segment_host_maintenance "$host" True
+
     for i in 1 2 3 ; do
         if _os_pre_failure_host_evacuation $env ; then
             break
@@ -1384,6 +1388,11 @@ os_pre_failure_host_evacuation_sequential()
 {
     local from_host=${1:-$HOSTNAME}
     local env=${2:-default}
+
+    # planned reboot (rolling upgrade relay): suppress masakari for the host so
+    # hostmonitor doesn't cold-evacuate it while it's deliberately down
+    os_segment_host_maintenance "$from_host" True
+
     local server_list_array=( $(hex_sdk os_nova_list ID STATUS POWERSTATE | grep -i 'active running' | cut -d' ' -f1) )
     local host_array=($(cubectl node -r compute list -j | jq -r .[].hostname | grep -v $from_host))
     local num_host=${#host_array[@]}
@@ -2681,6 +2690,62 @@ os_maintain_segment_hosts()
             $OPENSTACK segment host update $u $n --on_maintenance True
         done
     done
+}
+
+# Put ONE segment host into masakari maintenance so a PLANNED reboot isn't treated
+# as a host failure (per-host analog of os_maintain_segment_hosts). Without this,
+# hostmonitor cold-evacuates (rebuilds) a deliberately-rebooting node -- a hard
+# kill that also leaves grastate seqno=-1 -> forced Galera SST.
+os_segment_host_maintenance()   # $1=host  $2=True|False (default True)
+{
+    local host=$1 flag=${2:-True}
+    for u in $($OPENSTACK segment list -f value -c uuid) ; do
+        $OPENSTACK segment host list $u -f value -c name 2>/dev/null | grep -qx "$host" && \
+            $OPENSTACK segment host update $u $host --on_maintenance $flag
+    done
+}
+
+# 0 (uniform) only if every control node reports the same MariaDB major.minor --
+# the safe precondition to run mysql_upgrade (its system-table DDL replicates
+# cluster-wide). Firmware version (is_node_rolling_upgrade) is the wrong signal at
+# web-scale: Galera runs only on control, so storage/compute firmware skew must
+# NOT block, and control-tier version skew MUST block.
+os_mariadb_version_uniform()
+{
+    # Fail-safe: EVERY control node must be reachable AND report the same
+    # major.minor. An unreachable node is "unknown", not "absent" -- treating it
+    # as absent could report a mid-roll cluster as uniform and let mysql_upgrade
+    # replicate system-table DDL to a still-old member. Any miss => not uniform.
+    local hosts h v vers=
+    hosts=$(cubectl node list -r control -j 2>/dev/null | jq -r '.[].hostname')
+    [ -n "$hosts" ] || return 1
+    for h in $hosts ; do
+        v=$(remote_run "$h" "mysql -N -e 'SELECT VERSION()' 2>/dev/null" | cut -d- -f1 | cut -d. -f1,2)
+        [ -n "$v" ] || return 1
+        vers="$vers $v"
+    done
+    [ "$(printf '%s\n' $vers | sort -u | wc -l)" = "1" ]
+}
+
+# 0 (uniform) only if every control node reports the same RabbitMQ minor -- the
+# safe precondition to enable feature flags (enabling is IRREVERSIBLE and strands
+# nodes that don't support a newly-enabled flag).
+os_rabbitmq_version_uniform()
+{
+    # Fail-safe: EVERY control node must be reachable AND report the same
+    # major.minor. An unreachable node is "unknown", not "absent" -- treating it
+    # as absent could report a mid-roll cluster as uniform and enable feature
+    # flags the still-old node can't support, stranding it on rejoin. Any miss
+    # => not uniform. remote_run's is_sshable bounds each probe to ~3s.
+    local hosts h v vers=
+    hosts=$(cubectl node list -r control -j 2>/dev/null | jq -r '.[].hostname')
+    [ -n "$hosts" ] || return 1
+    for h in $hosts ; do
+        v=$(remote_run "$h" "rabbitmqctl version 2>/dev/null" | cut -d. -f1,2)
+        [ -n "$v" ] || return 1
+        vers="$vers $v"
+    done
+    [ "$(printf '%s\n' $vers | sort -u | wc -l)" = "1" ]
 }
 
 os_device_profile_create()

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -778,7 +778,6 @@ power_drain_host()
     # surprise -> reported via a non-zero return so the caller pauses the roll for
     # an operator. Host-scoped analog of os_pre_failure_host_evacuation_sequential.
     local from_host=${1:-$HOSTNAME}
-    local env=${2:-default}
     local server_list_array=( $($OPENSTACK server list --host "$from_host" --all-projects --status ACTIVE -f value -c ID) )
     local host_array=($(cubectl node -r compute list -j | jq -r .[].hostname | grep -v $from_host))
     local num_host=${#host_array[@]}
@@ -788,13 +787,13 @@ power_drain_host()
         return 1
     fi
 
-    for i in 1 2 3 ; do
-        if _os_pre_failure_host_evacuation $env ; then
-            break
-        else
-            sleep 10
-        fi
-    done
+    # repair+verify the live-migration path. This is the only gate covering
+    # the FIRST drain of a roll (no boot has happened yet) and drains released
+    # by a compute-node boot (the boot-path gate is an is_control_node no-op
+    # there); it runs on the master via power_node_evacuate, so it always
+    # gates. Best-effort -- the drain proceeds regardless and reacts only to
+    # nova's per-migration verdicts.
+    Quiet -n $HEX_SDK live_migration_gate 120 "$from_host" repair
 
     # Honor nova's concurrency cap. nova owns each migration's convergence
     # (completion_timeout -> force_complete -> post-copy guarantees completion),
@@ -902,7 +901,7 @@ power_node_evacuate()
     _power_roll_drain_poll "$host" "$total" "$sentinel" "$allstart" &
     local poll_pid=$!
 
-    power_drain_host $host upgrade
+    power_drain_host $host
     local rc=$?
     rm -f $sentinel ; kill $poll_pid 2>/dev/null ; wait $poll_pid 2>/dev/null
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Bundles the **mixed-version rolling-upgrade safety** changes for the Yoga→Epoxy SLURP path (established by the DB/MQ mixed-version spike). Five self-contained fixes, one per commit-worth of concern:

1. **gcache 300M → 4G** (`config_mysql.cpp`) — a rejoining node after a firmware-reboot-length downtime must catch up via **IST**; SST is broken for the MariaDB 10.6→10.11 jump (proven: the joiner crashes). Sizing the gcache guarantees IST. On-disk ring buffer, negligible cost. Ships from the Antelope image so the 10.6 **donors** carry it into the A→C roll.

2. **Live-migration gate on the rolling-upgrade relay** (`proj_functions` + `bootstrap_cube_config`) — the relay advanced to draining the next node on config-done **markers only**. `live_migration_gate` asserts the drain path is *functional* (Galera Synced+Primary, RabbitMQ clustered, ceph PGs servable, nova conductor/scheduler up + ≥1 live target, cinder-volume up, neutron alive) **without asserting version uniformity**, so a mixed N/N+1 SLURP window passes. keystone/haproxy/vip/memcached are covered transitively by the authenticated `openstack` calls; glance/cyborg are not on the live path. Pauses (never advances into a broken cluster) on timeout. Runs **after** `hex_config -p bootstrap standalone-done`.

3. **Masakari maintenance on planned reboot** (`sdk_os.sh`) — `os_segment_host_maintenance` marks a host in masakari maintenance **before** the planned drain (hooked into `os_pre_failure_host_evacuation[_sequential]`), so hostmonitor doesn't cold-evacuate (rebuild) a deliberately-rebooting node — a hard kill that also forces a Galera SST.

4. **`mysql_upgrade` gated on version uniformity** (`config_mysql.cpp` + `os_mariadb_version_uniform`) — defer the system-table upgrade until every control node reports the same MariaDB version, so its DDL never replicates into not-yet-upgraded peers. Version uniformity, not firmware, is the correct gate for web-scale.

5. **RabbitMQ feature-flag enable gated on version uniformity** (`config_rabbitmq.cpp` + `os_rabbitmq_version_uniform`) — enabling a flag is irreversible and strands nodes that don't support it; only enable when the cluster is version-uniform (pre-roll all-old = prep; post-roll all-new = graduate; never mid-roll).

Unifying principle for 4 & 5: cluster-wide graduations (`mysql_upgrade`, feature-flag enable) are gated on **per-service version uniformity**, never run mid-roll.

#### Which issue(s) this PR fixes

Relates to #651 (10.6→10.11 IST), #614/#785/#796 (RabbitMQ feature-flags/Erlang), and the traced rolling-upgrade gaps (marker-based advance, masakari-not-suppressed, mysql_upgrade mid-roll).

#### Special notes for your reviewer

> **Needs lab validation** — items 2/3 sit in the boot/relay path. Verify: a healthy same-version rolling restart still advances; a mixed-version rolling upgrade passes the gate and does NOT cold-evacuate; the version-uniformity gates defer during the mixed window and fire once converged. All C++ compiles (`config_mysql.o`, `config_rabbitmq.o`); shell syntax-checked. `cinder-volume` check assumes the pacemaker active/passive resource. Follow-up: unify the restart path onto `live_migration_gate` and drop the `if upgrading` fork.

#### Additional documentation

```docs
Handbook: kb/cubecos/architecture/db-mq-mixed-version-upgrade-spike.md and
slurp-upgrade-yoga-to-epoxy.md (spike, empirical IST/SST, the from-Antelope rule).
```

---
**Update:** folded in `feat(ha): always create the vaw resource in SetupCluster` — drops the `is_node_rolling_upgrade` guard so the vaw pacemaker resource (with its `vaw with vip` colocation) is created at every cluster setup, keeping FTS and upgrade paths consistent.