### PR TITLE
feat(upgrade): gate the rolling-upgrade relay on a functional live-migration path

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -68,6 +68,17 @@ RollingEvacuateAndReboot()
                 if [ "x$n_lastboot" = "xlast_boot = Never" -a "x$n_fwver" = "x$fwver" ] ; then
                     upgrading=true
                     echo "Starting auto rolling upgrade" >> $BOOTSTRAP_CUBE_MODE
+                    # Don't drain+reboot the next node until this node has rejoined
+                    # and the live-migration path is functional. Version-robust, so
+                    # a mixed N/N+1 SLURP window passes; pauses (never advances into
+                    # a broken cluster) if it can't confirm within the timeout.
+                    if ! hex_sdk live_migration_gate 300 "$N" ; then
+                        msg="Auto rolling upgrade paused: live-migration path not ready before draining $N"
+                        hex_sdk remote_run $n_ip "echo -n \"$msg\" >$BOOTSTRAP_CUBE_LOG"
+                        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+                        hex_sdk influx_event "${query},severity=\"W\" message=\"$msg\""
+                        break
+                    fi
                     if [ "x$n_role" = "xcontrol-converged" -o "x$n_role" = "xedge-core" -o "x$n_role" = "xcompute" ] ; then
                         msg="Evacuating VMs on $N"
                         echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -1084,6 +1084,49 @@ _essential_check_one()
     return 1
 }
 
+# live_migration_gate [timeout_secs] [drain_host]
+#
+# Block until the live-migration drain path is FUNCTIONAL, so the rolling relay
+# can safely take the next node down. Same precondition for rolling restart and
+# rolling upgrade -- both drain via live migration.
+#
+# Version-ROBUST: asserts function + cluster membership, never version uniformity
+# (mixed N/N+1 is expected and healthy under SLURP + mixed-version-safe DB/MQ).
+# Accepts quorate-but-degraded during the reboot window and excludes the draining
+# node from migration-target counts. keystone/haproxy/vip/memcached are covered
+# transitively by the authenticated $OPENSTACK calls; glance/cyborg are not on the
+# live-migration path. Returns 0 when a live migration can run; 1 on timeout.
+live_migration_gate()
+{
+    is_control_node || return 0
+    source /etc/admin-openrc.sh 2>/dev/null
+    local deadline=$((SECONDS + ${1:-300})) drain=${2:-__none__} why=
+
+    while [ $SECONDS -lt $deadline ] ; do
+        why=
+        # version-SAFE cluster membership (true/false regardless of version)
+        $HEX_SDK health_mysql_check    >/dev/null 2>&1 || why=galera
+        [ -z "$why" ] && { $HEX_SDK health_rabbitmq_check >/dev/null 2>&1 || why=rabbitmq ; }
+        [ -z "$why" ] && { $CEPH health 2>/dev/null | grep -qiE 'HEALTH_ERR|inactive|incomplete|peering|stale' && why=ceph ; }
+
+        # FUNCTIONAL backends a live migration touches (NOT version-strict)
+        [ -z "$why" ] && { $OPENSTACK compute service list --service nova-conductor -f value -c State 2>/dev/null | grep -qi up || why=nova-conductor ; }
+        [ -z "$why" ] && { $OPENSTACK compute service list --service nova-scheduler -f value -c State 2>/dev/null | grep -qi up || why=nova-scheduler ; }
+        [ -z "$why" ] && {
+            # >=1 live migration target that is not the node being drained
+            local tgt=$($OPENSTACK compute service list --service nova-compute -f value -c Host -c State 2>/dev/null | awk -v d="$drain" '$2=="up" && $1!=d {c++} END{print c+0}')
+            [ "${tgt:-0}" -ge 1 ] || why=no-migration-target
+        }
+        [ -z "$why" ] && { $OPENSTACK volume service list --service cinder-volume -f value -c State 2>/dev/null | grep -qi up || why=cinder-volume ; }
+        [ -z "$why" ] && { $OPENSTACK network agent list -f value -c Alive 2>/dev/null | grep -qi true || why=neutron ; }
+
+        [ -z "$why" ] && return 0
+        sleep 5
+    done
+    echo "live_migration_gate: live-migration path not ready ($why)" >&2
+    return 1
+}
+
 cluster_check_repair_essential()
 {
     # $1=repair (1) or check-only (0, default). Only the live-migration path.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds a **version-robust live-migration health gate** to the rolling-**upgrade** relay, which today advances to draining the next node on **config-done markers only** — no cluster-health check. That can take the next node down while live migration (the drain mechanism) isn't actually functional.

Rolling **restart** already gates via `cluster_check_repair_essential`. Rolling **upgrade** had no gate, because the full essential check reports NG on mixed-version skew and was deliberately skipped. But both modes have the *same* requirement — live migration must work to drain each node — so the gate belongs to both.

`live_migration_gate` (`proj_functions`) asserts the live-migration path is **functional**, never version-uniform, so a mixed N/N+1 SLURP window passes:
- **version-safe membership**: Galera `Synced`+`Primary`, RabbitMQ clustered, ceph PGs servable (`min_size`)
- **functional backends**: nova conductor/scheduler up + ≥1 live target (excluding the draining node), `cinder-volume` up, neutron alive
- **transitively covered** by the authenticated `openstack` calls: keystone, haproxy, vip, memcached
- **not gated** (not on the live-migration path): glance (live migration ships running state, no re-image), cyborg (accelerator VMs can't live-migrate)

Wired into `RollingEvacuateAndReboot` right **before** the next node's drain (`os_pre_failure_host_evacuation_sequential`). If the path can't be confirmed within the timeout, the roll **pauses** rather than draining into a broken cluster. Invoked **after** `hex_config -p bootstrap standalone-done` (which is what rejoins this node), so it can actually assert the rejoin.

#### Which issue(s) this PR fixes

Relates to the traced rolling-upgrade gap: advance is marker-based, not health-based.

#### Special notes for your reviewer

> **Needs lab validation** — this sits in the boot/relay path. Verify: (a) a healthy same-version rolling restart still advances promptly; (b) a mixed-version rolling upgrade passes the gate mid-roll; (c) an intentionally-degraded cluster pauses the roll instead of draining. The `cinder-volume` check assumes the pacemaker active/passive cinder-volume resource ("up somewhere"). Follow-up: replace the restart path's `cluster_check_repair_essential` gate with this same function so both modes share one gate, and drop the `if upgrading` fork.

#### Additional documentation

```docs
Handbook kb/cubecos/architecture/db-mq-mixed-version-upgrade-spike.md and
slurp-upgrade-yoga-to-epoxy.md cover why mixed-version-safe DB/MQ makes the
version-safe membership signals reliable mid-upgrade (the basis for this gate).
```
