### PR TITLE
fix(cluster): import builtin glance images at set_ready, not at boot

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -323,19 +323,6 @@ cube_cluster_start_cluster()
     # ready yet, leaving single-node flooding STONITH errors + unbounded pe-error.
     Quiet -n pcs property set stonith-enabled=false pe-error-series-max="1000" pe-warn-series-max="1000" cluster-recheck-interval="5min"
 
-    if $OPENSTACK image list -f value | grep -q "Cirros active" ; then
-        cmd rm -f /etc/glance/cirros-0.4.0-x86_64-disk.qcow2
-        cmd rm -f /etc/glance/alpine-tools.qcow2
-    else
-        [ ! -e /etc/glance/cirros-0.4.0-x86_64-disk.qcow2 ] || $HEX_SDK os_image_import /etc/glance cirros-0.4.0-x86_64-disk.qcow2 Cirros
-        [ ! -e /etc/glance/alpine-tools.qcow2 ] || $HEX_SDK os_image_import /etc/glance alpine-tools.qcow2 Alpine
-    fi
-    local cnt=0
-    for i in $($OPENSTACK image list -f value | grep "Cirros active" | cut -d " " -f1) ; do
-        ((cnt++))
-        [ $cnt -le 1 ] || $OPENSTACK image delete $i
-    done
-
     cmd "$HEX_SDK migrate_fixpack"
     nohup bash -c "$HEX_SDK git_init" >/dev/null 2>&1 &
 
@@ -374,6 +361,29 @@ cube_cluster_start_cluster_if_master()
         sleep 20
     done
     cube_cluster_start_cluster
+}
+
+# import the builtin glance images (Cirros, Alpine); set_ready-only -- never at
+# boot, where a still-forming ceph wedges the upload (#1139). Idempotent.
+cube_import_builtin_images()
+{
+    if $OPENSTACK image list -f value | grep -q "Cirros active" ; then
+        cmd rm -f /etc/glance/cirros-0.4.0-x86_64-disk.qcow2
+        cmd rm -f /etc/glance/alpine-tools.qcow2
+        return 0
+    fi
+    # heal an interrupted earlier attempt: a queued/saving record wedges the name
+    for i in $($OPENSTACK image list -f value | grep -E "(Cirros|Alpine) (queued|saving)" | cut -d" " -f1) ; do
+        $OPENSTACK image delete $i
+    done
+    [ ! -e /etc/glance/cirros-0.4.0-x86_64-disk.qcow2 ] || $HEX_SDK os_image_import /etc/glance cirros-0.4.0-x86_64-disk.qcow2 Cirros
+    [ ! -e /etc/glance/alpine-tools.qcow2 ] || $HEX_SDK os_image_import /etc/glance alpine-tools.qcow2 Alpine
+
+    # verify the import actually landed
+    if ! $OPENSTACK image list -f value | grep -q "Cirros active" ; then
+        echo "Error: built-in image Cirros could not be imported" >&2
+        return 1
+    fi
 }
 
 cube_cluster_stop()

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -857,28 +857,26 @@ ClusterReadyMain(int argc, const char** argv)
     CliPrintf("[1/6] Updating storage replication rule");
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run " HEX_SDK " ceph_pool_replicate_init");
 
-    CliPrintf("[2/6] Checking SDN services");
-    // Disabled to verify it's still needed (#1094): health_neutron_repair now waits for OVN
-    // metadata nb_cfg catch-up, and [6/6] cluster_check_repair_async repairs neutron anyway.
-    // HexUtilSystemF(0, 0,  HEX_SDK " host_local_run " HEX_SDK " health_neutron_repair");
-
-    CliPrintf("[3/6] Configuring modules");
+    CliPrintf("[2/6] Configuring modules");
     if (cfgFlatExt)
         HexSpawn(0, HEX_CFG, "-p", "trigger", "cluster_ready", cidr.c_str(), gw.c_str(), iplist.c_str(), ZEROCHAR_PTR);
     else
         HexSpawn(0, HEX_CFG, "-p", "trigger", "cluster_ready", ZEROCHAR_PTR);
 
-    CliPrintf("[4/6] Starting cluster");
+    CliPrintf("[3/6] Starting cluster");
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run hex_sdk cmd " HEX_SDK " cube_cluster_start");
+
+    // the cluster is guaranteed complete here -- never import at boot, where a
+    // still-forming ceph wedges the upload (#1139)
+    CliPrintf("[4/6] Importing builtin images");
+    if (HexUtilSystemF(0, 0, HEX_SDK " cube_import_builtin_images") != 0)
+        CliPrintf("      Warning: built-in image import failed; re-run 'cluster set_ready' to retry.");
 
     CliPrintf("[5/6] Strengthening password");
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run hex_sdk cmd " HEX_CFG " cube_password_init");
 
     CliPrintf("[6/6] Cluster check and repair started in the background.");
     CliPrintf("      The box is ready to use now; the result will pop up here when it completes.");
-    // Disabled to verify it's still needed (#1094): cluster_check_repair_async below already
-    // repairs neutron via check_repair, which now waits for OVN metadata nb_cfg catch-up.
-    // HexSpawn(0, HEX_SDK, "host_local_run", "hex_sdk", "-m force",  "health_neutron_repair", ZEROCHAR_PTR);
     HexSpawn(0, HEX_SDK, "cmd", "rm -f /tmp/health_*_error.count", ZEROCHAR_PTR);
     HexSystemF(0, HEX_SDK " cluster_check_repair_async");
 

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -775,8 +775,11 @@ os_image_import()
     local _distro=${7:-linux}
     local properties=${8:---property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_machine_type=q35 --property hw_video_model=vga}
 
-    # prevent duplicated importing
+    # prevent duplicated importing; a marker older than 2h is a leak from a
+    # killed import (only the success/quota paths remove it) -- sweep the leak
+    # so a retry of this same import is not blocked forever
     local mf_importing="/run/${FUNCNAME[0]}_${file}_${name}_${pool}"
+    cmd find $mf_importing -mmin +120 -delete >/dev/null 2>&1
     if  cmd -v ls $mf_importing | grep -q "|0|" ; then
         Error "Image is being imported. If this is not the case, remove $mf_importing on all nodes"
     else


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

**Moves the built-in glance image import (Cirros/Alpine) to `cluster set_ready` — the one point where the cluster is guaranteed complete — and removes it from the boot path entirely.**

Accept #691 — the first e2e run of the cluster-start refactor — lost the built-in **Cirros** image on both multi-node topologies: `3cc/test_23_cc3_server` ("No Image found for Cirros") and `2ec_1m/test_32_ec1_diagnostics-dns` (its `_diagSrvCreate Cirros` probe VM). Single-node `1ec` passed the identical diagnostics test, and sky (real hardware, near-simultaneous FTS) has the image.

**Failure mechanism** (multi-node serial install): the master's boot-time cluster half runs the import against a still-forming cluster. glance-api is up locally, so it *accepts the image record* (`queued`) — then the upload **blocks forever on the quorumless ceph backend** (ceph clients hang on no-quorum by design). The import marker stays held by the wedged process, so the set_ready retry aborts on "Image is being imported" — technically correctly, for an import that will never finish. All of it silent under `Quiet`.

**Why it never happened before the refactor**: the import lived inline in `cube_cluster_start()`, which ran on **every node's boot** and again on **every node at set_ready** — ≥4 attempts per install, each against a healthier cluster, with the queued-record cleanup healing debris in between. Robust by accidental brute force. The refactor collapsed that to a single doomed boot attempt plus one sabotage-able retry.

**The fix** stops patching around the doomed attempt and removes it:

1. New `cube_import_builtin_images()`, a numbered set_ready step (`[4/6] Importing builtin images`); the block is deleted from `cube_cluster_start_cluster()`, so boot never attempts an import. The function is deliberately lean — its only caller is set_ready on a complete cluster, so the earlier defensive layers (marker clearing, logger fallbacks) are gone; the one heal it keeps is deleting queued/saving records (restored old-code behavior: an interrupted set_ready leaves a `queued` record that would make a re-run create a duplicate name). After importing, the function **verifies** `Cirros` is `active` and returns an explicit "built-in image Cirros could not be imported" error otherwise; the set_ready step prints a `Warning: … re-run 'cluster set_ready' to retry.` on failure instead of proceeding silently.
2. set_ready's step list is renumbered with the two disabled no-op blocks removed (`[2/6] Checking SDN services` and the commented-out `[6/6]` neutron repair, both #1094 leftovers).
3. Defense in depth: `os_image_import` itself now sweeps import markers older than 2 h before its duplicate-import check (previously only the success/quota paths removed the marker).

**Attribution**: the regression trigger is the boot-time-initiative cluster-start split; the marker-hold behavior in `os_image_import` and ceph's block-on-no-quorum are pre-existing — the refactor removed the accidental retries that had been hiding them. Same latent-bug-exposed-by-refactor shape as the influxdb/ceph `CONFIG_REQUIRES` race (#1132). For the record, the third #691 failure (`3c_3p_5s/test_33_c1_network`) is unrelated: a transient neutron API connection drop (known pre-existing oslo_db/eventlet worker-crash window).

#### Which issue(s) this PR fixes

Fixes #1139

#### Special notes for your reviewer

> `cli_cluster.o` compiles; `bash -n` clean. All topologies run set_ready (e2e: `test_13_cc1_setready`, `test_29_*_setready*`), so no install path loses the import. Upgrades keep their already-imported images (glance persists). The `if_master` gate's wait-30-min-then-run-anyway semantics remain flagged in #1139 as a follow-up — with the import gone from boot, its blast radius is much smaller. Real verification = the next accept run: `test_23_cc3_server` and `test_32_ec1_diagnostics-dns` are the regression tests.

#### Additional documentation

```docs
Handbook: candidate known-issue on the wedged-import pattern (glance upload
blocks on quorumless ceph; marker holds; retry self-blocks) — see #1139 DoD.
```
