### PR TITLE
fix(influxdb): require ceph before enabling the influx mgr plugin

### DIFF
--- a/core/modules/config_influxdb.cpp
+++ b/core/modules/config_influxdb.cpp
@@ -99,7 +99,12 @@ EnableCephInfluxPlugin(bool update, const std::string sharedId)
     HexLogInfo("updating influxdb ceph plugin");
 
     if (stat(MAKRER, &ms) != 0) {
-        HexSystemF(0, "timeout 10 ceph mgr module enable influx 2>/dev/null");
+        // mark done only when the enable actually landed, so a transient
+        // mgr-not-ready failure is retried on the next commit
+        if (HexSystemF(0, "timeout 10 ceph mgr module enable influx 2>/dev/null") != 0) {
+            HexLogWarning("ceph mgr not ready to enable influx plugin; will retry on next commit");
+            return true;
+        }
         HexSystemF(0, "touch " MAKRER);
     }
 
@@ -107,9 +112,9 @@ EnableCephInfluxPlugin(bool update, const std::string sharedId)
     // or master node runs restart when other nodes are down (cluster start)
     // NOTE: timeout of HexSystemF doesn't work in this case
     //       since parent doesn't kill child process when timeout occurs
-    HexSystemF(0, "timeout 10 ceph influx config-set interval %d >/dev/null", INFLUX_INTERVAL);
-    HexSystemF(0, "timeout 10 ceph influx config-set hostname %s >/dev/null", sharedId.c_str());
-    HexSystemF(0, "timeout 10 ceph influx config-set port 8086 >/dev/null");
+    HexSystemF(0, "timeout 10 ceph influx config-set interval %d >/dev/null 2>&1", INFLUX_INTERVAL);
+    HexSystemF(0, "timeout 10 ceph influx config-set hostname %s >/dev/null 2>&1", sharedId.c_str());
+    HexSystemF(0, "timeout 10 ceph influx config-set port 8086 >/dev/null 2>&1");
 
     return true;
 }
@@ -228,6 +233,9 @@ ClusterReadyMain(int argc, char **argv)
 
 CONFIG_MODULE(influxdb, 0, Parse, 0, 0, Commit);
 CONFIG_REQUIRES(influxdb, ceph_dashboard_idp);
+// the influx mgr plugin needs a functioning ceph mgr; without this the
+// dataflow scheduler commits influxdb while ceph is still bootstrapping
+CONFIG_REQUIRES(influxdb, ceph);
 
 // extra tunings
 CONFIG_OBSERVES(influxdb, cubesys, ParseCube, NotifyCube);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fixes the FTS regression that has failed the accept e2e since the hex dataflow commit scheduler went default-on (first e2e run to hit it: accept #689, all four topologies).

- **`CONFIG_REQUIRES(influxdb, ceph)`** — the influx ceph-mgr plugin needs a functioning ceph mgr. influxdb only declared `ceph_dashboard_idp`, so the DAG scheduler (correctly, per its declared inputs) committed influxdb while ceph was still bootstrapping. The old level-barrier walk masked the missing edge via link order.
- **Marker only on success** — `ceph mgr module enable influx` failing (mgr not ready) no longer touches the done-marker, so the enable is retried on the next commit instead of being skipped forever (previously: ceph stats silently never reached influxdb after a racy FTS).
- **Silence stderr on the `config-set` calls** — an unknown/failing ceph command prints its closest-matches usage (the `pg …` family) to stderr; unredirected, it sprayed the serial console mid-FTS, which is what tripped triangle's fts-done expect.

Test-side hardening (loose `"*> "` expect fallback) is bigstack-oss/triangle#124 — independent, both should land.

#### Which issue(s) this PR fixes

Fixes #1132

#### Special notes for your reviewer

> Root cause chain verified empirically: the exact `pg …` closest-matches spew reproduces for any unknown ceph command family (sky lab), three dumps = the three `config-set` calls, stderr-only (matches the unredirected lines), and #681 (pre-scheduler) shows zero spew. `config_influxdb.o` compiles. Worth a follow-up audit: any other module that shells out to `ceph`/`rbd` in Commit but doesn't `CONFIG_REQUIRES` ceph has the same latent race.

#### Additional documentation

```docs
Handbook: candidate known-issue on module-commit concurrency (modules must
declare every cross-module runtime dependency now that commits parallelize).
```
