### PR TITLE
fix(gpu): fix jq scope bug in gpu_device_list that breaks gpuCards API

### DIFF
--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -389,7 +389,7 @@ gpu_device_list()
 
     local pgpu_ids
     pgpu_ids=$(echo "$gpu_config" | jq -c --argjson targetIds "$recorded_gpu_ids" \
-        '[.[] | select(($targetIds | index(.id)) == null)]')
+        '[.[] | select((.id as $id | $targetIds | index($id)) == null)]')
 
     while IFS= read -r entry; do
         [ -z "$entry" ] || [ "$entry" = "null" ] && continue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`gpu_device_list()`'s pgpu-reconciliation step builds `pgpu_ids` with:

    pgpu_ids=$(echo "$gpu_config" | jq -c --argjson targetIds "$recorded_gpu_ids" \
        '[.[] | select(($targetIds | index(.id)) == null)]')

Inside `$targetIds | index(.id)`, the pipe already rebinds `.` to
`$targetIds` (a plain string array) before `index(.id)` is evaluated, so
`.id` resolves against the array itself instead of the current
`gpu_config` element from the outer `.[] |`. jq fails with:

    jq: error (at <stdin>:1): Cannot index array with string "id"

This happens on stderr, and `cube-cos-api` calls `hex_sdk
gpu_device_list` via `exec.CommandContext(...).CombinedOutput()`
(`internal/cubecos/nodes.go`), so the stray error line gets merged into
the JSON it tries to parse - breaking `GET /nodes/:node/gpuCards` with a
500 (`invalid character 'j' looking for beginning of value`).

The trigger condition is simply: `config.json` has at least one entry
(i.e. any GPU has ever been assigned a resource type via
`gpu_resource_set`). An active vGPU instance is not required to hit it -
verified reproducing it with an idle, assigned-but-unused sriovVgpu GPU.
Practically, this means the `/gpuCards` API 500s permanently as soon as
the SR-IOV/MIG vGPU feature is used once on a node.

Fix: bind `.id` via `as $id` before the pipe so it still refers to the
current `gpu_config` element:

    '[.[] | select((.id as $id | $targetIds | index($id)) == null)]'

#### Which issue(s) this PR fixes

Fixes #
<!-- No tracked issue yet - found while hardware-testing a separate
     cube-cos-api NVML question on cn13. Let me know if you'd like this
     filed as its own ticket before merging. -->

#### Special notes for your reviewer

- Base is `develop`, not the old `feat/904-sriov-vgpu-infra` branch -
  that branch is already merged (#1141), so this is a standalone
  one-line fix on top of current `develop`.
- Verified live on cn13: reproduced the 500 with a real assigned
  sriovVgpu GPU (`config.json` non-empty), deployed the fix to
  `/usr/lib/hex_sdk/modules/sdk_gpu.sh`, confirmed `hex_sdk
  gpu_device_list` now returns clean JSON and `GET .../gpuCards` returns
  200 with correct data (tested both idle-assigned and
  active-vGPU-with-a-real-guest-driver states).
- No existing test harness covers `sdk_gpu.sh`'s shell/jq logic (the
  `feat-904-sriov-vgpu-infra/harness` only covers the C++ side), so this
  was verified against real hardware rather than an automated test.
- Scope is intentionally minimal: one line, no behavior change beyond
  fixing the crash - not bundling in any other cleanup.

#### Additional documentation

```docs

```