### PR TITLE
fix(rolling): survive a wedged cephfs client at staging time

### DIFF
--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2807,7 +2807,11 @@ ceph_mount_cephfs()
     done
     for i in {1..6} ; do
         mountpoint -q $CEPHFS_STORE_DIR && return 0
-        timeout $SRVSTO mount -t ceph :/ $CEPHFS_STORE_DIR -o name=admin,secretfile=/etc/ceph/admin.key >/dev/null 2>&1
+        # recover_session=clean: an MDS-evicted (blocklisted) kernel client
+        # reconnects with a clean session instead of failing every op with
+        # EACCES until someone remounts -- eviction happens under heavy write
+        # + cap churn (e.g. staging an 11G pkg right before a roll).
+        timeout $SRVSTO mount -t ceph :/ $CEPHFS_STORE_DIR -o name=admin,secretfile=/etc/ceph/admin.key,recover_session=clean >/dev/null 2>&1
         mountpoint -q $CEPHFS_STORE_DIR && return 0
         sleep 10
     done

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2807,10 +2807,8 @@ ceph_mount_cephfs()
     done
     for i in {1..6} ; do
         mountpoint -q $CEPHFS_STORE_DIR && return 0
-        # recover_session=clean: an MDS-evicted (blocklisted) kernel client
-        # reconnects with a clean session instead of failing every op with
-        # EACCES until someone remounts -- eviction happens under heavy write
-        # + cap churn (e.g. staging an 11G pkg right before a roll).
+        # recover_session=clean: an MDS-evicted client reconnects cleanly instead
+        # of EACCES-ing every op until remount (see PR for the eviction scenario).
         timeout $SRVSTO mount -t ceph :/ $CEPHFS_STORE_DIR -o name=admin,secretfile=/etc/ceph/admin.key,recover_session=clean >/dev/null 2>&1
         mountpoint -q $CEPHFS_STORE_DIR && return 0
         sleep 10

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -480,6 +480,21 @@ _power_roll_stage_all()
 {
     local pkg=$1 h rc=0
     local -A _pids=()
+    # Preflight: every node reads the pkg from shared cephfs, and a wedged
+    # cephfs client (MDS-evicted after the large pkg write, mount returns
+    # EACCES) fails its stage mid-flight. Verify mount+pkg per node first,
+    # self-heal once via ceph_mount_cephfs, and pause BEFORE staging if a
+    # node still can't see the package.
+    for h in $(jq -r '.nodes[].hostname' $ROLLING_JOB 2>/dev/null) ; do
+        if ! remote_run "$h" "mountpoint -q /mnt/cephfs && test -r $pkg" </dev/null >/dev/null 2>&1 ; then
+            log_warning "stage preflight: cephfs/pkg not readable on $h, running ceph_mount_cephfs"
+            remote_run "$h" "$HEX_SDK ceph_mount_cephfs" </dev/null >/dev/null 2>&1
+            if ! remote_run "$h" "mountpoint -q /mnt/cephfs && test -r $pkg" </dev/null >/dev/null 2>&1 ; then
+                _power_roll_pause "cephfs not mounted or $(basename $pkg) not readable on $h; nothing was staged"
+                return 1
+            fi
+        fi
+    done
     # Stage every node at once. Each writes its own inactive slot from a
     # read-only package on shared cephfs, so there is nothing to serialize --
     # doing them in turn just multiplies the wait before the roll can start.

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -480,11 +480,9 @@ _power_roll_stage_all()
 {
     local pkg=$1 h rc=0
     local -A _pids=()
-    # Preflight: every node reads the pkg from shared cephfs, and a wedged
-    # cephfs client (MDS-evicted after the large pkg write, mount returns
-    # EACCES) fails its stage mid-flight. Verify mount+pkg per node first,
-    # self-heal once via ceph_mount_cephfs, and pause BEFORE staging if a
-    # node still can't see the package.
+    # Preflight: verify each node can read the pkg from cephfs, self-heal once via
+    # ceph_mount_cephfs, and pause before staging if it still can't -- a wedged
+    # cephfs client would otherwise fail its stage mid-flight.
     for h in $(jq -r '.nodes[].hostname' $ROLLING_JOB 2>/dev/null) ; do
         if ! remote_run "$h" "mountpoint -q /mnt/cephfs && test -r $pkg" </dev/null >/dev/null 2>&1 ; then
             log_warning "stage preflight: cephfs/pkg not readable on $h, running ceph_mount_cephfs"
@@ -850,6 +848,17 @@ power_roll_status_json()
         }' $ROLLING_JOB
 }
 
+# 0 if node $1's ACTIVE firmware already matches the roll target (commit in
+# .version) -- it upgraded before/during a pause. Unreachable/mismatch => 1.
+_power_roll_node_on_target()
+{
+    local node=$1 target
+    target=$(jq -r '.version // ""' $ROLLING_JOB 2>/dev/null | grep -oE '[0-9a-f]{7,}' | tail -1)
+    [ -n "$target" ] || return 1
+    is_sshable "$node" || return 1
+    remote_run "$node" "hex_cli -c firmware list 2>/dev/null | grep -i active" </dev/null 2>/dev/null | grep -q "$target"
+}
+
 power_roll_decision()
 {
     [ -e "$ROLLING_JOB" ] || { echo "no rolling job in progress" >&2 ; return 1 ; }
@@ -867,20 +876,31 @@ power_roll_decision()
 
     case "$1" in
         continue)
-            # Reset the node that failed back to a clean pending so the resume
-            # re-kicks it first (its status is draining/rebooting, not pending).
             local stuck=$(jq -r '.inflight // ""' $ROLLING_JOB)
             if [ -n "$stuck" ] ; then
-                _power_roll_set_node_status "$stuck" pending
-                _power_roll_set_node_num "$stuck" started 0
-                _power_roll_set_node_num "$stuck" vms_total 0
-                _power_roll_set_node_num "$stuck" vms_done 0
+                if _power_roll_node_on_target "$stuck" ; then
+                    # already on target -- record done, don't re-drain+reboot it.
+                    log_info "continue: $stuck already on target firmware -- marking done"
+                    _power_roll_set_node_status "$stuck" done
+                    _power_roll_set_node_num "$stuck" finished $(date +%s)
+                else
+                    # unfinished: reset to pending so the resume re-kicks it first.
+                    _power_roll_set_node_status "$stuck" pending
+                    _power_roll_set_node_num "$stuck" started 0
+                    _power_roll_set_node_num "$stuck" vms_total 0
+                    _power_roll_set_node_num "$stuck" vms_done 0
+                fi
             fi
             _power_roll_set_str inflight ""
             _power_roll_set_str reason ""
+            # Zero the stale deadline before state=running so a watchdog tick can't
+            # re-pause on it (watchdog skips deadline=0; next _kick sets a fresh one).
+            _power_roll_set_raw deadline 0
             _power_roll_set_str state running
-            # re-take the guards the pause released
+            # re-take the guards the pause released; disarm the stale watchdog
+            # timer before re-arming so it can't fire on old state.
             Quiet -n $HEX_SDK ceph_enter_rolling
+            _power_roll_watchdog_disarm
             _power_roll_watchdog_arm
             power_roll_advance
             ;;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Hardening for the rolling upgrade, from the 3.1.0→3.1.10 sky rehearsal. Two independent fixes:

**1. Survive a wedged cephfs client at staging (commit 1).**
- `ceph_mount_cephfs` mounts with `recover_session=clean` so an MDS-evicted (blocklisted) kernel client reconnects instead of failing every op with EACCES until remount.
- `_power_roll_stage_all` preflights every node (cephfs mounted + pkg readable) before any `hex_install` runs, self-heals once via `ceph_mount_cephfs`, and pauses pre-stage with a precise reason instead of failing mid-stage.

**2. `continue` must not re-pause on a stale deadline or re-roll a finished node (commit 2).**
- continue set `state=running` and re-armed the watchdog BEFORE `_power_roll_kick` wrote a fresh deadline → a watchdog tick in that window read the old (blown) deadline and re-paused immediately. Now continue zeroes the deadline before `state=running` (watchdog skips the check at 0) and disarms any stale timer before re-arming.
- continue always reset the inflight node to pending and re-kicked it — even when it had actually finished (booted the target) before the pause, rebooting an already-upgraded node in a loop. New `_power_roll_node_on_target` checks the inflight node’s ACTIVE firmware against the roll target and records it **done** instead of re-rolling.

#### Which issue(s) this PR fixes

Fixes #1156 (cephfs staging wedge). Also fixes the watchdog stale-deadline / continue-re-kick edges found in the same rehearsal (finding 13; no separate issue — folded here at the reporter’s request).

#### Special notes for your reviewer

- Both were hit live recovering sky141 after a lab PXE-detour stall; the manual equivalents (heal + mark-done + resume) unblocked the roll.
- `_power_roll_node_on_target` only returns true on a reachable, positive firmware match — an unreachable node still falls through to re-kick (safe default).

#### Additional documentation

```docs
bigstack-handbook kb/cubecos/known-issues/rolling-upgrade-rehearsal-findings.md (findings 2, 13)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154HK1F8x8BhXYfTNBXc3AR