### PR TITLE
fix(apache): remove default welcome page on port 8080

### DIFF
--- a/core/keystone/keystone.mk
+++ b/core/keystone/keystone.mk
@@ -14,5 +14,9 @@ rootfs_install::
 	$(Q)cp -f $(ROOTDIR)/etc/keystone/keystone.conf $(ROOTDIR)/etc/keystone/keystone.conf.def
 	$(Q)[ -f $(ROOTDIR)/etc/httpd/conf.d/ssl.conf ] && mv $(ROOTDIR)/etc/httpd/conf.d/ssl.conf $(ROOTDIR)/etc/httpd/conf.d/ssl.conf.orig || /bin/true
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/keystone/ssl.conf ./etc/httpd/conf.d/
+# httpd ships a default welcome page; drop the config and its html so port 8080
+# serves no default content (cubecos-private#76)
+	$(Q)[ -f $(ROOTDIR)/etc/httpd/conf.d/welcome.conf ] && mv $(ROOTDIR)/etc/httpd/conf.d/welcome.conf $(ROOTDIR)/etc/httpd/conf.d/welcome.conf.orig || /bin/true
+	$(Q)rm -rf $(ROOTDIR)/usr/share/httpd/noindex
 # openssl 3.x requires no /dev/urandom for the written openssl command
 	$(Q)sed -i '/RANDFILE/d' $(ROOTDIR)/usr/libexec/mod_auth_mellon/mellon_create_metadata.sh

--- a/core/modules/config_apache2.cpp
+++ b/core/modules/config_apache2.cpp
@@ -14,6 +14,10 @@
 #include <hex/process.h>
 #include <hex/process_util.h>
 
+// httpd's only consumers are local: haproxy's openstack_horizon backend and the
+// monasca agent's server-status check. Binding loopback keeps 8080 off the
+// management network, where vulnerability scanners were reaching it.
+#define HTTP_ADDR "127.0.0.1"
 #define HTTP_PORT 8080
 
 static const char NAME[] = "httpd";
@@ -65,6 +69,24 @@ WriteSiteConf(const char* hostname, const bool debug)
         "ErrorLog /var/log/httpd/error.log\n",
         "CustomLog /var/log/httpd/access.log combined\n",
         std::string("LogLevel ") + (debug ? "debug" : "info") + "\n",
+
+        // Suppress the version banner here rather than relying on
+        // keystone's ssl.conf, which also sets these. Same values, so the
+        // duplication is inert.
+        "ServerTokens Prod\n",
+        "ServerSignature Off\n",
+        "TraceEnable Off\n",
+
+        // Stock httpd.conf grants Indexes on the DocumentRoot, and welcome.conf
+        // (removed from the image) carried the only "Options -Indexes" covering
+        // "/". DocumentRoot holds nothing -- /var/www is used for certs only --
+        // so deny it outright and serve a bare 403.
+        "<Directory \"/var/www/html\">\n",
+        "    Options -Indexes\n",
+        "    AllowOverride None\n",
+        "    Require all denied\n",
+        "</Directory>\n",
+
         std::string("<VirtualHost *:") + std::to_string(HTTP_PORT) + ">\n",
         "</VirtualHost>\n",
     };
@@ -151,7 +173,8 @@ Init()
 {
     if (HexSystemF(
             0,
-            "sed -e \"s/Listen 80/Listen %d/\" %s > %s",
+            "sed -e \"s/Listen 80/Listen %s:%d/\" %s > %s",
+            HTTP_ADDR,
             HTTP_PORT,
             ORIG,
             CONF)

--- a/core/modules/config_monasca.cpp
+++ b/core/modules/config_monasca.cpp
@@ -147,7 +147,9 @@ WriteAgentSetupDetectionConfigs()
     }
 
     fprintf(fout, "[client]\n");
-    fprintf(fout, "url=http://localhost:8080/server-status?auto\n");
+    // explicit IPv4 loopback: httpd binds 127.0.0.1 only, and "localhost" can
+    // resolve to ::1 first
+    fprintf(fout, "url=http://127.0.0.1:8080/server-status?auto\n");
     fclose(fout);
 
     fout = fopen(AGENT_MYSQL_CONF, "w");


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fixes the Apache default "Test Page" served on port 8080 of the management IP (Tenable plugin 112351). Default service pages fail CIS Benchmark, PCI-DSS 2.2.1, and NIST 800-53 CM-6/CM-7, which surfaces in enterprise procurement scans.

Two layers of defense:

- **Bind Apache's 8080 listener to loopback** (`config_apache2.cpp`). Port 8080 is httpd's main listener (Horizon, Keystone `/identity`, `/server-status`) so it can't be removed — but its only two consumers reach it over loopback (HAProxy's `openstack_horizon` backend, the Monasca agent's check). Binding `127.0.0.1` removes it from off-box scans.
- **Stop serving default content** even on-box: drop the RPM's `welcome.conf` + `/usr/share/httpd/noindex` from the image (`keystone.mk`), and deny the empty DocumentRoot with `Require all denied` / `Options -Indexes` (`config_apache2.cpp`). The deny block is required — without it, removing `welcome.conf` would expose a browsable directory listing, since stock httpd.conf grants `Options Indexes` on `/var/www/html` and `welcome.conf` carried the only `-Indexes` covering `/`.
- **Pin the Monasca check to `127.0.0.1`** (`config_monasca.cpp`), since `localhost` can resolve to `::1` where httpd no longer listens.

**Why literal `127.0.0.1` and not `localhost`**

Both the listener bind (`config_apache2.cpp`) and every consumer (the Monasca check, HAProxy's `openstack_horizon` backend) use the literal IPv4 address, never the hostname `localhost`. `localhost` resolves via `/etc/hosts` to **both** `127.0.0.1` and `::1`, and the resolver commonly returns `::1` (IPv6) first. That matters on both sides:

- **Bind side** — `Listen localhost:8080` would bind **both** `127.0.0.1:8080` *and* `[::1]:8080`, widening the surface this PR is trying to shrink, and making socket creation depend on name resolution at boot (a fragile dependency for an early-boot service). The literal binds exactly one IPv4 loopback socket, with no resolver step.
- **Connect side** — a client using `localhost` may hit `[::1]:8080`, where httpd (bound to IPv4 loopback only) is *not* listening → `connection refused`. This is exactly the failure the `fix(monasca)` commit prevents by pinning the check URL to `127.0.0.1`.

Using the literal keeps the whole path single address-family (IPv4 loopback), resolver-independent, and symmetric — matching what HAProxy already does.

Commits:
- `fix(monasca): pin the apache server-status check to 127.0.0.1`
- `fix(apache): bind 8080 to loopback and deny the empty docroot`
- `fix(apache): stop shipping the default welcome page`

#### Which issue(s) this PR fixes

Fixes bigstack-oss/cubecos-private#76

#### Special notes for your reviewer

> ⚠️ **Not yet verified on a node.** These commits were written and reviewed without a build environment (Docker/jail unavailable). The C++ passed `g++ -fsyntax-only`; a whole-branch review confirmed the sed expansion, generated Apache config, Makefile recipe, and — the load-bearing assumption — that no service depends on cross-node `:8080`, so the loopback bind does not break HA.
>
> **Do not merge until the checklist below passes in the jail against a test node.**

**Pre-merge verification (run in the jail)**

Build:
- [ ] `make rootfs` succeeds
- [ ] Staging tree has `welcome.conf.orig` and **no** `welcome.conf` in `etc/httpd/conf.d/`
- [ ] Staging tree has **no** `usr/share/httpd/noindex` directory

On a booted node:
- [ ] `ss -lntp | grep 8080` shows `127.0.0.1:8080` only — no `0.0.0.0` / `*` / `[::1]`
- [ ] `curl -I http://<mgmt-ip>:8080/` from another host → **connection refused** (the acceptance criterion)
- [ ] `curl -sI http://127.0.0.1:8080/` → `403`, `Server: Apache` with no version, no test page, no `Index of /`
- [ ] Horizon still loads through the VIP (`https://<vip>/horizon` → 200)
- [ ] `/server-status` still answers on loopback; `/root/.apache.cnf` reads `http://127.0.0.1:8080/server-status?auto`; monasca-agent logs show no apache connection errors

HA (multi-node):
- [ ] From control node B: `curl --max-time 5 http://<node-a-mgmt-ip>:8080/server-status?auto` → refused, **and** cluster health stays green with no Apache/Monasca alarms

If the HA check breaks something, that invalidates the design's core premise — fall back to keeping `0.0.0.0` and relying on the welcome-page removal alone, which still satisfies the ticket's acceptance criterion.

#### Additional documentation

The reasoning here is recorded as a handbook kb Topic — [bigstack-handbook#210](https://github.com/bigstack-oss/bigstack-handbook/pull/210), landing `kb/cubecos/architecture/httpd-8080-loopback-hardening.md`. It covers why 8080 can't be removed, why the `welcome.conf` deletion and the `Require all denied` docroot block are one change, and the load-bearing "no cross-node `:8080`" assumption plus its fallback.

```docs

```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

