### PR TITLE
fix(kafka): use a more permanent download link for kafka tarball

### DIFF
--- a/core/kafka/kafka.mk
+++ b/core/kafka/kafka.mk
@@ -10,7 +10,7 @@ KAFKA_VER := 3.9.2
 KAFKA_TGZ := kafka_2.13-$(KAFKA_VER).tgz
 
 $(ARCS_DIR)/$(KAFKA_TGZ):
-	$(Q)wget https://downloads.apache.org/kafka/$(KAFKA_VER)/$(KAFKA_TGZ) -O $@
+	$(Q)wget https://archive.apache.org/dist/kafka/$(KAFKA_VER)/$(KAFKA_TGZ) -O $@
 
 rootfs_install:: $(ARCS_DIR)/$(KAFKA_TGZ)
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KAFKA_BIN_DIR) $(KAFKA_APP_DIR) $(KAFKA_LOG_DIR) $(KAFKA_RUN_DIR)


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Use a more permanent download link for Kafka tarball

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation

Build error:

```bash
--2026-07-15 16:35:15--  https://downloads.apache.org/kafka/3.9.2/kafka_2.13-3.9.2.tgz
Resolving [downloads.apache.org](http://downloads.apache.org/) ([downloads.apache.org](http://downloads.apache.org/))... 95.216.224.44, 88.99.208.237, 2a01:4f9:2b:1cc2::2, ...
Connecting to [downloads.apache.org](http://downloads.apache.org/) ([downloads.apache.org](http://downloads.apache.org/))|95.216.224.44|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2026-07-15 16:35:16 ERROR 404: Not Found.

make[5]: *** [/root/workspace/cubecos/core/kafka/kafka.mk:13: /root/workspace/jim-dev/core/heavyfs/ARCS/kafka_2.13-3.9.2.tgz] Error 8
```
