### PR TITLE
feat(manila): multi-backend share types (CephFS-native + NetApp stub)

### DIFF
--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -689,9 +689,9 @@ SetupManilaCephFS()
     HexUtilSystemF(0, 0, "timeout 10 ceph fs set %s allow_new_snaps true", MANILA_CEPHFS_NAME);
 
     HexUtilSystemF(0, 0, "timeout 10 ceph auth get-or-create client.manila "
-                         "mon 'allow r' mgr 'allow rw' mds 'allow *' "
+                         "mon 'allow r' mgr 'allow rw' mds 'allow rw fsname=%s' "
                          "osd 'allow rw pool=%s, allow rw pool=%s' -o %s",
-        MANILA_CEPHFS_DATA_POOL, MANILA_CEPHFS_METADATA_POOL, MANILA_CEPH_KEYRING);
+        MANILA_CEPHFS_NAME, MANILA_CEPHFS_DATA_POOL, MANILA_CEPHFS_METADATA_POOL, MANILA_CEPH_KEYRING);
     HexUtilSystemF(0, 0, "chmod 0600 %s", MANILA_CEPH_KEYRING);
 
     HexSystemF(0, "touch " MAKRER_MANILA_CEPHFS);

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1471,6 +1471,7 @@ CommitCheck(bool modified, int dryLevel)
         | s_bNetModified
         | s_bCubeModified
         | s_bKeystoneModified
+        | s_bManilaModified
         | G_MOD(IS_MASTER)
         | G_MOD(CTRL_IP)
         | G_MOD(SHARED_ID)

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -33,6 +33,7 @@
 
 #define MAKRER_POOL "/etc/appliance/state/ceph_osd_pool_done"
 #define MAKRER_CEPHFS "/etc/appliance/state/cephfs_done"
+#define MAKRER_MANILA_CEPHFS "/etc/appliance/state/manila_cephfs_done"
 #define MAKRER_RESTFUL "/etc/appliance/state/ceph_restful_done"
 #define MAKRER_AUTOSCALE "/etc/appliance/state/ceph_autoscale_done"
 #define MAKRER_MSGR2 "/etc/appliance/state/ceph_msgr2_done"
@@ -66,6 +67,7 @@ const static char DUMMY_KEYRING[] = "/etc/ceph/ceph.client.None.keyring";
 const static char ADMIN_KEYRING[] = "/etc/ceph/ceph.client.admin.keyring";
 const static char K8S_KEYRING[] = "/etc/ceph/ceph.client.k8s.keyring";
 const static char CEPHFS_CLIENT_AUTHKEY[] = "/etc/ceph/admin.key";
+const static char MANILA_CEPH_KEYRING[] = "/etc/ceph/ceph.client.manila.keyring";
 
 static const char FSID[] = "c6e64c49-09cf-463b-9d1c-b6645b4b3b85";
 
@@ -79,6 +81,10 @@ static const char CEPHFS_METADATA_POOL[] = "cephfs_metadata";
 static const char CEPHFS_NAME[] = "cephfs";
 static const char CEPHFS_DEFAULT_SUB_VOLUME_GROUP[] = "cephfs_default_sub_volume_group";
 static const char CEPHFS_STORE_DIR[] = "/mnt/cephfs";
+
+static const char MANILA_CEPHFS_DATA_POOL[] = "manila_cephfs_data";
+static const char MANILA_CEPHFS_METADATA_POOL[] = "manila_cephfs_metadata";
+static const char MANILA_CEPHFS_NAME[] = "manila_cephfsnative";
 
 static const char SRV_KEY[] = "/var/www/certs/server.key";
 static const char SRV_CRT[] = "/var/www/certs/server.cert";
@@ -136,6 +142,7 @@ CONFIG_TUNING_SPEC_STR(CUBESYS_SEED);
 CONFIG_TUNING_SPEC_BOOL(CUBESYS_HA);
 CONFIG_TUNING_SPEC_BOOL(CUBESYS_SALTKEY);
 CONFIG_TUNING_SPEC_STR(KEYSTONE_ADMIN_CLI_PASS);
+CONFIG_TUNING_SPEC_BOOL(MANILA_CEPHFSNATIVE_ENABLED);
 
 // parse tunings
 PARSE_TUNING_BOOL(s_debugEnabled, CEPH_DEBUG_ENABLED);
@@ -157,6 +164,7 @@ PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 1);
 PARSE_TUNING_X_STR(s_seed, CUBESYS_SEED, 1);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 1);
 PARSE_TUNING_X_BOOL(s_saltkey, CUBESYS_SALTKEY, 1);
+PARSE_TUNING_X_BOOL(s_manilaCephfsnativeEnabled, MANILA_CEPHFSNATIVE_ENABLED, 3);
 
 // FIXME: circular issue
 // PARSE_TUNING_X_STR(s_adminCliPass, KEYSTONE_ADMIN_CLI_PASS, 2);
@@ -661,6 +669,36 @@ SetupFS()
     return true;
 }
 
+static bool
+SetupManilaCephFS()
+{
+    if (!IsControl(s_eCubeRole))
+        return true;
+
+    if (!s_manilaCephfsnativeEnabled)
+        return true;
+
+    if (access(MAKRER_MANILA_CEPHFS, F_OK) == 0)
+        return true;
+
+    HexUtilSystemF(0, 0, HEX_SDK " ceph_create_pool %s cephfs", MANILA_CEPHFS_DATA_POOL);
+    HexUtilSystemF(0, 0, HEX_SDK " ceph_create_pool %s cephfs", MANILA_CEPHFS_METADATA_POOL);
+
+    HexUtilSystemF(0, 0, "timeout 10 ceph fs new %s %s %s",
+        MANILA_CEPHFS_NAME, MANILA_CEPHFS_METADATA_POOL, MANILA_CEPHFS_DATA_POOL);
+    HexUtilSystemF(0, 0, "timeout 10 ceph fs set %s allow_new_snaps true", MANILA_CEPHFS_NAME);
+
+    HexUtilSystemF(0, 0, "timeout 10 ceph auth get-or-create client.manila "
+                         "mon 'allow r' mgr 'allow rw' mds 'allow *' "
+                         "osd 'allow rw pool=%s, allow rw pool=%s' -o %s",
+        MANILA_CEPHFS_DATA_POOL, MANILA_CEPHFS_METADATA_POOL, MANILA_CEPH_KEYRING);
+    HexUtilSystemF(0, 0, "chmod 0600 %s", MANILA_CEPH_KEYRING);
+
+    HexSystemF(0, "touch " MAKRER_MANILA_CEPHFS);
+
+    return true;
+}
+
 static bool SetupISCSI()
 {
     struct stat ms;
@@ -865,13 +903,14 @@ UpdateConfig(
         fprintf(fout, "rgw usage max shards = 32\n");
         fprintf(fout, "rgw usage max user shards = 1\n");
 
-        // manila share
-        // FIXME: Check if manila is enabled
-        fprintf(fout, "[client.manila]\n");
-        fprintf(fout, "client mount uid = 0\n");
-        fprintf(fout, "client mount gid = 0\n");
-        fprintf(fout, "log file = /var/log/ceph/ceph-client.manila.log\n");
-        fprintf(fout, "admin socket = /var/run/ceph/guests/ceph-$name.$pid.asok\n");
+        // manila share (CephFS-native backend)
+        if (s_manilaCephfsnativeEnabled) {
+            fprintf(fout, "[client.manila]\n");
+            fprintf(fout, "client mount uid = 0\n");
+            fprintf(fout, "client mount gid = 0\n");
+            fprintf(fout, "log file = /var/log/ceph/ceph-client.manila.log\n");
+            fprintf(fout, "admin socket = /var/run/ceph/guests/ceph-$name.$pid.asok\n");
+        }
     }
 
     if (IsControl(s_eCubeRole) || IsCompute(s_eCubeRole)) {
@@ -1372,6 +1411,21 @@ NotifyKeystone(bool modified)
     s_bKeystoneModified = IsModifiedTune(2);
 }
 
+static bool s_bManilaModified = false;
+
+static bool
+ParseManila(const char* name, const char* value, bool isNew)
+{
+    ParseTune(name, value, isNew, 3);
+    return true;
+}
+
+static void
+NotifyManila(bool modified)
+{
+    s_bManilaModified = IsModifiedTune(3);
+}
+
 static bool
 Validate()
 {
@@ -1522,7 +1576,7 @@ Commit(bool modified, int dryLevel)
         if (!monEnabled)
             RemoveMon(s_hostname.c_str());
 
-        if (!SetupPools() || !SetupFS() || !SetupMgr(s_hostname)
+        if (!SetupPools() || !SetupFS() || !SetupManilaCephFS() || !SetupMgr(s_hostname)
             || !SetupMds(s_hostname) || !SetupRgw(s_hostname.c_str())
             || !SetupOsd(s_hostname, fsid) || !SetupISCSI())
             return false;
@@ -1895,11 +1949,14 @@ CONFIG_REQUIRES(ceph_dashboard_idp, keycloak);
 CONFIG_OBSERVES(ceph, net, ParseNet, NotifyNet);
 CONFIG_OBSERVES(ceph, cubesys, ParseCube, NotifyCube);
 CONFIG_OBSERVES(ceph, keystone, ParseKeystone, NotifyKeystone);
+CONFIG_OBSERVES(ceph, manila, ParseManila, NotifyManila);
 
 CONFIG_MIGRATE(ceph, "/etc/cube/cos/ceph");
 CONFIG_MIGRATE(ceph, "/var/lib/ceph");
 CONFIG_MIGRATE(ceph, MAKRER_POOL);
 CONFIG_MIGRATE(ceph, MAKRER_CEPHFS);
+CONFIG_MIGRATE(ceph, MAKRER_MANILA_CEPHFS);
+CONFIG_MIGRATE(ceph, MANILA_CEPH_KEYRING);
 CONFIG_MIGRATE(ceph, MAKRER_CLIENT);
 CONFIG_MIGRATE(ceph, ADMIN_KEYRING);
 CONFIG_MIGRATE(ceph, K8S_KEYRING);

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -267,6 +267,7 @@ InitConfig(Configs& config)
 {
     std::vector<std::string> sections = std::vector<std::string> {
         "DEFAULT",
+        "cephfsnative",
         "cinder",
         "cors",
         "database",
@@ -520,6 +521,24 @@ SetDriverGeneric(
 }
 
 /**
+ * Set the CephFS-native driver. Talks directly to the dedicated
+ * "manila_cephfsnative" filesystem provisioned by the ceph module
+ * (config_ceph.cpp::SetupManilaCephFS) — no service VM, no Cinder volume.
+ */
+static void
+SetDriverCephFSNative(Configs& config)
+{
+    config["cephfsnative"]["share_backend_name"] = "CEPHFSNATIVE";
+    config["cephfsnative"]["share_driver"] = "manila.share.drivers.cephfs.driver.CephFSDriver";
+    config["cephfsnative"]["driver_handles_share_servers"] = "false";
+    config["cephfsnative"]["cephfs_conf_path"] = "/etc/ceph/ceph.conf";
+    config["cephfsnative"]["cephfs_auth_id"] = "manila";
+    config["cephfsnative"]["cephfs_cluster_name"] = "ceph";
+    config["cephfsnative"]["cephfs_filesystem_name"] = "manila_cephfsnative";
+    config["cephfsnative"]["cephfs_protocol_helper_type"] = "CEPHFS";
+}
+
+/**
  * Set up Manila service.
  * The function should be run after Keystone service is running.
  */
@@ -692,6 +711,17 @@ Commit(bool modified, int dryLevel)
             SetDriverGeneric(config, mgmtCidr, BUILTIN_VOLUME_TYPE);
         }
 
+        std::stringstream backends;
+        backends << "generic";
+
+        if (s_cephfsnativeEnabled) {
+            backends << ",cephfsnative";
+            SetDriverCephFSNative(config);
+            config["DEFAULT"]["enabled_share_protocols"] = "NFS,CIFS,CEPHFS";
+        }
+
+        config["DEFAULT"]["enabled_share_backends"] = backends.str();
+
         WriteConfig(CONF, SB_SEC_WFMT, '=', config);
     }
 
@@ -776,6 +806,7 @@ CONFIG_REQUIRES(manila, memcache);
 CONFIG_REQUIRES(manila, neutron);
 CONFIG_REQUIRES(manila, nova);
 CONFIG_REQUIRES(manila, cinder);
+CONFIG_REQUIRES(manila, ceph);
 
 // extra tunings
 CONFIG_OBSERVES(manila, rabbitmq, ParseRabbitMQ, NotifyMQ);

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -275,6 +275,7 @@ InitConfig(Configs& config)
         "glance",
         "healthcheck",
         "keystone_authtoken",
+        "netapp",
         "neutron",
         "nova",
         "oslo_concurrency",
@@ -539,6 +540,32 @@ SetDriverCephFSNative(Configs& config)
 }
 
 /**
+ * Set the NetApp driver. Config-surface only — no real array has been
+ * validated against this yet (see design spec Risks). Values come
+ * straight from admin-supplied tunings, unvalidated beyond the existing
+ * regex helpers.
+ */
+static void
+SetDriverNetapp(
+    Configs& config,
+    const std::string server,
+    const std::string username,
+    const std::string password,
+    const std::string vserver,
+    const std::string aggregate)
+{
+    config["netapp"]["share_backend_name"] = "NETAPP";
+    config["netapp"]["share_driver"] = "manila.share.drivers.netapp.common.NetAppDriver";
+    config["netapp"]["driver_handles_share_servers"] = "false";
+    config["netapp"]["netapp_storage_family"] = "ontap_cluster";
+    config["netapp"]["netapp_server_hostname"] = server;
+    config["netapp"]["netapp_login"] = username;
+    config["netapp"]["netapp_password"] = password;
+    config["netapp"]["netapp_vserver"] = vserver;
+    config["netapp"]["netapp_aggregate_name_search_pattern"] = aggregate;
+}
+
+/**
  * Set up Manila service.
  * The function should be run after Keystone service is running.
  */
@@ -718,6 +745,11 @@ Commit(bool modified, int dryLevel)
             backends << ",cephfsnative";
             SetDriverCephFSNative(config);
             config["DEFAULT"]["enabled_share_protocols"] = "NFS,CIFS,CEPHFS";
+        }
+
+        if (s_netappEnabled) {
+            backends << ",netapp";
+            SetDriverNetapp(config, s_netappServer, s_netappUsername, s_netappPassword, s_netappVserver, s_netappAggregate);
         }
 
         config["DEFAULT"]["enabled_share_backends"] = backends.str();

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -56,7 +56,7 @@ CONFIG_TUNING_BOOL(MANILA_CEPHFSNATIVE_ENABLED, "manila.cephfsnative.enabled", T
 CONFIG_TUNING_BOOL(MANILA_NETAPP_ENABLED, "manila.netapp.enabled", TUNING_PUB, "Set to true to enable the NetApp Manila share backend.", false);
 CONFIG_TUNING_STR(MANILA_NETAPP_SERVER, "manila.netapp.server", TUNING_PUB, "Set the NetApp management LIF hostname or IP.", "", ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(MANILA_NETAPP_USERNAME, "manila.netapp.username", TUNING_PUB, "Set the NetApp management username.", "", ValidateRegex, DFT_REGEX_STR);
-CONFIG_TUNING_STR(MANILA_NETAPP_PASSWORD, "manila.netapp.password", TUNING_PUB, "Set the NetApp management password.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(MANILA_NETAPP_PASSWORD, "manila.netapp.password", TUNING_UNPUB, "Set the NetApp management password.", "", ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(MANILA_NETAPP_VSERVER, "manila.netapp.vserver", TUNING_PUB, "Set the NetApp vserver (SVM) name.", "", ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(MANILA_NETAPP_AGGREGATE, "manila.netapp.aggregate", TUNING_PUB, "Set the NetApp aggregate name.", "", ValidateRegex, DFT_REGEX_STR);
 

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -52,6 +52,13 @@ CONFIG_TUNING_STR(MANILA_DBPASS, "manila.db.password", TUNING_UNPUB, "Set manila
 // public tunings
 CONFIG_TUNING_BOOL(MANILA_DEBUG, "manila.debug.enabled", TUNING_PUB, "Set to true to enable manila verbose log.", false);
 CONFIG_TUNING_STR(MANILA_VOLUME_TYPE, "manila.volume.type", TUNING_PUB, "Set manila backend volume type.", BUILTIN_VOLUME_TYPE, ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_BOOL(MANILA_CEPHFSNATIVE_ENABLED, "manila.cephfsnative.enabled", TUNING_PUB, "Set to true to enable the CephFS-native Manila share backend.", false);
+CONFIG_TUNING_BOOL(MANILA_NETAPP_ENABLED, "manila.netapp.enabled", TUNING_PUB, "Set to true to enable the NetApp Manila share backend.", false);
+CONFIG_TUNING_STR(MANILA_NETAPP_SERVER, "manila.netapp.server", TUNING_PUB, "Set the NetApp management LIF hostname or IP.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(MANILA_NETAPP_USERNAME, "manila.netapp.username", TUNING_PUB, "Set the NetApp management username.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(MANILA_NETAPP_PASSWORD, "manila.netapp.password", TUNING_PUB, "Set the NetApp management password.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(MANILA_NETAPP_VSERVER, "manila.netapp.vserver", TUNING_PUB, "Set the NetApp vserver (SVM) name.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(MANILA_NETAPP_AGGREGATE, "manila.netapp.aggregate", TUNING_PUB, "Set the NetApp aggregate name.", "", ValidateRegex, DFT_REGEX_STR);
 
 // using external tunings
 CONFIG_TUNING_SPEC_STR(RABBITMQ_OPENSTACK_PASSWD);
@@ -72,6 +79,13 @@ PARSE_TUNING_BOOL(s_debug, MANILA_DEBUG);
 PARSE_TUNING_STR(s_manilaPass, MANILA_USERPASS);
 PARSE_TUNING_STR(s_dbPass, MANILA_DBPASS);
 PARSE_TUNING_STR(s_volumeType, MANILA_VOLUME_TYPE);
+PARSE_TUNING_BOOL(s_cephfsnativeEnabled, MANILA_CEPHFSNATIVE_ENABLED);
+PARSE_TUNING_BOOL(s_netappEnabled, MANILA_NETAPP_ENABLED);
+PARSE_TUNING_STR(s_netappServer, MANILA_NETAPP_SERVER);
+PARSE_TUNING_STR(s_netappUsername, MANILA_NETAPP_USERNAME);
+PARSE_TUNING_STR(s_netappPassword, MANILA_NETAPP_PASSWORD);
+PARSE_TUNING_STR(s_netappVserver, MANILA_NETAPP_VSERVER);
+PARSE_TUNING_STR(s_netappAggregate, MANILA_NETAPP_AGGREGATE);
 PARSE_TUNING_X_STR(s_mqPass, RABBITMQ_OPENSTACK_PASSWD, 1);
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 2);
 PARSE_TUNING_X_STR(s_cubeDomain, CUBESYS_DOMAIN, 2);

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -825,6 +825,10 @@ ClusterStartMain(int argc, char** argv)
             HexSystemF(0, "touch " INIT_DONE);
         }
 
+        HexUtilSystemF(0, 0, HEX_SDK " os_manila_backend_types_init %d %d",
+            s_cephfsnativeEnabled ? 1 : 0,
+            s_netappEnabled ? 1 : 0);
+
         // post actions for db migration
         HexUtilSystemF(0, 0, HEX_SDK " migrate_manila_db_post");
     }

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2113,6 +2113,40 @@ os_manila_init()
     #fi
 }
 
+# Creates a share type per enabled backend and binds it to that backend
+# via the share_backend_name extra-spec (the mechanism spike #960
+# verified end-to-end). Idempotent — safe to call on every cluster_start,
+# not just first boot, so a toggle flipped after initial bootstrap still
+# takes effect on the next commit + restart.
+# params:
+# $1: cephfsnative backend enabled (1/0)
+# $2: netapp backend enabled (1/0)
+os_manila_backend_types_init()
+{
+    if ! is_control_node ; then
+        return 0
+    fi
+
+    local cephfsnative_enabled=$1
+    local netapp_enabled=$2
+
+    if [ "$cephfsnative_enabled" = "1" ] ; then
+        local cephfs_type_id=$(manila type-list | awk '/ cephfs_share_type /{print $2}')
+        if [ -z "$cephfs_type_id" ] ; then
+            manila type-create --snapshot_support true --create_share_from_snapshot_support true cephfs_share_type false
+            manila type-key cephfs_share_type set share_backend_name=CEPHFSNATIVE
+        fi
+    fi
+
+    if [ "$netapp_enabled" = "1" ] ; then
+        local netapp_type_id=$(manila type-list | awk '/ netapp_share_type /{print $2}')
+        if [ -z "$netapp_type_id" ] ; then
+            manila type-create --snapshot_support true --create_share_from_snapshot_support true netapp_share_type false
+            manila type-key netapp_share_type set share_backend_name=NETAPP
+        fi
+    fi
+}
+
 os_ironic_deploy_kernel_import()
 {
     local kernel=$1/$2


### PR DESCRIPTION
Close bigstack-oss/cubecmp#957

## Summary

COS-side implementation backing bigstack-oss/cubecmp#957 (spike: bigstack-oss/cubecmp#960). Adds two new optional Manila share backends, both disabled by default:

- **CephFS-native** (fully wired): dedicated `manila_cephfsnative` Ceph filesystem + `client.manila` cephx identity, `[cephfsnative]` manila.conf driver stanza, `CEPHFS` added to `enabled_share_protocols` (a real bug spike #960 caught — Manila rejects CephFS shares without it), and a bound `cephfs_share_type` created on every cluster start.
- **NetApp** (config-surface stub only): `[netapp]` stanza + `netapp_share_type`, not functionally validated — no real array available to test against.

Both toggle via `manila.cephfsnative.enabled` / `manila.netapp.enabled` (default `false`) — zero behavior change for existing clusters until an admin opts in.

## What changed

- `core/modules/config_manila.cpp` — new tunings, `SetDriverCephFSNative`/`SetDriverNetapp`, dynamic `enabled_share_backends`/`enabled_share_protocols`, `CONFIG_REQUIRES(manila, ceph)`, `ClusterStartMain` now also runs share-type binding on every start (not just first boot).
- `core/modules/config_ceph.cpp` — cross-reads the manila toggle, provisions the dedicated filesystem + cephx client, gates the pre-existing (previously unconditional, `FIXME`-marked) `[client.manila]` ceph.conf stanza.
- `core/sdk_sh/modules/sdk_os.sh` — new `os_manila_backend_types_init`, idempotent, creates+binds a share type per enabled backend via the `share_backend_name` extra-spec (the exact mechanism spike #960 verified end-to-end).

## Notable fixes caught during review

- A cross-module "modified" tracking variable in `config_ceph.cpp` was initially left unwired from `CommitCheck()`, which would have silently no-op'd a toggle flip on an already-running cluster — fixed and reconfirmed.
- Final whole-branch review flagged the `client.manila` cephx `mds` cap as `allow *` (unscoped, defeating the point of a dedicated filesystem) and the NetApp password tuning as publicly readable — both fixed and reconfirmed.

## Test plan

No automated test harness exists for hex config C++ modules in this repo (confirmed: only `config_etcd` has a bespoke rig). Verification is manual, against a live dev cluster, per the plan's Task 6:

- [ ] `cubectl config commit` with both toggles at default `false` — confirm zero diff to `manila.conf`/`ceph.conf`/`openstack share type list` vs. pre-branch baseline
- [ ] Enable `manila.cephfsnative.enabled`, commit, confirm `openstack share type list` shows `cephfs_share_type`, `openstack share pool list` shows the `cephfsnative` backend
- [ ] Create + mount a share on `cephfs_share_type`, write/read to confirm the data path
- [ ] Toggle back off, confirm revert to baseline

## Out of scope

CMP-side UI/API/billing (separate `cubecmp` repo/story) and the handbook knowledge update (DoD, lands in `bigstack-handbook`) are tracked separately, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)