### PR TITLE
build(qemu): pin qemu-kvm to 17:10.1.0-22.el9 from the kojihub archive

### DIFF
--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -99,27 +99,21 @@ rootfs_install::
 	$(Q)rm -rf $(ROOTDIR)/kernel-$(KERNEL_VERS)
 
 # qemu-kvm-17:9.1.0-27.el9 is not compatible with 17:9.1.0-20 (v3.0.0)
-# QEMU_VER := -17:9.1.0-24.el9
-QEMU_VER :=
-QEMU_LOCKED_RPMS := qemu-kvm$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-gpu-pci$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-gpu$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-device-display-virtio-vga$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-device-usb-redirect$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-device-usb-host$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-guest-agent$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-block-rbd$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-block-blkio$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-common$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-core$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-img$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-audio-pa$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-pr-helper$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-tools$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-ui-egl-headless$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-ui-opengl$(QEMU_VER)
-QEMU_LOCKED_RPMS += qemu-kvm-docs$(QEMU_VER)
+# Pinned NVR: live-migration-compatible with 3.1.0's qemu. Never unpin -- an
+# unpinned build floats to build-day c9s. Rig validation + drift: cubecos#1150.
+QEMU_VER := -17:10.1.0-22.el9
+# Filename NVR (no epoch); kojihub keeps builds the c9s mirror rotates away, so an
+# air-gapped rebuild resolves the exact NVR (same pattern as mysql.mk).
+QEMU_NVR := 10.1.0-22.el9
+QEMU_URL := https://kojihub.stream.centos.org/kojifiles/packages/qemu-kvm/10.1.0/22.el9/x86_64
+QEMU_PKGS := qemu-kvm qemu-kvm-device-display-virtio-gpu-pci qemu-kvm-device-display-virtio-gpu
+QEMU_PKGS += qemu-kvm-device-display-virtio-vga qemu-kvm-device-usb-redirect qemu-kvm-device-usb-host
+QEMU_PKGS += qemu-guest-agent qemu-kvm-block-rbd qemu-kvm-block-blkio qemu-kvm-common qemu-kvm-core
+QEMU_PKGS += qemu-img qemu-kvm-audio-pa qemu-pr-helper qemu-kvm-tools qemu-kvm-ui-egl-headless
+QEMU_PKGS += qemu-kvm-ui-opengl qemu-kvm-docs
+QEMU_LOCKED_RPMS := $(foreach p,$(QEMU_PKGS),$(p)$(QEMU_VER))
 LOCKED_DNF += $(QEMU_LOCKED_RPMS)
+$(foreach p,$(QEMU_PKGS),$(eval ROOTFS_DNF_DL_FROM += $(QEMU_URL)/$(p)-$(QEMU_NVR).x86_64.rpm))
 
 $(call PROJ_INSTALL_DNF_NOARCH,,$(LOCKED_DNF))
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`QEMU_VER` in `core/heavyfs/Makefile` was left empty (unpinned) by #855, so any rebuild floats to whatever c9s AppStream serves that day — the drift that silently replaced the 9.1.0 series with 10.1.0. This:

- Pins `QEMU_VER := -17:10.1.0-22.el9`, the version **certified live-migration-compatible with 3.1.0's 9.1.0-24** by the container migration rig (precopy + postcopy/auto-converge, both directions, on `pc-q35-rhel9.6.0` — the machine type 3.1.0's `q35` alias bakes). It is the source pair for the 3.1.0 → Antelope rolling upgrade.
- Sources the 18 pinned rpms from the **kojihub archive** via `ROOTFS_DNF_DL_FROM` (same pattern as the mariadb Rocky-CDN re-pin), because the c9s mirror rotates builds away — it already dropped every 9.1.0. An air-gapped rebuild now resolves the exact NVR.
- Refactors the rpm list to a single `QEMU_PKGS` base-name list driving both the versionlock (with epoch) and the download URLs (filename NVR, no epoch).

#### Which issue(s) this PR fixes

Refs #1150

#### Special notes for your reviewer

- Verified all 18 subpackages exist under the kojihub 10.1.0/22.el9/x86_64 path.
- Derived make vars checked: 18 locked (`qemu-kvm-17:10.1.0-22.el9` …) + 18 URLs (`…/qemu-kvm-10.1.0-22.el9.x86_64.rpm` …).
- Fully closing #1150 also needs the device-level DoD (vTPM/OVMF/vGPU spot-checks, no-new-machine-type-mid-roll); this PR covers the pin + stable source only.
- Draft until a clean build confirms heavyfs resolves the rpms from kojihub.

#### Additional documentation

```docs
bigstack-handbook kb/cubecos/known-issues/rolling-upgrade-rehearsal-findings.md (qemu 9.1.0-24 -> 10.1.0-22 certified)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154HK1F8x8BhXYfTNBXc3AR