### PR TITLE
feat(rolling): stall watchdog pauses a wedged roll from the VIP holder

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -12,31 +12,38 @@ fi
 
 systemctl mask openvswitch # openvswitch shouldn't be brought up by pacemaker commit
 
-export HOSTNAME=$(ssh localhost hostname 2>/dev/null)
-# Bring up influxdb early so boot-time health/metrics have a sink
-hex_sdk cmd -c "systemctl show -p SubState influxdb | grep -q -i running || systemctl restart influxdb"
-space_filler="                                                                                                    "
+# from the kernel: ssh-localhost returned empty whenever sshd wasn't up yet
+export HOSTNAME=$(hostname)
+# 79 cols fits an 80-col console row, so the status rewrites in place
+space_filler=$(printf '%79s' '')
+# console list is fixed at boot -- resolve once
+KERNEL_CONSOLES=$(hex_sdk GetKernelConsoleDevices)
+# console: blank, home, print, home (one write); log: plain line per status.
+# tee, not >$(...): a multi-device redirect target is ambiguous and fails.
+bootstrap_status()
+{
+    local msg="$1"
+    echo "$msg" >> $BOOTSTRAP_CUBE_LOG
+    echo -n "$space_filler"$'\r'"$msg"$'\r' | tee $KERNEL_CONSOLES >/dev/null 2>&1
+}
 BootstrapAndClusterstart()
 {
     if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
-        msg="Bootstrapping CubeCOS"
-        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+        bootstrap_status "Bootstrapping CubeCOS"
         hex_log_event -e BSP00001I "interface=system,host=$HOSTNAME,service=bootstrap,phase=bootstrapping"
         hex_sdk power_bootup_mark bootstrapping   # cluster bootup status: entering the config commit
-        [ -e /store/rolling_recover ] && hex_sdk _power_roll_set_phase_ts "$(hostname)" bootstrapping   # rolling_restart phase timing
-        bash -c "hex_config -p bootstrap standalone-done | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
+        [ -e /store/rolling_recover ] && hex_sdk _power_roll_set_phase_ts "$HOSTNAME" bootstrapping   # rolling_restart phase timing
+        bash -c "hex_config -p bootstrap standalone-done | tee -a $BOOTSTRAP_CUBE_LOG $KERNEL_CONSOLES"
         if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
-            msg="Bootstrap error: $(journalctl | grep hex | egrep -i 'failed to commit')"
-            echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+            bootstrap_status "Bootstrap error: $(journalctl | grep hex | egrep -i 'failed to commit')"
             hex_log_event -e BSP00003W "interface=system,host=$HOSTNAME,service=bootstrap,detail=$(journalctl | grep hex | egrep -i 'failed to commit|took' | tail -2 | tr -d ',\"=|' | tr '\n' ' ')"
             return 1
         else
-            msg="Starting cluster"
-            echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+            bootstrap_status "Starting cluster"
             hex_log_event -e BSP00002I "interface=system,host=$HOSTNAME,service=bootstrap,phase=cluster_start"
             hex_sdk power_bootup_mark finalizing   # cluster bootup status: entering cluster_start (+ master check_repair)
-            [ -e /store/rolling_recover ] && hex_sdk _power_roll_set_node_status "$(hostname)" finalizing   # rolling_restart: status + phase ts (until power_roll_advance -> done)
-            bash -c "hex_sdk -v cube_cluster_start | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)"
+            [ -e /store/rolling_recover ] && hex_sdk _power_roll_set_node_status "$HOSTNAME" finalizing   # rolling_restart: status + phase ts (until power_roll_advance -> done)
+            bash -c "hex_sdk -v cube_cluster_start | tee -a $BOOTSTRAP_CUBE_LOG $KERNEL_CONSOLES"
             return 0
         fi
     fi
@@ -46,8 +53,7 @@ BootstrapAndClusterstart()
 # turns one failed module into a whole-cluster hang on the ready-wait
 AbortBootstrap()
 {
-    msg="Bootstrap failed on $(hostname); aborting cluster bring-up. Fix the failing module, then re-run."
-    echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+    bootstrap_status "Bootstrap failed on $HOSTNAME; aborting cluster bring-up. Fix the failing module, then re-run."
     hex_log_event -e BSP00004E "interface=system,host=$HOSTNAME,service=bootstrap"
 }
 
@@ -68,8 +74,7 @@ PostBootRecovery()
     fi
 
     if hex_sdk cube_cluster_ready ; then
-        msg="Cluster checking and repairing"
-        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+        bootstrap_status "Cluster checking and repairing"
         hex_log_event -e BSP00005I "interface=system,host=$HOSTNAME,service=bootstrap"
         hex_sdk cmd "rm -f /tmp/health_*error.count"
         # normal boots only: 'cluster check' kicks auto_repair, which on a roll
@@ -87,8 +92,7 @@ PostBootRecovery()
                     continue
                 else
                     hex_sdk power_vm_restore "$i" "$disp"
-                    msg="Restored server: $i ${disp:+($disp)}"
-                    echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+                    bootstrap_status "Restored server: $i ${disp:+($disp)}"
                     hex_log_event -e BSP00011I "interface=system,host=$HOSTNAME,service=bootstrap,vm=$i,disposition=${disp:-hardreboot}"
                 fi
             done < /mnt/cephfs/rolling/active_running
@@ -104,15 +108,13 @@ PostBootRecovery()
             if ! hex_sdk live_migration_gate 180 "" repair ; then
                 hex_sdk _power_roll_pause "live-migration path not ready before releasing the next node"
             fi
-            msg="Cluster ready; live-migration path verified"
+            bootstrap_status "Cluster ready; live-migration path verified"
         else
-            msg="Cluster ready"
+            bootstrap_status "Cluster ready"
         fi
-        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
         hex_log_event -e BSP00006I "interface=system,host=$HOSTNAME,service=bootstrap,roll=${roll_kind:-none}"
     else
-        msg="Cluster check and repair skipped as not all nodes are bootstrapped and synced"
-        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+        bootstrap_status "Cluster check and repair skipped as not all nodes are bootstrapped and synced"
         hex_log_event -e BSP00007I "interface=system,host=$HOSTNAME,service=bootstrap"
     fi
 }
@@ -121,10 +123,9 @@ PostBootRecovery()
 export CLUSTER_SIZE=$(cubectl node list | wc -l)
 
 if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; then
-    echo -n "                                                                    " $'\r' | tee $(hex_sdk GetKernelConsoleDevices)
+    echo -n "                                                                    " $'\r' | tee $KERNEL_CONSOLES
     if grep -q manual $BOOTSTRAP_CUBE_MODE ; then
-        msg="Auto bootstrap is disabled"
-        echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+        bootstrap_status "Auto bootstrap is disabled"
         hex_log_event -e BSP00009I "interface=system,host=$HOSTNAME,service=bootstrap"
     else
         echo "Starting auto bootstrap" >> $BOOTSTRAP_CUBE_MODE
@@ -152,8 +153,7 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
             if hex_sdk cube_cluster_ready && [ -z "$(hex_sdk power_roll_kind_active 2>/dev/null)" ] ; then
                 hex_sdk cluster_check_repair_async
             else
-                msg="Cluster not ready: automatic check_repair skipped. Run \"cluster check_repair\" yourself once the cluster is ready."
-                echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+                bootstrap_status "Cluster not ready: automatic check_repair skipped. Run \"cluster check_repair\" yourself once the cluster is ready."
                 hex_log_event -e BSP00008W "interface=system,host=$HOSTNAME,service=bootstrap"
             fi
         elif [ "x$T_cubesys_role" = "xcontrol" -o "x$T_cubesys_role" = "xcontrol-converged" -o "x$T_cubesys_role" = "xedge-core" -o "x$T_cubesys_role" = "xmoderator" ] ; then
@@ -163,8 +163,7 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
             (
                 cnt=0
                 while ! hex_sdk remote_run ${MASTER_CONTROL:-NOMASTER} stat $BOOTSTRAP_CUBE_MARKER >/dev/null 2>&1 ; do
-                    msg="Waiting for master control to finish bootstrapping [$cnt min]"
-                    echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+                    bootstrap_status "Waiting for master control to finish bootstrapping [$cnt min]"
                     hex_log_event -e BSP00010I "interface=system,host=$HOSTNAME,service=bootstrap,for=master,waited_min=$cnt"
                     ((cnt++))
                     sleep 60
@@ -180,8 +179,7 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
             (
                 cnt=0
                 while ! hex_sdk cmd -c stat $BOOTSTRAP_CUBE_MARKER ; do
-                    msg="Waiting for control(s) to finish bootstrapping [$cnt min]"
-                    echo -n "$space_filler">$(hex_sdk GetKernelConsoleDevices) ; echo -n "$msg" $'\r' | tee $BOOTSTRAP_CUBE_LOG $(hex_sdk GetKernelConsoleDevices)
+                    bootstrap_status "Waiting for control(s) to finish bootstrapping [$cnt min]"
                     hex_log_event -e BSP00010I "interface=system,host=$HOSTNAME,service=bootstrap,for=control,waited_min=$cnt"
                     ((cnt++))
                     sleep 60

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -258,6 +258,11 @@ rootfs_install::
 	$(Q)mkdir -p $(ROOTDIR)/etc/systemd/system.conf.d
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-watchdog.conf ./etc/systemd/system.conf.d
 
+# roll stall watchdog -- installed disabled; the roll arms/disarms it
+rootfs_install::
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/hex-roll-watchdog.service ./lib/systemd/system
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/hex-roll-watchdog.timer ./lib/systemd/system
+
 # cube deterministic ssh key generation utility
 $(call PROJ_INSTALL_PROGRAM,,$(CORE_PKGDIR)/x86_64/oss/ssh-keydgen,./usr/sbin)
 

--- a/core/main/hex-roll-watchdog.service
+++ b/core/main/hex-roll-watchdog.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=CubeCOS rolling update/restart stall watchdog
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/hex_sdk power_roll_watchdog

--- a/core/main/hex-roll-watchdog.timer
+++ b/core/main/hex-roll-watchdog.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodic CubeCOS roll stall check
+
+[Timer]
+OnBootSec=120
+OnUnitActiveSec=60
+
+[Install]
+WantedBy=timers.target

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -6,7 +6,8 @@
 MARIADB_VER := 10.5.29-3.el9_7
 # rpmfind.net is often not responsive
 # MARIADB_URL := https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages
-MARIADB_URL := https://ftp.icm.edu.pl/packages/linux-rocky/9/devel/x86_64/os/Packages/m
+# ftp.icm.edu.pl went unreachable too; the CDN keeps rotated pins in /vault
+MARIADB_URL := https://dl.rockylinux.org/pub/rocky/9/devel/x86_64/os/Packages/m
 MARIADB_LOCKED_RPMS := mariadb-$(MARIADB_VER) mariadb-backup-$(MARIADB_VER) mariadb-common-$(MARIADB_VER) mariadb-errmsg-$(MARIADB_VER)
 MARIADB_LOCKED_RPMS += mariadb-gssapi-server-$(MARIADB_VER) mariadb-server-$(MARIADB_VER) mariadb-server-galera-$(MARIADB_VER) mariadb-server-utils-$(MARIADB_VER)
 LOCKED_DNF += $(MARIADB_LOCKED_RPMS)

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -137,7 +137,8 @@ _power_roll_pause()
     # release the roll's cluster guards; "continue" re-takes them
     Quiet -n $HEX_SDK ceph_leave_rolling
     echo "rolling $(_power_roll_kind) paused: $1" >&2
-    /usr/sbin/hex_log_event -e CLU00004W "interface=system,host=$HOSTNAME,category=cluster,sub=rolling_$(_power_roll_kind),action=pause,reason=$1"
+    # strip commas/newlines: attrs are comma-separated k=v (as CLU00006W does)
+    /usr/sbin/hex_log_event -e CLU00004W "interface=system,host=$HOSTNAME,category=cluster,sub=rolling_$(_power_roll_kind),action=pause,reason=${1//[,$'\n']/ }"
 }
 
 _power_roll_drain_poll()

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -25,11 +25,13 @@ ROLLING_RECOVER_MARKER=${ROLLING_RECOVER_MARKER:-/store/rolling_recover}
 # failover window. Temp name expanded once per attempt (avoids lost updates).
 _power_roll_write()
 {
-    local i t
+    # every write stamps .heartbeat -- the watchdog's liveness signal
+    local i t filter="${@: -1}"
+    set -- "${@:1:$(($#-1))}"
     for i in $(seq 1 30) ; do
         t=$ROLLING_JOB.tmp.$$.$i
         if ( flock -w 15 200 || exit 3
-             jq "$@" $ROLLING_JOB > "$t" && [ -s "$t" ] && mv "$t" $ROLLING_JOB || { rm -f "$t" ; exit 4 ; }
+             jq "$@" --argjson __hb "$(date +%s)" "($filter) | .heartbeat=\$__hb" $ROLLING_JOB > "$t" && [ -s "$t" ] && mv "$t" $ROLLING_JOB || { rm -f "$t" ; exit 4 ; }
            ) 200>$ROLLING_DIR/.lock 2>/dev/null ; then
             return 0
         fi
@@ -132,7 +134,8 @@ _power_roll_pause()
 {
     _power_roll_set_str reason "$1"
     _power_roll_set_str state paused
-    cluster_rolling_marker_clear
+    # release the roll's cluster guards; "continue" re-takes them
+    Quiet -n $HEX_SDK ceph_leave_rolling
     echo "rolling $(_power_roll_kind) paused: $1" >&2
     /usr/sbin/hex_log_event -e CLU00004W "interface=system,host=$HOSTNAME,category=cluster,sub=rolling_$(_power_roll_kind),action=pause,reason=$1"
 }
@@ -190,7 +193,19 @@ _power_roll_kick()
 
     _power_roll_set_str inflight "$host"
     _power_roll_set_node_num "$host" started $(date +%s)
-    _power_roll_set_raw deadline $(( $(date +%s) + ${ROLLING_NODE_TIMEOUT:-3600} ))
+
+    # node deadline scales with the VMs to drain (virsh on the target -- no
+    # OpenStack on the kick path); ROLLING_NODE_TIMEOUT is the floor
+    local _budget=${ROLLING_NODE_TIMEOUT:-2700}
+    case "$role" in
+        *compute*|control-converged|edge-core)
+            local _nvms=$(remote_run $host "virsh list --uuid --state-running 2>/dev/null | grep -c ." </dev/null 2>/dev/null | tr -dc 0-9)
+            if [ -n "$_nvms" ] && [ "$_nvms" -gt 0 ] && [ $(( 1500 + _nvms * 120 )) -gt $_budget ] ; then
+                _budget=$(( 1500 + _nvms * 120 ))
+            fi
+            ;;
+    esac
+    _power_roll_set_raw deadline $(( $(date +%s) + _budget ))
 
     case "$role" in
         *compute*|control-converged|edge-core)
@@ -584,7 +599,27 @@ power_roll_start()
     else
         echo "follow progress with \"cluster rolling_$kind status\"."
     fi
+    # arm only now that the job exists (a tick seeing no job self-stops)
+    _power_roll_watchdog_arm
     power_roll_advance
+}
+
+# Arm/disarm the stall watchdog on control-capable nodes (the only possible
+# VIP holders). Runtime start/stop only; the boot path re-arms mid-roll.
+_power_roll_watchdog_arm()
+{
+    local _h
+    for _h in $(cubectl node list -r control -j 2>/dev/null | jq -r '.[].hostname' 2>/dev/null) ; do
+        ( remote_run "$_h" "systemctl start hex-roll-watchdog.timer" ) >/dev/null 2>&1
+    done
+}
+
+_power_roll_watchdog_disarm()
+{
+    local _h
+    for _h in $(cubectl node list -r control -j 2>/dev/null | jq -r '.[].hostname' 2>/dev/null) ; do
+        ( remote_run "$_h" "systemctl stop hex-roll-watchdog.timer" ) >/dev/null 2>&1
+    done
 }
 
 # Kind of the roll this node is currently part of, or empty. The boot path uses
@@ -611,6 +646,9 @@ power_roll_advance()
 
     [ -e "$ROLLING_JOB" ] || return 0
     [ "$(jq -r .state $ROLLING_JOB 2>/dev/null)" = "running" ] || return 0
+
+    # a control node booting mid-roll re-arms its own timer
+    is_control_node && Quiet -n systemctl start hex-roll-watchdog.timer
 
     local master=$(_power_roll_master)
     local inflight=$(jq -r '.inflight // ""' $ROLLING_JOB)
@@ -654,6 +692,7 @@ power_roll_advance()
         _power_roll_set_str state done
         cluster_rolling_marker_clear
         Quiet -n $HEX_SDK ceph_leave_rolling
+        _power_roll_watchdog_disarm
         # The full check_repair pass belongs here -- when the ROLL is done --
         # not when a single node's boot is done. Running it mid-roll evaluates a
         # cluster with a node deliberately down and tries to "repair" it.
@@ -688,7 +727,7 @@ power_roll_status()
     fi
     echo ""
     local now=$(date +%s)
-    local window=${ROLLING_NODE_TIMEOUT:-3600}
+    local window=${ROLLING_NODE_TIMEOUT:-2700}
     printf " %-20s %-18s %-9s %-10s %s\n" "node" "role" "status" "vms(m+p/tot)" "elapsed"
     jq -r '.nodes[]|"\(.hostname)\t\(.role)\t\(.status)\t\(.started // 0)\t\(.finished // 0)\t\(.vms_total // 0)\t\(.vms_done // 0)\t\(.vms_paused // 0)\t\(.ip // "")"' $ROLLING_JOB | \
         while IFS=$'\t' read -r h r s st fin vt vd vp ip ; do
@@ -824,7 +863,9 @@ power_roll_decision()
             _power_roll_set_str inflight ""
             _power_roll_set_str reason ""
             _power_roll_set_str state running
-            cluster_rolling_marker_set
+            # re-take the guards the pause released
+            Quiet -n $HEX_SDK ceph_enter_rolling
+            _power_roll_watchdog_arm
             power_roll_advance
             ;;
         abort)
@@ -838,6 +879,7 @@ power_roll_decision()
             # mon_osd_down_out_interval) -- neither should outlive the roll
             cluster_rolling_marker_clear
             Quiet -n $HEX_SDK ceph_leave_rolling
+            _power_roll_watchdog_disarm
             echo "rolling $(_power_roll_kind) aborted"
             ;;
         *)
@@ -961,6 +1003,64 @@ power_vm_reconcile_error_state()
 
     log_info "vm_reconcile: $_reset stale, $_real real failure(s), $_skip host-mismatch"
     return 0
+}
+
+# Roll stall enforcement (hex-roll-watchdog.timer, armed only during a roll):
+# pause past the node deadline, or on heartbeat silence in write-constant
+# phases (reboot/boot phases are deadline-only). Only the VIP holder acts;
+# a trip also runs the per-node stale-ERROR reconcile.
+power_roll_watchdog()
+{
+    is_control_node || return 0
+
+    # Every ticking node stops its own timer when its roll is gone (paused
+    # stays armed; "continue" re-arms). Only the VIP holder acts below.
+    local _state=""
+    [ -e "$ROLLING_JOB" ] && _state=$(jq -r '.state // ""' $ROLLING_JOB 2>/dev/null)
+    [ "$_state" = "paused" ] && return 0
+    [ "$_state" != "running" ] && Quiet -n systemctl stop hex-roll-watchdog.timer
+
+    # Everything past here is a single actor's job: only the VIP holder acts.
+    local _vip
+    source hex_tuning $SETTINGS_TXT cubesys.control.vip
+    _vip=$T_cubesys_control_vip
+    [ -n "$_vip" ] || return 0                        # non-HA: boot paths own recovery
+    ip -o addr show 2>/dev/null | grep -qw "$_vip" || return 0
+
+    if [ "$_state" != "running" ] ; then
+        # sweep the roll's stale osd-out pin (an admin's own value is left alone)
+        if timeout 20 ceph config dump 2>/dev/null | grep -qE 'mon_osd_down_out_interval[[:space:]]+3600\b' ; then
+            log_warning "roll_watchdog: stale mon_osd_down_out_interval=3600 with no active roll -- clearing"
+            Quiet -n $HEX_SDK ceph_leave_rolling
+        fi
+        return 0
+    fi
+
+    local now=$(date +%s)
+    local deadline=$(jq -r '.deadline // 0' $ROLLING_JOB)
+    local hb=$(jq -r '.heartbeat // 0' $ROLLING_JOB)
+    local inflight=$(jq -r '.inflight // ""' $ROLLING_JOB)
+    local phase=""
+    [ -n "$inflight" ] && phase=$(jq -r --arg h "$inflight" '.nodes[]|select(.hostname==$h)|.status // ""' $ROLLING_JOB)
+
+    if [ "$deadline" -gt 0 ] && [ "$now" -gt "$deadline" ] ; then
+        log_warning "roll_watchdog: $inflight over deadline by $(( now - deadline ))s (phase: ${phase:-unknown})"
+        _power_roll_pause "watchdog: $inflight exceeded its ${ROLLING_NODE_TIMEOUT:-2700}s node deadline (phase: ${phase:-unknown})"
+        [ -n "$inflight" ] && Quiet -n $HEX_SDK power_vm_reconcile_error_state "$inflight"
+        return 0
+    fi
+
+    local quiet=0
+    case "$phase" in
+        draining) quiet=600 ;;
+        staging)  quiet=900 ;;
+        *)        return 0 ;;
+    esac
+    if [ "$hb" -gt 0 ] && [ $(( now - hb )) -gt $quiet ] ; then
+        log_warning "roll_watchdog: heartbeat silent $(( now - hb ))s while $inflight is $phase"
+        _power_roll_pause "watchdog: no orchestrator heartbeat for $(( now - hb ))s while $inflight is $phase"
+        Quiet -n $HEX_SDK power_vm_reconcile_error_state "$inflight"
+    fi
 }
 
 # Shared cephfs record of VMs running before a cluster poweroff/powercycle, written


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

A roll whose orchestrator dies freezes silently — the per-node deadline was only read by the status display, and nothing ran periodically to look (tripwire run 1 wedged at `draining` with zero signal; recovery cost an afternoon). Two commits:

1. **Stall watchdog** — every `job.json` write stamps `.heartbeat` (one choke point in `_power_roll_write`); a systemd-timer watchdog enforces the node deadline (any phase) and heartbeat silence (write-constant phases only: draining/staging) from the VIP holder, pausing the job with a reason and running the per-node stale-ERROR reconcile while the drain record is fresh. The deadline is load-aware (`max(ROLLING_NODE_TIMEOUT, 1500s + 120s × VMs on the host)`, floor 2700s) so a big drain isn't false-paused. The timer ships **disabled** and exists only during a roll, only on control-capable nodes: armed at start (runtime start, never enable), re-armed by a mid-roll control-node boot, disarmed on completion/abort, and every tick self-stops its own timer when no running/paused roll exists — before any VIP gating, so non-VIP leftovers can't tick forever. Pause/continue also now release/retake the roll's cluster guards **symmetrically** (auto-repair marker, `mon_osd_down_out_interval` pin, watchdog) — closing PR #1125 review issue #2 (orphaned ceph config after a crash) — with a VIP-holder stale-sweep as the backstop.
2. **Pause-reason sanitize** — `hex_log_event` attrs are comma-separated k=v; a comma in the pause reason (they essentially all have one) sheared the record and the pipeline dropped it silently — proven on the sky deploy roll, where the emitted `CLU00004W` never reached the events DB. Same `${var//[,$'\n']/ }` treatment as `CLU00006W`.

3. **Bootstrap console/status cleanup** (`refactor(bootstrap)`) — resolve the kernel console list once (was ~26 `hex_sdk` spawns per boot, two per status line) and fold the repeated status line into a `bootstrap_status` helper. Fixes it also carried: 79-col filler + home-print-home so statuses update one console line in place on real 80-col consoles (previously each status wrapped and walked down a row, text indented at the wrap point); `tee` instead of an ambiguous `>$(...)` redirect (silently failed with >1 `console=` device); `/run/cube_bootstrap.log` becomes a plain per-boot transcript (was truncated per write, one CR-riddled line); `HOSTNAME` from `$(hostname)` once (the old `ssh localhost hostname` yielded an empty hostname whenever sshd wasn't up — blank `host=` on boot events) with stray `$(hostname)` subshells unified onto it; and the early influxdb restart dropped — events moved to `hex_log_event` (journal + filebeat backfill tolerate a late sink) and influxdb comes up via its own config module during the commit.

Lab validation (sky 3cc, 2026-07-21): synthetic deadline + heartbeat wedges pause correctly with proper reasons; non-VIP nodes and done-state no-op; 3× rolling_update + 1× rolling_restart ran with the watchdog armed and untripped; the reconcile's reset branch had its first production execution on a real drain failure (neutron blip → phantom ERROR → reset → VM live-migrated cleanly 90s later).

#### Which issue(s) this PR fixes

Fixes #1135

#### Special notes for your reviewer

- The watchdog acts only from the VIP holder — reusing the cluster's existing leader election rather than inventing a second one. Trade-off discussed: if the VIP is unheld the watchdog is blind, but that state is a cluster-wide control-plane outage already loudly visible elsewhere; a reach-the-VIP fallback was deliberately deferred.
- The reconcile reset requires "domain running on exactly the host nova records" — the signature of a migration that died pre-switchover. Post-copy failures leave both sides paused (excluded by `--state-running`) and split-brain shows two hosts (excluded by host-match), so the damaged-VM modes classify themselves out.
- `Quiet -n systemctl stop` inside the watchdog (vs the cluster-wide `_power_roll_watchdog_disarm` used by lifecycle events) is deliberate: each tick self-stops its own timer — no N×N remote_run from a 60s tick path.

#### Additional documentation

```docs
bigstack-oss/bigstack-handbook#108 — design doc (watchdog, guard bracket, reconcile,
one-roll-two-kinds), runbook (enforced stalls + pause recovery), deck refresh.
```
