### PR TITLE
fix(rolling): init config-history git repo per-node, once per slot

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -303,6 +303,7 @@ cube_cluster_start_node()
     Quiet -n killall /usr/sbin/hex_banner # refresh console banner
     ( $HEX_SDK toggle_health_check | grep ceph_osd | grep -q disabled ) || Quiet -n $HEX_SDK toggle_health_check ceph_osd
     iptables-save > /run/iptables
+    cmd "$HEX_SDK migrate_git" # init this node's /.git before it's marked synced
     touch $CLUSTER_SYNC
 }
 
@@ -324,7 +325,6 @@ cube_cluster_start_cluster()
     Quiet -n pcs property set stonith-enabled=false pe-error-series-max="1000" pe-warn-series-max="1000" cluster-recheck-interval="5min"
 
     cmd "$HEX_SDK migrate_fixpack"
-    nohup bash -c "$HEX_SDK git_init" >/dev/null 2>&1 &
 
     $OPENSTACK ec2 credentials list --user admin -c Access -c Secret -f value 2>/dev/null | head -n 1 > /run/ec2.key
     local keys=$(cat /run/ec2.key 2>/dev/null)

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -22,6 +22,15 @@ migrate_fixpack()
     touch $STATE_DIR/fixpack_migrated
 }
 
+migrate_git()
+{
+    # Init this node's config-history /.git (per-slot root fs) during per-node
+    # bring-up, before it's marked synced, so the first ceph_mds check can't race
+    # the init. Per-slot marker + idempotent git_init => reboots skip. See #1163.
+    [ -f $STATE_DIR/git_migrated ] && return 0
+    $HEX_SDK git_init && touch $STATE_DIR/git_migrated
+}
+
 migrate_keystone_db()
 {
     if [ -f $STATE_DIR/keystone_db_migrated ] ; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The `ceph_mds` health check runs `git log` in `/` — the config-history working tree, which lives on the **per-slot root fs**. `cube_cluster_start_cluster()` initialized it with an **async** `nohup … git_init &` in the **master-only** cluster-wide half, which caused three problems:

- **Only the master's `/.git` was pre-initialized.** The other nodes got theirs lazily from the check's own `git_init` auto-repair, so they flashed **Storage NG — `ceph_mds(git not initialied)`** on their first `cluster check`.
- It ran on **every** bring-up even when nothing changed.
- A single master-side run **cannot cover a `rolling_update`**, where each node swaps A/B slots (and loses `/.git`) at **staggered** times — the master-only half runs once and can't re-init the nodes that roll after it.

This moves the init into a per-slot-guarded **`migrate_git`** (mirrors `migrate_fixpack`) called from the **per-node** half `cube_cluster_start_node`, just before the node is marked synced. Every node initializes **its own** `/.git` synchronously before its first `cluster check`, so the transient can't occur on any node — for first FTS or after a `rolling_update`.

#### Which issue(s) this PR fixes

Fixes #1163

#### Special notes for your reviewer

- **Per-node, not master-only:** `/.git` is per-node and the `ceph_mds` check runs per-node, so the init has to run on every node. The per-node half is also the only place that covers a `rolling_update`'s staggered slot swaps (each node inits on its own first boot on the new slot).
- **Guard / idempotency:** `$STATE_DIR/git_migrated` (per-slot marker) means real work runs once per slot; ordinary reboots skip. `git_init` is idempotent and `git_client_init` self-guards (`git log -1 || return 0`), and the per-node `git_init` auto-repair path already runs today (this just does it proactively, before the check, instead of reactively after an NG) — so no new concurrency behavior.
- Dropped an erroneous `cube_node_ready` gate from the first draft (redundant: the inner git functions already self-guard, and the node is ready by the time this runs).
- The check's existing `git_init` auto-repair is left intact as a backstop.

#### Additional documentation

```docs
Rolling-upgrade rehearsal known-issue note: the first `cluster check` after a
fresh bootstrap or `rolling_update` no longer shows `ceph_mds(git not
initialied)` — each node now initializes its config-history /.git during its
own bring-up, before the check runs.
```
