### PR TITLE
feat(watcher): allocation_balance strategy for idle-instance spreading

### DIFF
--- a/core/watcher/watcher.mk
+++ b/core/watcher/watcher.mk
@@ -25,3 +25,7 @@ rootfs_install::
 
 rootfs_install::
 	$(Q)[ -d $(WATCHER_PATCHDIR) ] && cp -rf $(WATCHER_PATCHDIR)/* $(WATCHER_SRCDIR)/ || /bin/true
+	# register the CubeCOS allocation_balance strategy entry point (idempotent)
+	$(Q)for ep in $(WATCHER_SRCDIR)/python_watcher-*.egg-info/entry_points.txt ; do \
+		grep -q '^allocation_balance =' $$ep || sed -i '/^\[watcher_strategies\]/a allocation_balance = watcher.decision_engine.strategy.strategies.allocation_balance:AllocationBalance' $$ep ; \
+	done

--- a/core/watcher/yoga_patch/watcher/decision_engine/strategy/strategies/allocation_balance.py
+++ b/core/watcher/yoga_patch/watcher/decision_engine/strategy/strategies/allocation_balance.py
@@ -1,0 +1,101 @@
+# CubeCOS: rebalance by allocation (compute model only, no metrics datasource),
+# so idle instances spread evenly where utilization-based strategies do nothing.
+
+from oslo_log import log
+
+from watcher._i18n import _
+from watcher.decision_engine.strategy.strategies import base
+
+LOG = log.getLogger(__name__)
+
+
+class AllocationBalance(base.WorkloadStabilizationBaseStrategy):
+    """Balance instances across compute nodes by allocated resources."""
+
+    def __init__(self, config, osc=None):
+        super(AllocationBalance, self).__init__(config, osc)
+        self._metric = 'instance'
+        self.instance_migrations_count = 0
+
+    @classmethod
+    def get_name(cls):
+        return "allocation_balance"
+
+    @classmethod
+    def get_display_name(cls):
+        return _("Allocation Balance Strategy")
+
+    @classmethod
+    def get_translatable_display_name(cls):
+        return "Allocation Balance Strategy"
+
+    @classmethod
+    def get_schema(cls):
+        return {
+            "properties": {
+                "metric": {
+                    "description": ("balance by 'instance' count, 'vcpu' or "
+                                    "'memory' allocation"),
+                    "type": "string",
+                    "default": "instance",
+                    "enum": ["instance", "vcpu", "memory"],
+                },
+            },
+        }
+
+    def _load(self, node):
+        """Allocated load on a node for the selected metric."""
+        if self._metric == 'instance':
+            return len(self.compute_model.get_node_instances(node))
+        free = self.compute_model.get_node_free_resources(node)
+        if self._metric == 'vcpu':
+            return node.vcpus - free['vcpu']
+        return node.memory - free['memory']
+
+    def _size(self, inst):
+        if self._metric == 'vcpu':
+            return inst.vcpus
+        if self._metric == 'memory':
+            return inst.memory
+        return 1
+
+    def _fits(self, node, inst):
+        free = self.compute_model.get_node_free_resources(node)
+        return free['vcpu'] >= inst.vcpus and free['memory'] >= inst.memory
+
+    def pre_execute(self):
+        self._pre_execute()
+        self._metric = self.input_parameters.get('metric', 'instance')
+
+    def do_execute(self, audit=None):
+        nodes = list(self.compute_model.get_all_compute_nodes().values())
+        if len(nodes) < 2:
+            LOG.info("allocation_balance: fewer than 2 compute nodes")
+            return
+        # Greedy: move one instance at a time, most- to least-allocated node,
+        # only while the move shrinks the spread (prevents ping-pong); capped.
+        for _step in range(1000):
+            nodes.sort(key=self._load)
+            dest = nodes[0]
+            src = nodes[-1]
+            spread = self._load(src) - self._load(dest)
+            movable = None
+            for inst in sorted(self.compute_model.get_node_instances(src),
+                               key=self._size):
+                if self._size(inst) < spread and self._fits(dest, inst):
+                    movable = inst
+                    break
+            if movable is None:
+                break
+            if self.compute_model.migrate_instance(movable, src, dest):
+                self.add_action_migrate(movable, 'live', src, dest)
+                self.instance_migrations_count += 1
+        LOG.info("allocation_balance: %d migration(s) planned (metric=%s)",
+                 self.instance_migrations_count, self._metric)
+
+    def post_execute(self):
+        self.solution.model = self.compute_model
+        self.solution.set_efficacy_indicators(
+            instance_migrations_count=self.instance_migrations_count,
+            instances_count=len(self.compute_model.get_all_instances()))
+        LOG.debug(self.compute_model.to_string())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds a `allocation_balance` Watcher strategy (yoga_patch) that spreads **idle** instances across compute hosts by allocation count. The stock strategies balance on load (CPU/RAM utilization), which never rebalances a cluster of mostly-idle VMs — after a rolling restart or an instance-HA failover, VMs pile up on the first hosts to come back and stay there. This strategy migrates the smallest number of idle instances needed to even out per-host allocation counts, and is what the sky instance-HA test harness runs after each failover round.

Carried as a `.py` addition under `core/watcher/yoga_patch/` per the OpenStack patch-format convention (applied by `watcher.mk`).

#### Which issue(s) this PR fixes

Fixes #1131

#### Special notes for your reviewer

> Validated by the sky-ha harness (24 HA-enabled VMs, watcher rebalance after each host-failure round).

#### Additional documentation

```docs
Handbook: sky instance-HA test harness notes.
```
