### PR TITLE
Add an eBPF toolchain to the build jail and bump Go to 1.25.12

### DIFF
--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -5,7 +5,11 @@ ARG WEAK_DEP=0
 FROM quay.io/centos/centos:stream9 AS tier1
 ENV LANG=C.UTF-8
 ENV HEX_VER=hex2.0
-ENV GOLANG_VER=1.24.2
+# 1.25.x is required by components whose go.mod declares `go 1.25.3` (lachesis);
+# pinned to the latest 1.25 patch rather than the bare minimum so the jail is not
+# a release behind on toolchain fixes. Bumping this recompiles every Go component
+# in the tree -- see the regression note in the PR.
+ENV GOLANG_VER=1.25.12
 ENV HEX_ARCH=x86_64
 ENV DEVOPS_ENV=__JAIL__
 ENV TZ=Asia/Taipei
@@ -74,17 +78,27 @@ ARG HEX_TEST="qemu-kvm-core telnet net-tools iproute iputils expect nmap-ncat dn
 # extra packages for building projects
 ARG HEX_EXTRA="sudo kpartx python3-pip python3-devel java-21-openjdk java-21-openjdk-devel ruby ruby-devel rpm-build rubygems squashfs-tools podman podman-docker skopeo buildah toilet linux-firmware"
 
+# eBPF toolchain, for components that compile BPF C (lachesis / network telemetry).
+# clang is the only compiler with a BPF target -- gcc cannot build these objects.
+# libbpf-devel supplies <bpf/bpf_helpers.h> and comes from CRB, enabled above.
+# kernel-headers supplies the UAPI headers (/usr/include/{linux,asm,asm-generic});
+# gcc pulls it in transitively today, but it is declared here because BPF builds
+# reference those paths directly and must not depend on a transitive dep.
+# bpftool is diagnostic only -- the BPF sources use UAPI types and take no CO-RE
+# relocation, so nothing in the build needs BTF.
+ARG HEX_BPF="clang llvm libbpf-devel kernel-headers bpftool"
+
 RUN echo "hex" > /etc/machine-id
 RUN echo "_WEAK_DEP=$WEAK_DEP" >> /etc/hex.manifest
 
 ###### install packages with WEAK_DEP == 0
 FROM tier2 AS tier2_weak_dep_0
-RUN dnf install -y $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
+RUN dnf install -y $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST $HEX_BPF
 # Jenkins is with java 21
 RUN alternatives --set java java-21-openjdk.x86_64
 ###### install packages with WEAK_DEP == 1
 FROM tier2 AS tier2_weak_dep_1
-RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
+RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST $HEX_BPF
 
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds an eBPF compilation toolchain to the build jail, and bumps Go.

The network-telemetry agent (`bigstack-oss/lachesis`) is being onboarded as a CubeCOS component, and it is the first component in the tree that compiles eBPF C. A grep of cubecos returns zero hits for `clang`, `llvm`, `libbpf` or `bpftool` — the capability is simply absent, and `gcc` cannot substitute because it has no BPF target. Without this the component cannot be built by the pipeline at all.

Two changes, both in `jail/jail.ubi9.dockerfile`:

- **New `HEX_BPF` package group** — `clang llvm libbpf-devel kernel-headers bpftool` — added to both the `weak_dep_0` and `weak_dep_1` install lines, following the existing `HEX_BE` / `HEX_SDK` / `HEX_EXTRA` / `HEX_TEST` grouping. `libbpf-devel` comes from CRB, which tier1 already enables.
- **`GOLANG_VER` 1.24.2 → 1.25.12.** lachesis declares `go 1.25.3`, so 1.24.2 cannot build it. Pinned to the latest 1.25 patch rather than the bare minimum so the jail is not a release behind on toolchain fixes.

`kernel-headers` is declared explicitly even though `glibc-devel` already requires it transitively (`kernel-headers >= 3.2`): BPF builds reference `/usr/include/{linux,asm,asm-generic}` by path, and a build input that is only present by transitive luck is a latent breakage.

`bpftool` is diagnostic only. The BPF sources use UAPI types and take no CO-RE relocation, so nothing in the build needs BTF — worth stating so nobody later adds a `bpftool btf dump` step assuming it is required.

#### Which issue(s) this PR fixes

Fixes bigstack-oss/lachesis#279

#### Special notes for your reviewer

> **The Go bump is the regression risk here, not the new packages.** It recompiles every Go component in the tree. Verified by building `core/cubectl` (pure Go) inside the freshly built jail under 1.25.12 — clean, 2m55s.

Verified end to end on a CentOS Stream 9 host by running the real target, not a replica:

- `make centos9-jail` completes and the container comes **up** — `Up`, PID 1 is `systemd`
- inside the running jail: `clang 22.1.3`, `go1.25.12`, `bpftool v7.5.0`, `libbpf-devel-1.5.0-3.el9`, `/usr/include/bpf/bpf_helpers.h`, `/usr/include/asm`
- the lachesis RPM builds **inside the jail, non-privileged** → `lachesis-v0.1.0-1.el9.x86_64.rpm`
- `core/cubectl` still builds (the regression check above)

Two dockerfile warnings appear in the build output and are **pre-existing, not from this change**: `InvalidDefaultArgInFrom` (line 46, `FROM tier1_${DIST}` has no default) and `LegacyKeyValueFormat` (line 146, `ENV BASH_ENV /root/.bash_env`). The `ENV` added here uses the modern `key=value` form. Similarly, an rpm transaction-lock failure importing Chrome's GPG key and a pip dependency-resolver warning both occur in untouched layers and do not abort the build.

One environment note for anyone reproducing this on a VM rather than bare metal, since it cost me two false starts and presents as a hang rather than an error: on an OpenStack guest the interface MTU is 1442 (geneve overlay) while `docker0` defaults to 1500, so `dnf` stalls on whichever metalink mirrors do not handle PMTUD — one 25 KB package took 378 s to resolve and then hung. `/etc/docker/daemon.json` with `{"mtu": 1442}` fixes it. The host also needs `docker-buildx-plugin`, since the target invokes `DOCKER_BUILDKIT=1 docker build --progress=plain`.

Not addressed here, deliberately: `core/lachesis/` (the component itself) and `config_lachesis.cpp` are separate tasks — lachesis#280 and #281. This PR only makes the jail *capable* of building them.

#### Additional documentation

```docs

```
