### PR TITLE
fix(config): hex CONFIG_PROVIDES_GLOBALS companion + converged storage config fixes

### DIFF
--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -146,9 +146,7 @@ hex_config_MODULES += config_ironic.o
 hex_config_MODULES += config_neutron.o
 hex_config_MODULES += config_nova.o
 hex_config_MODULES += config_cinder.o
-# linked after config_cinder.o: config_multipath observes CINDER_STORAGE_BACKEND,
-# so cinder's tuning must be static-initialized first (commit order is dependency-
-# resolved separately, so this does not affect when multipath commits)
+# (tuning specs are construct-on-first-use; grouping kept only for readability)
 hex_config_MODULES += config_multipath.o
 hex_config_MODULES += config_glance.o
 hex_config_MODULES += config_swift.o

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -895,11 +895,10 @@ UpdateConfig(
 
     // bluestore osd perf tuning
     if (perfTuned) {
-        fprintf(fout, "bluestore cache autotune = 0\n");
+        fprintf(fout, "bluestore cache autotune = 0\n");    // off: autotune's PriorityCache mem_avail assert aborts OSDs during unclean-shutdown recovery
         fprintf(fout, "bluestore cache kv ratio = 0.2\n");
         fprintf(fout, "bluestore cache meta ratio = 0.8\n");
-        fprintf(fout, "bluestore cache size ssd = 8G\n");
-        fprintf(fout, "bluestore csum type = none\n");
+        fprintf(fout, "bluestore csum type = crc32c\n");     // corruption detection on for tenant data
         fprintf(fout, "bluestore extent map shard max size = 200\n");
         fprintf(fout, "bluestore extent map shard min size = 50\n");
         fprintf(fout, "bluestore extent map shard target size = 100\n");
@@ -921,14 +920,14 @@ UpdateConfig(
                       "flusher_threads=8,"
                       "compaction_readahead_size=2MB\n");
         fprintf(fout, "osd map share max epochs = 100\n");
-        fprintf(fout, "osd max backfills = 5\n");
-        fprintf(fout, "osd memory target = 2147483648\n");
+        fprintf(fout, "osd max backfills = 1\n");           // Ceph default; protect client IO during recovery
+        fprintf(fout, "osd memory target = 4294967296\n");  // 4G, now effective under autotune; tune to node RAM
         fprintf(fout, "osd op num shards = 8\n");
         fprintf(fout, "osd op num threads per shard = 2\n");
-        fprintf(fout, "osd min pg log entries = 10\n");
-        fprintf(fout, "osd max pg log entries = 10\n");
-        fprintf(fout, "osd pg log dups tracked = 10\n");
-        fprintf(fout, "osd pg log trim min = 10\n");
+        fprintf(fout, "osd min pg log entries = 500\n");    // enough for log-recovery on brief blips, not full backfill
+        fprintf(fout, "osd max pg log entries = 500\n");
+        fprintf(fout, "osd pg log dups tracked = 500\n");
+        fprintf(fout, "osd pg log trim min = 100\n");
         fprintf(fout, "osd bench small size max iops = 1000000\n");
     }
 

--- a/core/modules/config_cube_scan.cpp
+++ b/core/modules/config_cube_scan.cpp
@@ -519,6 +519,9 @@ CONFIG_OBSERVES(cube_scan, net, ParseNet, NotifyNet);
 CONFIG_OBSERVES(cube_scan, cubesys, ParseCube, NotifyCube);
 
 CONFIG_REQUIRES(cube_scan, standalone);
+// owns CTRL_IP / SHARED_ID / EXTERNAL / MGMT_ADDR, which other modules read when
+// writing their configs -- must commit even for a scoped module range
+CONFIG_PROVIDES_GLOBALS(cube_scan);
 
 CONFIG_MODULE(cube_last, 0, 0, 0, 0, CommitLast);
 CONFIG_REQUIRES(cube_last, monasca_setup);

--- a/core/modules/config_k3s.cpp
+++ b/core/modules/config_k3s.cpp
@@ -50,7 +50,7 @@ ParseNet(const char* name, const char* value, bool isNew)
 {
     const char* p = 0;
 
-    if (HexMatchPrefix(name, NET_IF_MTU.format.c_str(), &p)) {
+    if (HexMatchPrefix(name, NET_IF_MTU().format.c_str(), &p)) {
         ConfigUInt& m = s_Mtu[p];
         m.parse(value, isNew);
     }

--- a/core/modules/config_multipath.cpp
+++ b/core/modules/config_multipath.cpp
@@ -110,13 +110,23 @@ Commit(bool modified, int dryLevel)
     if (!enabled)
         return true;
 
+    // multipathd may still be starting its path checkers; wait until it
+    // answers before issuing map operations
+    int i;
+    for (i = 0; i < 30; i++) {
+        if (HexUtilSystemF(0, 0, "/usr/sbin/multipathd show status >/dev/null 2>&1") == 0)
+            break;
+        sleep(2);
+    }
+    if (i == 30)
+        HexLogWarning("multipathd not responding after 60s; refreshing maps anyway");
+
     // Reload /etc/multipath.conf so the overrides{} take effect, then refresh maps.
     HexUtilSystemF(0, 0, "/usr/sbin/multipathd reconfigure");
 
-    if (HexUtilSystemF(0, 0, "/usr/sbin/hex_sdk storage_update_device_maps") != 0) {
-        HexLogError("failed to update multipath device maps");
-        return false;
-    }
+    // best-effort: a failed map refresh must not abort the whole commit
+    if (HexUtilSystemF(0, 0, "/usr/sbin/hex_sdk storage_update_device_maps") != 0)
+        HexLogWarning("failed to update multipath device maps; continuing");
 
     return true;
 }

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -654,7 +654,7 @@ ParseNet(const char *name, const char *value, bool isNew)
     if (strcmp(name, NET_HOSTNAME) == 0) {
         s_hostname.parse(value, isNew);
     }
-    else if (HexMatchPrefix(name, NET_IF_MTU.format.c_str(), &p)) {
+    else if (HexMatchPrefix(name, NET_IF_MTU().format.c_str(), &p)) {
         ConfigUInt& m = s_Mtu[p];
         m.parse(value, isNew);
     }

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -76,13 +76,6 @@ static bool s_bCubeModified = false;
 static bool s_bNeutronModified = false;
 static bool s_bIronicModified = false;
 
-// cinder's external-backend setting, matched as a literal rather than via
-// CONFIG_TUNING_SPEC_STR(CINDER_STORAGE_BACKEND): config_cinder parses nova's
-// spec at static-init, so referencing cinder's spec here would be a circular
-// cross-TU dependency that crashes hex_config at startup under any link order.
-static const char CINDER_BACKEND_PREFIX[] = "cinder.storage.backend.";
-static bool s_bExtBackendOld = false;
-static bool s_bExtBackendNew = false;
 static bool s_bStorageBackendModified = false;
 
 static bool s_bDbPassChanged = false;
@@ -132,6 +125,7 @@ CONFIG_TUNING_SPEC_BOOL(CUBESYS_HA);
 CONFIG_TUNING_SPEC_STR(NEUTRON_USERPASS);
 CONFIG_TUNING_SPEC_STR(NEUTRON_METAPASS);
 CONFIG_TUNING_SPEC_STR(IRONIC_USERPASS);
+CONFIG_TUNING_SPEC_STR(CINDER_STORAGE_BACKEND);
 
 // parse tunings
 PARSE_TUNING_BOOL(s_enabled, NOVA_ENABLED);
@@ -158,6 +152,7 @@ PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 2);
 PARSE_TUNING_X_STR(s_neutronPass, NEUTRON_USERPASS, 3);
 PARSE_TUNING_X_STR(s_metaPass, NEUTRON_METAPASS, 3);
 PARSE_TUNING_X_STR(s_ironicPass, IRONIC_USERPASS, 4);
+PARSE_TUNING_X_STR_ARRAY(s_storageBackends, CINDER_STORAGE_BACKEND, 5);
 
 // depends on mysqld (called inside commit())
 static bool
@@ -428,6 +423,19 @@ UpdateSharedId(std::string sharedId)
     return true;
 }
 
+// True when an operator added an external storage backend; the built-in ceph
+// backend is not in this list.
+static bool
+HasExternalStorageBackend()
+{
+    for (std::vector<ConfigString>::const_iterator it = s_storageBackends.begin();
+         it != s_storageBackends.end(); it++) {
+        if (it->newValue().length() > 0)
+            return true;
+    }
+    return false;
+}
+
 static bool
 UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::string hwType,
           std::string novaPass, std::string placePass, std::string neutronPass, std::string metaPass,
@@ -499,7 +507,7 @@ UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::s
         cfg["libvirt"]["snapshot_image_format"] = "raw";
         // only external FC/iSCSI backends use multipath; leaving it on makes
         // every live migration probe multipathd
-        cfg["libvirt"]["volume_use_multipath"] = s_bExtBackendNew ? "true" : "false";
+        cfg["libvirt"]["volume_use_multipath"] = HasExternalStorageBackend() ? "true" : "false";
         // post-copy: bounded convergence with no downtime (dest faults pages from source)
         cfg["libvirt"]["live_migration_permit_post_copy"] = "true";
         // throttle guest CPU to help pre-copy converge before post-copy is needed
@@ -742,18 +750,10 @@ ParseIronic(const char *name, const char *value, bool isNew)
     return true;
 }
 
-// a non-empty cinder.storage.backend.<N>.name means an external backend exists;
-// the built-in ceph backend is not listed there
 static bool
 ParseCinder(const char *name, const char *value, bool isNew)
 {
-    if (strncmp(name, CINDER_BACKEND_PREFIX, sizeof(CINDER_BACKEND_PREFIX) - 1) == 0 &&
-        value != NULL && value[0] != '\0') {
-        if (isNew)
-            s_bExtBackendNew = true;
-        else
-            s_bExtBackendOld = true;
-    }
+    ParseTune(name, value, isNew, 5);
     return true;
 }
 
@@ -792,7 +792,7 @@ static void
 NotifyCinder(bool modified)
 {
     // rewrite nova.conf when a SAN backend is added or removed
-    s_bStorageBackendModified = (s_bExtBackendOld != s_bExtBackendNew);
+    s_bStorageBackendModified = s_storageBackends.modified();
 }
 
 static bool

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -76,6 +76,15 @@ static bool s_bCubeModified = false;
 static bool s_bNeutronModified = false;
 static bool s_bIronicModified = false;
 
+// cinder's external-backend setting, matched as a literal rather than via
+// CONFIG_TUNING_SPEC_STR(CINDER_STORAGE_BACKEND): config_cinder parses nova's
+// spec at static-init, so referencing cinder's spec here would be a circular
+// cross-TU dependency that crashes hex_config at startup under any link order.
+static const char CINDER_BACKEND_PREFIX[] = "cinder.storage.backend.";
+static bool s_bExtBackendOld = false;
+static bool s_bExtBackendNew = false;
+static bool s_bStorageBackendModified = false;
+
 static bool s_bDbPassChanged = false;
 static bool s_bPlaDbPassChanged = false;
 static bool s_bConfigChanged = false;
@@ -488,7 +497,9 @@ UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::s
             cfg["libvirt"]["live_migration_inbound_addr"] = overlayAddr;
         cfg["libvirt"]["hw_disk_discard"] = "unmap";
         cfg["libvirt"]["snapshot_image_format"] = "raw";
-        cfg["libvirt"]["volume_use_multipath"] = "true";
+        // only external FC/iSCSI backends use multipath; leaving it on makes
+        // every live migration probe multipathd
+        cfg["libvirt"]["volume_use_multipath"] = s_bExtBackendNew ? "true" : "false";
         // post-copy: bounded convergence with no downtime (dest faults pages from source)
         cfg["libvirt"]["live_migration_permit_post_copy"] = "true";
         // throttle guest CPU to help pre-copy converge before post-copy is needed
@@ -731,6 +742,21 @@ ParseIronic(const char *name, const char *value, bool isNew)
     return true;
 }
 
+// a non-empty cinder.storage.backend.<N>.name means an external backend exists;
+// the built-in ceph backend is not listed there
+static bool
+ParseCinder(const char *name, const char *value, bool isNew)
+{
+    if (strncmp(name, CINDER_BACKEND_PREFIX, sizeof(CINDER_BACKEND_PREFIX) - 1) == 0 &&
+        value != NULL && value[0] != '\0') {
+        if (isNew)
+            s_bExtBackendNew = true;
+        else
+            s_bExtBackendOld = true;
+    }
+    return true;
+}
+
 static void
 NotifyNet(bool modified)
 {
@@ -762,6 +788,13 @@ NotifyIronic(bool modified)
     s_bIronicModified = IsModifiedTune(4);
 }
 
+static void
+NotifyCinder(bool modified)
+{
+    // rewrite nova.conf when a SAN backend is added or removed
+    s_bStorageBackendModified = (s_bExtBackendOld != s_bExtBackendNew);
+}
+
 static bool
 CommitCheck(bool modified, int dryLevel)
 {
@@ -775,6 +808,7 @@ CommitCheck(bool modified, int dryLevel)
 
     s_bConfigChanged = modified | s_bNetModified | s_bMqModified |
                 s_bCubeModified | s_bNeutronModified | s_bIronicModified |
+                s_bStorageBackendModified |
                G_MOD(MGMT_ADDR) | G_MOD(CTRL_IP) | G_MOD(SHARED_ID);
 
     s_bEndpointChanged = s_bCubeModified | G_MOD(SHARED_ID) | G_MOD(EXTERNAL);
@@ -926,6 +960,8 @@ CONFIG_OBSERVES(nova, rabbitmq, ParseRabbitMQ, NotifyMQ);
 CONFIG_OBSERVES(nova, cubesys, ParseCube, NotifyCube);
 CONFIG_OBSERVES(nova, neutron, ParseNeutron, NotifyNeutron);
 CONFIG_OBSERVES(nova, ironic, ParseIronic, NotifyIronic);
+// observe cinder's external-storage backends: multipath is only needed for FC/iSCSI
+CONFIG_OBSERVES(nova, cinder, ParseCinder, NotifyCinder);
 
 CONFIG_TRIGGER_WITH_SETTINGS(nova, "cluster_start", ClusterStartMain);
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The cubecos companion to **bigstack-oss/hex#135** (`CONFIG_PROVIDES_GLOBALS`, construct-on-first-use tuning specs, rootfs copy-tracking), plus the storage-config fixes validated with it. Supersedes #1121 (its ceph commit is included here unchanged).

- **ceph perf-tuned defaults for converged nodes** (ex-#1121) — the default-on `ceph.perf.tuned` block was copied from Red Hat's 2019 all-flash dedicated-OSD benchmark; on converged nodes it starved tenant IO. `osd max backfills` 5→1, drop the uncapped 8G static cache, pg log entries 10→500 (no full backfill on a brief OSD blip), `csum type` none→crc32c. Full analysis in #1120.
- **hex bump to feat/config-provides-globals** — scoped `hex_config commit <settings> <module>` no longer runs with unset globals (the class of bug that corrupted configs and keystone endpoints cluster-wide when a module-scoped commit ran live).
- **cube_scan declares itself provider of the config globals** — with lazy specs, the provider must be explicit for scoped commits to populate them.
- **nova reads cinder's backend tuning directly** — now safe because specs construct on first use; removes the copy-paste indirection in `config_nova/neutron/k3s`.
- **`volume_use_multipath` only when an FC/iSCSI backend exists** — unconditional multipath made every RBD-only deployment pay the multipathd path (and broke when it wasn't running).
- **multipath commit robustness** — wait for multipathd to be up; a map refresh failure logs instead of failing the whole commit.

#### Which issue(s) this PR fixes

Fixes #1120

#### Special notes for your reviewer

> Merge **bigstack-oss/hex#135 first**; the hex bump here points at its head (9633566). Content comes unchanged from the lab-validated `combined/local-work` branch.

#### Additional documentation

```docs
Handbook: multipath_link / storage-backend detection notes; hex_config
scoped-commit globals RCA.
```
