### PR TITLE
fix(boot): cold-boot bring-up reliability batch

### DIFF
--- a/core/cubectl/app/cmd/root.go
+++ b/core/cubectl/app/cmd/root.go
@@ -80,7 +80,10 @@ func RootExecute() int {
 	if err := RootCmd.Execute(); err != nil {
 		var fields []zap.Field
 		if rootOpts.stacktrace {
-			fields = append(fields, zap.String("errstack", fmt.Sprintf("%+v", err.(stackTracer).StackTrace())))
+			// comma-ok: plain errors carry no StackTrace()
+			if st, ok := err.(stackTracer); ok {
+				fields = append(fields, zap.String("errstack", fmt.Sprintf("%+v", st.StackTrace())))
+			}
 		}
 
 		zap.L().Error(fmt.Sprintf("%v", err), fields...)

--- a/core/cubectl/app/config/config_cluster.go
+++ b/core/cubectl/app/config/config_cluster.go
@@ -95,6 +95,12 @@ func commitCluster() error {
 			}
 			zap.L().Info("Cert data synced from cube-controller")
 
+			// wipe leftovers before mirroring the controller's terraform state:
+			// stale dirs collide with incoming symlinks (rsync code 23)
+			if err := os.RemoveAll(terraformWorkDir); err != nil {
+				return errors.WithStack(err)
+			}
+
 			if _, outErr, err := util.ExecCmd("cubectl", "node", "rsync",
 				cubeSettings.GetControllerIp()+":"+terraformWorkDir,
 			); err != nil {

--- a/core/cubectl/app/config/config_main.go
+++ b/core/cubectl/app/config/config_main.go
@@ -84,6 +84,7 @@ func runConfigCommand(cmd *cobra.Command, args []string) error {
 		modules = args
 	}
 
+	var failed []string
 	for _, name := range modules {
 		if mod, ok := modMap[name]; ok {
 			var cmdFunc func() error
@@ -104,7 +105,12 @@ func runConfigCommand(cmd *cobra.Command, args []string) error {
 				zap.L().Debug("Executing module", zap.String("module", name), zap.String("command", cmd.Name()))
 				if err := cmdFunc(); err != nil {
 					if cmd.Name() == "commit" || cmd.Name() == "check" {
-						return err
+						// One module failing must not skip the rest: e.g. a failed
+						// 'cluster' commit must still let 'host' write /etc/hosts.
+						// Record and continue; report the aggregate at the end.
+						zap.L().Error("module failed; continuing", zap.String("module", name), zap.Error(err))
+						failed = append(failed, name)
+						continue
 					}
 
 					zap.L().Warn(err.Error())
@@ -116,6 +122,10 @@ func runConfigCommand(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("%s module not found", name)
 		}
 
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("modules failed: %v", failed)
 	}
 
 	return nil

--- a/core/elk/logstash/conf.d/hex-event-mapper.conf.in
+++ b/core/elk/logstash/conf.d/hex-event-mapper.conf.in
@@ -56,6 +56,14 @@ filter {
   ruby {
     code => "event.set('[event][timestamp]', event.get('@timestamp').to_i * 1000)"
   }
+  # drop redundant category= from attrs (dup of the event-key category tag;
+  # influxdb rejects duplicate tags); it stays in metadata
+  mutate {
+    gsub => [
+      "attrs", "(^|,)category=[^,]*", "",
+      "attrs", "^,", ""
+    ]
+  }
   if [event][metadata] {
     mutate {
       add_field => {

--- a/core/influxdb/influxdb.conf
+++ b/core/influxdb/influxdb.conf
@@ -13,3 +13,7 @@
   wal-dir = "/var/lib/influxdb/wal"
   index-version = "tsi1"
   query-log-enabled = false
+
+[logging]
+  # error-only: the flux engine logs benign "Invalid column reader" pivot notices at info
+  level = "error"

--- a/core/kafka/kafka.mk
+++ b/core/kafka/kafka.mk
@@ -10,7 +10,7 @@ KAFKA_VER := 3.9.2
 KAFKA_TGZ := kafka_2.13-$(KAFKA_VER).tgz
 
 $(ARCS_DIR)/$(KAFKA_TGZ):
-	$(Q)wget https://archive.apache.org/dist/kafka/$(KAFKA_VER)/$(KAFKA_TGZ) -O $@
+	$(Q)wget https://archive.apache.org/dist/kafka/$(KAFKA_VER)/$(KAFKA_TGZ) -O $@ || { rm -f $@; false; }
 
 rootfs_install:: $(ARCS_DIR)/$(KAFKA_TGZ)
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KAFKA_BIN_DIR) $(KAFKA_APP_DIR) $(KAFKA_LOG_DIR) $(KAFKA_RUN_DIR)

--- a/core/modules/config_keystone.cpp
+++ b/core/modules/config_keystone.cpp
@@ -477,9 +477,10 @@ Commit(bool modified, int dryLevel)
         HexUtilSystemF(0, 0, "chown -R %s:%s %s", USER, GROUP, CKEY_DIR);
     }
 
-    // 4. keystone relies on httpd wsgi
+    // 4. keystone relies on httpd wsgi, reached via the VIP; on a cold boot
+    // the VIP+haproxy+keystone chain can take >1 min, so wait up to 180s
     SystemdCommitService(IsControl(s_eCubeRole), "httpd");
-    if (HexUtilSystemF(0, 0, HEX_SDK " wait_for_http_endpoint %s 5000 60", sharedId.c_str()) != 0) {
+    if (HexUtilSystemF(0, 0, HEX_SDK " wait_for_http_endpoint %s 5000 180", sharedId.c_str()) != 0) {
         return false;
     }
 

--- a/core/modules/config_pacemaker.cpp
+++ b/core/modules/config_pacemaker.cpp
@@ -198,6 +198,13 @@ Commit(bool modified, int dryLevel)
         if (isMaster) {
             if (access(CONFIGURED_FILE, F_OK) != 0)
                 HexUtilSystemF(0, 0, "ip addr add %s dev %s label %s", sharedId.c_str(), mgmtIf.c_str(), mgmtIf.c_str());
+            else {
+                // configured reboot/powercycle: bring pacemaker up so its vip
+                // resource re-adds the VIP (corosync may not have quorum yet, but
+                // a lone master is quorate and starts its resources).
+                SystemdCommitService(enabled, NAME);
+                HexUtilSystemF(0, 0, HEX_SDK " pacemaker_node_start");
+            }
         }
         else {
             HexUtilSystemF(0, 0, HEX_SDK " pacemaker_node_stop");

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -398,10 +398,10 @@ power_bootup_status()
             if   [ -n "$bs" ] ; then pu=$(( bs - ${bt:-$bs} ))
             elif [ -n "$bt" ] ; then pu=$(( now - bt )) ; pu_p=1
             else pu=-1 ; fi
-            if   [ -n "$fn" ] ; then bsd=$(( fn - bs ))
+            if   [ -n "$fn" ] ; then bsd=$(( fn - ${bs:-$fn} ))
             elif [ -n "$bs" ] ; then bsd=$(( now - bs )) ; bs_p=1
             else bsd=-1 ; fi
-            if   [ -n "$dn" ] ; then fnd=$(( dn - fn ))
+            if   [ -n "$dn" ] ; then fnd=$(( dn - ${fn:-$dn} ))
             elif [ -n "$fn" ] ; then fnd=$(( now - fn )) ; fn_p=1
             else fnd=-1 ; fi
             if   [ -n "$dn" ] ; then phase="done" ; idx=3 ; tot=$(( dn - ${bt:-$dn} ))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Six independent cold-boot / bring-up reliability fixes found while chasing the boot-time initiative's lab-validation bugs. All are small and file-disjoint from the rolling-roll PR:

1. **Pacemaker starts on a configured master reboot** — the master skipped the raw `ip addr add` (configured file exists) but nothing started pacemaker either, so the VIP-fronted stack stayed down after a reboot/powercycle.
2. **One module's commit failure must not skip the rest of bootstrap** — a transient `cluster`-module error (stale terraform dir → rsync code 23) aborted the whole `cubectl config commit cluster host`, so `/etc/hosts` never got `cube-controller` and k3s never joined. The loop now aggregates errors and continues; the join path wipes `terraformWorkDir` first.
3. **Cold-boot timing tolerance** — keystone endpoint wait 60s→180s (VIP→haproxy→keystone takes >1min after pacemaker anchors the VIP); `power_bootup_status` duration math no longer breaks on a missing phase stamp.
4. **kafka tarball fetch** — keep the partial-download guard (`|| { rm -f $@; false; }`) on top of the archive.apache.org URL switch that landed upstream (749d7af), so a failed wget can't leave a truncated artifact that satisfies the make target.
5. **Event pipeline** — hex-event-mapper strips the redundant `category=` attr that made influxdb reject points with HTTP 400 "duplicate tags" (CLU/CMP events never reached the events DB); influxd log level raised to error to stop benign flux pivot notices flooding the journal.
6. **cubectl `--stacktrace` panic** — an error without `StackTrace()` (any plain `errors.New`) panicked the process while reporting, truncating the real failure message.

#### Which issue(s) this PR fixes

Fixes #1130

#### Special notes for your reviewer

> Content comes unchanged from the lab-validated `combined/local-work` branch. Each commit message carries the full RCA. Independent of (and mergeable in any order with) the rolling-roll PR.

#### Additional documentation

```docs
Handbook: boot-time initiative notes (45→20min bring-up batch).
```
