### PR TITLE
feat(rabbitmq): upgrade rabbitmq from 3.9 to 3.10

### DIFF
--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -136,14 +136,6 @@ rootfs_install::
 # python3-xmlsec
 PYTHON3_SAML_REQUIRE := libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel python-xmlsec
 
-# erlang 26.2.5-1.el9 doesn't work with rabbitmq
-ERLANG_VER := 24.3.4.2-1.el9s
-ERLANG += erlang-asn1-$(ERLANG_VER) erlang-compiler-$(ERLANG_VER) erlang-crypto-$(ERLANG_VER) erlang-eldap-$(ERLANG_VER) erlang-erts-$(ERLANG_VER) erlang-inets-$(ERLANG_VER) erlang-kernel-$(ERLANG_VER) erlang-mnesia-$(ERLANG_VER) erlang-os_mon-$(ERLANG_VER)
-ERLANG += erlang-public_key-$(ERLANG_VER) erlang-runtime_tools-$(ERLANG_VER) erlang-sasl-$(ERLANG_VER) erlang-snmp-$(ERLANG_VER) erlang-ssl-$(ERLANG_VER) erlang-stdlib-$(ERLANG_VER) erlang-syntax_tools-$(ERLANG_VER) erlang-tools-$(ERLANG_VER) erlang-xmerl-$(ERLANG_VER)
-LOCKED_DNF += $(ERLANG)
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) dnf -y install $(ERLANG)
-
 # ruby-3.1.2-141.module_el9+156+2e0939d1 has no i686 and conflicts with ruby-3.0.4-161.el9.i686.rpm
 RUBY := ruby-3.0.7-166.el9
 LOCKED_DNF += $(RUBY)

--- a/core/nova/openstack-nova-compute.service
+++ b/core/nova/openstack-nova-compute.service
@@ -4,6 +4,7 @@ After=syslog.target network.target libvirtd.service
 
 [Service]
 Environment=LIBGUESTFS_ATTACH_METHOD=appliance
+LimitNOFILE=infinity
 Type=notify
 NotifyAccess=all
 Restart=always

--- a/core/nova/openstack-nova-conductor.service
+++ b/core/nova/openstack-nova-conductor.service
@@ -3,6 +3,7 @@ Description=OpenStack Nova Conductor Server
 After=syslog.target network.target
 
 [Service]
+LimitNOFILE=infinity
 Type=notify
 NotifyAccess=all
 Restart=always

--- a/core/rabbitmq/erlang.repo
+++ b/core/rabbitmq/erlang.repo
@@ -1,0 +1,38 @@
+##
+## Zero dependency Erlang RPM
+##
+
+[modern-erlang]
+name=modern-erlang-el9
+# Use a set of mirrors maintained by the RabbitMQ core team.
+# The mirrors have significantly higher bandwidth quotas.
+baseurl=https://yum1.rabbitmq.com/erlang/el/9/$basearch
+        https://yum2.rabbitmq.com/erlang/el/9/$basearch
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md
+
+[modern-erlang-noarch]
+name=modern-erlang-el9-noarch
+# Use a set of mirrors maintained by the RabbitMQ core team.
+# The mirrors have significantly higher bandwidth quotas.
+baseurl=https://yum1.rabbitmq.com/erlang/el/9/noarch
+        https://yum2.rabbitmq.com/erlang/el/9/noarch
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
+       https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md

--- a/core/rabbitmq/rabbitmq-server.service
+++ b/core/rabbitmq/rabbitmq-server.service
@@ -1,16 +1,18 @@
 # systemd unit example
 [Unit]
 Description=RabbitMQ broker
-After=network.target epmd@0.0.0.0.socket
-Wants=network.target epmd@0.0.0.0.socket
+After=syslog.target network.target epmd@0.0.0.0.socket
+Wants=syslog.target network.target epmd@0.0.0.0.socket
 
 [Service]
 Type=notify
 User=rabbitmq
 Group=rabbitmq
+UMask=0027
 NotifyAccess=all
 TimeoutStartSec=3600
-LimitNOFILE=16384
+LimitNOFILE=65536
+
 # Note:
 # You *may* wish to add the following to automatically restart RabbitMQ
 # in the event of a failure. systemd service restarts are not a
@@ -20,9 +22,10 @@ LimitNOFILE=16384
 # Restart=on-failure
 # RestartSec=10
 WorkingDirectory=/var/lib/rabbitmq
-ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
-ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop
-ExecStop=/bin/sh -c "while ps -p $MAINPID >/dev/null 2>&1; do sleep 1; done"
+ExecStart=/usr/sbin/rabbitmq-server
+ExecStop=/usr/sbin/rabbitmqctl shutdown
+# See rabbitmq/rabbitmq-server-release#51
+SuccessExitStatus=69
 
 [Install]
 WantedBy=multi-user.target

--- a/core/rabbitmq/rabbitmq.mk
+++ b/core/rabbitmq/rabbitmq.mk
@@ -3,6 +3,16 @@
 
 ROOTFS_DNF += logrotate
 
+# erlang 26.2.5-1.el9 doesn't work with rabbitmq, and modern-erlang also serves
+# 25/26/27 - pin what we install so a later dnf update can't bump it
+ERLANG_VER := 24.3.4.15-1.el9
+LOCKED_DNF += erlang-$(ERLANG_VER)
+
+# rabbitmq refuses to skip minor versions on upgrade, so 3.10 is the only step
+# reachable from 3.9 - pin it against the 3.11/3.12/4.x the repo also serves
+RABBITMQ_VER := 3.10.25-1.el8
+LOCKED_DNF += rabbitmq-server-$(RABBITMQ_VER)
+
 # install erlang
 rootfs_install::
 	$(Q)# primary RabbitMQ signing key
@@ -10,13 +20,13 @@ rootfs_install::
 	$(Q)# modern Erlang repository
 	$(Q)chroot $(ROOTDIR) rpm --import 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key'
 	$(Q)cp -f $(COREDIR)/rabbitmq/erlang.repo $(ROOTDIR)/etc/yum.repos.d/
-	$(Q)chroot $(ROOTDIR) dnf install -y erlang-24.3.4.15-1.el9.x86_64
+	$(Q)chroot $(ROOTDIR) dnf install -y erlang-$(ERLANG_VER).x86_64
 
 # install rabbitmq
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) rpm --import 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key'
 	$(Q)cp -f $(COREDIR)/rabbitmq/rabbitmq.repo $(ROOTDIR)/etc/yum.repos.d/
-	$(Q)chroot $(ROOTDIR) dnf install -y rabbitmq-server-3.10.25-1.el8.noarch
+	$(Q)chroot $(ROOTDIR) dnf install -y rabbitmq-server-$(RABBITMQ_VER).noarch
 
 rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/rabbitmq/epmd@.socket ./lib/systemd/system

--- a/core/rabbitmq/rabbitmq.mk
+++ b/core/rabbitmq/rabbitmq.mk
@@ -1,7 +1,22 @@
 # Cube SDK
 # rabbitmq installation
 
-ROOTFS_DNF += rabbitmq-server
+ROOTFS_DNF += logrotate
+
+# install erlang
+rootfs_install::
+	$(Q)# primary RabbitMQ signing key
+	$(Q)chroot $(ROOTDIR) rpm --import 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc'
+	$(Q)# modern Erlang repository
+	$(Q)chroot $(ROOTDIR) rpm --import 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key'
+	$(Q)cp -f $(COREDIR)/rabbitmq/erlang.repo $(ROOTDIR)/etc/yum.repos.d/
+	$(Q)chroot $(ROOTDIR) dnf install -y erlang-24.3.4.15-1.el9.x86_64
+
+# install rabbitmq
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rpm --import 'https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key'
+	$(Q)cp -f $(COREDIR)/rabbitmq/rabbitmq.repo $(ROOTDIR)/etc/yum.repos.d/
+	$(Q)chroot $(ROOTDIR) dnf install -y rabbitmq-server-3.10.25-1.el8.noarch
 
 rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/rabbitmq/epmd@.socket ./lib/systemd/system

--- a/core/rabbitmq/rabbitmq.repo
+++ b/core/rabbitmq/rabbitmq.repo
@@ -1,0 +1,37 @@
+##
+## RabbitMQ Server
+##
+
+[rabbitmq-el9]
+name=rabbitmq-el9
+baseurl=https://yum2.rabbitmq.com/rabbitmq/el/9/$basearch
+        https://yum1.rabbitmq.com/rabbitmq/el/9/$basearch
+repo_gpgcheck=1
+enabled=1
+# Cloudsmith's repository key and RabbitMQ package signing key
+gpgkey=https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key
+       https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md
+
+[rabbitmq-el9-noarch]
+name=rabbitmq-el9-noarch
+baseurl=https://yum2.rabbitmq.com/rabbitmq/el/9/noarch
+        https://yum1.rabbitmq.com/rabbitmq/el/9/noarch
+repo_gpgcheck=1
+enabled=1
+# Cloudsmith's repository key and RabbitMQ package signing key
+gpgkey=https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key
+       https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

- Upgrades RabbitMQ from **3.9.21 to 3.10.25**, and Erlang from the 18 split `erlang-*-24.3.4.2-1.el9s` subpackages to the monolithic **`erlang-24.3.4.15-1.el9`** published by the RabbitMQ team, so the broker runs a version OpenStack Antelope is validated against.
- 3.10 is deliberately an *intermediate* rung. Per the spike recorded on #614, RabbitMQ refuses to skip minor versions on upgrade (rolling **and** offline), so `3.9 -> 3.12` is invalid and the reachable ladder is `3.9 -> 3.10 -> 3.11 -> 3.12`, one minor per firmware hop. This PR delivers the first rung.
- Adds `core/rabbitmq/erlang.repo` and `core/rabbitmq/rabbitmq.repo` (the Cloudsmith mirrors maintained by the RabbitMQ core team) and imports the three signing keys their packages are verified against.
- Replaces `ROOTFS_DNF += rabbitmq-server` with explicit version-pinned installs in `core/rabbitmq/rabbitmq.mk`, and drops the now-redundant Erlang block from `core/heavyfs/Makefile` (the monolithic package supersedes it).
- `core/rabbitmq/rabbitmq-server.service`: `LimitNOFILE` 16384 -> 65536, `ExecStart` -> `/usr/sbin/rabbitmq-server`, plus `UMask=0027` and `SuccessExitStatus=69` to match what the 3.10 package expects.
- Restores the version-lock that moved out along with the heavyfs block. `LOCKED_DNF` now pins both `erlang-24.3.4.15-1.el9` and `rabbitmq-server-3.10.25-1.el8`; without it nothing stops a later `dnf update` from pulling the Erlang 27.x / RabbitMQ 4.x that these same repos also serve, and a jump to 4.x would be a hard break rather than a no-op.
- Also carries a nova fix found while validating this: `LimitNOFILE=infinity` had been dropped from the nova-compute and nova-conductor units, and is added back.

#### Which issue(s) this PR fixes

Part of #614

#### Special notes for your reviewer

> Note

This PR is after #1170.

The branch is stacked on `jim.lin/feat/openstack-a-upgrade-neutron`, so 16 of the 19 commits against `openstack-develop` belong to #1170. This PR's own change set is 3 commits over 7 files:

| Commit | Change |
| -- | -- |
| `1c28833` | `fix(nova)`: add back the dropped file descriptor limit lifting line |
| `623de2b` | `feat(rabbitmq)`: upgrade rabbitmq from 3.9 to 3.10 |
| `1c4a411` | `fix(rabbitmq)`: restore the erlang and rabbitmq-server version locks |

Two things reviewers should know before this is rolled anywhere beyond a fresh build:

1. **Feature-flag enablement is not in this PR, and it is a hard prerequisite.** RabbitMQ 3.10 will not come up unless every 3.9 stable feature flag was enabled first, and enabling is irreversible. `develop` already solves this (`1cd87be` + `e3d79a9`, splitting the enable into an FTS `cluster_ready` path and a migration path, both gated on `os_rabbitmq_version_uniform`), but `openstack-develop` does not have it yet. Note both gates also require `cubesys.ha`, so a standalone control node never enables flags on either path.
2. **An already-built node needs an explicit Erlang swap that a fresh build never hits.** The monolithic `erlang-24.3.4.15-1.el9` collides with the split `erlang-*-24.3.4.2-1.el9s` subpackages over files under `/usr/lib64/erlang/`. `dnf` does not catch it at depsolve -- an `--assumeno` dry run reports a clean "install 1 / upgrade 1" and only rpm's transaction test surfaces the conflict. Relevant if the bridge is delivered as a no-reboot fixpack, as #614 contemplates.

Scope against #614: the story's original acceptance-criteria items are covered and evidenced below. The "Rolling-upgrade / mixed-version DoD" block added 2026-07-12 is **not** covered by this PR -- every item in it requires a live 3-node HA cluster, and the node used for this validation is standalone (`rabbitmqctl eval 'rabbit_mnesia:is_clustered().'` returns `false`). Per @steven-chiu-bigstack's note on the issue that split is intended, with @traviswu-bigstack taking E2E. Marked `Part of` rather than `Close` for that reason.

Validated on the `centos9_cubecos_jim_200.13-1cc` e2e environment. The upgrade took the AMQP bus down for ~14s (01:21:27 -> 01:21:41); every `oslo.messaging` client reconnected on its own with no manual restarts.

For the requirement "RabbitMQ is on 3.10", verified from the package, the CLI, the diagnostics suite and the cluster's own version report:

```bash
[cc1 ~]# rpm -q rabbitmq-server erlang
rabbitmq-server-3.10.25-1.el8.noarch
erlang-24.3.4.15-1.el9.x86_64
[cc1 ~]# rabbitmqctl version
3.10.25
[cc1 ~]# rabbitmq-diagnostics check_running
Checking if RabbitMQ is running on node rabbit@cc1 ...
RabbitMQ on node rabbit@cc1 is fully booted and running
[cc1 ~]# rabbitmq-diagnostics check_local_alarms
Asking node rabbit@cc1 to report any local resource alarms ...
Node rabbit@cc1 reported no local alarms
[cc1 ~]# rabbitmqctl cluster_status
Cluster status of node rabbit@cc1 ...
Basics

Cluster name: rabbit@cc1
Total CPU cores available cluster-wide: 12

Disk Nodes

rabbit@cc1

Running Nodes

rabbit@cc1

Versions

rabbit@cc1: RabbitMQ 3.10.25 on Erlang 24.3.4.15

CPU Cores

Node: rabbit@cc1, available CPU cores: 12

Maintenance status

Node: rabbit@cc1, status: not under maintenance

Alarms

(none)

Network Partitions

(none)

Listeners

Node: rabbit@cc1, interface: [::], port: 15672, protocol: http, purpose: HTTP API
Node: rabbit@cc1, interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication
Node: rabbit@cc1, interface: 10.1.0.1, port: 5672, protocol: amqp, purpose: AMQP 0-9-1 and AMQP 1.0

Feature flags

Flag: classic_mirrored_queue_version, state: enabled
Flag: classic_queue_type_delivery_support, state: enabled
Flag: drop_unroutable_metric, state: enabled
Flag: empty_basic_get_metric, state: enabled
Flag: implicit_default_bindings, state: enabled
Flag: maintenance_mode_status, state: enabled
Flag: quorum_queue, state: enabled
Flag: stream_queue, state: enabled
Flag: user_limits, state: enabled
Flag: virtual_host_metadata, state: enabled
```

Since the running Erlang VM is what actually serves traffic -- an RPM can report 3.10 while a resident 3.9 VM is still up -- the loaded code path was checked directly:

```bash
[cc1 ~]# rabbitmqctl eval 'application:get_key(rabbit, vsn).'
{ok,"3.10.25"}
[cc1 ~]# rabbitmqctl eval 'code:lib_dir(rabbit).'
"/usr/lib/rabbitmq/lib/rabbitmq_server-3.10.25/plugins/rabbit-3.10.25"
```

All 10 stable feature flags are enabled, which is the precondition for the next rung (3.11):

```bash
[cc1 ~]# rabbitmqctl list_feature_flags
Listing feature flags ...
name	state
classic_mirrored_queue_version	enabled
classic_queue_type_delivery_support	enabled
drop_unroutable_metric	enabled
empty_basic_get_metric	enabled
implicit_default_bindings	enabled
maintenance_mode_status	enabled
quorum_queue	enabled
stream_queue	enabled
user_limits	enabled
virtual_host_metadata	enabled
```

For the requirement "Ensure the queue is set up and exchanges for OpenStack are shown up", 53 exchanges are present, including the nine per-project topic roots (`cyborg`, `designate`, `heat`, `masakari`, `neutron`, `nova`, `octavia`, `openstack`, `watcher`) and 37 OpenStack fanout exchanges. `cinder` and `manila` do not declare their own topic exchange -- they use the `oslo.messaging` default and bind onto the shared `openstack` exchange:

```bash
[cc1 ~]# rabbitmqctl list_exchanges name type
Listing exchanges for vhost / ...
name	type
producer_fanout	fanout
engine_fanout	fanout
ha_engine_fanout	fanout
	direct
masakari	topic
q-server-resource-versions_fanout	fanout
neutron	topic
octavia_prov_fanout	fanout
heat	topic
neutron-vo-Port-1.7_fanout	fanout
neutron-vo-Subnet-1.1_fanout	fanout
amq.headers	headers
cyborg	topic
openstack	topic
octavia_provisioning_v2_fanout	fanout
cinder-volume.cube@ceph_fanout	fanout
amq.direct	direct
q-plugin_fanout	fanout
q-agent-notifier-port-delete_fanout	fanout
ipsec_agent.cc1_fanout	fanout
designate	topic
cyborg-conductor_fanout	fanout
neutron-vo-SecurityGroup-1.5_fanout	fanout
cinder-backup_fanout	fanout
manila-scheduler_fanout	fanout
engine_worker_fanout	fanout
compute_fanout	fanout
central_fanout	fanout
amq.rabbitmq.trace	topic
amq.fanout	fanout
heat-engine-listener_fanout	fanout
amq.topic	topic
q-agent-notifier-security_group-update_fanout	fanout
watcher.decision.control_fanout	fanout
q-agent-notifier-port-update_fanout	fanout
conductor_fanout	fanout
nova	topic
cinder-volume_fanout	fanout
q-agent-notifier-network-delete_fanout	fanout
octavia	topic
manila-share_fanout	fanout
scheduler_fanout	fanout
mdns_fanout	fanout
cyborg-agent_fanout	fanout
worker_fanout	fanout
ipsec_driver_fanout	fanout
cinder-scheduler_fanout	fanout
watcher.applier.control_fanout	fanout
q-reports-plugin_fanout	fanout
dhcp_agent_fanout	fanout
neutron-vo-Network-1.1_fanout	fanout
watcher	topic
amq.match	headers
```

The queues are set up and healthy -- 96 queues, all `classic` and `running`, every one with at least one consumer and nothing backlogged, wired by 181 bindings:

```bash
[cc1 ~]# rabbitmqctl list_queues name type state consumers messages
Timeout: 60.0 seconds ...
Listing queues for vhost / ...
name	type	state	consumers	messages
q-reports-plugin	classic	running	1	0
ipsec_agent.cc1_fanout_7171beb5cef944e5bceccdefa1845d74	classic	running	1	0
heat-engine-listener_fanout_318b602470e747a590895d173b21ac9a	classic	running	1	0
octavia_provisioning_v2.cc1	classic	running	2	0
q-server-resource-versions	classic	running	1	0
cinder-volume.cube@ceph.cube	classic	running	1	0
watcher.decision.control.cc1	classic	running	1	0
producer	classic	running	1	0
q-plugin	classic	running	1	0
octavia_prov.cc1	classic	running	2	0
scheduler	classic	running	1	0
central.cc1	classic	running	1	0
engine.cc1	classic	running	1	0
heat-engine-listener.c275ea2f-a41a-44e3-8bd2-71b8431b25ff	classic	running	1	0
cyborg-conductor_fanout_fbd48ee611694336a9a36ac8360c59c6	classic	running	1	0
cinder-backup_fanout_570b8a4f788b43ac921a1b3821f4def5	classic	running	1	0
ipsec_agent.cc1	classic	running	1	0
engine_fanout_6e25a65bfad94451af4c4da7ff379fd1	classic	running	1	0
... (96 queues in total; all of them type=classic, state=running,
     every one with at least 1 consumer, and 0 messages backlogged)
```

For the requirement "smoke test end to end for the nova component on the updated RabbitMQ", a full instance lifecycle. This is the check that actually exercises the broker, since booting an instance drives `nova-api -> conductor build_instance RPC -> scheduler -> compute spawn`, all of it over AMQP:

```bash
[cc1 ~]# openstack compute service list
+--------------------------------------+----------------+------+----------+---------+-------+----------------------------+
| ID                                   | Binary         | Host | Zone     | Status  | State | Updated At                 |
+--------------------------------------+----------------+------+----------+---------+-------+----------------------------+
| 84cc5b87-f206-4cac-b16f-e863a33ad91c | nova-conductor | cc1  | internal | enabled | up    | 2026-07-25T18:45:00.000000 |
| ec3784d5-93dd-4e25-aa2c-e6a1321c07ee | nova-scheduler | cc1  | internal | enabled | up    | 2026-07-25T18:45:02.000000 |
| d30afcaf-90fc-40f4-b160-b3e734fefc7e | nova-compute   | cc1  | nova     | enabled | up    | 2026-07-25T18:45:00.000000 |
+--------------------------------------+----------------+------+----------+---------+-------+----------------------------+
[cc1 ~]# rabbitmqctl list_queues name consumers | grep -E 'compute|conductor|scheduler'
scheduler	1
cyborg-conductor_fanout_fbd48ee611694336a9a36ac8360c59c6	1
cyborg-conductor.cc1	1
conductor.cc1	1
compute	1
scheduler_fanout_4ec266b822214d6f8e9f8b20e0752452	1
manila-scheduler	1
conductor	1
cinder-scheduler_fanout_9d76e33f6d444c49b4cf344d504980b4	1
cyborg-conductor	1
compute.cc1	1
cinder-scheduler.cc1	1
compute_fanout_c3dcb8d0164546209e0f6127dd5719f0	1
cinder-scheduler	1
scheduler.cc1	1
manila-scheduler_fanout_4d0db94c5404451791ad8c6f2a3c1a9b	1
manila-scheduler.cc1	1
conductor_fanout_ab8d23bd549c4cc7883a79504146635c	1
[cc1 ~]# openstack server create --os-compute-api-version 2.37 --flavor t2.pico --image Cirros --nic none rabbitmq-310-smoke-test
+-------------------------------------+------------------------------------------------+
| Field                               | Value                                          |
+-------------------------------------+------------------------------------------------+
| OS-DCF:diskConfig                   | MANUAL                                         |
| OS-EXT-AZ:availability_zone         |                                                |
| OS-EXT-SRV-ATTR:host                | None                                           |
| OS-EXT-SRV-ATTR:hostname            | rabbitmq-310-smoke-test                        |
| OS-EXT-SRV-ATTR:hypervisor_hostname | None                                           |
| OS-EXT-SRV-ATTR:instance_name       |                                                |
| OS-EXT-SRV-ATTR:kernel_id           |                                                |
| OS-EXT-SRV-ATTR:launch_index        | 0                                              |
| OS-EXT-SRV-ATTR:ramdisk_id          |                                                |
| OS-EXT-SRV-ATTR:reservation_id      | r-0p8fl9sm                                     |
| OS-EXT-SRV-ATTR:root_device_name    | None                                           |
| OS-EXT-SRV-ATTR:user_data           | None                                           |
| OS-EXT-STS:power_state              | NOSTATE                                        |
| OS-EXT-STS:task_state               | scheduling                                     |
| OS-EXT-STS:vm_state                 | building                                       |
| OS-SRV-USG:launched_at              | None                                           |
| OS-SRV-USG:terminated_at            | None                                           |
| accessIPv4                          |                                                |
| accessIPv6                          |                                                |
| addresses                           |                                                |
| adminPass                           | j6un4ZgvSGAx                                   |
| config_drive                        |                                                |
| created                             | 2026-07-25T18:45:05Z                           |
| description                         | None                                           |
| flavor                              | t2.pico (6b0501d7-e6bd-4737-bd9f-ed7d7f6b80b3) |
| hostId                              |                                                |
| host_status                         |                                                |
| id                                  | 4d8aa79f-a949-456c-bd3b-41ea680fa7d2           |
| image                               | Cirros (c26a469b-c231-4151-8a54-72b523e04232)  |
| key_name                            | None                                           |
| locked                              | False                                          |
| name                                | rabbitmq-310-smoke-test                        |
| progress                            | 0                                              |
| project_id                          | c16111fe5d5f4786a63982430072f66e               |
| properties                          |                                                |
| security_groups                     | name='default'                                 |
| status                              | BUILD                                          |
| tags                                |                                                |
| updated                             | 2026-07-25T18:45:05Z                           |
| user_id                             | 96a79278f9b14fd99bfa7cf61c22caff               |
| volumes_attached                    |                                                |
+-------------------------------------+------------------------------------------------+
[cc1 ~]# openstack server show rabbitmq-310-smoke-test -c status -c OS-EXT-STS:vm_state -c OS-EXT-STS:power_state -c OS-EXT-SRV-ATTR:host -c OS-EXT-SRV-ATTR:instance_name
+-------------------------------+-------------------+
| Field                         | Value             |
+-------------------------------+-------------------+
| OS-EXT-SRV-ATTR:host          | cc1               |
| OS-EXT-SRV-ATTR:instance_name | instance-00000002 |
| OS-EXT-STS:power_state        | Running           |
| OS-EXT-STS:vm_state           | active            |
| status                        | ACTIVE            |
+-------------------------------+-------------------+
[cc1 ~]# openstack console log show rabbitmq-310-smoke-test | tail -12
[    1.567491] ACPI: PCI Interrupt Link [GSIH] (IRQs *23)
[    1.571748] ACPI: Enabled 2 GPEs in block 00 to 3F
[    1.573054] vgaarb: setting as boot device: PCI:0000:00:01.0
[    1.576000] vgaarb: device added: PCI:0000:00:01.0,decodes=io+mem,owns=io+mem,locks=none
[    1.576024] vgaarb: loaded
[    1.579974] vgaarb: bridge control possible 0000:00:01.0
[    1.580928] SCSI subsystem initialized
[    1.584354] ACPI: bus type USB registered
[    1.588092] usbcore: registered new interface driver usbfs
[    1.592076] usbcore: registered new interface driver hub
[    1.596026] usbcore: registered new device driver usb
[    1.600272] PCI: Using ACPI for IRQ routing
[cc1 ~]# openstack console url show rabbitmq-310-smoke-test --novnc
+----------+------------------------------------------------------------------------------------------+
| Field    | Value                                                                                    |
+----------+------------------------------------------------------------------------------------------+
| protocol | vnc                                                                                      |
| type     | novnc                                                                                    |
| url      | https://10.1.0.1:6080/vnc_auto.html?path=%3Ftoken%3D3baacfee-0764-453d-9e3a-f228d31b7852 |
+----------+------------------------------------------------------------------------------------------+
[cc1 ~]# virsh -c qemu:///system list --all
 Id   Name                State
-----------------------------------
 2    instance-00000002   running
[cc1 ~]# openstack server delete rabbitmq-310-smoke-test

[cc1 ~]# openstack server list --name rabbitmq-310-smoke-test

[cc1 ~]# virsh -c qemu:///system list --all
 Id   Name   State
--------------------
```

The instance reached `ACTIVE` on `cc1` with `power_state Running`, the guest kernel booted (console log above), libvirt showed the domain running, and after deletion it was gone from both nova and libvirt. Nova's own RPC queues (`compute`, `compute.cc1`, `conductor`, `conductor.cc1`, `scheduler`, `scheduler.cc1` and their fanouts) each hold a live consumer on the new broker.

#### Additional documentation

```docs

```
