### PR TITLE
fix(horizon): escape the timezone without assuming two components

### DIFF
--- a/core/modules/config_horizon.cpp
+++ b/core/modules/config_horizon.cpp
@@ -176,8 +176,10 @@ Commit(bool modified, int dryLevel)
     if (s_bConfigChanged) {
         std::string sharedId = G(SHARED_ID);
         std::string cachesrvs = "'" + sharedId + ":11211'";
-        std::vector<std::string> tzv = hex_string_util::split(s_timezone.newValue(), '/');
-        std::string tz = tzv[0] + "\\/" + tzv[1];
+        // escape every '/' as '\/' for the django conf; safe for slashless zones (e.g. UTC)
+        std::string tz = s_timezone.newValue();
+        for (size_t pos = 0; (pos = tz.find('/', pos)) != std::string::npos; pos += 2)
+            tz.replace(pos, 1, "\\/");
         WriteDjangoConf(sharedId.c_str(), cachesrvs.c_str(), dbPass.c_str(), tz.c_str());
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`config_horizon`'s `Commit()` escapes the `/` in the timezone for the Django settings file by splitting on `/` and rejoining `tzv[0] + "\/" + tzv[1]`, assuming the timezone always has **exactly two** components:

```cpp
std::vector<std::string> tzv = hex_string_util::split(s_timezone.newValue(), '/');
std::string tz = tzv[0] + "\\/" + tzv[1];
```

For a **slashless** timezone such as `UTC`, `split` returns a 1-element vector, so `tzv[1]` reads **out of bounds** — an uninitialized `std::string` whose garbage data pointer makes the following concatenation `memmove` from bad memory and **SIGSEGV**. Because it depends on heap layout it is intermittent (~1/50), and the 16-worker parallel commit scheduler churning the heap makes it surface. When it hits during FTS, hex_config dies mid-commit → `Failed to apply policy changes` → `cubesys/network/time` land in `failed_policies` → role stays `undef` → **FTS never completes** (confirmed by core dump; crashing frame is `config_horizon.cpp:180` with `s_timezone="UTC"`, `tzv={"UTC"}`).

This escapes **every** `/` in place, with no indexing past the split — correct for 0, 1, or N components (also fixes the latent bug where 3-part zones like `America/Argentina/Buenos_Aires` silently dropped their third part):

```cpp
std::string tz = s_timezone.newValue();
for (size_t pos = 0; (pos = tz.find('/', pos)) != std::string::npos; pos += 2)
    tz.replace(pos, 1, "\\/");
```

#### Which issue(s) this PR fixes

Fixes #1172

#### Special notes for your reviewer

- Single-line-of-logic change in `core/modules/config_horizon.cpp`; the produced `tz` is identical to before for two-component zones (`America/New_York` → `America\/New_York`).
- Root-caused from a core dump on a live 1cc (`timezone=UTC`): unpatched binary cored within 1–2 `apply_snapshot` runs (core symbolicated to `config_horizon.cpp:180`, `s_timezone="UTC"`, `tzv={"UTC"}`); patched binary ran **15/15** consecutive runs with **zero** crashes and `role` recovered `undef` → `control-converged`.
- Distinct from #1168 (keycloak SAML metadata). Both present as "FTS breaks services"; this is the dominant, timezone-dependent crash.

#### Additional documentation

```docs
Known-issue: intermittent hex_config SIGSEGV during FTS on clusters using a
slashless timezone (UTC/GMT/Singapore/…). Root cause: out-of-bounds tzv[1] in
config_horizon when escaping the timezone '/'. Symptom chain: crash →
"Failed to apply policy changes" → failed_policies/{cubesys,network,time} →
role=undef → FTS never completes.
```
