### PR TITLE
fix(keycloak): gate the commit on the SAML metadata download

### DIFF
--- a/core/cube_sdk_library/src/http.cpp
+++ b/core/cube_sdk_library/src/http.cpp
@@ -130,16 +130,26 @@ DoHttp(const HttpRequest& req)
         bodyString = "-d '" + req.body + "'";
     }
 
+    // form the time-bound string; empty keeps curl's default (unbounded)
+    std::stringstream timeoutString;
+    if (req.connectTimeoutSecs > 0) {
+        timeoutString << "--connect-timeout " << req.connectTimeoutSecs << " ";
+    }
+    if (req.maxTimeSecs > 0) {
+        timeoutString << "--max-time " << req.maxTimeSecs << " ";
+    }
+
     // send the request via curl
     bool isCurlSuccessful = false;
     if (req.url.scheme == "http") {
         isCurlSuccessful = HexUtilSystemF(
                                0,
                                0,
-                               "curl --silent --show-error "
+                               "curl --silent --show-error %s"
                                "--output %s --write-out \"%%{http_code}\" "
                                "--request %s \"%s\" "
                                "%s %s >%s 2>%s",
+                               timeoutString.str().c_str(),
                                outputFile.fileName.c_str(),
                                req.method.c_str(),
                                req.url.String().c_str(),
@@ -152,10 +162,11 @@ DoHttp(const HttpRequest& req)
         isCurlSuccessful = HexUtilSystemF(
                                0,
                                0,
-                               "curl --insecure --silent --show-error "
+                               "curl --insecure --silent --show-error %s"
                                "--output %s --write-out \"%%{http_code}\" "
                                "--request %s \"%s\" "
                                "%s %s >%s 2>%s",
+                               timeoutString.str().c_str(),
                                outputFile.fileName.c_str(),
                                req.method.c_str(),
                                req.url.String().c_str(),

--- a/core/cube_sdk_library/src/http.hpp
+++ b/core/cube_sdk_library/src/http.hpp
@@ -14,6 +14,11 @@ struct HttpRequest {
     Url url;
     std::map<std::string, std::string> header;
     std::string body;
+    /**
+     * curl time bounds in seconds; 0 keeps curl's default (unbounded).
+     */
+    int connectTimeoutSecs = 0;
+    int maxTimeSecs = 0;
 };
 
 struct HttpResponse {

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -12,6 +12,10 @@ static const char KEYCLOAK_SAML_METADATA_FILE[] = "/etc/keycloak/saml-metadata.x
 static const std::string KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET = "admin-password";
 static const std::string KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE
     = "/etc/cube/cos/terraform/values/keycloak-admin-password.tfvars";
+static const int SAML_METADATA_STUCK_NOTIFY_SECS = 600;
+// operator escape hatch: touching this releases the saml metadata gate below
+// (one-shot; consumed when honored). /run is tmpfs so it cannot outlive a boot.
+static const char SAML_METADATA_GATE_RELEASE[] = "/run/cube_keycloak_saml_gate_release";
 
 // external global variables
 CONFIG_GLOBAL_STR_REF(MGMT_ADDR);
@@ -314,6 +318,8 @@ checkKeycloakEndpoint(const std::string& endpointIp)
     for (int i = 0; i < 15; i++) {
         const HttpRequest req = {
             .url = url,
+            .connectTimeoutSecs = 10,
+            .maxTimeSecs = 60,
         };
         const HttpResponse res = GetHttp(req);
 
@@ -383,46 +389,44 @@ downloadKeycloakSamlMetadata(const std::string& endpointIp)
     Url url = Url(host, "/auth/realms/master/protocol/saml/descriptor");
     url.scheme = "https";
 
-    // retry 120 times
+    // single time-bounded attempt: the commit gate loop owns the retry policy
+    // and must regain control quickly enough to notify the console on schedule
     bool isDownloadSuccessful = false;
     bool isCopySuccessful = false;
-    for (int i = 0; i < 120; i++) {
-        const HttpRequest req = {
-            .url = url,
-        };
-        const HttpResponse res = GetHttp(req);
+    const HttpRequest req = {
+        .url = url,
+        .connectTimeoutSecs = 10,
+        .maxTimeSecs = 60,
+    };
+    const HttpResponse res = GetHttp(req);
 
-        if (res.error.length() > 0) {
-            HexLogError("failed to send the http request");
+    if (res.error.length() > 0) {
+        HexLogError("failed to send the http request");
+    } else {
+        if (!isHttpResponseSuccessful(res)) {
+            HexLogError("failed to download keycloak saml metadata");
         } else {
-            if (!isHttpResponseSuccessful(res)) {
-                HexLogError("failed to download keycloak saml metadata");
-            } else {
-                isDownloadSuccessful = true;
+            isDownloadSuccessful = true;
 
-                std::string fsError;
-                isCopySuccessful = CopyFile(
-                    fsError,
-                    res.outputFileName,
-                    KEYCLOAK_SAML_METADATA_FILE);
-            }
-        }
-
-        CleanupHttpResponse(res);
-
-        if (isDownloadSuccessful) {
-            HexLogInfo("downloaded keycloak saml metadata");
-            break;
-        } else {
-            sleep(1);
+            std::string fsError;
+            isCopySuccessful = CopyFile(
+                fsError,
+                res.outputFileName,
+                KEYCLOAK_SAML_METADATA_FILE);
         }
     }
+
+    CleanupHttpResponse(res);
 
     if (isDownloadSuccessful && !isCopySuccessful) {
         HexLogError("failed to persist keycloak saml metadata");
     }
 
-    return isDownloadSuccessful && isCopySuccessful;
+    if (isDownloadSuccessful && isCopySuccessful) {
+        HexLogInfo("downloaded keycloak saml metadata");
+        return true;
+    }
+    return false;
 }
 
 static bool
@@ -499,28 +503,68 @@ Commit(bool modified, int dryLevel)
     }
 
     if (isKeycloakUpdated) {
-        // check if the Keycloak endpoint is reachable
+        // check if the Keycloak endpoint is reachable; an unreachable endpoint is
+        // one way the saml metadata cannot be downloaded, so do not bail out --
+        // defer the cube-groups terraform and fall through to the gate below
         std::string sharedId = G(SHARED_ID);
+        bool isCubeGroupsApplied = false;
         if (!checkKeycloakEndpoint(sharedId)) {
             HexLogError("keycloak endpoint is not ready");
-
-            // let other modules to commit
-            return true;
+        } else {
+            // create default cube groups
+            if (!ExecTerraform(
+                    "apply",
+                    "keycloak",
+                    { "cube_controller=" + sharedId },
+                    { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
+                HexLogError("failed to create default cube groups via terraform");
+            }
+            isCubeGroupsApplied = true;
         }
 
-        // create default cube groups
-        if (!ExecTerraform(
-                "apply",
-                "keycloak",
-                { "cube_controller=" + sharedId },
-                { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
-            HexLogError("failed to create default cube groups via terraform");
+        // pull down the saml metadata and save it to /etc/keycloak/saml-metadata.xml.
+        // keystone_idp, rancher and the ceph dashboard all configure SSO from this
+        // file, so never proceed without it: retry forever and notify the console
+        // every SAML_METADATA_STUCK_NOTIFY_SECS while stuck. An operator can
+        // release the gate by touching SAML_METADATA_GATE_RELEASE (one-shot).
+        time_t lastNotify = time(NULL);
+        while (!hasKeycloakSamlMetadataFile()) {
+            if (downloadKeycloakSamlMetadata(sharedId))
+                break;
+            HexLogError("failed to download the saml metadata from keycloak");
+
+            if (access(SAML_METADATA_GATE_RELEASE, F_OK) == 0) {
+                unlink(SAML_METADATA_GATE_RELEASE);
+                HexLogWarning("saml metadata gate released by operator via %s;"
+                              " proceeding without %s (SSO will be degraded)",
+                              SAML_METADATA_GATE_RELEASE, KEYCLOAK_SAML_METADATA_FILE);
+                break;
+            }
+
+            if (time(NULL) - lastNotify >= SAML_METADATA_STUCK_NOTIFY_SECS) {
+                HexLogWarning("keycloak saml metadata download is stuck; notified the console");
+                HexSystemF(0,
+                    "echo 'CUBE: setup is waiting for the keycloak SAML metadata"
+                    " (https://%s:%d/auth/realms/master/protocol/saml/descriptor)"
+                    " and cannot proceed until it is downloaded."
+                    " Check keycloak and k3s."
+                    " To skip and continue with degraded SSO, run: touch %s' > /dev/console",
+                    sharedId.c_str(), K3S_INGRESS_HTTPS_PORT, SAML_METADATA_GATE_RELEASE);
+                lastNotify = time(NULL);
+            }
+
+            sleep(10);
         }
 
-        // pull down the saml metadata and save it to /etc/keycloak/saml-metadata.xml
-        if (!hasKeycloakSamlMetadataFile()) {
-            if (!downloadKeycloakSamlMetadata(sharedId)) {
-                HexLogError("failed to download the saml metadata from keycloak");
+        // create default cube groups, deferred from above when the endpoint check
+        // failed; a successful metadata download implies the endpoint answers now
+        if (!isCubeGroupsApplied) {
+            if (!ExecTerraform(
+                    "apply",
+                    "keycloak",
+                    { "cube_controller=" + sharedId },
+                    { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
+                HexLogError("failed to create default cube groups via terraform");
             }
         }
     }

--- a/core/modules/config_keystone.cpp
+++ b/core/modules/config_keystone.cpp
@@ -549,6 +549,9 @@ CONFIG_REQUIRES(keystone, mysql);
 CONFIG_REQUIRES(keystone, haproxy);
 
 CONFIG_REQUIRES(keystone_idp, keycloak);
+// SetupIdp drives keystone's API (identity provider/mapping/group/role/protocol
+// creation), so the running keystone is a hard prerequisite, not a timing accident
+CONFIG_REQUIRES(keystone_idp, keystone);
 
 // extra tunings
 CONFIG_OBSERVES(keystone, cubesys, ParseCube, NotifyCube);


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`/etc/keycloak/saml-metadata.xml` is consumed at configure time by `keystone_idp` (the mellon httpd conf), `rancher` and the ceph dashboard — all `CONFIG_REQUIRES(keycloak)`. Today the download is a best-effort step inside the deploying run: if that run is interrupted (e.g. the hex_config timezone crash, #1172) or the retries run out, `Commit()` still returns success, every consumer configures against a missing file (httpd `AH00526` → keystone + UI login down; rancher auth and ceph dashboard SSO fail), and no later commit ever retries (`checkKeycloak()` short-circuits to a ~1.2 s skip). The breakage is permanent.

This makes the download a **gate**: the deploying run does not return until the metadata is on disk.

- **Retry forever**: one download attempt per ~10 s round, unbounded, until it succeeds. By DAG ordering no SSO consumer can ever configure without the file.
- **Console notification every 600 s while stuck** (plus a journal Warning), so a hung FTS tells the operator what it is waiting on and where to look.
- **Time-bounded attempts**: new optional `connectTimeoutSecs`/`maxTimeSecs` on `HttpRequest` (default 0 = existing unbounded behavior for all other callers) let the keycloak requests use `--connect-timeout 10 --max-time 60`. Without this, one curl against a blackholed/hung endpoint could block for hours and starve the notification schedule; the previous inner 120-retry loop is folded into the outer gate (same unbounded retries, one bounded attempt per round).
- **Unreachable endpoint falls into the same gate** instead of bailing out with success: the cube-groups terraform is deferred until after the gate (a successful download implies the endpoint answers).
- **Operator release valve**: touching `/run/cube_keycloak_saml_gate_release` releases the gate deliberately (one-shot — the marker is consumed; `/run` is tmpfs so it cannot outlive a boot). The console message names the exact command, so the escape hatch is discoverable exactly when needed. Releasing means accepting degraded SSO until keycloak is repaired.
- **`CONFIG_REQUIRES(keystone_idp, keystone)`** (second commit): `SetupIdp` drives keystone's API (identity provider/mapping/group/role/protocol creation) but only declared keycloak — the scheduler could legally run it while keystone was still committing. Declare the real dependency instead of relying on timing.

#### Which issue(s) this PR fixes

Fixes #1168

#### Special notes for your reviewer

- Gate semantics: the module **waits**, it does not fail — other independent modules keep committing on the other dataflow workers; the commit as a whole completes once the metadata exists. There is no state where keycloak "succeeds" without the file.
- Verified on a live 1cc:
  - fresh purge + bootstrap: rc=0 in 87 s, file present (happy path unchanged);
  - stuck simulation (file unproducible): gated 12+ min without proceeding, console notification at **603 s** after loop entry, released within **10 s** of the blocker clearing, commit completed (`keycloak commit(o) took 712.9 secs`);
  - executed curl journal-verified to carry `--connect-timeout 10 --max-time 60`;
  - release valve: gate engaged (blocked download) → `touch /run/cube_keycloak_saml_gate_release` → gate released within **5 s**, commit completed rc=0, marker consumed, journal Warning logged.
- Normal FTS keycloak commit is ~80–90 s end-to-end, so the 600 s threshold cannot false-alarm on a healthy install.
- Residual (by design): a file deleted *after* a successful deploy is re-distributed by the `cluster_start` sync on the next boot; this PR only guarantees the producing run. The companion crash fix (#1172) removes the observed cause of that run dying.
- Needs a clean 1cc + 3cc FTS with the built image as final validation (lab node was reclaimed mid-verification).

#### Additional documentation

```docs
Known-issue: missing /etc/keycloak/saml-metadata.xml after FTS permanently broke
httpd/keystone SSO, rancher auth and ceph dashboard SSO with no retry path.
The keycloak commit now gates on the metadata download (retry forever,
console notification every 600s while stuck).
```
