### PR TITLE
Onboard the lachesis network-telemetry agent as a CubeCOS component

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -10,6 +10,7 @@ SUBDIRS += ui
 SUBDIRS += cubectl
 SUBDIRS += phone-home-agent
 SUBDIRS += appctl
+SUBDIRS += lachesis
 SUBDIRS += telegraf
 SUBDIRS += yq
 SUBDIRS += prometheus

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -188,7 +188,7 @@ HEAVY_COMPONENTS += yq api ui skyline nginx
 HEAVY_COMPONENTS += mysql mongodb ntp rabbitmq memcache etcd ceph pacemaker haproxy grafana
 HEAVY_COMPONENTS += influxdb prometheus kapacitor elk telegraf kafka keystone glance nova ironic neutron cinder swift multipath
 HEAVY_COMPONENTS += heat horizon octavia barbican manila designate masakari monasca watcher cyborg
-HEAVY_COMPONENTS += terraform docker k3s keycloak rancher appfw appctl
+HEAVY_COMPONENTS += terraform docker k3s keycloak rancher appfw appctl lachesis
 
 include $(shell for m in $(HEAVY_COMPONENTS); do ls $(COREDIR)/$$m/$$m.mk; done)
 $(shell for r in $(LOCKED_DNF); do echo $$r >> $(LOCKED_RPMS); done)

--- a/core/lachesis/Makefile
+++ b/core/lachesis/Makefile
@@ -1,0 +1,65 @@
+# Cube SDK
+
+include ../../build.mk
+LACHESIS_RPM := lachesis.rpm
+PKG_NAME := lachesis
+GITHUB_URL := https://github.com/bigstack-oss/lachesis
+
+# no RC prebuilt-download branch yet: lachesis has no tagged release to wget.
+# add one mirroring core/api when the first release is cut.
+GIT_DIR := git
+RPMBUILD_DIR := rpmbuild
+RPMBUILD_SPECS := $(RPMBUILD_DIR)/SPECS
+RPMBUILD_SOURCES := $(RPMBUILD_DIR)/SOURCES
+RPMBUILD_RPMS := $(RPMBUILD_DIR)/RPMS
+
+# prepare the lachesis source code, being pulled from GitHub using the default branch
+$(GIT_DIR):
+	$(call RUN_CMD_TIMED, \
+		for i in {1..3} ; do \
+		rm -fr $@ && timeout 120 git clone --depth 1 $(GITHUB_URL).git $@ && break ; \
+		done,\
+		"  CLONE   $(GITHUB_URL)")
+
+version: $(GIT_DIR)
+	$(Q)head -n 1 $(GIT_DIR)/VERSION > version
+
+build_number: $(GIT_DIR)
+	$(Q)cd $(GIT_DIR) && \
+		git rev-parse --short HEAD > ../build_number
+
+# prepare the rpm build directory
+$(RPMBUILD_DIR):
+	$(Q)mkdir $(RPMBUILD_DIR)
+	$(Q)cd $(RPMBUILD_DIR) && mkdir BUILD SRPMS SPECS
+
+# make the source tarball
+# RPMBUILD_DIR is order-only (|): the rule writes rpmbuild/SOURCES.tgz into it,
+# bumping the dir's mtime every build, which would otherwise rebuild SOURCES forever.
+$(RPMBUILD_SOURCES): $(GIT_DIR) version | $(RPMBUILD_DIR)
+	$(Q)mkdir ./source
+	$(Q)cp -r $(GIT_DIR)/.git/ ./source/
+	$(Q)cd ./source && git checkout . $(QEND)
+	$(Q)rm -r ./source/.git/ ./source/.github/ ./source/.gitignore
+	$(Q)tar -cvzf $@.tgz source $(QEND)
+	$(Q)mkdir -p $(RPMBUILD_DIR)/SOURCES
+	$(Q)mv $@.tgz $(RPMBUILD_DIR)/SOURCES/$(PKG_NAME)-`cat version`.tar.gz
+	$(Q)rm -r ./source
+	$(Q)touch $@
+
+# build the lachesis rpm package; %build needs the jail's BPF toolchain (HEX_BPF)
+$(RPMBUILD_RPMS): $(RPMBUILD_SOURCES) build_number
+	$(Q)cp $(GIT_DIR)/init/$(PKG_NAME).spec $(RPMBUILD_DIR)/SPECS/
+	$(call RUN_CMD_TIMED, \
+		rpmbuild -bb --nodeps --define "_topdir $(CURDIR)/$(RPMBUILD_DIR)" --define "version `cat version`" --define "build_number `cat build_number`" $(RPMBUILD_DIR)/SPECS/$(PKG_NAME).spec,\
+		"  BUILD   $(PKG_NAME)-`cat version`-1.el9.`cat build_number`.x86_64.rpm")
+	$(Q)touch $@
+
+# move the built rpm back to the local directory
+$(LACHESIS_RPM): $(RPMBUILD_RPMS)
+	$(Q)cp -f $</x86_64/$(PKG_NAME)-`cat version`-1.el9.`cat build_number`.x86_64.rpm $@
+
+BUILD += $(LACHESIS_RPM)
+BUILDCLEAN += $(LACHESIS_RPM) $(RPMBUILD_DIR) $(GIT_DIR) version build_number
+
+include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/core/lachesis/lachesis.mk
+++ b/core/lachesis/lachesis.mk
@@ -1,0 +1,22 @@
+# Cube SDK
+# lachesis (per-tenant network telemetry agent) installation
+
+LACHESIS_RPM = $(TOP_BLDDIR)/core/lachesis/lachesis.rpm
+
+# the rpm owns /etc/cube/lachesis, /var/lib/lachesis and /var/log/lachesis.
+# installed disabled everywhere; config_lachesis enables per role at commit time.
+rootfs_install::
+	$(Q)cp -f $(LACHESIS_RPM) $(ROOTDIR)/tmp/
+	$(Q)chroot $(ROOTDIR) dnf install -y /tmp/lachesis.rpm
+	$(Q)rm -f $(ROOTDIR)/tmp/lachesis.rpm
+	$(Q)chroot $(ROOTDIR) systemctl disable lachesis
+	$(Q)cp -f $(COREDIR)/lachesis/lachesis.yaml.in $(ROOTDIR)/etc/cube/lachesis/
+
+# for RC builds
+heavyfs_install::
+	$(Q)cp -f $(LACHESIS_RPM) $(ROOTDIR)/tmp/
+	$(Q)chroot $(ROOTDIR) rpm -e lachesis
+	$(Q)chroot $(ROOTDIR) rpm -i /tmp/lachesis.rpm
+	$(Q)rm -f $(ROOTDIR)/tmp/lachesis.rpm
+	$(Q)chroot $(ROOTDIR) systemctl disable lachesis
+	$(Q)cp -f $(COREDIR)/lachesis/lachesis.yaml.in $(ROOTDIR)/etc/cube/lachesis/

--- a/core/lachesis/lachesis.mk
+++ b/core/lachesis/lachesis.mk
@@ -3,6 +3,11 @@
 
 LACHESIS_RPM = $(TOP_BLDDIR)/core/lachesis/lachesis.rpm
 
+# grafana dashboards come from the lachesis clone, not a vendored copy, so they
+# cannot drift from the metrics they query. grafana.mk installs provisioning/
+# first: lachesis is last in HEAVY_COMPONENTS, so this lands on top of it.
+LACHESIS_DASHBOARDS = $(TOP_BLDDIR)/core/lachesis/git/deploy/grafana/dashboards
+
 # the rpm owns /etc/cube/lachesis, /var/lib/lachesis and /var/log/lachesis.
 # installed disabled everywhere; config_lachesis enables per role at commit time.
 rootfs_install::
@@ -11,6 +16,8 @@ rootfs_install::
 	$(Q)rm -f $(ROOTDIR)/tmp/lachesis.rpm
 	$(Q)chroot $(ROOTDIR) systemctl disable lachesis
 	$(Q)cp -f $(COREDIR)/lachesis/lachesis.yaml.in $(ROOTDIR)/etc/cube/lachesis/
+	$(Q)cp -f $(LACHESIS_DASHBOARDS)/*.json $(ROOTDIR)/etc/grafana/provisioning/dashboards/
+	$(Q)chmod 0644 $(ROOTDIR)/etc/grafana/provisioning/dashboards/lachesis-*.json
 
 # for RC builds
 heavyfs_install::

--- a/core/lachesis/lachesis.yaml.in
+++ b/core/lachesis/lachesis.yaml.in
@@ -1,0 +1,18 @@
+# CubeCOS-managed config for the lachesis telemetry agent.
+# Rendered to lachesis.yaml by config_lachesis on every commit -- do not hand-edit
+# the rendered file. @NAME@ tokens are substituted there.
+# Only values CubeCOS must decide appear here; the agent defaults the rest.
+
+version: "1"
+
+neutron:
+  enabled: true
+  # written by config_keystone on every role, so present on compute too
+  credentials_file: /etc/admin-openrc.sh
+
+kafka:
+  # live Neutron notifications, so metadata refreshes in seconds
+  enabled: true
+  brokers:
+    - "@CONTROL_VIP@:9095"
+  topic: notifications.info

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -41,6 +41,7 @@ hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_health.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_hwdetect.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_k3s.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_kafka.sh
+hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_lachesis.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_logs.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_memcache.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_migrate.sh
@@ -178,6 +179,7 @@ hex_config_MODULES += config_logstash.o
 hex_config_MODULES += config_kafka.o
 hex_config_MODULES += config_prometheus.o
 hex_config_MODULES += config_gpu.o
+hex_config_MODULES += config_lachesis.o
 
 PROGRAMS += hex_config
 

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -141,6 +141,7 @@ CompMap s_comps = {
     { "monasca", { 0, Q } },
     { "watcher", { 0, Q, R_CTRL_NOT_EDGE } },
     { "telegraf", { 0, Q } },
+    { "lachesis", { 0, Q } },
     { "influxdb", { 0, Q } },
     { "kapacitor", { 0, Q } },
     { "grafana", { 0, Q } },
@@ -190,7 +191,7 @@ CheckRepairItem s_services[] = {
     { S[InstanceHa], "masakari", true },
     { S[BusinessLogic], "watcher", true, R_CTRL_NOT_EDGE },
     { S[DataPipe], "zookeeper,kafka", true },
-    { S[Metrics], "monasca,telegraf,grafana", true },
+    { S[Metrics], "monasca,telegraf,grafana,lachesis", true },
     { S[LogAnalytics], "filebeat,auditbeat,logstash,opensearch,opensearch-dashboards", true },
     { S[Notifications], "influxdb,kapacitor", true },
     { S[Node], "node", true, R_ALL, BLVL_STD }

--- a/core/modules/config_lachesis.cpp
+++ b/core/modules/config_lachesis.cpp
@@ -1,0 +1,109 @@
+// CUBE SDK
+
+#include <hex/log.h>
+#include <hex/process.h>
+#include <hex/process_util.h>
+
+#include <hex/config_global.h>
+#include <hex/config_module.h>
+#include <hex/config_tuning.h>
+#include <hex/dryrun.h>
+#include <hex/logrotate.h>
+
+#include <cube/systemd_util.h>
+
+#include "include/role_cubesys.h"
+
+static const char NAME[] = "lachesis";
+static const char CONF_IN[] = "/etc/cube/lachesis/lachesis.yaml.in";
+static const char CONF[] = "/etc/cube/lachesis/lachesis.yaml";
+
+static bool s_bCubeModified = false;
+
+static CubeRole_e s_eCubeRole;
+
+// external global variables
+CONFIG_GLOBAL_STR_REF(SHARED_ID);
+
+// using external tunings
+CONFIG_TUNING_SPEC_STR(CUBESYS_ROLE);
+
+// parse tunings
+PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
+
+// rotate daily and enable copytruncate; the unit holds the log open via append:
+static LogRotateConf log_conf(NAME, "/var/log/lachesis/*.log", DAILY, 128, 0, true);
+
+static bool
+ParseCube(const char* name, const char* value, bool isNew)
+{
+    ParseTune(name, value, isNew, 1);
+    return true;
+}
+
+static void
+NotifyCube(bool modified)
+{
+    s_bCubeModified = IsModifiedTune(1);
+    s_eCubeRole = GetCubeRole(s_cubeRole);
+}
+
+static bool
+WriteConf(const std::string& sharedId)
+{
+    if (HexSystemF(0, "sed -e \"s/@CONTROL_VIP@/%s/\" %s > %s",
+                   sharedId.c_str(), CONF_IN, CONF) != 0) {
+        HexLogError("failed to update %s", CONF);
+        return false;
+    }
+
+    return true;
+}
+
+static bool
+CommitCheck(bool modified, int dryLevel)
+{
+    if (IsBootstrap()) {
+        return true;
+    }
+
+    return modified | s_bCubeModified | G_MOD(SHARED_ID);
+}
+
+static bool
+Commit(bool modified, int dryLevel)
+{
+    // todo: remove this if support dry run
+    HEX_DRYRUN_BARRIER(dryLevel, true);
+
+    if (IsUndef(s_eCubeRole) || !CommitCheck(modified, dryLevel)) {
+        return true;
+    }
+
+    // the agent attaches to VM taps, so it belongs wherever instances run
+    bool enabled = IsCompute(s_eCubeRole);
+
+    if (enabled) {
+        if (!WriteConf(G(SHARED_ID))) {
+            return false;
+        }
+
+        WriteLogRotateConf(log_conf);
+    }
+
+    // no systemctl enable: nothing in cubecos is systemd-enabled, hex_config
+    // restarts services on every boot. retry so a settling dep does not fail the commit.
+    return SystemdCommitService(enabled, NAME, true);
+}
+
+CONFIG_MODULE(lachesis, 0, 0, 0, 0, Commit);
+CONFIG_REQUIRES(lachesis, cube_scan);   // SHARED_ID
+CONFIG_REQUIRES(lachesis, keystone);    // /etc/admin-openrc.sh
+CONFIG_REQUIRES(lachesis, neutron);     // OVN up, so VM taps exist
+CONFIG_REQUIRES(lachesis, kafka);       // notification brokers
+
+// extra tunings
+CONFIG_OBSERVES(lachesis, cubesys, ParseCube, NotifyCube);
+
+// the WAL carries settled per-tenant byte totals; losing it resets billing counters
+CONFIG_MIGRATE(lachesis, "/var/lib/lachesis");

--- a/core/modules/config_prometheus.cpp
+++ b/core/modules/config_prometheus.cpp
@@ -1,6 +1,8 @@
 // CUBE SDK
 
 #include <hex/log.h>
+#include <hex/process.h>
+#include <hex/process_util.h>
 #include <hex/config_module.h>
 #include <hex/config_tuning.h>
 #include <hex/config_global.h>
@@ -19,6 +21,9 @@ static const char NAME[] = "prometheus";
 #define TSDB_RP "90d"
 
 #define CONF "/etc/prometheus/prometheus.yml"
+#define LACHESIS_TARGETS "/etc/prometheus/targets/lachesis.json"
+// the agent applies kernel deltas every 10s; the 60s global is coarse for it
+#define LACHESIS_SCRAPE_INTERVAL "30s"
 #define SCRAPE_INTERVAL "60s"
 #define EVA_INTERVAL "60s"
 #define QUERY_LOG "/var/log/prometheus/query.log"
@@ -84,6 +89,15 @@ WriteConf(bool ha, const std::string& sharedId)
     else
         fprintf(fout, "    - targets: ['%s:9283']\n", sharedId.c_str());
 
+    // lachesis, one agent per compute node. file_sd not static_configs: this
+    // module does not re-commit when compute membership changes, and prometheus
+    // reloads file_sd on its own. A missing file is not an error.
+    fprintf(fout, "  - job_name: 'lachesis-agent'\n");
+    fprintf(fout, "    scrape_interval: " LACHESIS_SCRAPE_INTERVAL "\n");
+    fprintf(fout, "    file_sd_configs:\n");
+    fprintf(fout, "    - files:\n");
+    fprintf(fout, "      - '" LACHESIS_TARGETS "'\n");
+
     fclose(fout);
 
     return true;
@@ -128,6 +142,10 @@ Commit(bool modified, int dryLevel)
     if (enabled) {
         WriteDefaultConf();
         WriteConf(s_ha, sharedId);
+
+        // seed the target list; non-fatal, and bounded so a wedged etcd
+        // cannot hang the commit
+        HexUtilSystemF(0, 30, HEX_SDK " lachesis_prometheus_targets");
 
         log_conf.postRotateCmds = "killall -HUP prometheus";
         WriteLogRotateConf(log_conf);

--- a/core/modules/config_prometheus.cpp
+++ b/core/modules/config_prometheus.cpp
@@ -1,6 +1,10 @@
 // CUBE SDK
 
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <hex/log.h>
+#include <hex/filesystem.h>
 #include <hex/process.h>
 #include <hex/process_util.h>
 #include <hex/config_module.h>
@@ -22,6 +26,7 @@ static const char NAME[] = "prometheus";
 
 #define CONF "/etc/prometheus/prometheus.yml"
 #define LACHESIS_TARGETS "/etc/prometheus/targets/lachesis.json"
+#define LACHESIS_TARGETS_CRON "/etc/cron.d/lachesis_targets"
 // the agent applies kernel deltas every 10s; the 60s global is coarse for it
 #define LACHESIS_SCRAPE_INTERVAL "30s"
 #define SCRAPE_INTERVAL "60s"
@@ -103,6 +108,34 @@ WriteConf(bool ha, const std::string& sharedId)
     return true;
 }
 
+// same shape as glance's export-sync and influxdb's curator cron jobs
+static bool
+WriteLachesisTargetsCronJob(void)
+{
+    int fd = open(LACHESIS_TARGETS_CRON, O_CREAT | O_WRONLY | O_TRUNC,
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (fd == -1) {
+        HexLogError("Unable to open file %s", LACHESIS_TARGETS_CRON);
+        return false;
+    }
+    FILE* fout = fdopen(fd, "w");
+    if (!fout) {
+        HexLogError("Unable to write lachesis target cron job: %s", LACHESIS_TARGETS_CRON);
+        close(fd);
+        return false;
+    }
+
+    fprintf(fout, "* * * * * root " HEX_SDK " lachesis_prometheus_targets\n");
+    fclose(fout);
+
+    if (HexSetFileMode(LACHESIS_TARGETS_CRON, "root", "root", 0644) != 0) {
+        HexLogError("Unable to set file %s mode/permission", LACHESIS_TARGETS_CRON);
+        return false;
+    }
+
+    return true;
+}
+
 static bool
 ParseCube(const char *name, const char *value, bool isNew)
 {
@@ -147,8 +180,16 @@ Commit(bool modified, int dryLevel)
         // cannot hang the commit
         HexUtilSystemF(0, 30, HEX_SDK " lachesis_prometheus_targets");
 
+        // membership changes (node join/remove) do not re-commit this module,
+        // so a cron keeps the list current; the generator only rewrites the
+        // file when membership actually changed
+        WriteLachesisTargetsCronJob();
+
         log_conf.postRotateCmds = "killall -HUP prometheus";
         WriteLogRotateConf(log_conf);
+    }
+    else {
+        unlink(LACHESIS_TARGETS_CRON);
     }
 
     SystemdCommitService(enabled, NAME);

--- a/core/modules/tests/config_lachesis/Makefile
+++ b/core/modules/tests/config_lachesis/Makefile
@@ -1,0 +1,13 @@
+# HEX SDK
+
+include ../../../../build.mk
+
+hex_config_LIBS = $(PROJ_LIBDIR)/libcube_sdk.a
+
+TESTS_EXTRA_PROGRAMS = hex_config
+
+hex_config_MODULES = config_dummies.o config_lachesis.o
+
+CPPFLAGS += -I$(COREDIR)/modules -I$(TOP_SRCDIR)/hex/src/modules/include -I$(COREDIR)/cube_sdk_library/include
+
+include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/core/modules/tests/config_lachesis/config_dummies.cpp
+++ b/core/modules/tests/config_lachesis/config_dummies.cpp
@@ -1,0 +1,57 @@
+// HEX SDK
+
+#include <hex/config_module.h>
+
+#include <hex/config_global.h>
+
+#include <include/role_cubesys.h>
+
+CONFIG_TUNING(NET_HOSTNAME, "net.hostname", TUNING_UNPUB, "Set appliance hostname.");
+
+// private tunings
+CONFIG_TUNING_STR(CUBESYS_ROLE, "cubesys.role", TUNING_UNPUB, "Set the role of cube appliance.", "undef", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_DOMAIN, "cubesys.domain", TUNING_UNPUB, "Set the domain of cube appliance.", DOMAIN_DEF, ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_REGION, "cubesys.region", TUNING_UNPUB, "Set the region of cube appliance.", REGION_DEF, ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_CONTROLLER, "cubesys.controller", TUNING_UNPUB, "Set controller.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_CONTROLLER_IP, "cubesys.controller.ip", TUNING_UNPUB, "Set controller IP address.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_MGMT, "cubesys.management", TUNING_UNPUB, "Set management interface.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_PROVIDER, "cubesys.provider", TUNING_UNPUB, "Set provider interface.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_OVERLAY, "cubesys.overlay", TUNING_UNPUB, "Set overlay network interface.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_STORAGE, "cubesys.storage", TUNING_UNPUB, "Set storage network interface.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_COMPUTE_PREFIX, "cubesys.compute.prefix", TUNING_UNPUB, "Set compute node host prefix.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_COMPUTE_START, "cubesys.compute.start", TUNING_UNPUB, "Set compute node start IPv4 address.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_INT(CUBESYS_COMPUTE_NUMBER, "cubesys.compute.number", TUNING_UNPUB, "Set max compute node number.", 0, 1, 255);
+CONFIG_TUNING_STR(CUBESYS_SEED, "cubesys.seed", TUNING_UNPUB, "Set CubeCOS cluster secret seed.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_MGMT_CIDR, "cubesys.mgmt.cidr", TUNING_UNPUB, "Set CubeCOS cluster management CIDR.", MGMT_CIDR_DEF, ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_CONTROL_VIP, "cubesys.control.vip", TUNING_UNPUB, "Set cluster virtual ip.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_CONTROL_HOSTS, "cubesys.control.hosts", TUNING_UNPUB, "Set control group hostname [hostname,hostname,...].", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_CONTROL_ADDRS, "cubesys.control.addrs", TUNING_UNPUB, "Set control group address [ip,ip,...].", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_STORAGE_HOSTS, "cubesys.storage.hosts", TUNING_UNPUB, "Set storage group hostname [hostname,hostname,...].", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CUBESYS_STORAGE_ADDRS, "cubesys.storage.addrs", TUNING_UNPUB, "Set storage group address [ip,ip,...].", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_BOOL(CUBESYS_HA, "cubesys.ha", TUNING_UNPUB, "Set true for indicate a HA setup.", false);
+CONFIG_TUNING_BOOL(CUBESYS_SALTKEY, "cubesys.saltkey", TUNING_UNPUB, "Set true for enabling key scrambling.", false);
+
+bool
+GetIPAddr(const char* ifname, char* ipaddr, int len, int af)
+{
+    ipaddr[0] = '9';
+    ipaddr[1] = '.';
+    ipaddr[2] = '4';
+    ipaddr[3] = '.';
+    ipaddr[4] = '8';
+    ipaddr[5] = '.';
+    ipaddr[6] = '7';
+    return true;
+}
+
+CONFIG_MODULE(net, NULL, NULL, NULL, NULL, NULL);
+CONFIG_MODULE(cubesys, NULL, NULL, NULL, NULL, NULL);
+CONFIG_MODULE(cube_scan, NULL, NULL, NULL, NULL, NULL);
+CONFIG_MODULE(keystone, NULL, NULL, NULL, NULL, NULL);
+CONFIG_MODULE(neutron, NULL, NULL, NULL, NULL, NULL);
+CONFIG_MODULE(kafka, NULL, NULL, NULL, NULL, NULL);
+CONFIG_MODULE(standalone, NULL, NULL, NULL, NULL, NULL);
+
+// config_lachesis takes CONFIG_GLOBAL_STR_REF(SHARED_ID); the real definition
+// lives in config_cube_scan.cpp, which is not linked into this test binary.
+CONFIG_GLOBAL_STR(SHARED_ID)("10.99.99.99");

--- a/core/modules/tests/config_lachesis/test_config_lachesis_01.sh
+++ b/core/modules/tests/config_lachesis/test_config_lachesis_01.sh
@@ -1,0 +1,69 @@
+#
+# TEST - config_lachesis renders the agent config and gates on node role
+#   compute / control-converged -> rendered + started
+#   control / undef             -> not rendered + stopped
+#
+# SHARED_ID is stubbed to 10.99.99.99 in config_dummies.cpp, so asserting on that
+# literal proves the module substituted @CONTROL_VIP@ rather than just running sed.
+# Asserts start/stop, not is-enabled: nothing in cubecos is systemd-enabled.
+#
+
+CONF=/etc/cube/lachesis/lachesis.yaml
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+run_role() {
+    rm -f $CONF
+    systemctl stop lachesis >/dev/null 2>&1
+    # reset committed settings: CommitCheck short-circuits when the role is
+    # unchanged, which looks identical to a broken module
+    : > /etc/settings.txt
+    cat >/tmp/settings.txt <<EOF
+cubesys.role=$1
+cubesys.controller=mydomain
+cubesys.controller.ip=1.2.3.4
+cubesys.control.hosts=node0,node4
+cubesys.management=IF.1
+net.hostname=node4
+EOF
+    # non-zero exit is not a failure here: only the module under test is linked
+    ./hex_config -vvve commit /tmp/settings.txt >/tmp/commit_$1.log 2>&1 || true
+}
+
+# ---- 1. compute: renders + starts ----
+run_role compute
+[ -f $CONF ] || fail "compute: config was not written"
+grep -q "10.99.99.99:9095" $CONF \
+    || fail "compute: @CONTROL_VIP@ not substituted with SHARED_ID"
+grep -q "@CONTROL_VIP@" $CONF \
+    && fail "compute: placeholder survived into the rendered config"
+grep -q "credentials_file: /etc/admin-openrc.sh" $CONF \
+    || fail "compute: neutron credentials_file missing from rendered config"
+[ "$(systemctl is-active lachesis 2>/dev/null)" = "active" ] \
+    || fail "compute: service not started (is-active=$(systemctl is-active lachesis 2>&1))"
+echo "  ok  compute            -> rendered + started"
+
+# ---- 2. control: no render, stopped ----
+run_role control
+[ -f $CONF ] && fail "control: config written on a non-compute node"
+[ "$(systemctl is-active lachesis 2>/dev/null)" = "active" ] \
+    && fail "control: service left running on a non-compute node"
+echo "  ok  control            -> not rendered + stopped"
+
+# ---- 3. control-converged: the bitmask case ----
+run_role control-converged
+[ -f $CONF ] \
+    || fail "control-converged: config not written (IsCompute bitmask regression)"
+grep -q "10.99.99.99:9095" $CONF || fail "control-converged: VIP not substituted"
+[ "$(systemctl is-active lachesis 2>/dev/null)" = "active" ] \
+    || fail "control-converged: service not started"
+echo "  ok  control-converged  -> rendered + started"
+
+# ---- 4. undef: inert, and no static-init/null-string abort ----
+run_role undef
+[ -f $CONF ] && fail "undef: config written for an undefined role"
+grep -qiE "_M_construct null not valid|Segmentation fault" /tmp/commit_undef.log \
+    && fail "undef: hex_config aborted (static-init order?)"
+echo "  ok  undef              -> inert, no abort"
+
+echo "config_lachesis: all role cases passed"

--- a/core/modules/tests/config_lachesis/testpost.sh
+++ b/core/modules/tests/config_lachesis/testpost.sh
@@ -1,0 +1,4 @@
+systemctl stop lachesis >/dev/null 2>&1
+rm -f /usr/lib/systemd/system/lachesis.service
+systemctl daemon-reload >/dev/null 2>&1
+rm -f /tmp/settings.txt /etc/cube/lachesis/lachesis.yaml

--- a/core/modules/tests/config_lachesis/testprep.sh
+++ b/core/modules/tests/config_lachesis/testprep.sh
@@ -1,0 +1,25 @@
+# stand in for what the component .mk and rpm populate in a real rootfs
+mkdir -p /etc/cube/lachesis /var/log/lachesis /var/lib/lachesis
+rm -f /etc/cube/lachesis/lachesis.yaml
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cp -f $DIR/../../../lachesis/lachesis.yaml.in /etc/cube/lachesis/lachesis.yaml.in
+
+# a stand-in unit rather than a mocked systemctl: the jail runs real systemd as
+# PID 1, so SystemdCommitService is exercised for real and is-active reads back
+cat > /usr/lib/systemd/system/lachesis.service <<'UNIT'
+[Unit]
+Description=lachesis test stand-in (config_lachesis unit test)
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl stop lachesis >/dev/null 2>&1
+
+touch /etc/settings.txt

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -309,6 +309,11 @@ SRV="telegraf"
 eval "ERR_DESC_$SRV[1]='daemon down'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
+SRV="lachesis"
+eval "ERR_DESC_$SRV[1]='daemon down'"
+eval "ERR_DESC_$SRV[2]='metrics not responding'"
+eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
+
 SRV="influxdb"
 eval "ERR_DESC_$SRV[1]='daemon down'"
 eval "ERR_DESC_$SRV[2]='port not responding'"

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -3292,6 +3292,46 @@ health_telegraf_repair()
     done
 }
 
+health_lachesis_report()
+{
+    _health_report ${FUNCNAME[0]}
+}
+
+health_lachesis_check()
+{
+    # the agent logs to a file (systemd append:), not the journal
+    ERR_LOG="/var/log/lachesis/lachesis.log"
+
+    # CUBE_NODE_COMPUTE_HOSTNAMES is role-bitmask filtered (-r compute), i.e.
+    # compute + control-converged + edge-core: exactly the nodes with an agent
+    for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
+        if ! is_remote_running $node lachesis ; then
+            ERR_CODE=1
+            ERR_MSG+="lachesis on $node is not running\n"
+        elif ! remote_run $node "curl -sf -m 5 -o /dev/null http://localhost:9090/metrics" >/dev/null 2>&1 ; then
+            ERR_CODE=2
+            ERR_MSG+="lachesis on $node is not serving metrics\n"
+        fi
+    done
+
+    _health_fail_log
+}
+
+health_lachesis_repair()
+{
+    for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
+        if ! is_remote_running $node lachesis || \
+           ! remote_run $node "curl -sf -m 5 -o /dev/null http://localhost:9090/metrics" >/dev/null 2>&1 ; then
+            remote_systemd_restart $node lachesis
+        fi
+    done
+}
+
+_health_lachesis_auto_repair()
+{
+    health_lachesis_repair
+}
+
 health_influxdb_report()
 {
     _health_report ${FUNCNAME[0]}

--- a/core/sdk_sh/modules/sdk_lachesis.sh
+++ b/core/sdk_sh/modules/sdk_lachesis.sh
@@ -11,28 +11,38 @@ lachesis_metrics()
     curl -sf --max-time 5 http://localhost:9090/metrics
 }
 
-# Regenerate prometheus's file_sd target list for the agent fleet. Control-side.
-# Safe to re-run: prometheus picks up file_sd changes without a reload.
+# Regenerate prometheus's file_sd target list for the agent fleet. Control-side,
+# invoked at prometheus commit and from the every-minute cron: file_sd solves
+# reload, but nothing re-commits this module when compute membership changes.
 lachesis_prometheus_targets()
 {
     local out=/etc/prometheus/targets/lachesis.json
     local port=9090
+    local nodes
+
+    # -r compute is a role-bitmask match (compute, control-converged, edge-core)
+    # -- exactly IsCompute() in core/modules/include/role_cubesys.h. Empty
+    # output means cubectl/etcd gave no answer (e.g. bootstrap commits before
+    # the node registers itself), never a zero-node cluster: fail instead of
+    # truncating the list. Bounded so a wedged etcd cannot stall the cron.
+    nodes=$(timeout 20 cubectl node list -j -r compute 2>/dev/null)
+    [ -n "$nodes" ] || return 1
 
     mkdir -p "$(dirname $out)"
 
-    # `cubectl node list compute` does not filter, and matching "compute" as a
-    # substring would miss control-converged. Roles here mirror IsCompute() in
-    # core/modules/include/role_cubesys.h.
-    #
     # One group per node so instance carries the hostname rather than ip:port;
     # the dashboards populate their node picker from label_values(up, instance).
-    cubectl node list -j 2>/dev/null | jq -c --arg port "$port" '
-        [ .[]
-          | select(.role == "compute" or .role == "control-converged" or .role == "edge-core")
-          | { targets: [ .ip.management + ":" + $port ],
-              labels: { instance: .hostname } } ]' > "$out.tmp" || { rm -f "$out.tmp" ; return 1 ; }
+    echo "$nodes" | jq -c --arg port "$port" '
+        [ .[] | { targets: [ .ip.management + ":" + $port ],
+                  labels: { instance: .hostname } } ]' > "$out.tmp" || { rm -f "$out.tmp" ; return 1 ; }
 
-    mv -f "$out.tmp" "$out"
+    # a removed node's target is dropped, not retained-as-down: removal is
+    # deliberate, and a permanent up==0 alert for it would only be noise
+    if cmp -s "$out.tmp" "$out" 2>/dev/null ; then
+        rm -f "$out.tmp"
+    else
+        mv -f "$out.tmp" "$out"
+    fi
 }
 
 # Taps carrying the telemetry filters. The agent does not detach on shutdown, so

--- a/core/sdk_sh/modules/sdk_lachesis.sh
+++ b/core/sdk_sh/modules/sdk_lachesis.sh
@@ -23,11 +23,14 @@ lachesis_prometheus_targets()
     # `cubectl node list compute` does not filter, and matching "compute" as a
     # substring would miss control-converged. Roles here mirror IsCompute() in
     # core/modules/include/role_cubesys.h.
+    #
+    # One group per node so instance carries the hostname rather than ip:port;
+    # the dashboards populate their node picker from label_values(up, instance).
     cubectl node list -j 2>/dev/null | jq -c --arg port "$port" '
-        [ { targets: [ .[]
-              | select(.role == "compute" or .role == "control-converged" or .role == "edge-core")
-              | .ip.management + ":" + $port ],
-            labels: {} } ]' > "$out.tmp" || { rm -f "$out.tmp" ; return 1 ; }
+        [ .[]
+          | select(.role == "compute" or .role == "control-converged" or .role == "edge-core")
+          | { targets: [ .ip.management + ":" + $port ],
+              labels: { instance: .hostname } } ]' > "$out.tmp" || { rm -f "$out.tmp" ; return 1 ; }
 
     mv -f "$out.tmp" "$out"
 }

--- a/core/sdk_sh/modules/sdk_lachesis.sh
+++ b/core/sdk_sh/modules/sdk_lachesis.sh
@@ -1,0 +1,24 @@
+# CUBE SDK
+
+# PROG must be set before sourcing this file
+if [ -z "$PROG" ] ; then
+    echo "Error: PROG not set" >&2
+    exit 1
+fi
+
+lachesis_metrics()
+{
+    curl -sf --max-time 5 http://localhost:9090/metrics
+}
+
+# Taps carrying the telemetry filters. The agent does not detach on shutdown, so
+# this is what to check before reclaiming a node; other subsystems share clsact.
+lachesis_tc_filters()
+{
+    local dev
+    for dev in $(ip -br link | awk '/^tap/ {sub(/@.*/, "", $1); print $1}') ; do
+        if tc filter show dev $dev ingress 2>/dev/null | grep -q telemetry ; then
+            echo $dev
+        fi
+    done
+}

--- a/core/sdk_sh/modules/sdk_lachesis.sh
+++ b/core/sdk_sh/modules/sdk_lachesis.sh
@@ -11,6 +11,27 @@ lachesis_metrics()
     curl -sf --max-time 5 http://localhost:9090/metrics
 }
 
+# Regenerate prometheus's file_sd target list for the agent fleet. Control-side.
+# Safe to re-run: prometheus picks up file_sd changes without a reload.
+lachesis_prometheus_targets()
+{
+    local out=/etc/prometheus/targets/lachesis.json
+    local port=9090
+
+    mkdir -p "$(dirname $out)"
+
+    # `cubectl node list compute` does not filter, and matching "compute" as a
+    # substring would miss control-converged. Roles here mirror IsCompute() in
+    # core/modules/include/role_cubesys.h.
+    cubectl node list -j 2>/dev/null | jq -c --arg port "$port" '
+        [ { targets: [ .[]
+              | select(.role == "compute" or .role == "control-converged" or .role == "edge-core")
+              | .ip.management + ":" + $port ],
+            labels: {} } ]' > "$out.tmp" || { rm -f "$out.tmp" ; return 1 ; }
+
+    mv -f "$out.tmp" "$out"
+}
+
 # Taps carrying the telemetry filters. The agent does not detach on shutdown, so
 # this is what to check before reclaiming a node; other subsystems share clsact.
 lachesis_tc_filters()

--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -5,7 +5,8 @@ ARG WEAK_DEP=0
 FROM quay.io/centos/centos:stream9 AS tier1
 ENV LANG=C.UTF-8
 ENV HEX_VER=hex2.0
-ENV GOLANG_VER=1.24.2
+# 1.25.x required by lachesis' go.mod; bumping recompiles every Go component
+ENV GOLANG_VER=1.25.12
 ENV HEX_ARCH=x86_64
 ENV DEVOPS_ENV=__JAIL__
 ENV TZ=Asia/Taipei
@@ -74,17 +75,23 @@ ARG HEX_TEST="qemu-kvm-core telnet net-tools iproute iputils expect nmap-ncat dn
 # extra packages for building projects
 ARG HEX_EXTRA="sudo kpartx python3-pip python3-devel java-21-openjdk java-21-openjdk-devel ruby ruby-devel rpm-build rubygems squashfs-tools podman podman-docker skopeo buildah toilet linux-firmware"
 
+# eBPF toolchain for components that compile BPF C (lachesis). clang is the only
+# compiler with a BPF target. kernel-headers is declared explicitly because BPF
+# builds reference /usr/include/{linux,asm,asm-generic} by path. bpftool is
+# diagnostic only.
+ARG HEX_BPF="clang llvm libbpf-devel kernel-headers bpftool"
+
 RUN echo "hex" > /etc/machine-id
 RUN echo "_WEAK_DEP=$WEAK_DEP" >> /etc/hex.manifest
 
 ###### install packages with WEAK_DEP == 0
 FROM tier2 AS tier2_weak_dep_0
-RUN dnf install -y $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
+RUN dnf install -y $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST $HEX_BPF
 # Jenkins is with java 21
 RUN alternatives --set java java-21-openjdk.x86_64
 ###### install packages with WEAK_DEP == 1
 FROM tier2 AS tier2_weak_dep_1
-RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
+RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST $HEX_BPF
 
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Onboards the network-telemetry agent (`bigstack-oss/lachesis`) as a CubeCOS component: built from source in the jail, installed disabled, started per role by `hex_config`, scraped by prometheus, dashboards provisioned in grafana, auto-repaired by `cluster check`.

> Supersedes #1181 (closed as collateral of a branch rename).

One commit per task — review and bisect per concern:

| commit | change | the one thing to know |
|---|---|---|
| `build(jail)` | `HEX_BPF` package group; Go 1.24.2 → 1.25.12 | first eBPF-compiling component in the tree; `gcc` has no BPF target |
| `build(make)` | `core/lachesis/`: clone → `rpmbuild` → install into rootfs, **disabled**; dashboards provisioned from the clone | `core/api` pattern; dashboards can't drift from the metrics they query |
| `feat(hex_config)` | `config_lachesis`: `IsCompute()` gate, renders config from template, `CONFIG_MIGRATE /var/lib/lachesis` | the WAL holds settled billing accumulators — losing it resets exposed counters |
| `feat(prometheus)` | `file_sd_configs` scrape job for the agent fleet | first scraped *fleet* in the tree; ceph's one-VIP model would drop every non-local node's traffic |
| `feat(grafana)` | dashboards resolve the existing `Dashboard1` datasource via `${datasource}` | no new datasource |
| `feat(prometheus)` regen | `/etc/cron.d/lachesis_targets` + hardened generator (`-r compute`, fail-on-empty, `timeout 20`, write-if-changed) | membership changes never re-commit this module, and bootstrap commits before etcd registration — without the cron, day zero starts with an empty target list |
| `feat(health)` | `health_lachesis_{report,check,repair}`, registered in `cluster check`'s Metrics group | check = unit active **and** `/metrics` answers (codes: 1 daemon down, 2 metrics not responding) |

#### Which issue(s) this PR fixes

Fixes bigstack-oss/lachesis#279
Fixes bigstack-oss/lachesis#280
Fixes bigstack-oss/lachesis#281
Fixes bigstack-oss/lachesis#283
Fixes bigstack-oss/lachesis#285
Fixes bigstack-oss/lachesis#286
Fixes bigstack-oss/lachesis#291

#### Special notes for your reviewer

Risks and deliberate decisions, in review order:

1. **The Go bump recompiles every Go component in the tree** — the real regression surface. Mitigated: `core/cubectl` builds clean under 1.25.12, and the full-image pass rebuilt everything.
2. **`config_lachesis.o` must stay last in `cube.mk`'s `hex_config_MODULES`.** Referenced tuning defaults are copied at C++ static-init time in link order; placing it earlier aborts `hex_config` at startup (`_M_construct null not valid`).
3. **No `systemctl enable`, deliberately.** Nothing in CubeCOS is systemd-enabled (`disable *` preset); `hex_config` re-commits every boot and owns lifecycle.
4. **A removed node's scrape target is dropped, not retained as `up==0`.** Removal is deliberate; a permanent alert is noise.
5. **No `RC=` prebuilt branch in `core/lachesis/Makefile` yet** — lachesis has no tagged release; a comment marks where to add it.

Verified end-to-end through the real pipeline (`centos9_cubecos_arashi_200.13` builds 8+9) and live on the resulting 1cc:

- full `distclean iso` from this branch: RPM built in the jail (20s) and baked into `heavy_rootfs`; the no-change re-run rebuilt nothing in `core/lachesis`; the ISO KVM-installed and the 1cc e2e passed
- on that 1cc: service `active`+`disabled`, config rendered with the real VIP, taps BPF-attached and traffic classified, `up{job="lachesis-agent"} == 1`, both dashboards loaded in Grafana
- target-list regen: cron.d written at commit (0644 via `open()`, CodeQL-clean), file mtime frozen across repeat runs and a live cron firing, empty-`cubectl` output keeps the last good list instead of truncating
- health: `cluster check Metrics` → `lachesis(v)`; stopped daemon → code 1; SIGSTOP-wedged daemon → code 2; `cluster check_repair` fixed it autonomously (`lachesis(1 daemon down)` → `lachesis(f1)`)
- hermetic tier: role-matrix test in `core/modules/tests/config_lachesis/` (compute / control / converged / undef) against real systemd

Not exercised: the `heavyfs_install::` RC branch — no lachesis release exists to RC-build against.

#### Additional documentation

```docs
kb/cubecos/architecture/building-a-bpf-component.md (bigstack-handbook, merged)
```
