### PR TITLE
feat(manila): expose one generic share backend per configured Cinder volume type

### DIFF
--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -287,7 +287,6 @@ SetDefaults(Configs& config)
 {
     config["DEFAULT"]["api_paste_config"] = "/etc/manila/api-paste.ini";
     config["DEFAULT"]["default_share_type"] = "tenant_share_type";
-    config["DEFAULT"]["enabled_share_backends"] = "generic";
     config["DEFAULT"]["enabled_share_protocols"] = "NFS,CIFS";
     config["DEFAULT"]["rootwrap_config"] = "/etc/manila/rootwrap.conf";
     config["DEFAULT"]["share_name_template"] = "share-%s";
@@ -483,30 +482,91 @@ SetGlanceInfo(
 }
 
 /**
- * Set the generic driver.
+ * Set a generic share driver backend section.
+ *
+ * sectionName is the manila.conf section (and enabled_share_backends member);
+ * shareBackendName is the driver's "share_backend_name" value used by Manila's
+ * scheduler to route a share type's "share_backend_name" extra-spec to this
+ * backend. They coincide for additional backends (both equal the configured
+ * Cinder volume-type name) but differ for the pre-existing default backend
+ * (section "generic", share_backend_name "GENERIC" -- unchanged from before
+ * this feature, to keep manila.conf byte-for-byte identical when no
+ * additional backends are configured).
  */
 static void
 SetDriverGeneric(
     Configs& config,
+    const std::string sectionName,
+    const std::string shareBackendName,
     const std::string networkCidr,
     const std::string volumeType)
 {
-    config["generic"]["share_backend_name"] = "GENERIC";
-    config["generic"]["share_driver"] = "manila.share.drivers.generic.GenericShareDriver";
-    config["generic"]["driver_handles_share_servers"] = "true";
-    config["generic"]["interface_driver"] = "manila.network.linux.interface.OVSInterfaceDriver";
-    config["generic"]["connect_share_server_to_tenant_network"] = "true";
-    config["generic"]["service_image_name"] = "manila-service-image";
-    config["generic"]["service_instance_flavor_id"] = "653443";
-    config["generic"]["service_instance_user"] = "manila";
-    config["generic"]["service_instance_password"] = "manila";
+    config[sectionName]["share_backend_name"] = shareBackendName;
+    config[sectionName]["share_driver"] = "manila.share.drivers.generic.GenericShareDriver";
+    config[sectionName]["driver_handles_share_servers"] = "true";
+    config[sectionName]["interface_driver"] = "manila.network.linux.interface.OVSInterfaceDriver";
+    config[sectionName]["connect_share_server_to_tenant_network"] = "true";
+    config[sectionName]["service_image_name"] = "manila-service-image";
+    config[sectionName]["service_instance_flavor_id"] = "653443";
+    config[sectionName]["service_instance_user"] = "manila";
+    config[sectionName]["service_instance_password"] = "manila";
 
-    config["generic"]["service_network_cidr"] = networkCidr;
+    config[sectionName]["service_network_cidr"] = networkCidr;
     int mask = std::stoi(hex_string_util::split(networkCidr, '/')[1]) + 7;
     mask = std::min(mask, 32);
-    config["generic"]["service_network_division_mask"] = std::to_string(mask);
+    config[sectionName]["service_network_division_mask"] = std::to_string(mask);
 
-    config["generic"]["cinder_volume_type"] = volumeType;
+    config[sectionName]["cinder_volume_type"] = volumeType;
+}
+
+/**
+ * Collect the configured additional share-backend names (the Cinder
+ * volume-type names from manila.share.backend.%d.volume_type), skipping
+ * empty entries and names reserved by the default backend.
+ */
+static std::vector<std::string>
+GetConfiguredShareBackendNames(const TuningStringArray& shareBackends)
+{
+    std::vector<std::string> names;
+
+    for (std::vector<ConfigString>::const_iterator it = shareBackends.begin(); it != shareBackends.end(); it++) {
+        std::string name = it->newValue();
+        if (name.length() == 0) {
+            continue;
+        }
+        if (name == "generic" || name == "tenant_share_type") {
+            HexLogWarning("manila share backend name \"%s\" is reserved, skipping", name.c_str());
+            continue;
+        }
+        names.push_back(name);
+    }
+
+    return names;
+}
+
+/**
+ * Set the enabled generic share backends: the built-in default plus any
+ * additional Cinder volume types configured in
+ * manila.share.backend.%d.volume_type.
+ */
+static void
+SetShareBackends(
+    Configs& config,
+    const std::string mgmtCidr,
+    const std::string defaultVolumeType,
+    const TuningStringArray& shareBackends)
+{
+    SetDriverGeneric(config, "generic", "GENERIC", mgmtCidr, defaultVolumeType);
+
+    std::stringstream enabledBackendLine;
+    enabledBackendLine << "generic";
+
+    for (const std::string& backendName : GetConfiguredShareBackendNames(shareBackends)) {
+        SetDriverGeneric(config, backendName, backendName, mgmtCidr, backendName);
+        enabledBackendLine << "," << backendName;
+    }
+
+    config["DEFAULT"]["enabled_share_backends"] = enabledBackendLine.str();
 }
 
 /**
@@ -674,13 +734,15 @@ Commit(bool modified, int dryLevel)
         SetNeutronInfo(config, sharedId, s_cubeRegion, s_cubeDomain, adminCliPass);
         SetGlanceInfo(config, sharedId, s_cubeRegion, s_cubeDomain, adminCliPass);
 
+        std::string defaultVolumeType;
         if (s_volumeType.length() > 0 && s_volumeType.newValue() != BUILTIN_VOLUME_TYPE) {
-            SetDriverGeneric(config, mgmtCidr, s_volumeType);
+            defaultVolumeType = s_volumeType.newValue();
         } else if (s_cinderVolumeTypeDefault.newValue() != "") {
-            SetDriverGeneric(config, mgmtCidr, s_cinderVolumeTypeDefault);
+            defaultVolumeType = s_cinderVolumeTypeDefault.newValue();
         } else {
-            SetDriverGeneric(config, mgmtCidr, BUILTIN_VOLUME_TYPE);
+            defaultVolumeType = BUILTIN_VOLUME_TYPE;
         }
+        SetShareBackends(config, mgmtCidr, defaultVolumeType, s_shareBackends);
 
         WriteConfig(CONF, SB_SEC_WFMT, '=', config);
     }

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -189,11 +189,15 @@ CommitCheck(bool modified, int dryLevel)
     s_bDbPassChanged = s_dbPass.modified()
         || s_bCubeModified;
 
+    s_bShareBackendsChanged = s_shareBackends.modified()
+        || s_volumeType.modified();
+
     s_bConfigChanged = modified
         || s_bMqModified
         || s_bCubeModified
         || s_bKeystoneModified
         || s_bCinderModified
+        || s_bShareBackendsChanged
         || G_MOD(MGMT_ADDR)
         || G_MOD(SHARED_ID);
 
@@ -203,7 +207,8 @@ CommitCheck(bool modified, int dryLevel)
 
     return s_bDbPassChanged
         || s_bConfigChanged
-        || s_bEndpointChanged;
+        || s_bEndpointChanged
+        || s_bShareBackendsChanged;
 }
 
 /**
@@ -764,6 +769,16 @@ Commit(bool modified, int dryLevel)
 
     // start services
     StartManilaService(s_enabled);
+
+    // create/prune additional share-backend types whenever the configured
+    // list changes
+    if (IsControl(s_eCubeRole) && s_bShareBackendsChanged) {
+        std::stringstream typesLine;
+        for (const std::string& name : GetConfiguredShareBackendNames(s_shareBackends)) {
+            typesLine << name << " ";
+        }
+        HexUtilSystemF(0, 0, HEX_SDK " os_manila_backend_types_init \"%s\"", typesLine.str().c_str());
+    }
 
     return true;
 }

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -52,6 +52,7 @@ CONFIG_TUNING_STR(MANILA_DBPASS, "manila.db.password", TUNING_UNPUB, "Set manila
 // public tunings
 CONFIG_TUNING_BOOL(MANILA_DEBUG, "manila.debug.enabled", TUNING_PUB, "Set to true to enable manila verbose log.", false);
 CONFIG_TUNING_STR(MANILA_VOLUME_TYPE, "manila.volume.type", TUNING_PUB, "Set manila backend volume type.", BUILTIN_VOLUME_TYPE, ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(MANILA_SHARE_BACKEND, "manila.share.backend.%d.volume_type", TUNING_PUB, "Set an additional Cinder volume type Manila should serve as a share backend.", "", ValidateRegex, DFT_REGEX_STR);
 
 // using external tunings
 CONFIG_TUNING_SPEC_STR(RABBITMQ_OPENSTACK_PASSWD);
@@ -72,6 +73,7 @@ PARSE_TUNING_BOOL(s_debug, MANILA_DEBUG);
 PARSE_TUNING_STR(s_manilaPass, MANILA_USERPASS);
 PARSE_TUNING_STR(s_dbPass, MANILA_DBPASS);
 PARSE_TUNING_STR(s_volumeType, MANILA_VOLUME_TYPE);
+PARSE_TUNING_STR_ARRAY(s_shareBackends, MANILA_SHARE_BACKEND);
 PARSE_TUNING_X_STR(s_mqPass, RABBITMQ_OPENSTACK_PASSWD, 1);
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 2);
 PARSE_TUNING_X_STR(s_cubeDomain, CUBESYS_DOMAIN, 2);
@@ -94,6 +96,7 @@ static bool s_bCinderModified = false;
 static bool s_bDbPassChanged = false;
 static bool s_bConfigChanged = false;
 static bool s_bEndpointChanged = false;
+static bool s_bShareBackendsChanged = false;
 
 static CubeRole_e s_eCubeRole;
 static Configs config;

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -52,7 +52,6 @@ CONFIG_TUNING_STR(MANILA_DBPASS, "manila.db.password", TUNING_UNPUB, "Set manila
 // public tunings
 CONFIG_TUNING_BOOL(MANILA_DEBUG, "manila.debug.enabled", TUNING_PUB, "Set to true to enable manila verbose log.", false);
 CONFIG_TUNING_STR(MANILA_VOLUME_TYPE, "manila.volume.type", TUNING_PUB, "Set manila backend volume type.", BUILTIN_VOLUME_TYPE, ValidateRegex, DFT_REGEX_STR);
-CONFIG_TUNING_STR(MANILA_SHARE_BACKEND, "manila.share.backend.%d.volume_type", TUNING_PUB, "Set an additional Cinder volume type Manila should serve as a share backend.", "", ValidateRegex, DFT_REGEX_STR);
 
 // using external tunings
 CONFIG_TUNING_SPEC_STR(RABBITMQ_OPENSTACK_PASSWD);
@@ -66,6 +65,7 @@ CONFIG_TUNING_SPEC_BOOL(CUBESYS_HA);
 CONFIG_TUNING_SPEC_STR(CUBESYS_CONTROL_ADDRS);
 CONFIG_TUNING_SPEC_STR(KEYSTONE_ADMIN_CLI_PASS);
 CONFIG_TUNING_SPEC_STR(CINDER_VOLUME_TYPE_DEFAULT);
+CONFIG_TUNING_SPEC_STR(CINDER_STORAGE_BACKEND);
 
 // parse tunings
 PARSE_TUNING_BOOL(s_enabled, MANILA_ENABLED);
@@ -73,7 +73,6 @@ PARSE_TUNING_BOOL(s_debug, MANILA_DEBUG);
 PARSE_TUNING_STR(s_manilaPass, MANILA_USERPASS);
 PARSE_TUNING_STR(s_dbPass, MANILA_DBPASS);
 PARSE_TUNING_STR(s_volumeType, MANILA_VOLUME_TYPE);
-PARSE_TUNING_STR_ARRAY(s_shareBackends, MANILA_SHARE_BACKEND);
 PARSE_TUNING_X_STR(s_mqPass, RABBITMQ_OPENSTACK_PASSWD, 1);
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 2);
 PARSE_TUNING_X_STR(s_cubeDomain, CUBESYS_DOMAIN, 2);
@@ -85,6 +84,7 @@ PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 2);
 PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 2);
 PARSE_TUNING_X_STR(s_adminCliPass, KEYSTONE_ADMIN_CLI_PASS, 3);
 PARSE_TUNING_X_STR(s_cinderVolumeTypeDefault, CINDER_VOLUME_TYPE_DEFAULT, 4);
+PARSE_TUNING_X_STR_ARRAY(s_shareBackends, CINDER_STORAGE_BACKEND, 4);
 
 static bool s_bSetup = true;
 
@@ -525,9 +525,11 @@ SetDriverGeneric(
 }
 
 /**
- * Collect the configured additional share-backend names (the Cinder
- * volume-type names from manila.share.backend.%d.volume_type), skipping
- * empty entries and names reserved by the default backend.
+ * Collect the configured additional share-backend names -- mirrors
+ * Cinder's own additional storage backends (cinder.storage.backend.%d.name,
+ * the same tuning Glance and Nova already observe for their own Cinder
+ * integration), skipping empty entries and names reserved by the default
+ * backend.
  */
 static std::vector<std::string>
 GetConfiguredShareBackendNames(const TuningStringArray& shareBackends)
@@ -550,9 +552,8 @@ GetConfiguredShareBackendNames(const TuningStringArray& shareBackends)
 }
 
 /**
- * Set the enabled generic share backends: the built-in default plus any
- * additional Cinder volume types configured in
- * manila.share.backend.%d.volume_type.
+ * Set the enabled generic share backends: the built-in default plus one
+ * backend per additional Cinder storage backend (cinder.storage.backend.%d.name).
  */
 static void
 SetShareBackends(

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2042,6 +2042,50 @@ os_manila_init()
     #fi
 }
 
+# Create/prune one Manila share type per additional Cinder volume type
+# Manila should serve as a generic-driver backend.
+#
+# params:
+# $1: space-separated list of currently-configured additional Cinder
+#     volume-type names (already filtered of empty/reserved entries by
+#     the caller)
+os_manila_backend_types_init()
+{
+    local configured_types="$1"
+
+    if ! is_control_node ; then
+        return 0
+    fi
+
+    # bind the pre-existing default share type to the default backend
+    # explicitly, so it can no longer be scheduled onto any additional
+    # backend below (idempotent -- harmless to set on every call)
+    manila type-key tenant_share_type set share_backend_name=GENERIC
+
+    # create: idempotent check-then-create, same shape as os_volume_type_create
+    for vt in $configured_types ; do
+        if ! manila type-list -f value -c Name | grep -qx "$vt" ; then
+            manila type-create --snapshot_support true --create_share_from_snapshot_support true "$vt" true
+            manila type-key "$vt" set share_backend_name="$vt"
+        fi
+    done
+
+    # prune: delete share types no longer configured, unless shares still
+    # reference them (refuse-if-in-use, mirrors cinder_is_volume_type_in_use)
+    for existing in $(manila type-list -f value -c Name | grep -v '^tenant_share_type$') ; do
+        if echo " $configured_types " | grep -q " $existing " ; then
+            continue
+        fi
+
+        if $OPENSTACK share list --all-tenants --share-type "$existing" -f value -c ID | grep -q . ; then
+            echo "skip delete: share type $existing still has shares"
+            continue
+        fi
+
+        manila type-delete "$existing"
+    done
+}
+
 os_ironic_deploy_kernel_import()
 {
     local kernel=$1/$2


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Lets Manila expose one additional generic share backend per Cinder volume type, so tenants can place file shares on different storage tiers the same way block volumes already can.

Manila mirrors Cinder's own existing multi-backend array (`cinder.storage.backend.%d.name`) directly -- the same way `config_glance.cpp` and `config_nova.cpp` already observe it for their own Cinder integration -- rather than introducing a separate Manila-specific config knob. Whatever additional Cinder backends an admin configures automatically become Manila share backends too; there's no independent Manila-side list to keep in sync.

Stays entirely within the existing **generic** driver (Nova service-VM + Cinder volume, Neutron-isolated) -- never a native protocol driver. This supersedes the native-driver approach (CephFS-native / NetApp toggles) built in the closed PR #1114, which was rejected on an architecture decision: native drivers let tenants reach the storage backend's own network directly, bypassing the isolation the generic driver already provides.

Landed in 4 commits, each independently reviewed:
- `3e191bd`, `c0ec03c` -- (superseded by `4a0dc9d`, see below) originally added a dedicated `manila.share.backend.%d.volume_type` tuning and generalized the previously-hardcoded single `[generic]` manila.conf backend section into a reusable per-backend writer; assembles `enabled_share_backends` as a loop over configured entries (mirrors Cinder's `SetStorageBackend()`).
- `6bd55a4` -- idempotent share-type create/prune (`os_manila_backend_types_init` in `sdk_os.sh`), wired to run on every `cubectl config commit` where the backend list changed. Deleting a config entry removes the `manila.conf` backend section immediately (blocking new share placement on it) but the Manila share-type object itself refuses deletion while any share still references it (mirrors Cinder's `cinder_is_volume_type_in_use` pattern) -- existing shares are never orphaned.
- `4a0dc9d` -- **revision from offline review**: removed the dedicated `manila.share.backend.%d.volume_type` tuning entirely; Manila now observes Cinder's own `CINDER_STORAGE_BACKEND` array on the existing "cinder" observer channel (group 4, already used for `CINDER_VOLUME_TYPE_DEFAULT`), matching the established Glance/Nova pattern. No other logic changed -- `SetShareBackends()`, `GetConfiguredShareBackendNames()`, and `os_manila_backend_types_init()` already treated the array as an opaque list of Cinder volume-type names.

The default backend's rendered output (section name `generic`, `share_backend_name=GENERIC`) remains byte-for-byte unchanged when no additional Cinder backends are configured.

Design spec and implementation plan (not committed to this branch, kept local per request) walked through the acceptance criteria, removal semantics, and the byte-for-byte-when-empty requirement in detail before implementation.

#### Which issue(s) this PR fixes

Fixes bigstack-oss/cubecmp#1053

#### Special notes for your reviewer

- No automated test harness exists for hex config C++ modules in this repo (confirmed during design research -- only `config_etcd` has one), so verification is manual against a live dev cluster. **That manual verification (build via the jailed `make full`, then configure/create/mount/remove/prune against a real cluster) has not been run yet** -- this is opened as a draft pending that pass.
- Each commit went through an isolated task-scoped review (spec compliance + code quality) plus a final whole-branch review; all came back clean with no Critical/Important findings. A few Minor, explicitly-triaged edge cases were left as-is: no de-duplication of a repeated volume-type name in Cinder's config, case-sensitive reserved-name check (`generic`/`tenant_share_type`), and a `CommitCheck()` bootstrap-time gap that's an exact structural mirror of Cinder's own already-shipped behavior for its analogous flag.
- CMP-side UI/API/billing (share-type selection at create time, per-type pricing) is out of scope, tracked in sibling stories under epic bigstack-oss/cubecmp#907.

#### Additional documentation

```docs

```