### PR TITLE
fix(gpu): make sriovVgpu carve and pgpu passthrough actually work

### DIFF
--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -87,8 +87,12 @@ RunSriovManageWithRetry(const char* op, const std::string& sysfsAddr)
     static const int MAX_ATTEMPTS = 5;
 
     for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        // The exit-code marker must be single-token to the shell: the '|'
+        // characters are quoted so sh treats it as a literal echo argument,
+        // not as pipes. Unquoted, "echo |__HEX_RC_$?__|" is a syntax error and
+        // the whole line aborts before sriov-manage ever runs.
         const std::string output = HexUtilPOpen(
-            "%s %s %s 2>&1; echo |__HEX_RC_$?__|", NVIDIA_SRIOV, op, sysfsAddr.c_str());
+            "%s %s %s 2>&1; echo \"|__HEX_RC_$?__|\"", NVIDIA_SRIOV, op, sysfsAddr.c_str());
 
         const size_t marker = output.rfind("|__HEX_RC_");
         const int rc = (marker != std::string::npos) ? atoi(output.c_str() + marker + 10) : -1;

--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -602,13 +602,9 @@ ResourceSetMain(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    if (HexUtilSystemF(0, 0, HEX_SDK " gpu_resource_set_check %s %s %s", gpuId, newType, profiles) != 0) {
-        HexLogError("gpu_resource_set: pre-condition check failed for GPU %s", gpuId);
-        return EXIT_FAILURE;
-    }
-
-    // Existence already confirmed by gpu_resource_set_validate above; this
-    // is purely to fetch name/pciAddress for binding and persisting.
+    // Read the device up front: releasing a pgpu from vfio-pci below has to
+    // happen before the pre-condition check, so name/pciAddress/type are
+    // needed earlier than the binding and persisting steps that follow.
     const json11::Json device = FindGpuDevice(gpuId);
     if (!device.is_object()) {
         HexLogError("gpu_resource_set: GPU %s not found", gpuId);
@@ -622,15 +618,49 @@ ResourceSetMain(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    // Validate profiles before gpu_unset_current_type below so that a bad
+    const std::string currentType = device["type"].is_string() ? device["type"].string_value() : "";
+
+    // A pgpu is bound to vfio-pci, which makes it invisible to nvidia-smi -
+    // and both checks below read the card's supported vGPU types through
+    // nvidia-smi, so on a pgpu they would reject every profile as unsupported.
+    // Hand the card back to its native driver first, and re-bind it if the
+    // checks fail, so a rejected request still leaves it exactly as it was.
+    const bool releasedFromVfio = (currentType == "pgpu" && strcmp(newType, "pgpu") != 0);
+    if (releasedFromVfio &&
+        HexUtilSystemF(0, 0, HEX_SDK " gpu_unbind_vfio_pci %s", pciAddress.c_str()) != 0) {
+        HexLogError("gpu_resource_set: failed to release GPU %s from vfio-pci for validation", gpuId);
+        return EXIT_FAILURE;
+    }
+
+    // Both checks run before gpu_unset_current_type below so that a bad
     // request cannot tear down the GPU's existing configuration.
-    if ((strcmp(newType, "sriovVgpu") == 0 || strcmp(newType, "migBackedVgpu") == 0) &&
-        !ValidateVgpuProfiles(gpuId, newType, profiles, pciAddress)) {
+    const bool preChecksPassed =
+        HexUtilSystemF(0, 0, HEX_SDK " gpu_resource_set_check %s %s %s", gpuId, newType, profiles) == 0 &&
+        (strcmp(newType, "pgpu") == 0 ||
+         ValidateVgpuProfiles(gpuId, newType, profiles, pciAddress));
+
+    if (!preChecksPassed) {
+        HexLogError("gpu_resource_set: pre-condition check failed for GPU %s", gpuId);
+
+        if (releasedFromVfio &&
+            HexUtilSystemF(0, 0, HEX_SDK " gpu_bind_vfio_pci %s", pciAddress.c_str()) != 0) {
+            HexLogError("gpu_resource_set: GPU %s also failed to re-bind to vfio-pci; it is left out of passthrough despite still being recorded as pgpu", gpuId);
+        }
+
         return EXIT_FAILURE;
     }
 
     if (HexUtilSystemF(0, 0, HEX_SDK " gpu_unset_current_type %s", gpuId) != 0) {
         HexLogError("gpu_resource_set: failed to unset current type for GPU %s", gpuId);
+
+        // Same rollback as the failed-checks path above: the card is still
+        // recorded as pgpu, so put it back into passthrough rather than
+        // leaving the record and the hardware disagreeing.
+        if (releasedFromVfio &&
+            HexUtilSystemF(0, 0, HEX_SDK " gpu_bind_vfio_pci %s", pciAddress.c_str()) != 0) {
+            HexLogError("gpu_resource_set: GPU %s also failed to re-bind to vfio-pci; it is left out of passthrough despite still being recorded as pgpu", gpuId);
+        }
+
         return EXIT_FAILURE;
     }
 

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -768,6 +768,28 @@ gpu_unset_current_type()
             echo "Error: failed to disable MIG mode for GPU $gpu_id" >&2
             exit 1
         fi
+    elif [ "$current_type" = "pgpu" ]; then
+        # Hand the card back from vfio-pci to the nvidia driver. Without this
+        # the card stays bound to vfio-pci (and keeps its sticky
+        # driver_override), so switching it to sriovVgpu/migBackedVgpu next
+        # fails: nvidia-smi cannot see a vfio-bound device.
+        #
+        # The address comes from config.json, not nvidia-smi: a pgpu is bound
+        # to vfio-pci and therefore invisible to nvidia-smi, so the
+        # --query-gpu lookup used for sriovVgpu above would return nothing here.
+        local pgpu_pci_address
+        pgpu_pci_address=$(jq -r --arg id "$gpu_id" \
+            'map(select(.id == $id)) | if length > 0 then (.[0].pciAddress // "") else "" end' \
+            "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
+
+        if [ -z "$pgpu_pci_address" ]; then
+            echo "Error: GPU $gpu_id has type pgpu but no recorded pciAddress; cannot release it from vfio-pci" >&2
+            exit 1
+        fi
+
+        if ! gpu_unbind_vfio_pci "$pgpu_pci_address"; then
+            exit 1
+        fi
     fi
 }
 
@@ -775,26 +797,120 @@ gpu_unset_current_type()
 # Pure sysfs operation - does not depend on nvidia-smi being able to see the
 # device, so it is safe to call during hex_config Commit() re-apply, after the
 # device is no longer enumerable by nvidia-smi.
+#
+# driver_override is what makes the bind work at all: vfio-pci carries no id
+# table entry matching an NVIDIA display device, so writing the address to
+# vfio-pci/bind is refused (confirmed on cn13: the device's driver_override was
+# (null) and /sys/bus/pci/drivers/vfio-pci/ held zero device ids). The unbind
+# ahead of it still succeeded, so the card was left bound to *no* driver, and
+# because both writes discarded stderr the caller only saw a bare exit 1.
+# Setting driver_override first tells the PCI core which driver the device must
+# use; drivers_probe then binds it. If the bind still fails, roll the device
+# back to the driver it had rather than leaving it stranded.
 gpu_bind_vfio_pci()
 {
     # nvidia-smi uses 8-char domain (00000000:bb:ss.f); sysfs uses 4-char (0000:bb:ss.f)
     local sysfs_pci_addr
     sysfs_pci_addr=$(echo "$1" | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]')
 
-    modprobe vfio-pci
+    local device_path="/sys/bus/pci/devices/${sysfs_pci_addr}"
+    if [ ! -d "$device_path" ]; then
+        echo "Error: gpu_bind_vfio_pci: no PCI device at $sysfs_pci_addr" >&2
+        return 1
+    fi
 
-    local driver_path="/sys/bus/pci/devices/${sysfs_pci_addr}/driver"
+    if ! modprobe vfio-pci; then
+        echo "Error: gpu_bind_vfio_pci: failed to load the vfio-pci module" >&2
+        return 1
+    fi
+
+    local driver_path="${device_path}/driver"
+    local previous_driver=""
     if [ -e "$driver_path" ]; then
-        local current_driver
-        current_driver=$(basename "$(readlink -f "$driver_path")")
-        if [ "$current_driver" != "vfio-pci" ]; then
-            echo "$sysfs_pci_addr" > "/sys/bus/pci/drivers/${current_driver}/unbind" 2>/dev/null
+        previous_driver=$(basename "$(readlink -f "$driver_path")")
+        # Already where we want it - nothing to do. Keeps Commit() re-apply
+        # idempotent instead of pointlessly cycling a live passthrough device.
+        if [ "$previous_driver" = "vfio-pci" ]; then
+            return 0
         fi
     fi
 
-    echo "$sysfs_pci_addr" > /sys/bus/pci/drivers/vfio-pci/bind 2>/dev/null
+    if ! echo "vfio-pci" > "${device_path}/driver_override"; then
+        echo "Error: gpu_bind_vfio_pci: failed to set driver_override on $sysfs_pci_addr" >&2
+        return 1
+    fi
 
-    [ "$(basename "$(readlink -f "$driver_path" 2>/dev/null)" 2>/dev/null)" = "vfio-pci" ]
+    if [ -n "$previous_driver" ]; then
+        if ! echo "$sysfs_pci_addr" > "/sys/bus/pci/drivers/${previous_driver}/unbind"; then
+            echo "Error: gpu_bind_vfio_pci: failed to unbind $sysfs_pci_addr from $previous_driver" >&2
+            echo "" > "${device_path}/driver_override"
+            return 1
+        fi
+    fi
+
+    echo "$sysfs_pci_addr" > /sys/bus/pci/drivers_probe
+
+    if [ "$(basename "$(readlink -f "$driver_path" 2>/dev/null)" 2>/dev/null)" = "vfio-pci" ]; then
+        return 0
+    fi
+
+    # Bind failed and the device is now driverless. Put it back rather than
+    # leaving the GPU stranded (which is what used to happen, silently).
+    echo "Error: gpu_bind_vfio_pci: $sysfs_pci_addr did not bind to vfio-pci; restoring ${previous_driver:-its original driver}" >&2
+    echo "" > "${device_path}/driver_override"
+    echo "$sysfs_pci_addr" > /sys/bus/pci/drivers_probe
+
+    local restored
+    restored=$(basename "$(readlink -f "$driver_path" 2>/dev/null)" 2>/dev/null)
+    if [ -z "$restored" ] || [ "$restored" = "driver" ]; then
+        echo "Error: gpu_bind_vfio_pci: $sysfs_pci_addr is left with no driver bound; recover with: echo $sysfs_pci_addr > /sys/bus/pci/drivers_probe" >&2
+    fi
+
+    return 1
+}
+
+# Releases a PCI device from vfio-pci and lets its native driver claim it again.
+# The driver_override set by gpu_bind_vfio_pci is sticky: without clearing it the
+# device re-binds to vfio-pci on every probe, so a card switched away from pgpu
+# would never come back to the nvidia driver.
+gpu_unbind_vfio_pci()
+{
+    local sysfs_pci_addr
+    sysfs_pci_addr=$(echo "$1" | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]')
+
+    local device_path="/sys/bus/pci/devices/${sysfs_pci_addr}"
+    if [ ! -d "$device_path" ]; then
+        echo "Error: gpu_unbind_vfio_pci: no PCI device at $sysfs_pci_addr" >&2
+        return 1
+    fi
+
+    local driver_path="${device_path}/driver"
+    local current_driver=""
+    if [ -e "$driver_path" ]; then
+        current_driver=$(basename "$(readlink -f "$driver_path")")
+    fi
+
+    if [ -e "${device_path}/driver_override" ]; then
+        echo "" > "${device_path}/driver_override"
+    fi
+
+    if [ "$current_driver" = "vfio-pci" ]; then
+        if ! echo "$sysfs_pci_addr" > /sys/bus/pci/drivers/vfio-pci/unbind; then
+            echo "Error: gpu_unbind_vfio_pci: failed to unbind $sysfs_pci_addr from vfio-pci" >&2
+            return 1
+        fi
+    fi
+
+    echo "$sysfs_pci_addr" > /sys/bus/pci/drivers_probe
+
+    local bound
+    bound=$(basename "$(readlink -f "$driver_path" 2>/dev/null)" 2>/dev/null)
+    if [ -z "$bound" ] || [ "$bound" = "driver" ] || [ "$bound" = "vfio-pci" ]; then
+        echo "Error: gpu_unbind_vfio_pci: $sysfs_pci_addr did not return to its native driver (now: ${bound:-none})" >&2
+        return 1
+    fi
+
+    return 0
 }
 
 gpu_host_stats()

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -314,7 +314,13 @@ gpu_device_list()
 
         local status="idle"
         local allocation
-        local profile_count_limit="null"
+        # Must match the name used below and in the jq call at the end of this
+        # loop. It was declared as profile_count_limit while the sriovVgpu
+        # branch assigned (and the jq call read) sriov_vgpu_profile_count_limit,
+        # so on any other type the latter was an unset, non-local variable:
+        # --argjson got an empty string and the whole gpu_device_list jq failed.
+        # Being non-local also let one card's limit leak into the next.
+        local sriov_vgpu_profile_count_limit="null"
 
         if [ "$gpu_type" = "pgpu" ]; then
             local pci_bus pci_slot
@@ -375,7 +381,7 @@ gpu_device_list()
             --arg type "$gpu_type" \
             --argjson supportTypes "$support_types" \
             --arg pciAddress "$pci_bus_id" \
-            --argjson sriovVgpuProfileCountLimit "$sriov_vgpu_profile_count_limit" \
+            --argjson sriovVgpuProfileCountLimit "${sriov_vgpu_profile_count_limit:-null}" \
             --arg status "$status" \
             --argjson allocation "$allocation" \
             '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, sriovVgpuProfileCountLimit:$sriovVgpuProfileCountLimit, status:$status, allocation:$allocation}]')
@@ -497,6 +503,16 @@ gpu_device_list()
             --argjson allocation "$allocation" \
             '. + [{id:$id, name:$name, type:"pgpu", supportTypes:["pgpu"], pciAddress:$pciAddress, profileCountLimit:null, status:$status, allocation:$allocation}]')
     done
+
+    # Every step above rebuilds $output through jq, so a single failed jq call
+    # (e.g. --argjson handed an empty variable) collapses it to an empty string
+    # and the accumulated devices are gone. Emitting that as-is with exit 0
+    # tells the caller "this node has no GPUs", which is indistinguishable from
+    # the truth and silently wrong - cube-cos-api would drop every card.
+    if ! echo "$output" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        echo "Error: gpu_device_list: built a malformed device list; refusing to report it as an empty one" >&2
+        return 1
+    fi
 
     echo "$output"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Three bugs that, together, made GPU resource-type management unusable on a
node with real hardware. They are one causal chain, which is why they ship
together — each commit is self-contained and can be reviewed on its own.

---

**Commit 1 — `sriovVgpu` carve failed 100% of the time.**

`RunSriovManageWithRetry` (core/modules/config_gpu.cpp) captured
`sriov-manage`'s exit code with an **unquoted** marker:

```c
"%s %s %s 2>&1; echo |__HEX_RC_$?__|"
```

The shell parses those `|` as pipes, so `echo |__HEX_RC_$?__|` is a syntax
error (a trailing pipe with no following command). `/bin/sh -c` aborts the
**entire** command line on that syntax error, so `sriov-manage` **never
runs**. The marker never appears, `marker == npos` → `rc = -1` → treated as
failure, and the call logs an empty message:

```
Error: gpu_resource_set: sriov-manage -e 0001:c8:00.0 failed:
```

Regressed in `44011f4f` ("use a more unique exit-code delimiter"), which
wrapped the delimiter in `|...|` without quoting it. Quoting it makes `|` a
literal `echo` argument; `$?` still expands inside double quotes, and the
existing `rfind` / `atoi(... + 10)` parsing is unchanged (`"|__HEX_RC_"` is
exactly 10 characters).

---

**Commit 2 — `pgpu` left the card bound to no driver, and could never be undone.**

vfio-pci carries no id-table entry matching an NVIDIA display device, so
`echo <addr> > /sys/bus/pci/drivers/vfio-pci/bind` is refused by the kernel.
The unbind that runs immediately before it *does* succeed, so the card ended
up bound to **no driver at all** — invisible to nvidia-smi, unusable by any
VM, recoverable only by running `echo <addr> > /sys/bus/pci/drivers_probe` by
hand. Both sysfs writes discarded stderr, so the caller saw a bare exit 1
with no explanation. Confirmed on cn13: the device's `driver_override` read
`(null)` and `/sys/bus/pci/drivers/vfio-pci/` held **zero** device ids.

The fix sets `driver_override` before unbinding and binds via
`drivers_probe`. `driver_override` tells the PCI core which driver the device
must use, bypassing the id-table match that was rejecting the bind. If the
bind still fails, the override is cleared and the device re-probed so it
returns to its previous driver instead of being stranded, and every failure
path explains itself on stderr. Re-binding a device already on vfio-pci
returns early, so `Commit()` re-apply does not cycle a live passthrough card.

`gpu_unset_current_type` also gained the pgpu branch it never had, calling
the new `gpu_unbind_vfio_pci`. `driver_override` is sticky: without clearing
it the device re-binds to vfio-pci on every probe and can never return to the
nvidia driver. Its PCI address is read from config.json, not nvidia-smi,
because a vfio-bound card is invisible to nvidia-smi.

`ResourceSetMain` releases a pgpu from vfio-pci **before** running
`gpu_resource_set_check` and `ValidateVgpuProfiles`, and re-binds it if
either fails. Both read the card's supported vGPU types through nvidia-smi,
which cannot see a vfio-bound device — so on a pgpu they rejected every
profile (`profile id 1518 is not a valid sriovVgpu profile`) before the
teardown step could hand the card back. The `gpu_unset_current_type` failure
path re-binds too, so no early exit leaves the hardware disagreeing with what
config.json records.

---

**Commit 3 — `gpu_device_list` silently reported an empty device list.**

The loop declared `local profile_count_limit="null"` while the sriovVgpu
branch assigned — and the jq call read — `sriov_vgpu_profile_count_limit`. On
any other type that second name was never set, so `--argjson
sriovVgpuProfileCountLimit ""` failed with `jq: invalid JSON text passed to
--argjson`. Since the loop rebuilds `$output` by piping it through jq, that
one failure collapses `$output` to an empty string and every device
accumulated so far is lost — yet the function still exited 0 and printed
nothing, which callers cannot distinguish from "this node has no GPUs"
(`gpu_resource_set_check` reports the GPU as not found; cube-cos-api drops
every card on the node). Being non-local also let one card's value leak into
the next.

Triggering it needs a card recorded as pgpu that nvidia-smi can still see —
exactly the state a failed pgpu bind used to leave behind, and the state
commit 2 now passes through deliberately when releasing a pgpu for
validation. Commit 2 without this one would trade a broken bind for a broken
listing.

The listing now also refuses to print anything that is not a JSON array,
rather than passing an empty one off as success.

#### Which issue(s) this PR fixes

Fixes # <!-- #818 "Set GPU Resource Type to pGPU" is the feature this unblocks -->

#### Special notes for your reviewer

None

#### Additional documentation

```docs
Hardware verification (cn13, NVIDIA RTX PRO 6000 Blackwell, 2026-07-25/27).

Commit 1:
- Reproduced: the exact emitted string
  `/usr/lib/nvidia/sriov-manage -e 0001:c8:00.0 2>&1; echo |__HEX_RC_$?__|`
  run in a shell → "syntax error: unexpected end of file"; numvfs stays 0.
  The pre-fix binary failed the carve 100% of the time.
- With the fix: carve → exit 0, numvfs=48, VF 0001:c8:00.2
  current_vgpu_type=1518, and a Nova VM booted ACTIVE against the carved VF
  (nvidia-smi vgpu -q: Active vGPUs 1).
- The unbindLock retry this helper exists for had never executed since
  44011f4f (rc always -1, so the "Cannot obtain unbindLock" branch was
  unreachable). Re-verified by holding the device open in a background loop
  while carving: "unbindLock busy, retrying (1/5)...(4/5)" fires, i.e. rc
  capture and contention detection both work again.

Commit 2 — diagnosis was done step by step rather than through hex_config,
which swallowed the detail:
- `hex_sdk gpu_unset_current_type <uuid>` alone → exit 0, numvfs 0, PF still
  on nvidia. Rules out the teardown step.
- Pre-state: driver_override = (null); vfio-pci has 0 device ids.
- `hex_sdk gpu_bind_vfio_pci <addr>` alone → exit 1, PF left with no driver.
  Reproduces the reported symptom exactly.
- After the fix, a full cycle, every step exit 0:
      sriovVgpu -> pgpu -> sriovVgpu -> pgpu -> sriovVgpu
  Each step checked against three sources that must agree: config.json's
  recorded type, sysfs sriov_numvfs, and the driver symlink.
    into pgpu:   driver = vfio-pci, driver_override = vfio-pci, numvfs = 0
    out of pgpu: driver = nvidia, driver_override = (null), numvfs = 48,
                 VF 0001:c8:00.2 current_vgpu_type = 1518
  Before this change the very first step exited 1 and left the PF driverless.
- Failure handling exercised on purpose by holding the device open during a
  teardown: the call failed after 5 unbindLock retries and the card was left
  fully consistent — config.json unchanged, numvfs 48, driver nvidia,
  driver_override empty.

Commit 3:
- With GPU-0a5ba9ad recorded as pgpu and bound to nvidia, gpu_device_list
  returned nothing (exit 0) before; lists all four cards after.

End to end with all three, plus the cube-cos-api side: /gpuCards reports
degraded false, profile 1518 count 1 with its alias, attachedInstances[0].id
== the VM UUID, per-instance 128 MiB == host FB Used, device 4240 ==
Reserved 2288 + Used 1952.

NOT covered, stated so this is not over-read:
- Boot-time Commit() re-apply of a pgpu card. After a reboot driver_override
  is gone and nvidia has claimed the card, so Commit() takes the full
  set-override/unbind/probe path rather than the early return. A pgpu card
  that fails to re-bind at boot would not be available to its VM. Needs a
  node that can actually be rebooted.
- cube-cos-api's /gpuCards was never called while a card was in pgpu state,
  so the API-side pgpu reporting path is unverified end to end.
- TeardownSriov's `sriov-manage -d` is only reachable from the apply-rollback
  at config_gpu.cpp:158; that specific path was not contrived.
```
