### PR TITLE
feat(core): build + ship phone-home-agent in the node OS image

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -8,6 +8,7 @@ include ../build.mk
 SUBDIRS += api
 SUBDIRS += ui
 SUBDIRS += cubectl
+SUBDIRS += phone-home-agent
 SUBDIRS += appctl
 SUBDIRS += telegraf
 SUBDIRS += yq

--- a/core/main/Makefile
+++ b/core/main/Makefile
@@ -65,6 +65,7 @@ PROJ_BASE_ROOTFS = $(CURDIR)/rootfs
 include $(SRCDIR)/cube.mk
 
 ROOT_COMPONENTS += cubectl
+ROOT_COMPONENTS += phone-home-agent
 include $(shell for m in $(ROOT_COMPONENTS); do ls $(COREDIR)/$$m/$$m.mk; done)
 
 # cube finalizer
@@ -94,6 +95,15 @@ pxeserver_ramdisk_install::
 	$(Q)sed -i "s/hex/cube/" $(ROOTDIR)/etc/settings.sys
 	$(Q)sed -i 1,6d $(ROOTDIR)/etc/settings.sys
 	$(Q)echo "Welcome to $(PROJ_LONGNAME) pxe installer" > $(ROOTDIR)/etc/motd
+	@# Zero-touch driver: SPA + snapshot generator + deploy orchestrator on :3001;
+	@# generated snapshots also export to /var/ftpboot for `snapshot pull url`.
+	$(Q)if [ -f $(TOP_BLDDIR)/core/phone-home-agent/cube-cos-driver ]; then \
+		mkdir -p $(ROOTDIR)/usr/local/bin $(ROOTDIR)/var/lib/cube-cos-driver && \
+		cp -f $(TOP_BLDDIR)/core/phone-home-agent/cube-cos-driver $(ROOTDIR)/usr/local/bin/ && \
+		chmod 755 $(ROOTDIR)/usr/local/bin/cube-cos-driver && \
+		cp -f $(COREDIR)/phone-home-agent/cube-cos-driver.service $(ROOTDIR)/usr/lib/systemd/system/ && \
+		chroot $(ROOTDIR) systemctl enable cube-cos-driver.service ; \
+	else echo "  WARN    cube-cos-driver not built; pxeserver ships without the zero-touch driver" ; fi
 
 pxeserver_iso_ramdisk_install::
 	$(Q)sed -i "s/Hex Appliance/$(PROJ_LONGNAME)/" $(ROOTDIR)/etc/settings.sys
@@ -102,6 +112,14 @@ pxeserver_iso_ramdisk_install::
 	$(Q)sed -i "s/hex/cube/" $(ROOTDIR)/etc/settings.sys
 	$(Q)sed -i 1,6d $(ROOTDIR)/etc/settings.sys
 	$(Q)echo "Welcome to $(PROJ_LONGNAME) pxe installer" > $(ROOTDIR)/etc/motd
+	@# Zero-touch driver (same as pxeserver_ramdisk_install)
+	$(Q)if [ -f $(TOP_BLDDIR)/core/phone-home-agent/cube-cos-driver ]; then \
+		mkdir -p $(ROOTDIR)/usr/local/bin $(ROOTDIR)/var/lib/cube-cos-driver && \
+		cp -f $(TOP_BLDDIR)/core/phone-home-agent/cube-cos-driver $(ROOTDIR)/usr/local/bin/ && \
+		chmod 755 $(ROOTDIR)/usr/local/bin/cube-cos-driver && \
+		cp -f $(COREDIR)/phone-home-agent/cube-cos-driver.service $(ROOTDIR)/usr/lib/systemd/system/ && \
+		chroot $(ROOTDIR) systemctl enable cube-cos-driver.service ; \
+	else echo "  WARN    cube-cos-driver not built; pxeserver ships without the zero-touch driver" ; fi
 
 include $(HEX_MAKEDIR)/hex_sdk.mk
 

--- a/core/phone-home-agent/Makefile
+++ b/core/phone-home-agent/Makefile
@@ -1,0 +1,53 @@
+# Cube SDK
+# cube-cos-driver binaries, built from bigstack-oss/cube-cos-driver (default
+# branch): phone-home-agent (installer preflight + first-boot snapshot apply)
+# and the driver server (SPA + snapshot generator + deploy orchestrator, shipped
+# in the pxeserver image). Deps resolved at build time only (Go proxy + npm).
+
+include ../../build.mk
+
+APP := phone-home-agent
+SRV := cube-cos-driver
+GITHUB_URL := https://github.com/bigstack-oss/cube-cos-driver
+GIT_DIR := git
+
+ifneq ($(V),)
+GOVERBOSE := -v
+endif
+
+# Clone the source (retry, shallow, default branch). Init only the first-level
+# UI-lib submodule — its own nested submodules are SSH-URL and not needed.
+$(GIT_DIR):
+	$(call RUN_CMD_TIMED, \
+		for i in 1 2 3 ; do \
+		rm -fr $@ && timeout 300 git clone --depth 1 $(GITHUB_URL).git $@ && \
+		(cd $@ && git submodule update --init --depth 1 external/cube-cos-ui) && break ; \
+		done, \
+		"  CLONE   $(GITHUB_URL)")
+
+# Build the static agent binary (deps resolved via the Go module proxy).
+$(APP): $(GIT_DIR)
+	$(call RUN_CMD_TIMED, \
+		cd $(GIT_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go build -trimpath -ldflags '-s -w' $(GOVERBOSE) \
+		-o $(BLDDIR)/$(APP) ./cmd/phone-home-agent, \
+		"  GEN     $(APP)")
+
+# Build the server (SPA via Node 24 + pnpm, embedded into the Go binary).
+$(SRV): $(GIT_DIR)
+	$(Q)# enable nvm
+	$(Q)sed -i 's/^#//g' $$BASH_ENV
+	$(Q)cd $(GIT_DIR) && nvm install 24 $(QEND)
+	$(Q)cd $(GIT_DIR) && nvm use 24 $(QEND) && npm install -g pnpm@latest-10 $(QEND)
+	$(call RUN_CMD_TIMED, \
+		cd $(GIT_DIR) && nvm use 24 $(QEND) && make all $(QEND) && \
+		cp -f bin/$(SRV) $(BLDDIR)/$(SRV), \
+		"  GEN     $(SRV)")
+	$(Q)# disable nvm
+	$(Q)sed -i '/^#/! s/^/#/' $$BASH_ENV
+
+BUILD += $(APP) $(SRV)
+BUILDCLEAN += $(APP) $(SRV)
+CLEAN += $(GIT_DIR)
+
+include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/core/phone-home-agent/cube-cos-driver.service
+++ b/core/phone-home-agent/cube-cos-driver.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=CubeCOS zero-touch driver (snapshot generator + deploy orchestrator)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/cube-cos-driver --port 3001 --data-dir /var/lib/cube-cos-driver --export-dir /var/ftpboot
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/core/phone-home-agent/phone-home-agent.mk
+++ b/core/phone-home-agent/phone-home-agent.mk
@@ -1,0 +1,19 @@
+# Cube SDK
+# phone-home-agent installation into the node OS image.
+
+PHONE_HOME_AGENT_PROG := phone-home-agent
+
+$(call PROJ_INSTALL_PROGRAM,-S,$(TOP_BLDDIR)/core/phone-home-agent/$(PHONE_HOME_AGENT_PROG),./usr/local/bin)
+
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) ln -sf /usr/local/bin/$(PHONE_HOME_AGENT_PROG) /usr/sbin/
+	$(Q)mkdir -p $(ROOTDIR)/etc/cube
+	$(Q)cp -f $(COREDIR)/phone-home-agent/$(PHONE_HOME_AGENT_PROG).service $(ROOTDIR)/usr/lib/systemd/system/
+	$(Q)chroot $(ROOTDIR) systemctl enable $(PHONE_HOME_AGENT_PROG).service
+
+# for RC builds
+heavyfs_install::
+	$(Q)chroot $(ROOTDIR) ln -sf /usr/local/bin/$(PHONE_HOME_AGENT_PROG) /usr/sbin/
+	$(Q)mkdir -p $(ROOTDIR)/etc/cube
+	$(Q)cp -f $(COREDIR)/phone-home-agent/$(PHONE_HOME_AGENT_PROG).service $(ROOTDIR)/usr/lib/systemd/system/
+	$(Q)chroot $(ROOTDIR) systemctl enable $(PHONE_HOME_AGENT_PROG).service

--- a/core/phone-home-agent/phone-home-agent.service
+++ b/core/phone-home-agent/phone-home-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=CubeCOS phone-home snapshot agent (zero-touch first boot)
+After=network-online.target
+Wants=network-online.target
+# Only runs while the node is unconfigured; once FTS writes the marker it stays
+# inert across reboots.
+ConditionPathExists=!/etc/appliance/state/configured
+
+[Service]
+Type=simple
+# Server URL resolution order: --server flag / DRIVER_SERVER env (this file),
+# then driver_server= on the kernel cmdline, then the pxeserver default.
+EnvironmentFile=-/etc/cube/phone-home-agent.env
+ExecStart=/usr/local/bin/phone-home-agent
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/project.mk
+++ b/project.mk
@@ -14,6 +14,13 @@ CORE_PKGDIR   := $(COREDIR)/pkg
 # core specific modules
 PROJ_MODDIR := $(TOP_BLDDIR)/core/modules
 
+# Node config namespace: the installer (hex) drops the phone-home agent's env
+# file here (overrides hex's default).
+HEX_AGENT_ENV_DIR := /etc/cube
+# Installer disk auto-detect: skip our OSD/data disks (cube_ partition labels).
+# SAN LUNs (Compellent, etc.) are excluded by hex's default transport filter.
+HEX_INSTALL_DATA_LABEL_PREFIX := cube_
+
 # policy source tree
 CORE_POLICYDIR := $(COREDIR)/policies
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Node-image + pxeserver half of the zero-touch feature (installer half is hex #144):

- `core/phone-home-agent` — build both `cube-cos-driver` binaries from the public repo: the static `phone-home-agent` (Go) and the driver server (SPA via Node 24 + pnpm in the jail, embedded).
- Node OS image: agent + systemd unit gated on `!…/configured`; first-boot snapshot apply via `driver_server=`.
- pxeserver image (usb + iso): driver server + unit — SPA/snapshot-generator/deploy-orchestrator on `:3001`, snapshots exported to `/var/ftpboot` for `snapshot pull url`.
- `project.mk`: `HEX_AGENT_ENV_DIR=/etc/cube` + installer disk-detect `cube_` label prefix (hex vars with neutral defaults).
- Bump `hex` → `feat/zero-touch-orchestrator`.

#### Which issue(s) this PR fixes

Fixes #1177

#### Special notes for your reviewer

- Depends on hex #144 (submodule at its branch tip) — merge hex first, then re-point at the merged commit.
- Field-validated 2026-07-28: full zero-touch 1cc + 3cc HA reimage to `cluster check` all-ok; the driver-server jail build verified (SPA embedded, 28 MB static binary).
- pxeserver data dir is RAM-backed (`/var/lib/cube-cos-driver`) — cluster defs don't survive a pxeserver reboot; persistence is a follow-up.

#### Additional documentation

```docs
The pxeserver image now ships the zero-touch driver (SPA + snapshot generator +
deploy orchestrator) on :3001; generated snapshots export to /var/ftpboot.
The node image ships phone-home-agent for first-boot snapshot apply.
```
