### PR TITLE
fix(nginx): SPA cache contract for the cube-cos-ui vhost

### DIFF
--- a/core/nginx/nginx.conf.in
+++ b/core/nginx/nginx.conf.in
@@ -291,6 +291,15 @@ http {
         access_log /var/log/cube-cos-ui/cube-cos-ui-nginx-access.log ui;
         error_log /var/log/cube-cos-ui/cube-cos-ui-nginx-error.log;
 
+        # SPA cache contract: everything mutable under its URL (index.html,
+        # favicon, dist-root files) revalidates every load; hashed bundles
+        # never change under their name and cache forever
+        add_header Cache-Control "no-cache";
+
+        location /assets/ {
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
         location / {
             # health check endpoint for HAProxy
             if ($request_method = OPTIONS) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The UI vhost serves everything with no `Cache-Control`, so browsers apply heuristic caching (~10% of the file's age since `Last-Modified`). On a long-lived production cluster that means **days to weeks** of a stale `index.html` → stale hashed bundle against a new API after every upgrade, in brand-new tabs, with no request ever reaching nginx — the classic inverted SPA cache contract.

Fix (simplified from the originally proposed per-location patch): a **server-level `Cache-Control: no-cache` default** makes every mutable path revalidate per load — `index.html`, the `try_files` SPA fallback for deep links, and the dist-root files the per-location version missed (`favicon.svg`, `mockServiceWorker.js`, `LICENSE`) — and a single `location /assets/` override gives the content-hashed bundles `public, max-age=31536000, immutable` (25 MB / 872 files load once per browser instead of per heuristic window; matters most over VPN/WAN/edge links). `add_header` inheritance does the work: locations without their own header inherit the server default. Side benefit: missing assets now 404 instead of falling back to `index.html`.

Validated live on all three sky nodes (config hot-applied + `nginx -t` + reload):
`/`, deep link `/events`, `favicon.svg` → `no-cache`; `assets/index-CS-U1iMP.js` → `immutable`; haproxy `OPTIONS` health check unaffected (200).

**Known one-release lag**: browsers that already cached `index.html` heuristically never ask nginx, so the upgrade *delivering* this fix still shows one final stale window — only upgrades after it are protected. Suggest a release-note line: hard-reload the UI once after upgrading to the release containing this.

#### Which issue(s) this PR fixes

Fixes #1134

#### Special notes for your reviewer

- `location = /index.html` from the original proposal became unnecessary — the server-level default covers it (including the internal-redirect fallback path), with fewer blocks and wider coverage.
- `add_header` applies to success codes only by default; error pages and the health-check `return 200` behave as before.
- The template renders via hex_config's nginx module; a config commit or reboot re-renders `/etc/nginx/nginx.conf`.

#### Additional documentation

```docs
Issue #1134 DoD calls for a handbook known-issue entry (SPA cache policy);
pending as a follow-up handbook PR.
```