### PR TITLE
fix(ceph): harden perf-tuned defaults for converged nodes

### DIFF
--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -895,11 +895,10 @@ UpdateConfig(
 
     // bluestore osd perf tuning
     if (perfTuned) {
-        fprintf(fout, "bluestore cache autotune = 0\n");
+        fprintf(fout, "bluestore cache autotune = 0\n");    // off: autotune's PriorityCache mem_avail assert aborts OSDs during unclean-shutdown recovery
         fprintf(fout, "bluestore cache kv ratio = 0.2\n");
         fprintf(fout, "bluestore cache meta ratio = 0.8\n");
-        fprintf(fout, "bluestore cache size ssd = 8G\n");
-        fprintf(fout, "bluestore csum type = none\n");
+        fprintf(fout, "bluestore csum type = crc32c\n");     // corruption detection on for tenant data
         fprintf(fout, "bluestore extent map shard max size = 200\n");
         fprintf(fout, "bluestore extent map shard min size = 50\n");
         fprintf(fout, "bluestore extent map shard target size = 100\n");
@@ -921,14 +920,14 @@ UpdateConfig(
                       "flusher_threads=8,"
                       "compaction_readahead_size=2MB\n");
         fprintf(fout, "osd map share max epochs = 100\n");
-        fprintf(fout, "osd max backfills = 5\n");
-        fprintf(fout, "osd memory target = 2147483648\n");
+        fprintf(fout, "osd max backfills = 1\n");           // Ceph default; protect client IO during recovery
+        fprintf(fout, "osd memory target = 4294967296\n");  // 4G, now effective under autotune; tune to node RAM
         fprintf(fout, "osd op num shards = 8\n");
         fprintf(fout, "osd op num threads per shard = 2\n");
-        fprintf(fout, "osd min pg log entries = 10\n");
-        fprintf(fout, "osd max pg log entries = 10\n");
-        fprintf(fout, "osd pg log dups tracked = 10\n");
-        fprintf(fout, "osd pg log trim min = 10\n");
+        fprintf(fout, "osd min pg log entries = 500\n");    // enough for log-recovery on brief blips, not full backfill
+        fprintf(fout, "osd max pg log entries = 500\n");
+        fprintf(fout, "osd pg log dups tracked = 500\n");
+        fprintf(fout, "osd pg log trim min = 100\n");
         fprintf(fout, "osd bench small size max iops = 1000000\n");
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The `ceph.perf.tuned` block in `config_ceph.cpp` (default-on, hidden tuning) was copied near-verbatim from Red Hat's 2019 **all-flash** BlueStore "Tuned" benchmark config ([blog](https://ceph.io/community/bluestore-default-vs-tuned-performance-comparison/), [ceph.conf gist](https://gist.github.com/likid0/1b52631ff5d0d649a22a3f30106ccea7)). That profile assumes **dedicated all-flash OSD nodes with spare RAM/CPU**; CubeCOS runs it on **converged nodes** where OSDs share resources with OpenStack + K8s + the tenant. Several settings hurt tenant workloads there (full analysis in #1120):

| Setting | Was | Now | Why |
|---|---|---|---|
| `osd max backfills` | 5 | **1** | 5× concurrency storms client IO on any recovery/rebalance (the observed sky incident) |
| `bluestore cache size ssd = 8G` | set | **removed** | uncapped 8G static cache per OSD; the 3G ssd default now bounds it |
| `bluestore cache autotune` | 0 | **0 (kept off)** | first drafted as `1` (so `osd_memory_target` would govern cache), but **reverted**: enabling autotune aborts every OSD with `PriorityCache.cc:300 FAILED ceph_assert(mem_avail >= 0)` during unclean-shutdown allocator recovery. The `bstore_mempool` `balance()` only runs under autotune, so leaving it **off** structurally avoids the crash. |
| `osd memory target` | 2G | **4G** | kept as the intended floor, but **inert while autotune is off** (bluestore's 3G ssd cache default governs); becomes effective if autotune is ever safely re-enabled |
| `osd {min,max} pg log entries` / `dups tracked` / `trim min` | 10 | **500 / 500 / 500 / 100** | 10 forced a **full backfill** on any brief OSD blip missing >10 ops; 500 lets cheap log-recovery run |
| `bluestore csum type` | none | **crc32c** | restore silent-corruption detection on tenant data |

Net effect on converged nodes: recovery no longer starves tenant IO, per-OSD cache is bounded and predictable (~3G ssd default vs an uncapped 8G static cache), brief OSD restarts don't trigger full-backfill storms, data integrity is checked, and OSDs survive unclean-shutdown recovery.

#### Which issue(s) this PR fixes

Fixes #1120

#### Special notes for your reviewer

> **Lab-validated on the sky 3-node HA cluster** (converged, 18 OSDs). A full **poweroff + power-on** cold-boot recovery test exercised exactly the recovery paths this PR touches:
> - **`autotune=1` failed the test** — after the unclean poweroff, all 18 OSDs crash-looped on `PriorityCache mem_avail>=0` (945 pgs inactive, cluster unrecoverable) until `bluestore cache autotune` was set back to `0`. That single row is the reason this PR now keeps autotune off; everything else held up.
> - **`osd_max_backfills=1` + pg-log=500** behaved as intended — once OSDs came up, recovery proceeded without starving client IO, and brief OSD restarts did cheap log-recovery rather than full backfills.
>
> Remaining reviewer checks before ready:
> - **Memory** — confirm per-OSD RSS with the static 3G ssd cache default is within budget at the real OSD count (`ceph daemon osd.N dump_mempools`); if a dynamic cap is wanted later, re-evaluate autotune only alongside a fix/mitigation for the `mem_avail` assert (or a newer Ceph).
> - **pg-log memory** — 500 vs 10 adds a little RAM per PG; verify it's within budget at the cluster's PG count.
> - **csum** — `crc32c` adds minor CPU; confirm no meaningful throughput regression.
>
> **Deliberately out of scope** (separate, benchmarked change): the RocksDB `compaction_threads=32` / `max_background_compactions=31` / `flusher_threads=8` and `level0_slowdown=32` / `stop=64` values (Tier 3 in #1120) — CPU/write-contention on converged nodes, but retuning them safely needs benchmarking.
>
> **Alternative worth discussing:** instead of a static `osd_max_backfills=1`, adopt the mClock `high_client_ops` scheduler (Reef) which prioritizes client IO over recovery automatically.
>
> Air-gapped: no impact — config-only, no new artifacts.

#### Additional documentation

```docs
Handbook note pending (issue #1120 DoD): kb/cubecos/… — Ceph perf-tuned profile provenance (RH 2019 all-flash template) + the converged-node latency/integrity review + recovery-vs-client-IO tuning guidance, including the autotune `mem_avail` unclean-shutdown crash finding. Will land before the issue closes.
```
