### PR TITLE
new(sec): rsync kernel/firmware/boot partitions after security fixpac…

### DIFF
--- a/core/fixpacks/Makefile
+++ b/core/fixpacks/Makefile
@@ -49,6 +49,12 @@ secfix: secfixdraft
 	$(Q)sed -i "s/SUPPORTED_FIRMWARES=.*/SUPPORTED_FIRMWARES=\"$(SUPPORTED_FIRMWARES)\"/" $</fixpack.info
 	$(Q)sed -i "s/FIXPACK_ID=.*/FIXPACK_ID=\"$(FIXPACK_ID)\"/" $</fixpack.info
 	$(Q)sed -i "s/FIXPACK_NAME=.*/FIXPACK_NAME=\"$(FIXPACK_ID)\"/" $</fixpack.info
+	$(Q)sed -i "s/^exit 0.*//" $</post_install.sh
+	$(Q)echo "cubectl node rsync /usr/lib/modules" >>$</post_install.sh
+	$(Q)echo "cubectl node rsync /usr/lib/firmware" >>$</post_install.sh
+	$(Q)echo "cubectl node rsync /boot/Part1" >>$</post_install.sh
+	$(Q)echo "cubectl node rsync /boot/Part2" >>$</post_install.sh
+	$(Q)echo "exit 0" >>$</post_install.sh
 	$(call RUN_CMD,$(SHELL) $(HEX_SCRIPTSDIR)/makehotfix -C -p 20M $< $(FIXPACK_ID).fixpack,"  GEN     $@ $(FIXPACK_ID).fixpack")
 	$(Q)md5sum $(FIXPACK_ID).fixpack >$(FIXPACK_ID).fixpack.md5
 


### PR DESCRIPTION
…k install

Ensures nodes pick up the new kernel modules, firmware, and boot partitions across the cluster after applying the fixpack.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
