### PR TITLE
fix(glance,cinder): let rootwrap resolve the venv privsep-helper

### DIFF
--- a/core/cinder/rootwrap.conf
+++ b/core/cinder/rootwrap.conf
@@ -10,7 +10,14 @@ filters_path=/etc/cinder/rootwrap.d,/usr/share/cinder/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
-exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/usr/lpp/mmfs/bin
+#
+# TEMPORARY: /opt/openstack-antelope/bin is prepended so that rootwrap picks the
+# venv privsep-helper. /usr/local/bin was already listed but loses to /bin and
+# /usr/bin on order, and its privsep-helper is a system-python script too, so
+# every candidate ahead of the venv cannot import os_brick and exits 1.
+# Remove this entry once all OpenStack components are upgraded to the venv and
+# the system-python console scripts are gone.
+exec_dirs=/opt/openstack-antelope/bin,/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/usr/lpp/mmfs/bin
 
 # Enable logging to syslog
 # Default value is False

--- a/core/glance/glance-rootwrap.conf
+++ b/core/glance/glance-rootwrap.conf
@@ -10,7 +10,14 @@ filters_path=/etc/glance/rootwrap.d,/usr/share/glance/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
-exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+#
+# TEMPORARY: /opt/openstack-antelope/bin is prepended so that rootwrap picks the
+# venv privsep-helper. The leftover /usr/bin/privsep-helper from the pre-venv
+# packages runs under the system python, which cannot import os_brick, so it
+# exits 1 and every volume attach fails with FailedToDropPrivileges.
+# Remove this entry once all OpenStack components are upgraded to the venv and
+# the system-python console scripts are gone.
+exec_dirs=/opt/openstack-antelope/bin,/sbin,/usr/sbin,/bin,/usr/bin
 
 # Enable logging to syslog
 # Default value is False


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

- Prepends `/opt/openstack-antelope/bin` to `exec_dirs` in `core/glance/glance-rootwrap.conf` and `core/cinder/rootwrap.conf`, so rootwrap resolves the **venv** `privsep-helper` instead of the leftover system-python console script.
- Without this, the Glance → Cinder path (volume-backed images) is completely broken. `/usr/bin/privsep-helper` carries `#!/usr/bin/python3`, and the system python cannot import `os_brick`:

  ```bash
  [cc1 ~]# /usr/bin/python3 -c "import os_brick.privileged"
  ModuleNotFoundError: No module named 'os_brick'
  ```

  So the helper exits 1, `oslo.privsep` raises `FailedToDropPrivileges`, and every volume attach the Cinder glance_store driver needs fails. Uploading an image to a cinder-backed store returns HTTP 500 and leaves the image `queued` with `locations: []`.
- `core/nova/rootwrap.conf` already carries `/opt/openstack-antelope/bin` for exactly this reason, so this change brings glance and cinder in line with nova rather than introducing a new pattern.

| service | `exec_dirs` before | resolved to | worked? |
| -- | -- | -- | -- |
| nova | `/opt/openstack-antelope/bin,…` | venv helper | yes |
| glance | `/sbin,/usr/sbin,/bin,/usr/bin` | `/usr/bin/privsep-helper` | no |
| cinder | `…,/bin,/usr/bin,/usr/local/bin,…` | `/bin/privsep-helper` | no |

Cinder is the subtler of the two: `/usr/local/bin` was already on `exec_dirs`, but it loses to `/bin` and `/usr/bin` on order — **and** `/usr/local/bin/privsep-helper` is a system-python script too, so ordering alone would not have fixed it. Only `/opt/openstack-antelope/bin/privsep-helper` runs under the venv interpreter.

Both entries are marked `TEMPORARY` in the config comments: they exist only because the pre-venv console scripts are still on the image, and should be dropped once every OpenStack component is on the venv.

#### Which issue(s) this PR fixes

Close #617

#### Special notes for your reviewer

> Note

This PR is after #1171.

The branch is stacked on `jim.lin/feat/openstack-a-upgrade-rabbitmq`, so 19 of the 21 commits against `openstack-develop` belong to #1170 and #1171. This PR's own change set is 2 commits over 2 files:

| Commit | Change |
| -- | -- |
| `89fe9d2` | `fix(glance)`: prepend the venv bin to rootwrap exec_dirs |
| `e269677` | `fix(cinder)`: prepend the venv bin to rootwrap exec_dirs |

Three things reviewers should know:

1. **The two commits must land together.** Fixing glance alone is not enough — verified empirically. With only the glance side patched, the failure moves from "no volume created at all" to "volume created and its file allocated on the NFS share, then the attachment update fails", because cinder-volume then hits the same stale helper from its own rootwrap. The path only completes with both.
2. **This is config-only, and it is not hot-applied.** `glance.mk` installs `glance-rootwrap.conf` to `/etc/glance/rootwrap.conf` at image build time and no config module regenerates it, so an already-built node needs the file edited in place (or a rebuild) — a `hex_config apply` will not pick it up.
3. **Nothing here is NFS-specific.** The NFS external storage backend was only the vehicle used to exercise the Cinder glance_store driver, since a `<volumeType>:cinder` Glance store only ever exists for an *external* backend. The same privsep failure would hit any external Cinder backend (Dell EMC SC FC, PowerStore, Fujitsu Eternus).

Validated on the `centos9_cubecos_jim_200.13-1cc` e2e environment against a generic-NFS external storage backend, using the Alpine tools image. After the fix the image lands as a Cinder volume with a `cinder://` location:

```bash
[cc1 ~]# openstack image show Alpine-NFS -c status -c stores -c direct_url
+------------+-----------------------------------------------------------+
| Field      | Value                                                     |
+------------+-----------------------------------------------------------+
| direct_url | cinder://NFSStorage/34e179ee-3ecf-4d6b-8ffb-5c1007048f8b  |
| status     | active                                                    |
| stores     | NFSStorage                                                |
+------------+-----------------------------------------------------------+
```

Full command input/output for the before/after, the backend registration and the on-disk evidence is recorded as a comment on #617.
