### PR TITLE
upgrade heat from yoga to antelope

### DIFF
--- a/core/heat/heat.conf.sample
+++ b/core/heat/heat.conf.sample
@@ -1,0 +1,2501 @@
+[DEFAULT]
+
+#
+# From heat.common.config
+#
+
+# Name of the engine node. This can be an opaque identifier. It is not
+# necessarily a hostname, FQDN, or IP address. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#host = <Hostname>
+
+# List of directories to search for plug-ins. (list value)
+#plugin_dirs = /usr/lib64/heat,/usr/lib/heat,/usr/local/lib/heat,/usr/local/lib64/heat
+
+# The directory to search for environment files. (string value)
+#environment_dir = /etc/heat/environment.d
+
+# The directory to search for template files. (string value)
+#template_dir = /etc/heat/templates
+
+# DEPRECATED: Select deferred auth method, stored password or trusts. (string
+# value)
+# Possible values:
+# password - <No description provided>
+# trusts - <No description provided>
+# This option is deprecated for removal since 9.0.0.
+# Its value may be silently ignored in the future.
+# Reason: Stored password based deferred auth is broken when used with keystone
+# v3 and is not supported.
+#deferred_auth_method = trusts
+
+# Allow reauthentication on token expiry, such that long-running tasks may
+# complete. Note this defeats the expiry of any provided user tokens. (string
+# value)
+# Possible values:
+# '' - <No description provided>
+# trusts - <No description provided>
+#reauthentication_auth_method =
+
+# Create trusts with redelegation enabled. This option is only used when
+# reauthentication_auth_method is set to "trusts". Note that enabling this
+# option does have security implications as all trusts created by Heat will use
+# both impersonation and redelegation enabled. Enable it only when there are
+# other services that need to create trusts from tokens Heat uses to access
+# them, examples are Aodh and Heat in another region when configured to use
+# trusts too. (boolean value)
+#allow_trusts_redelegation = false
+
+# Subset of trustor roles to be delegated to heat. If left unset, all roles of
+# a user will be delegated to heat when creating a stack. (list value)
+#trusts_delegated_roles =
+
+# Maximum resources allowed per top-level stack. -1 stands for unlimited.
+# (integer value)
+#max_resources_per_stack = 1000
+
+# Maximum number of stacks any one tenant may have active at one time. -1
+# stands for unlimited. (integer value)
+#max_stacks_per_tenant = 512
+
+# Number of times to retry to bring a resource to a non-error state. Set to 0
+# to disable retries. (integer value)
+#action_retry_limit = 5
+
+# Number of times to retry when a client encounters an expected intermittent
+# error. Set to 0 to disable retries. (integer value)
+#client_retry_limit = 2
+
+# Maximum length of a server name to be used in nova. (integer value)
+# Maximum value: 53
+#max_server_name_length = 53
+
+# Number of times to check whether an interface has been attached or detached.
+# (integer value)
+# Minimum value: 1
+#max_interface_check_attempts = 10
+
+# Maximum nova API version for client plugin. With this limitation, any nova
+# feature supported with microversion number above max_nova_api_microversion
+# will not be available. (floating point value)
+#max_nova_api_microversion = <None>
+
+# Maximum ironic API version for client plugin. With this limitation, any
+# ironic feature supported with microversion number above
+# max_ironic_api_microversion will not be available. (floating point value)
+#max_ironic_api_microversion = <None>
+
+# Controls how many events will be pruned whenever a stack's events are purged.
+# Set this lower to keep more events at the expense of more frequent purges.
+# (integer value)
+# Minimum value: 1
+#event_purge_batch_size = 200
+
+# Rough number of maximum events that will be available per stack. Actual
+# number of events can be a bit higher since purge checks take place randomly
+# 200/event_purge_batch_size percent of the time. Older events are deleted when
+# events are purged. Set to 0 for unlimited events per stack. (integer value)
+#max_events_per_stack = 1000
+
+# Timeout in seconds for stack action (ie. create or update). (integer value)
+#stack_action_timeout = 3600
+
+# The amount of time in seconds after an error has occurred that tasks may
+# continue to run before being cancelled. (integer value)
+#error_wait_time = 240
+
+# RPC timeout for the engine liveness check that is used for stack locking.
+# (integer value)
+#engine_life_check_timeout = 2
+
+# Enable the preview Stack Abandon feature. (boolean value)
+#enable_stack_abandon = false
+
+# Enable the preview Stack Adopt feature. (boolean value)
+#enable_stack_adopt = false
+
+# Enables engine with convergence architecture. All stacks with this option
+# will be created using convergence engine. (boolean value)
+#convergence_engine = true
+
+# On update, enables heat to collect existing resource properties from reality
+# and converge to updated template. (boolean value)
+#observe_on_update = false
+
+# Template default for how the server should receive the metadata required for
+# software configuration. POLL_SERVER_CFN will allow calls to the cfn API
+# action DescribeStackResource authenticated with the provided keypair
+# (requires enabled heat-api-cfn). POLL_SERVER_HEAT will allow calls to the
+# Heat API resource-show using the provided keystone credentials (requires
+# keystone v3 API, and configured stack_user_* config options). POLL_TEMP_URL
+# will create and populate a Swift TempURL with metadata for polling (requires
+# object-store endpoint which supports TempURL).ZAQAR_MESSAGE will create a
+# dedicated zaqar queue and post the metadata for polling. (string value)
+# Possible values:
+# POLL_SERVER_CFN - <No description provided>
+# POLL_SERVER_HEAT - <No description provided>
+# POLL_TEMP_URL - <No description provided>
+# ZAQAR_MESSAGE - <No description provided>
+#default_software_config_transport = POLL_SERVER_CFN
+
+# Template default for how the server should signal to heat with the deployment
+# output values. CFN_SIGNAL will allow an HTTP POST to a CFN keypair signed URL
+# (requires enabled heat-api-cfn). TEMP_URL_SIGNAL will create a Swift TempURL
+# to be signaled via HTTP PUT (requires object-store endpoint which supports
+# TempURL). HEAT_SIGNAL will allow calls to the Heat API resource-signal using
+# the provided keystone credentials. ZAQAR_SIGNAL will create a dedicated zaqar
+# queue to be signaled using the provided keystone credentials. (string value)
+# Possible values:
+# CFN_SIGNAL - <No description provided>
+# TEMP_URL_SIGNAL - <No description provided>
+# HEAT_SIGNAL - <No description provided>
+# ZAQAR_SIGNAL - <No description provided>
+#default_deployment_signal_transport = CFN_SIGNAL
+
+# Template default for how the user_data should be formatted for the server.
+# For HEAT_CFNTOOLS, the user_data is bundled as part of the heat-cfntools
+# cloud-init boot configuration data. For RAW the user_data is passed to Nova
+# unmodified. For SOFTWARE_CONFIG user_data is bundled as part of the software
+# config data, and metadata is derived from any associated SoftwareDeployment
+# resources. (string value)
+# Possible values:
+# HEAT_CFNTOOLS - <No description provided>
+# RAW - <No description provided>
+# SOFTWARE_CONFIG - <No description provided>
+#default_user_data_format = HEAT_CFNTOOLS
+
+# Stacks containing these tag names will be hidden. Multiple tags should be
+# given in a comma-delimited list (eg. hidden_stack_tags=hide_me,me_too). (list
+# value)
+#hidden_stack_tags = data-processing-cluster
+
+# Deprecated. (string value)
+#onready = <None>
+
+# When this feature is enabled, scheduler hints identifying the heat stack
+# context of a server or volume resource are passed to the configured
+# schedulers in nova and cinder, for creates done using heat resource types
+# OS::Cinder::Volume, OS::Nova::Server, and AWS::EC2::Instance.
+# heat_root_stack_id will be set to the id of the root stack of the resource,
+# heat_stack_id will be set to the id of the resource's parent stack,
+# heat_stack_name will be set to the name of the resource's parent stack,
+# heat_path_in_stack will be set to a list of comma delimited strings of
+# stackresourcename and stackname with list[0] being 'rootstackname',
+# heat_resource_name will be set to the resource's name, and heat_resource_uuid
+# will be set to the resource's orchestration id. (boolean value)
+#stack_scheduler_hints = false
+
+# Encrypt template parameters that were marked as hidden and also all the
+# resource properties before storing them in database. (boolean value)
+#encrypt_parameters_and_properties = false
+
+# Seconds between running periodic tasks. (integer value)
+#periodic_interval = 60
+
+# URL of the Heat metadata server. NOTE: Setting this is only needed if you
+# require instances to use a different endpoint than in the keystone catalog
+# (string value)
+#heat_metadata_server_url = <None>
+
+# URL of the Heat waitcondition server. (string value)
+#heat_waitcondition_server_url = <None>
+
+# Instance connection to CFN/CW API via https. (string value)
+#instance_connection_is_secure = 0
+
+# Instance connection to CFN/CW API validate certs if SSL is used. (string
+# value)
+#instance_connection_https_validate_certificates = 1
+
+# Default region name used to get services endpoints. (string value)
+#region_name_for_services = <None>
+
+# Region name for shared services endpoints. (string value)
+#region_name_for_shared_services = <None>
+
+# The shared services located in the other region.Needs
+# region_name_for_shared_services option to be set for this to take effect.
+# (list value)
+#shared_services_types = image,volume,volumev3
+
+# Keystone role for heat template-defined users. (string value)
+#heat_stack_user_role = heat_stack_user
+
+# Keystone domain ID which contains heat template-defined users. If this option
+# is set, stack_user_domain_name option will be ignored. (string value)
+# Deprecated group/name - [DEFAULT]/stack_user_domain
+#stack_user_domain_id = <None>
+
+# Keystone domain name which contains heat template-defined users. If
+# `stack_user_domain_id` option is set, this option is ignored. (string value)
+#stack_user_domain_name = <None>
+
+# Keystone username, a user with roles sufficient to manage users and projects
+# in the stack_user_domain. (string value)
+#stack_domain_admin = <None>
+
+# Keystone password for stack_domain_admin user. (string value)
+#stack_domain_admin_password = <None>
+
+# Maximum raw byte size of any template. (integer value)
+#max_template_size = 524288
+
+# Maximum depth allowed when using nested stacks. (integer value)
+#max_nested_stack_depth = 5
+
+# Number of heat-engine processes to fork and run. Will default to either to 4
+# or number of CPUs on the host, whichever is greater. (integer value)
+#num_engine_workers = <None>
+
+# If set, is used to control which authentication endpoint is used by user-
+# controlled servers to make calls back to Heat. If unset www_authenticate_uri
+# is used. (string value)
+# Possible values:
+# '' - <No description provided>
+# public - <No description provided>
+# internal - <No description provided>
+# admin - <No description provided>
+#server_keystone_endpoint_type =
+
+#
+# From heat.common.crypt
+#
+
+# Key used to encrypt authentication info in the database. Length of this key
+# must be 32 characters. (string value)
+#auth_encryption_key = notgood but just long enough i t
+
+#
+# From heat.common.wsgi
+#
+
+# Maximum raw byte size of JSON request body. Should be larger than
+# max_template_size. (integer value)
+#max_json_body_size = 1048576
+
+#
+# From heat.engine.clients
+#
+
+# Fully qualified class name to use as a client backend. (string value)
+#cloud_backend = heat.engine.clients.OpenStackClients
+
+#
+# From heat.engine.clients.os.keystone.heat_keystoneclient
+#
+
+# Fully qualified class name to use as a keystone backend. (string value)
+#keystone_backend = heat.engine.clients.os.keystone.heat_keystoneclient.KsClientWrapper
+
+#
+# From heat.engine.notification
+#
+
+# Default notification level for outgoing notifications. (string value)
+#default_notification_level = INFO
+
+# Default publisher_id for outgoing notifications. (string value)
+#default_publisher_id = <None>
+
+#
+# From heat.engine.resources
+#
+
+# Custom template for the built-in loadbalancer nested stack. (string value)
+#loadbalancer_template = <None>
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, log-date-format). (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and
+# Linux platform is used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_syslog = false
+
+# Enable journald for logging. If running in a systemd environment you may wish
+# to enable journal support. Doing so will use the journal native protocol
+# which includes structured metadata in addition to log messages.This option is
+# ignored if log_config_append is set. (boolean value)
+#use_journal = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Use JSON formatting for logging. This option is ignored if log_config_append
+# is set. (boolean value)
+#use_json = false
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = false
+
+# Log output to Windows Event Log. (boolean value)
+#use_eventlog = false
+
+# The amount of time before the log files are rotated. This option is ignored
+# unless log_rotation_type is set to "interval". (integer value)
+#log_rotate_interval = 1
+
+# Rotation interval type. The time of the last file change (or the time when
+# the service was started) is used when scheduling the next rotation. (string
+# value)
+# Possible values:
+# Seconds - <No description provided>
+# Minutes - <No description provided>
+# Hours - <No description provided>
+# Days - <No description provided>
+# Weekday - <No description provided>
+# Midnight - <No description provided>
+#log_rotate_interval_type = days
+
+# Maximum number of rotated log files. (integer value)
+#max_logfile_count = 30
+
+# Log file maximum size in MB. This option is ignored if "log_rotation_type" is
+# not set to "size". (integer value)
+#max_logfile_size_mb = 200
+
+# Log rotation type. (string value)
+# Possible values:
+# interval - Rotate logs at predefined time intervals.
+# size - Rotate logs once they reach a predefined size.
+# none - Do not rotate log files.
+#log_rotation_type = none
+
+# Format string to use for log messages with context. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(global_request_id)s %(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message
+# is DEBUG. Used by oslo_log.formatters.ContextFormatter (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. Used by oslo_log.formatters.ContextFormatter
+# (string value)
+#logging_user_identity_format = %(user)s %(project)s %(domain)s %(system_scope)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo_policy=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string
+# value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval. (integer value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO, WARNING, DEBUG
+# or empty string. Logs with level greater or equal to rate_limit_except_level
+# are not filtered. An empty string means that all levels are filtered. (string
+# value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+#
+# From oslo.messaging
+#
+
+# Size of RPC connection pool. (integer value)
+# Minimum value: 1
+#rpc_conn_pool_size = 30
+
+# The pool size limit for connections expiration policy (integer value)
+#conn_pool_min_size = 2
+
+# The time-to-live in sec of idle connections in the pool (integer value)
+#conn_pool_ttl = 1200
+
+# Size of executor thread pool when executor is threading or eventlet. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/rpc_thread_pool_size
+#executor_thread_pool_size = 64
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout = 60
+
+# The network address and optional user credentials for connecting to the
+# messaging backend, in URL format. The expected format is:
+#
+# driver://[user:pass@]host:port[,[userN:passN@]hostN:portN]/virtual_host?query
+#
+# Example: rabbit://rabbitmq:password@127.0.0.1:5672//
+#
+# For full details on the fields in the URL see the documentation of
+# oslo_messaging.TransportURL at
+# https://docs.openstack.org/oslo.messaging/latest/reference/transport.html
+# (string value)
+#transport_url = rabbit://
+
+# The default exchange under which topics are scoped. May be overridden by an
+# exchange name specified in the transport_url option. (string value)
+#control_exchange = openstack
+
+# Add an endpoint to answer to ping calls. Endpoint is named
+# oslo_rpc_server_ping (boolean value)
+#rpc_ping_enabled = false
+
+#
+# From oslo.service.periodic_task
+#
+
+# Some periodic tasks can be run in a separate process. Should we run them
+# here? (boolean value)
+#run_external_periodic_tasks = true
+
+#
+# From oslo.service.service
+#
+
+# Enable eventlet backdoor.  Acceptable values are 0, <port>, and
+# <start>:<end>, where 0 results in listening on a random tcp port number;
+# <port> results in listening on the specified port number (and not enabling
+# backdoor if that port is in use); and <start>:<end> results in listening on
+# the smallest unused port number within the specified range of port numbers.
+# The chosen port is displayed in the service's log file. (string value)
+#backdoor_port = <None>
+
+# Enable eventlet backdoor, using the provided path as a unix socket that can
+# receive connections. This option is mutually exclusive with 'backdoor_port'
+# in that only one should be provided. If both are provided then the existence
+# of this option overrides the usage of that option. Inside the path {pid} will
+# be replaced with the PID of the current process. (string value)
+#backdoor_socket = <None>
+
+# Enables or disables logging values of all registered options when starting a
+# service (at DEBUG level). (boolean value)
+#log_options = true
+
+# Specify a timeout after which a gracefully shutdown server will exit. Zero
+# value means endless wait. (integer value)
+#graceful_shutdown_timeout = 60
+
+
+[auth_password]
+
+#
+# From heat.common.config
+#
+
+# Allow orchestration of multiple clouds. (boolean value)
+#multi_cloud = false
+
+# Allowed keystone endpoints for auth_uri when multi_cloud is enabled. At least
+# one endpoint needs to be specified. (list value)
+#allowed_auth_uris =
+
+
+[cache]
+
+#
+# From oslo.cache
+#
+
+# Prefix for building the configuration dictionary for the cache region. This
+# should not need to be changed unless there is another dogpile.cache region
+# with the same configuration name. (string value)
+#config_prefix = cache.oslo
+
+# Default TTL, in seconds, for any cached item in the dogpile.cache region.
+# This applies to any cached method that doesn't have an explicit cache
+# expiration time defined for it. (integer value)
+#expiration_time = 600
+
+# Cache backend module. For eventlet-based or environments with hundreds of
+# threaded servers, Memcache with pooling (oslo_cache.memcache_pool) is
+# recommended. For environments with less than 100 threaded servers, Memcached
+# (dogpile.cache.memcached) or Redis (dogpile.cache.redis) is recommended. Test
+# environments with a single instance of the server can use the
+# dogpile.cache.memory backend. (string value)
+# Possible values:
+# oslo_cache.memcache_pool - <No description provided>
+# oslo_cache.dict - <No description provided>
+# oslo_cache.mongo - <No description provided>
+# oslo_cache.etcd3gw - <No description provided>
+# dogpile.cache.pymemcache - <No description provided>
+# dogpile.cache.memcached - <No description provided>
+# dogpile.cache.pylibmc - <No description provided>
+# dogpile.cache.bmemcached - <No description provided>
+# dogpile.cache.dbm - <No description provided>
+# dogpile.cache.redis - <No description provided>
+# dogpile.cache.memory - <No description provided>
+# dogpile.cache.memory_pickle - <No description provided>
+# dogpile.cache.null - <No description provided>
+#backend = dogpile.cache.null
+
+# Arguments supplied to the backend module. Specify this option once per
+# argument to be passed to the dogpile.cache backend. Example format:
+# "<argname>:<value>". (multi valued)
+#backend_argument =
+
+# Proxy classes to import that will affect the way the dogpile.cache backend
+# functions. See the dogpile.cache documentation on changing-backend-behavior.
+# (list value)
+#proxies =
+
+# Global toggle for caching. (boolean value)
+#enabled = false
+
+# Extra debugging from the cache backend (cache keys, get/set/delete/etc
+# calls). This is only really useful if you need to see the specific cache-
+# backend get/set/delete calls with the keys/values.  Typically this should be
+# left set to false. (boolean value)
+#debug_cache_backend = false
+
+# Memcache servers in the format of "host:port". This is used by backends
+# dependent on Memcached.If ``dogpile.cache.memcached`` or
+# ``oslo_cache.memcache_pool`` is used and a given host refer to an IPv6 or a
+# given domain refer to IPv6 then you should prefix the given address withthe
+# address family (``inet6``) (e.g ``inet6[::1]:11211``,
+# ``inet6:[fd12:3456:789a:1::1]:11211``,
+# ``inet6:[controller-0.internalapi]:11211``). If the address family is not
+# given then these backends will use the default ``inet`` address family which
+# corresponds to IPv4 (list value)
+#memcache_servers = localhost:11211
+
+# Number of seconds memcached server is considered dead before it is tried
+# again. (dogpile.cache.memcache and oslo_cache.memcache_pool backends only).
+# (integer value)
+#memcache_dead_retry = 300
+
+# Timeout in seconds for every call to a server. (dogpile.cache.memcache and
+# oslo_cache.memcache_pool backends only). (floating point value)
+#memcache_socket_timeout = 1.0
+
+# Max total number of open connections to every memcached server.
+# (oslo_cache.memcache_pool backend only). (integer value)
+#memcache_pool_maxsize = 10
+
+# Number of seconds a connection to memcached is held unused in the pool before
+# it is closed. (oslo_cache.memcache_pool backend only). (integer value)
+#memcache_pool_unused_timeout = 60
+
+# Number of seconds that an operation will wait to get a memcache client
+# connection. (integer value)
+#memcache_pool_connection_get_timeout = 10
+
+# Global toggle if memcache will be flushed on reconnect.
+# (oslo_cache.memcache_pool backend only). (boolean value)
+#memcache_pool_flush_on_reconnect = false
+
+# Enable the SASL(Simple Authentication and SecurityLayer) if the SASL_enable
+# is true, else disable. (boolean value)
+#memcache_sasl_enabled = false
+
+# the user name for the memcached which SASL enabled (string value)
+#memcache_username =
+
+# the password for the memcached which SASL enabled (string value)
+#memcache_password =
+
+# Global toggle for TLS usage when comunicating with the caching servers.
+# (boolean value)
+#tls_enabled = false
+
+# Path to a file of concatenated CA certificates in PEM format necessary to
+# establish the caching servers' authenticity. If tls_enabled is False, this
+# option is ignored. (string value)
+#tls_cafile = <None>
+
+# Path to a single file in PEM format containing the client's certificate as
+# well as any number of CA certificates needed to establish the certificate's
+# authenticity. This file is only required when client side authentication is
+# necessary. If tls_enabled is False, this option is ignored. (string value)
+#tls_certfile = <None>
+
+# Path to a single file containing the client's private key in. Otherwise the
+# private key will be taken from the file specified in tls_certfile. If
+# tls_enabled is False, this option is ignored. (string value)
+#tls_keyfile = <None>
+
+# Set the available ciphers for sockets created with the TLS context. It should
+# be a string in the OpenSSL cipher list format. If not specified, all OpenSSL
+# enabled ciphers will be available. (string value)
+#tls_allowed_ciphers = <None>
+
+# Global toggle for the socket keepalive of dogpile's pymemcache backend
+# (boolean value)
+#enable_socket_keepalive = false
+
+# The time (in seconds) the connection needs to remain idle before TCP starts
+# sending keepalive probes. Should be a positive integer most greater than
+# zero. (integer value)
+# Minimum value: 0
+#socket_keepalive_idle = 1
+
+# The time (in seconds) between individual keepalive probes. Should be a
+# positive integer greater than zero. (integer value)
+# Minimum value: 0
+#socket_keepalive_interval = 1
+
+# The maximum number of keepalive probes TCP should send before dropping the
+# connection. Should be a positive integer greater than zero. (integer value)
+# Minimum value: 0
+#socket_keepalive_count = 1
+
+# Enable retry client mechanisms to handle failure. Those mechanisms can be
+# used to wrap all kind of pymemcache clients. The wrapper allows you to define
+# how many attempts to make and how long to wait between attemots. (boolean
+# value)
+#enable_retry_client = false
+
+# Number of times to attempt an action before failing. (integer value)
+# Minimum value: 1
+#retry_attempts = 2
+
+# Number of seconds to sleep between each attempt. (floating point value)
+#retry_delay = 0
+
+# Amount of times a client should be tried before it is marked dead and removed
+# from the pool in the HashClient's internal mechanisms. (integer value)
+# Minimum value: 1
+#hashclient_retry_attempts = 2
+
+# Time in seconds that should pass between retry attempts in the HashClient's
+# internal mechanisms. (floating point value)
+#hashclient_retry_delay = 1
+
+# Time in seconds before attempting to add a node back in the pool in the
+# HashClient's internal mechanisms. (floating point value)
+#dead_timeout = 60
+
+
+[clients]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = publicURL
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = false
+
+
+[clients_aodh]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_barbican]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_cinder]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+# Allow client's debug log output. (boolean value)
+#http_log_debug = false
+
+
+[clients_designate]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_glance]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_heat]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+# Optional heat url in format like http://0.0.0.0:8004/v1/%(tenant_id)s.
+# (string value)
+#url =
+
+
+[clients_keystone]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+# Unversioned keystone url in format like http://0.0.0.0:5000. (string value)
+#auth_uri =
+
+
+[clients_magnum]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_manila]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_mistral]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_monasca]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_neutron]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_nova]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+# Allow client's debug log output. (boolean value)
+#http_log_debug = false
+
+
+[clients_octavia]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_sahara]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_senlin]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_swift]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_trove]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_vitrage]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[clients_zaqar]
+
+#
+# From heat.common.config
+#
+
+# Type of endpoint in Identity service catalog to use for communication with
+# the OpenStack service. (string value)
+#endpoint_type = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = <None>
+
+
+[cors]
+
+#
+# From oslo.middleware
+#
+
+# Indicate whether this resource may be shared with the domain received in the
+# requests "origin" header. Format: "<protocol>://<host>[:<port>]", no trailing
+# slash. Example: https://horizon.example.com (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to HTTP Simple
+# Headers. (list value)
+#expose_headers = X-Auth-Token,X-Subject-Token,X-Service-Token,X-OpenStack-Request-ID
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list value)
+#allow_methods = GET,PUT,POST,DELETE,PATCH
+
+# Indicate which header field names may be used during the actual request.
+# (list value)
+#allow_headers = X-Auth-Token,X-Identity-Status,X-Roles,X-Service-Catalog,X-User-Id,X-Tenant-Id,X-OpenStack-Request-ID
+
+
+[database]
+
+#
+# From heat.common.config
+#
+
+# If True, SQLite uses synchronous mode. (boolean value)
+#sqlite_synchronous = true
+
+# The back end to use for the database. (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend = sqlalchemy
+
+# The SQLAlchemy connection string to use to connect to the database. (string
+# value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+#connection = <None>
+
+# The SQLAlchemy connection string to use to connect to the slave database.
+# (string value)
+#slave_connection = <None>
+
+# The SQL mode to be used for MySQL sessions. This option, including the
+# default, overrides any server-set SQL mode. To use whatever SQL mode is set
+# by the server configuration, set this to no value. Example: mysql_sql_mode=
+# (string value)
+#mysql_sql_mode = TRADITIONAL
+
+# For Galera only, configure wsrep_sync_wait causality checks on new
+# connections.  Default is None, meaning don't configure any setting. (integer
+# value)
+#mysql_wsrep_sync_wait = <None>
+
+# DEPRECATED: If True, transparently enables support for handling MySQL Cluster
+# (NDB). (boolean value)
+# This option is deprecated for removal since 12.1.0.
+# Its value may be silently ignored in the future.
+# Reason: Support for the MySQL NDB Cluster storage engine has been deprecated
+# and will be removed in a future release.
+#mysql_enable_ndb = false
+
+# Connections which have been present in the connection pool longer than this
+# number of seconds will be replaced with a new one the next time they are
+# checked out from the pool. (integer value)
+#connection_recycle_time = 3600
+
+# Maximum number of SQL connections to keep open in a pool. Setting a value of
+# 0 indicates no limit. (integer value)
+#max_pool_size = 5
+
+# Maximum number of database connection retries during startup. Set to -1 to
+# specify an infinite retry count. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries = 10
+
+# Interval between retries of opening a SQL connection. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval = 10
+
+# If set, use this value for max_overflow with SQLAlchemy. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow = 50
+
+# Verbosity of SQL debugging information: 0=None, 100=Everything. (integer
+# value)
+# Minimum value: 0
+# Maximum value: 100
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug = 0
+
+# Add Python stack traces to SQL as comment strings. (boolean value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace = false
+
+# If set, use this value for pool_timeout with SQLAlchemy. (integer value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout = <None>
+
+# Enable the experimental use of database reconnect on connection lost.
+# (boolean value)
+#use_db_reconnect = false
+
+# Seconds between retries of a database transaction. (integer value)
+#db_retry_interval = 1
+
+# If True, increases the interval between retries of a database operation up to
+# db_max_retry_interval. (boolean value)
+#db_inc_retry_interval = true
+
+# If db_inc_retry_interval is set, the maximum seconds between retries of a
+# database operation. (integer value)
+#db_max_retry_interval = 10
+
+# Maximum retries in case of connection error or deadlock error before error is
+# raised. Set to -1 to specify an infinite retry count. (integer value)
+#db_max_retries = 20
+
+# Optional URL parameters to append onto the connection URL at connect time;
+# specify as param1=value1&param2=value2&... (string value)
+#connection_parameters =
+
+
+[ec2authtoken]
+
+#
+# From heat.api.aws.ec2token
+#
+
+# Authentication Endpoint URI. (string value)
+#auth_uri = <None>
+
+# Allow orchestration of multiple clouds. (boolean value)
+#multi_cloud = false
+
+# Allowed keystone endpoints for auth_uri when multi_cloud is enabled. At least
+# one endpoint needs to be specified. (list value)
+#allowed_auth_uris =
+
+# Optional PEM-formatted certificate chain file. (string value)
+#cert_file = <None>
+
+# Optional PEM-formatted file that contains the private key. (string value)
+#key_file = <None>
+
+# Optional CA cert file to use in SSL connections. (string value)
+#ca_file = <None>
+
+# If set, then the server's certificate will not be verified. (boolean value)
+#insecure = false
+
+
+[eventlet_opts]
+
+#
+# From heat.common.wsgi
+#
+
+# If False, closes the client socket connection explicitly. (boolean value)
+#wsgi_keep_alive = true
+
+# Timeout for client connections' socket operations. If an incoming connection
+# is idle for this number of seconds it will be closed. A value of '0' means
+# wait forever. (integer value)
+#client_socket_timeout = 900
+
+
+[healthcheck]
+
+#
+# From oslo.middleware
+#
+
+# DEPRECATED: The path to respond to healtcheck requests on. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#path = /healthcheck
+
+# Show more detailed information as part of the response. Security note:
+# Enabling this option may expose sensitive details about the service being
+# monitored. Be sure to verify that it will not violate your security policies.
+# (boolean value)
+#detailed = false
+
+# Additional backends that can perform health checks and report that
+# information back as part of a request. (list value)
+#backends =
+
+# Check the presence of a file to determine if an application is running on a
+# port. Used by DisableByFileHealthcheck plugin. (string value)
+#disable_by_file_path = <None>
+
+# Check the presence of a file based on a port to determine if an application
+# is running on a port. Expects a "port:path" list of strings. Used by
+# DisableByFilesPortsHealthcheck plugin. (list value)
+#disable_by_file_paths =
+
+
+[heat_api]
+
+#
+# From heat.common.wsgi
+#
+
+# Address to bind the server. Useful when selecting a particular network
+# interface. (IP address value)
+#bind_host = 0.0.0.0
+
+# The port on which the server will listen. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#bind_port = 8004
+
+# Number of backlog requests to configure the socket with. (integer value)
+#backlog = 4096
+
+# Location of the SSL certificate file to use for SSL mode. (string value)
+#cert_file = <None>
+
+# Location of the SSL key file to use for enabling SSL mode. (string value)
+#key_file = <None>
+
+# Number of workers for Heat service. Default value 0 means, that service will
+# start number of workers equal number of cores on server. (integer value)
+# Minimum value: 0
+#workers = 0
+
+# Maximum line size of message headers to be accepted. max_header_line may need
+# to be increased when using large tokens (typically those generated by the
+# Keystone v3 API with big service catalogs). (integer value)
+#max_header_line = 16384
+
+# The value for the socket option TCP_KEEPIDLE.  This is the time in seconds
+# that the connection must be idle before TCP starts sending keepalive probes.
+# (integer value)
+#tcp_keepidle = 600
+
+
+[heat_api_cfn]
+
+#
+# From heat.common.wsgi
+#
+
+# Address to bind the server. Useful when selecting a particular network
+# interface. (IP address value)
+#bind_host = 0.0.0.0
+
+# The port on which the server will listen. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#bind_port = 8000
+
+# Number of backlog requests to configure the socket with. (integer value)
+#backlog = 4096
+
+# Location of the SSL certificate file to use for SSL mode. (string value)
+#cert_file = <None>
+
+# Location of the SSL key file to use for enabling SSL mode. (string value)
+#key_file = <None>
+
+# Number of workers for Heat service. (integer value)
+# Minimum value: 0
+#workers = 1
+
+# Maximum line size of message headers to be accepted. max_header_line may need
+# to be increased when using large tokens (typically those generated by the
+# Keystone v3 API with big service catalogs). (integer value)
+#max_header_line = 16384
+
+# The value for the socket option TCP_KEEPIDLE.  This is the time in seconds
+# that the connection must be idle before TCP starts sending keepalive probes.
+# (integer value)
+#tcp_keepidle = 600
+
+
+[keystone_authtoken]
+
+#
+# From keystonemiddleware.auth_token
+#
+
+# Complete "public" Identity API endpoint. This endpoint should not be an
+# "admin" endpoint, as it should be accessible by all end users.
+# Unauthenticated clients are redirected to this endpoint to authenticate.
+# Although this endpoint should ideally be unversioned, client support in the
+# wild varies. If you're using a versioned v2 endpoint here, then this should
+# *not* be the same endpoint the service user utilizes for validating tokens,
+# because normal end users may not be able to reach that endpoint. (string
+# value)
+# Deprecated group/name - [keystone_authtoken]/auth_uri
+#www_authenticate_uri = <None>
+
+# DEPRECATED: Complete "public" Identity API endpoint. This endpoint should not
+# be an "admin" endpoint, as it should be accessible by all end users.
+# Unauthenticated clients are redirected to this endpoint to authenticate.
+# Although this endpoint should ideally be unversioned, client support in the
+# wild varies. If you're using a versioned v2 endpoint here, then this should
+# *not* be the same endpoint the service user utilizes for validating tokens,
+# because normal end users may not be able to reach that endpoint. This option
+# is deprecated in favor of www_authenticate_uri and will be removed in the S
+# release. (string value)
+# This option is deprecated for removal since Queens.
+# Its value may be silently ignored in the future.
+# Reason: The auth_uri option is deprecated in favor of www_authenticate_uri
+# and will be removed in the S  release.
+#auth_uri = <None>
+
+# API version of the Identity API endpoint. (string value)
+#auth_version = <None>
+
+# Interface to use for the Identity API endpoint. Valid values are "public",
+# "internal" (default) or "admin". (string value)
+#interface = internal
+
+# Do not handle authorization requests within the middleware, but delegate the
+# authorization decision to downstream WSGI components. (boolean value)
+#delay_auth_decision = false
+
+# Request timeout value for communicating with Identity API server. (integer
+# value)
+#http_connect_timeout = <None>
+
+# How many times are we trying to reconnect when communicating with Identity
+# API Server. (integer value)
+#http_request_max_retries = 3
+
+# Request environment key where the Swift cache object is stored. When
+# auth_token middleware is deployed with a Swift cache, use this option to have
+# the middleware share a caching backend with swift. Otherwise, use the
+# ``memcached_servers`` option instead. (string value)
+#cache = <None>
+
+# Required if identity server requires client certificate (string value)
+#certfile = <None>
+
+# Required if identity server requires client certificate (string value)
+#keyfile = <None>
+
+# A PEM encoded Certificate Authority to use when verifying HTTPs connections.
+# Defaults to system CAs. (string value)
+#cafile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# The region in which the identity server can be found. (string value)
+#region_name = <None>
+
+# Optionally specify a list of memcached server(s) to use for caching. If left
+# undefined, tokens will instead be cached in-process. (list value)
+# Deprecated group/name - [keystone_authtoken]/memcache_servers
+#memcached_servers = <None>
+
+# In order to prevent excessive effort spent validating tokens, the middleware
+# caches previously-seen tokens for a configurable duration (in seconds). Set
+# to -1 to disable caching completely. (integer value)
+#token_cache_time = 300
+
+# (Optional) If defined, indicate whether token data should be authenticated or
+# authenticated and encrypted. If MAC, token data is authenticated (with HMAC)
+# in the cache. If ENCRYPT, token data is encrypted and authenticated in the
+# cache. If the value is not one of these options or empty, auth_token will
+# raise an exception on initialization. (string value)
+# Possible values:
+# None - <No description provided>
+# MAC - <No description provided>
+# ENCRYPT - <No description provided>
+#memcache_security_strategy = None
+
+# (Optional, mandatory if memcache_security_strategy is defined) This string is
+# used for key derivation. (string value)
+#memcache_secret_key = <None>
+
+# (Optional) Number of seconds memcached server is considered dead before it is
+# tried again. (integer value)
+#memcache_pool_dead_retry = 300
+
+# (Optional) Maximum total number of open connections to every memcached
+# server. (integer value)
+#memcache_pool_maxsize = 10
+
+# (Optional) Socket timeout in seconds for communicating with a memcached
+# server. (integer value)
+#memcache_pool_socket_timeout = 3
+
+# (Optional) Number of seconds a connection to memcached is held unused in the
+# pool before it is closed. (integer value)
+#memcache_pool_unused_timeout = 60
+
+# (Optional) Number of seconds that an operation will wait to get a memcached
+# client connection from the pool. (integer value)
+#memcache_pool_conn_get_timeout = 10
+
+# (Optional) Use the advanced (eventlet safe) memcached client pool. (boolean
+# value)
+#memcache_use_advanced_pool = true
+
+# (Optional) Indicate whether to set the X-Service-Catalog header. If False,
+# middleware will not ask for service catalog on token validation and will not
+# set the X-Service-Catalog header. (boolean value)
+#include_service_catalog = true
+
+# Used to control the use and type of token binding. Can be set to: "disabled"
+# to not check token binding. "permissive" (default) to validate binding
+# information if the bind type is of a form known to the server and ignore it
+# if not. "strict" like "permissive" but if the bind type is unknown the token
+# will be rejected. "required" any form of token binding is needed to be
+# allowed. Finally the name of a binding method that must be present in tokens.
+# (string value)
+#enforce_token_bind = permissive
+
+# A choice of roles that must be present in a service token. Service tokens are
+# allowed to request that an expired token can be used and so this check should
+# tightly control that only actual services should be sending this token. Roles
+# here are applied as an ANY check so any role in this list must be present.
+# For backwards compatibility reasons this currently only affects the
+# allow_expired check. (list value)
+#service_token_roles = service
+
+# For backwards compatibility reasons we must let valid service tokens pass
+# that don't pass the service_token_roles check as valid. Setting this true
+# will become the default in a future release and should be enabled if
+# possible. (boolean value)
+#service_token_roles_required = false
+
+# The name or type of the service as it appears in the service catalog. This is
+# used to validate tokens that have restricted access rules. (string value)
+#service_type = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [keystone_authtoken]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string value)
+#auth_section = <None>
+
+
+[noauth]
+
+#
+# From heat.common.config
+#
+
+# JSON file containing the content returned by the noauth middleware. (string
+# value)
+#token_response =
+
+
+[oslo_messaging_amqp]
+
+#
+# From oslo.messaging
+#
+
+# Name for the AMQP container. must be globally unique. Defaults to a generated
+# UUID (string value)
+#container_name = <None>
+
+# Timeout for inactive connections (in seconds) (integer value)
+#idle_timeout = 0
+
+# Debug: dump AMQP frames to stdout (boolean value)
+#trace = false
+
+# Attempt to connect via SSL. If no other ssl-related parameters are given, it
+# will use the system's CA-bundle to verify the server's certificate. (boolean
+# value)
+#ssl = false
+
+# CA certificate PEM file used to verify the server's certificate (string
+# value)
+#ssl_ca_file =
+
+# Self-identifying certificate PEM file for client authentication (string
+# value)
+#ssl_cert_file =
+
+# Private key PEM file used to sign ssl_cert_file certificate (optional)
+# (string value)
+#ssl_key_file =
+
+# Password for decrypting ssl_key_file (if encrypted) (string value)
+#ssl_key_password = <None>
+
+# By default SSL checks that the name in the server's certificate matches the
+# hostname in the transport_url. In some configurations it may be preferable to
+# use the virtual hostname instead, for example if the server uses the Server
+# Name Indication TLS extension (rfc6066) to provide a certificate per virtual
+# host. Set ssl_verify_vhost to True if the server's SSL certificate uses the
+# virtual host name instead of the DNS name. (boolean value)
+#ssl_verify_vhost = false
+
+# Space separated list of acceptable SASL mechanisms (string value)
+#sasl_mechanisms =
+
+# Path to directory that contains the SASL configuration (string value)
+#sasl_config_dir =
+
+# Name of configuration file (without .conf suffix) (string value)
+#sasl_config_name =
+
+# SASL realm to use if no realm present in username (string value)
+#sasl_default_realm =
+
+# Seconds to pause before attempting to re-connect. (integer value)
+# Minimum value: 1
+#connection_retry_interval = 1
+
+# Increase the connection_retry_interval by this many seconds after each
+# unsuccessful failover attempt. (integer value)
+# Minimum value: 0
+#connection_retry_backoff = 2
+
+# Maximum limit for connection_retry_interval + connection_retry_backoff
+# (integer value)
+# Minimum value: 1
+#connection_retry_interval_max = 30
+
+# Time to pause between re-connecting an AMQP 1.0 link that failed due to a
+# recoverable error. (integer value)
+# Minimum value: 1
+#link_retry_delay = 10
+
+# The maximum number of attempts to re-send a reply message which failed due to
+# a recoverable error. (integer value)
+# Minimum value: -1
+#default_reply_retry = 0
+
+# The deadline for an rpc reply message delivery. (integer value)
+# Minimum value: 5
+#default_reply_timeout = 30
+
+# The deadline for an rpc cast or call message delivery. Only used when caller
+# does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_send_timeout = 30
+
+# The deadline for a sent notification message delivery. Only used when caller
+# does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_notify_timeout = 30
+
+# The duration to schedule a purge of idle sender links. Detach link after
+# expiry. (integer value)
+# Minimum value: 1
+#default_sender_link_timeout = 600
+
+# Indicates the addressing mode used by the driver.
+# Permitted values:
+# 'legacy'   - use legacy non-routable addressing
+# 'routable' - use routable addresses
+# 'dynamic'  - use legacy addresses if the message bus does not support routing
+# otherwise use routable addressing (string value)
+#addressing_mode = dynamic
+
+# Enable virtual host support for those message buses that do not natively
+# support virtual hosting (such as qpidd). When set to true the virtual host
+# name will be added to all message bus addresses, effectively creating a
+# private 'subnet' per virtual host. Set to False if the message bus supports
+# virtual hosting using the 'hostname' field in the AMQP 1.0 Open performative
+# as the name of the virtual host. (boolean value)
+#pseudo_vhost = true
+
+# address prefix used when sending to a specific server (string value)
+#server_request_prefix = exclusive
+
+# address prefix used when broadcasting to all servers (string value)
+#broadcast_prefix = broadcast
+
+# address prefix when sending to any server in group (string value)
+#group_request_prefix = unicast
+
+# Address prefix for all generated RPC addresses (string value)
+#rpc_address_prefix = openstack.org/om/rpc
+
+# Address prefix for all generated Notification addresses (string value)
+#notify_address_prefix = openstack.org/om/notify
+
+# Appended to the address prefix when sending a fanout message. Used by the
+# message bus to identify fanout messages. (string value)
+#multicast_address = multicast
+
+# Appended to the address prefix when sending to a particular RPC/Notification
+# server. Used by the message bus to identify messages sent to a single
+# destination. (string value)
+#unicast_address = unicast
+
+# Appended to the address prefix when sending to a group of consumers. Used by
+# the message bus to identify messages that should be delivered in a round-
+# robin fashion across consumers. (string value)
+#anycast_address = anycast
+
+# Exchange name used in notification addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_notification_exchange if set
+# else control_exchange if set
+# else 'notify' (string value)
+#default_notification_exchange = <None>
+
+# Exchange name used in RPC addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_rpc_exchange if set
+# else control_exchange if set
+# else 'rpc' (string value)
+#default_rpc_exchange = <None>
+
+# Window size for incoming RPC Reply messages. (integer value)
+# Minimum value: 1
+#reply_link_credit = 200
+
+# Window size for incoming RPC Request messages (integer value)
+# Minimum value: 1
+#rpc_server_credit = 100
+
+# Window size for incoming Notification messages (integer value)
+# Minimum value: 1
+#notify_server_credit = 100
+
+# Send messages of this type pre-settled.
+# Pre-settled messages will not receive acknowledgement
+# from the peer. Note well: pre-settled messages may be
+# silently discarded if the delivery fails.
+# Permitted values:
+# 'rpc-call' - send RPC Calls pre-settled
+# 'rpc-reply'- send RPC Replies pre-settled
+# 'rpc-cast' - Send RPC Casts pre-settled
+# 'notify'   - Send Notifications pre-settled
+#  (multi valued)
+#pre_settled = rpc-cast
+#pre_settled = rpc-reply
+
+
+[oslo_messaging_kafka]
+
+#
+# From oslo.messaging
+#
+
+# Max fetch bytes of Kafka consumer (integer value)
+#kafka_max_fetch_bytes = 1048576
+
+# Default timeout(s) for Kafka consumers (floating point value)
+#kafka_consumer_timeout = 1.0
+
+# DEPRECATED: Pool Size for Kafka Consumers (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#pool_size = 10
+
+# DEPRECATED: The pool size limit for connections expiration policy (integer
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_min_size = 2
+
+# DEPRECATED: The time-to-live in sec of idle connections in the pool (integer
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_ttl = 1200
+
+# Group id for Kafka consumer. Consumers in one group will coordinate message
+# consumption (string value)
+#consumer_group = oslo_messaging_consumer
+
+# Upper bound on the delay for KafkaProducer batching in seconds (floating
+# point value)
+#producer_batch_timeout = 0.0
+
+# Size of batch for the producer async send (integer value)
+#producer_batch_size = 16384
+
+# The compression codec for all data generated by the producer. If not set,
+# compression will not be used. Note that the allowed values of this depend on
+# the kafka version (string value)
+# Possible values:
+# none - <No description provided>
+# gzip - <No description provided>
+# snappy - <No description provided>
+# lz4 - <No description provided>
+# zstd - <No description provided>
+#compression_codec = none
+
+# Enable asynchronous consumer commits (boolean value)
+#enable_auto_commit = false
+
+# The maximum number of records returned in a poll call (integer value)
+#max_poll_records = 500
+
+# Protocol used to communicate with brokers (string value)
+# Possible values:
+# PLAINTEXT - <No description provided>
+# SASL_PLAINTEXT - <No description provided>
+# SSL - <No description provided>
+# SASL_SSL - <No description provided>
+#security_protocol = PLAINTEXT
+
+# Mechanism when security protocol is SASL (string value)
+#sasl_mechanism = PLAIN
+
+# CA certificate PEM file used to verify the server certificate (string value)
+#ssl_cafile =
+
+# Client certificate PEM file used for authentication. (string value)
+#ssl_client_cert_file =
+
+# Client key PEM file used for authentication. (string value)
+#ssl_client_key_file =
+
+# Client key password file used for authentication. (string value)
+#ssl_client_key_password =
+
+
+[oslo_messaging_notifications]
+
+#
+# From oslo.messaging
+#
+
+# The Drivers(s) to handle sending notifications. Possible values are
+# messaging, messagingv2, routing, log, test, noop (multi valued)
+# Deprecated group/name - [DEFAULT]/notification_driver
+#driver =
+
+# A URL representing the messaging driver to use for notifications. If not set,
+# we fall back to the same configuration used for RPC. (string value)
+# Deprecated group/name - [DEFAULT]/notification_transport_url
+#transport_url = <None>
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+# Deprecated group/name - [DEFAULT]/notification_topics
+#topics = notifications
+
+# The maximum number of attempts to re-send a notification message which failed
+# to be delivered due to a recoverable error. 0 - No retry, -1 - indefinite
+# (integer value)
+#retry = -1
+
+
+[oslo_messaging_rabbit]
+
+#
+# From oslo.messaging
+#
+
+# Use durable queues in AMQP. If rabbit_quorum_queue is enabled, queues will be
+# durable and this value will be ignored. (boolean value)
+#amqp_durable_queues = false
+
+# Auto-delete queues in AMQP. (boolean value)
+#amqp_auto_delete = false
+
+# Connect over SSL. (boolean value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_use_ssl
+#ssl = false
+
+# SSL version to use (valid only if SSL enabled). Valid values are TLSv1 and
+# SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be available on some
+# distributions. (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_version
+#ssl_version =
+
+# SSL key file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_keyfile
+#ssl_key_file =
+
+# SSL cert file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_certfile
+#ssl_cert_file =
+
+# SSL certification authority file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_ca_certs
+#ssl_ca_file =
+
+# Global toggle for enforcing the OpenSSL FIPS mode. This feature requires
+# Python support. This is available in Python 3.9 in all environments and may
+# have been backported to older Python versions on select environments. If the
+# Python executable used does not support OpenSSL FIPS mode, an exception will
+# be raised. (boolean value)
+#ssl_enforce_fips_mode = false
+
+# Run the health check heartbeat thread through a native python thread by
+# default. If this option is equal to False then the health check heartbeat
+# will inherit the execution model from the parent process. For example if the
+# parent process has monkey patched the stdlib by using eventlet/greenlet then
+# the heartbeat will be run through a green thread. This option should be set
+# to True only for the wsgi services. (boolean value)
+#heartbeat_in_pthread = false
+
+# How long to wait (in seconds) before reconnecting in response to an AMQP
+# consumer cancel notification. (floating point value)
+# Minimum value: 0.0
+# Maximum value: 4.5
+#kombu_reconnect_delay = 1.0
+
+# EXPERIMENTAL: Possible values are: gzip, bz2. If not set compression will not
+# be used. This option may not be available in future versions. (string value)
+#kombu_compression = <None>
+
+# How long to wait a missing client before abandoning to send it its replies.
+# This value should not be longer than rpc_response_timeout. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_reconnect_timeout
+#kombu_missing_consumer_retry_timeout = 60
+
+# Determines how the next RabbitMQ node is chosen in case the one we are
+# currently connected to becomes unavailable. Takes effect only if more than
+# one RabbitMQ node is provided in config. (string value)
+# Possible values:
+# round-robin - <No description provided>
+# shuffle - <No description provided>
+#kombu_failover_strategy = round-robin
+
+# The RabbitMQ login method. (string value)
+# Possible values:
+# PLAIN - <No description provided>
+# AMQPLAIN - <No description provided>
+# EXTERNAL - <No description provided>
+# RABBIT-CR-DEMO - <No description provided>
+#rabbit_login_method = AMQPLAIN
+
+# How frequently to retry connecting with RabbitMQ. (integer value)
+#rabbit_retry_interval = 1
+
+# How long to backoff for between retries when connecting to RabbitMQ. (integer
+# value)
+#rabbit_retry_backoff = 2
+
+# Maximum interval of RabbitMQ connection retries. Default is 30 seconds.
+# (integer value)
+#rabbit_interval_max = 30
+
+# Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
+# option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring
+# is no longer controlled by the x-ha-policy argument when declaring a queue.
+# If you just want to make sure that all queues (except those with auto-
+# generated names) are mirrored across all nodes, run: "rabbitmqctl set_policy
+# HA '^(?!amq\.).*' '{"ha-mode": "all"}' " (boolean value)
+#rabbit_ha_queues = false
+
+# Use quorum queues in RabbitMQ (x-queue-type: quorum). The quorum queue is a
+# modern queue type for RabbitMQ implementing a durable, replicated FIFO queue
+# based on the Raft consensus algorithm. It is available as of RabbitMQ 3.8.0.
+# If set this option will conflict with the HA queues (``rabbit_ha_queues``)
+# aka mirrored queues, in other words the HA queues should be disabled, quorum
+# queues durable by default so the amqp_durable_queues opion is ignored when
+# this option enabled. (boolean value)
+#rabbit_quorum_queue = false
+
+# Each time a message is redelivered to a consumer, a counter is incremented.
+# Once the redelivery count exceeds the delivery limit the message gets dropped
+# or dead-lettered (if a DLX exchange has been configured) Used only when
+# rabbit_quorum_queue is enabled, Default 0 which means dont set a limit.
+# (integer value)
+#rabbit_quorum_delivery_limit = 0
+
+# By default all messages are maintained in memory if a quorum queue grows in
+# length it can put memory pressure on a cluster. This option can limit the
+# number of messages in the quorum queue. Used only when rabbit_quorum_queue is
+# enabled, Default 0 which means dont set a limit. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_length
+#rabbit_quorum_max_memory_length = 0
+
+# By default all messages are maintained in memory if a quorum queue grows in
+# length it can put memory pressure on a cluster. This option can limit the
+# number of memory bytes used by the quorum queue. Used only when
+# rabbit_quorum_queue is enabled, Default 0 which means dont set a limit.
+# (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_bytes
+#rabbit_quorum_max_memory_bytes = 0
+
+# Positive integer representing duration in seconds for queue TTL (x-expires).
+# Queues which are unused for the duration of the TTL are automatically
+# deleted. The parameter affects only reply and fanout queues. (integer value)
+# Minimum value: 1
+#rabbit_transient_queues_ttl = 1800
+
+# Specifies the number of messages to prefetch. Setting to zero allows
+# unlimited messages. (integer value)
+#rabbit_qos_prefetch_count = 0
+
+# Number of seconds after which the Rabbit broker is considered down if
+# heartbeat's keep-alive fails (0 disables heartbeat). (integer value)
+#heartbeat_timeout_threshold = 60
+
+# How often times during the heartbeat_timeout_threshold we check the
+# heartbeat. (integer value)
+#heartbeat_rate = 2
+
+# DEPRECATED: (DEPRECATED) Enable/Disable the RabbitMQ mandatory flag for
+# direct send. The direct send is used as reply, so the MessageUndeliverable
+# exception is raised in case the client queue does not
+# exist.MessageUndeliverable exception will be used to loop for a timeout to
+# lets a chance to sender to recover.This flag is deprecated and it will not be
+# possible to deactivate this functionality anymore (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Mandatory flag no longer deactivable.
+#direct_mandatory_flag = true
+
+# Enable x-cancel-on-ha-failover flag so that rabbitmq server will cancel and
+# notify consumerswhen queue is down (boolean value)
+#enable_cancel_on_failover = false
+
+
+[oslo_middleware]
+
+#
+# From oslo.middleware
+#
+
+# The maximum body size for each  request, in bytes. (integer value)
+# Deprecated group/name - [DEFAULT]/osapi_max_request_body_size
+# Deprecated group/name - [DEFAULT]/max_request_body_size
+#max_request_body_size = 114688
+
+# DEPRECATED: The HTTP Header that will be used to determine what the original
+# request protocol scheme was, even if it was hidden by a SSL termination
+# proxy. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#secure_proxy_ssl_header = X-Forwarded-Proto
+
+# Whether the application is behind a proxy or not. This determines if the
+# middleware should parse the headers or not. (boolean value)
+#enable_proxy_headers_parsing = false
+
+# HTTP basic auth password file. (string value)
+#http_basic_auth_user_file = /etc/htpasswd
+
+
+[oslo_policy]
+
+#
+# From oslo.policy
+#
+
+# This option controls whether or not to enforce scope when evaluating
+# policies. If ``True``, the scope of the token used in the request is compared
+# to the ``scope_types`` of the policy being enforced. If the scopes do not
+# match, an ``InvalidScope`` exception will be raised. If ``False``, a message
+# will be logged informing operators that policies are being invoked with
+# mismatching scope. (boolean value)
+#enforce_scope = false
+
+# This option controls whether or not to use old deprecated defaults when
+# evaluating policies. If ``True``, the old deprecated defaults are not going
+# to be evaluated. This means if any existing token is allowed for old defaults
+# but is disallowed for new defaults, it will be disallowed. It is encouraged
+# to enable this flag along with the ``enforce_scope`` flag so that you can get
+# the benefits of new defaults and ``scope_type`` together. If ``False``, the
+# deprecated policy check string is logically OR'd with the new policy check
+# string, allowing for a graceful upgrade experience between releases with new
+# policies, which is the default behavior. (boolean value)
+#enforce_new_defaults = false
+
+# The relative or absolute path of a file that maps roles to permissions for a
+# given service. Relative paths must be specified in relation to the
+# configuration file setting this option. (string value)
+#policy_file = policy.yaml
+
+# Default rule. Enforced when a requested rule is not found. (string value)
+#policy_default_rule = default
+
+# Directories where policy configuration files are stored. They can be relative
+# to any directory in the search path defined by the config_dir option, or
+# absolute paths. The file defined by policy_file must exist for these
+# directories to be searched.  Missing or empty directories are ignored. (multi
+# valued)
+#policy_dirs = policy.d
+
+# Content Type to send and receive data for REST based policy check (string
+# value)
+# Possible values:
+# application/x-www-form-urlencoded - <No description provided>
+# application/json - <No description provided>
+#remote_content_type = application/x-www-form-urlencoded
+
+# server identity verification for REST based policy check (boolean value)
+#remote_ssl_verify_server_crt = false
+
+# Absolute path to ca cert file for REST based policy check (string value)
+#remote_ssl_ca_crt_file = <None>
+
+# Absolute path to client cert for REST based policy check (string value)
+#remote_ssl_client_crt_file = <None>
+
+# Absolute path client key file REST based policy check (string value)
+#remote_ssl_client_key_file = <None>
+
+
+[oslo_reports]
+
+#
+# From oslo.reports
+#
+
+# Path to a log directory where to create a file (string value)
+#log_dir = <None>
+
+# The path to a file to watch for changes to trigger the reports, instead of
+# signals. Setting this option disables the signal trigger for the reports. If
+# application is running as a WSGI application it is recommended to use this
+# instead of signals. (string value)
+#file_event_handler = <None>
+
+# How many seconds to wait between polls when file_event_handler is set
+# (integer value)
+#file_event_handler_interval = 1
+
+
+[paste_deploy]
+
+#
+# From heat.common.config
+#
+
+# The flavor to use. (string value)
+#flavor = <None>
+
+# The API paste config file to use. (string value)
+#api_paste_config = api-paste.ini
+
+
+[profiler]
+
+#
+# From heat.common.config
+#
+
+#
+# Enable the profiling for all services on this node.
+#
+# Default value is False (fully disable the profiling feature).
+#
+# Possible values:
+#
+# * True: Enables the feature
+# * False: Disables the feature. The profiling cannot be started via this
+# project
+#   operations. If the profiling is triggered by another project, this project
+#   part will be empty.
+#  (boolean value)
+# Deprecated group/name - [profiler]/profiler_enabled
+#enabled = false
+
+#
+# Enable SQL requests profiling in services.
+#
+# Default value is False (SQL requests won't be traced).
+#
+# Possible values:
+#
+# * True: Enables SQL requests profiling. Each SQL query will be part of the
+#   trace and can the be analyzed by how much time was spent for that.
+# * False: Disables SQL requests profiling. The spent time is only shown on a
+#   higher level of operations. Single SQL queries cannot be analyzed this way.
+#  (boolean value)
+#trace_sqlalchemy = false
+
+#
+# Secret key(s) to use for encrypting context data for performance profiling.
+#
+# This string value should have the following format:
+# <key1>[,<key2>,...<keyn>],
+# where each key is some random string. A user who triggers the profiling via
+# the REST API has to set one of these keys in the headers of the REST API call
+# to include profiling results of this node for this particular project.
+#
+# Both "enabled" flag and "hmac_keys" config options should be set to enable
+# profiling. Also, to generate correct profiling information across all
+# services
+# at least one key needs to be consistent between OpenStack projects. This
+# ensures it can be used from client side to generate the trace, containing
+# information from all possible resources.
+#  (string value)
+#hmac_keys = SECRET_KEY
+
+#
+# Connection string for a notifier backend.
+#
+# Default value is ``messaging://`` which sets the notifier to oslo_messaging.
+#
+# Examples of possible values:
+#
+# * ``messaging://`` - use oslo_messaging driver for sending spans.
+# * ``redis://127.0.0.1:6379`` - use redis driver for sending spans.
+# * ``mongodb://127.0.0.1:27017`` - use mongodb driver for sending spans.
+# * ``elasticsearch://127.0.0.1:9200`` - use elasticsearch driver for sending
+#   spans.
+# * ``jaeger://127.0.0.1:6831`` - use jaeger tracing as driver for sending
+# spans.
+#  (string value)
+#connection_string = messaging://
+
+#
+# Document type for notification indexing in elasticsearch.
+#  (string value)
+#es_doc_type = notification
+
+#
+# This parameter is a time value parameter (for example: es_scroll_time=2m),
+# indicating for how long the nodes that participate in the search will
+# maintain
+# relevant resources in order to continue and support it.
+#  (string value)
+#es_scroll_time = 2m
+
+#
+# Elasticsearch splits large requests in batches. This parameter defines
+# maximum size of each batch (for example: es_scroll_size=10000).
+#  (integer value)
+#es_scroll_size = 10000
+
+#
+# Redissentinel provides a timeout option on the connections.
+# This parameter defines that timeout (for example: socket_timeout=0.1).
+#  (floating point value)
+#socket_timeout = 0.1
+
+#
+# Redissentinel uses a service name to identify a master redis service.
+# This parameter defines the name (for example:
+# ``sentinal_service_name=mymaster``).
+#  (string value)
+#sentinel_service_name = mymaster
+
+#
+# Enable filter traces that contain error/exception to a separated place.
+#
+# Default value is set to False.
+#
+# Possible values:
+#
+# * True: Enable filter traces that contain error/exception.
+# * False: Disable the filter.
+#  (boolean value)
+#filter_error_trace = false
+
+
+[revision]
+
+#
+# From heat.common.config
+#
+
+# Heat build revision. If you would prefer to manage your build revision
+# separately, you can move this section to a different file and add it as
+# another config option. (string value)
+#heat_revision = unknown
+
+
+[ssl]
+
+#
+# From oslo.service.sslutils
+#
+
+# CA certificate file to use to verify connecting clients. (string value)
+# Deprecated group/name - [DEFAULT]/ssl_ca_file
+#ca_file = <None>
+
+# Certificate file to use when starting the server securely. (string value)
+# Deprecated group/name - [DEFAULT]/ssl_cert_file
+#cert_file = <None>
+
+# Private key file to use when starting the server securely. (string value)
+# Deprecated group/name - [DEFAULT]/ssl_key_file
+#key_file = <None>
+
+# SSL version to use (valid only if SSL enabled). Valid values are TLSv1 and
+# SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be available on some
+# distributions. (string value)
+#version = <None>
+
+# Sets the list of available ciphers. value should be a string in the OpenSSL
+# cipher list format. (string value)
+#ciphers = <None>
+
+
+[trustee]
+
+#
+# From heat.common.context
+#
+
+# Authentication type to load (string value)
+# Deprecated group/name - [trustee]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string value)
+#auth_section = <None>
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [trustee]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [trustee]/tenant_name
+#project_name = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will be used for both
+# the user and project domain in v3 and ignored in v2 authentication. (string
+# value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters. It will be used
+# for both the user and project domain in v3 and ignored in v2 authentication.
+# (string value)
+#default_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [trustee]/user_name
+#username = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User's password (string value)
+#password = <None>
+
+
+[volumes]
+
+#
+# From heat.common.config
+#
+
+# Indicate if cinder-backup service is enabled. This is a temporary workaround
+# until cinder-backup service becomes discoverable, see LP#1334856. (boolean
+# value)
+#backups_enabled = true

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -1,9 +1,97 @@
 # Cube SDK
 # heat installation
 
-ROOTFS_DNF_NOARCH += openstack-heat-api openstack-heat-api-cfn openstack-heat-engine openstack-heat-ui
+# No extra rootfs packages are needed. The RDO spec's only non-python Requires
+# was shadow-utils, for the heat user and group, and
+# core/heavyfs/account/centos9 already carries heat statically.
+#
+# openstack-heat-ui, the Horizon dashboard plugin, is deliberately no longer
+# installed: Horizon imports it and Horizon still runs on the system python 3.9,
+# so it cannot follow heat into the 3.10 venv. Restoring the Orchestration panel
+# belongs to #609 (Upgrade Horizon from Yoga to Antelope), whose acceptance
+# criteria already cover "Ensure other panels are functioning on the dashboard".
 
 HEAT_CONFDIR := $(ROOTDIR)/etc/heat
 
+# install heat
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			openstack-heat==20.0.1"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+	$(Q)# Link the six console scripts heat declares. The venv also gains
+	$(Q)# heat-db-setup and heat-keystone-setup{,-domain} (manual deployment
+	$(Q)# helpers that hex_config replaces), heat-wsgi-api{,-cfn} (only used when
+	$(Q)# heat is hosted under a wsgi server, which is not the layout here) and
+	$(Q)# heat (the deprecated python-heatclient CLI, called nowhere in this
+	$(Q)# tree); those are left unlinked on purpose.
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-all /usr/bin/heat-all
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-api /usr/bin/heat-api
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-api-cfn /usr/bin/heat-api-cfn
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-engine /usr/bin/heat-engine
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-manage /usr/bin/heat-manage
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-status /usr/bin/heat-status
+
+# prepare the build directory
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rm -rf /tmp/heat
+	$(Q)chroot $(ROOTDIR) mkdir -p /tmp/heat
+
+# stage the checked-in sample config and systemd units
+# NOTE: core/heat/oslo-config-generator/heat.conf is not staged. It is the input
+# that produced heat.conf.sample and is kept in the repo for the next release
+# hop; the image has no use for it.
+rootfs_install::
+	$(Q)cp -f $(COREDIR)/heat/heat.conf.sample $(ROOTDIR)/tmp/heat/
+	$(Q)cp -f $(COREDIR)/heat/openstack-heat-api.service $(ROOTDIR)/tmp/heat/
+	$(Q)cp -f $(COREDIR)/heat/openstack-heat-api-cfn.service $(ROOTDIR)/tmp/heat/
+	$(Q)cp -f $(COREDIR)/heat/openstack-heat-engine.service $(ROOTDIR)/tmp/heat/
+	$(Q)cp -f $(COREDIR)/heat/openstack-heat-all.service $(ROOTDIR)/tmp/heat/
+
+# install system directories and files
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /etc/heat
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /usr/share/heat
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/lib/heat
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/log/heat
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/run/heat
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/heat/heat.conf.sample /etc/heat/heat.conf
+	$(Q)# api-paste.ini, environment.d and templates ship inside the wheel, so
+	$(Q)# pip lands them under the venv prefix; relocate them into /etc/heat the
+	$(Q)# same way the RDO spec's %install does.
+	$(Q)chroot $(ROOTDIR) cp -f /opt/openstack-antelope/etc/heat/api-paste.ini /etc/heat/api-paste.ini
+	$(Q)chroot $(ROOTDIR) cp -rf /opt/openstack-antelope/etc/heat/environment.d /etc/heat/
+	$(Q)chroot $(ROOTDIR) cp -rf /opt/openstack-antelope/etc/heat/templates /etc/heat/
+	$(Q)# install systemd unit files
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/heat/openstack-heat-api.service /usr/lib/systemd/system/openstack-heat-api.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/heat/openstack-heat-api-cfn.service /usr/lib/systemd/system/openstack-heat-api-cfn.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/heat/openstack-heat-engine.service /usr/lib/systemd/system/openstack-heat-engine.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/heat/openstack-heat-all.service /usr/lib/systemd/system/openstack-heat-all.service
+
+# adjust file ownerships and permissions
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) chown root:heat /etc/heat/heat.conf
+	$(Q)chroot $(ROOTDIR) chmod 0640 /etc/heat/heat.conf
+	$(Q)chroot $(ROOTDIR) chown root:heat /etc/heat/api-paste.ini
+	$(Q)chroot $(ROOTDIR) chmod 0640 /etc/heat/api-paste.ini
+	$(Q)chroot $(ROOTDIR) chown -R root:heat /etc/heat/environment.d
+	$(Q)chroot $(ROOTDIR) chown -R root:heat /etc/heat/templates
+	$(Q)chroot $(ROOTDIR) chown heat:heat /var/lib/heat
+	$(Q)chroot $(ROOTDIR) chmod 0755 /var/lib/heat
+	$(Q)chroot $(ROOTDIR) chown heat:heat /var/log/heat
+	$(Q)chroot $(ROOTDIR) chmod 0750 /var/log/heat
+	$(Q)chroot $(ROOTDIR) chown heat:heat /var/run/heat
+	$(Q)chroot $(ROOTDIR) chmod 0755 /var/run/heat
+
+# clean up the build directory
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rm -rf /tmp/heat
+
+# hex_config reads this baseline and regenerates /etc/heat/heat.conf from it, so
+# it has to be taken after the install step above has replaced the file the RPMs
+# used to provide.
 rootfs_install::
 	$(Q)cp -f $(HEAT_CONFDIR)/heat.conf $(HEAT_CONFDIR)/heat.conf.def

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -1,9 +1,20 @@
 # Cube SDK
 # heat installation
 
-# No extra rootfs packages are needed. The RDO spec's only non-python Requires
-# was shadow-utils, for the heat user and group, and
-# core/heavyfs/account/centos9 already carries heat statically.
+# The heat service itself comes from pip below, but the client has to stay an
+# RPM under the *system* python: /usr/bin/openstack is `#!/usr/bin/python3`
+# (3.9), and its `orchestration` subcommand is an entry point owned by
+# python-heatclient ([openstack.cli.extension] orchestration =
+# heatclient.osc.plugin). The copy pip puts in the 3.10 venv is invisible to
+# that CLI. hex_sdk's health_heat_check() runs
+# `openstack orchestration service list`, so without this RPM `cluster check`
+# reports Orchestration NG (errcode 3, "engine down") even when heat-engine is
+# perfectly healthy. It used to arrive as an openstack-heat-* dependency.
+ROOTFS_DNF_NOARCH += python3-heatclient
+#
+# Nothing else is needed: the RDO spec's only non-python Requires was
+# shadow-utils, for the heat user and group, and core/heavyfs/account/centos9
+# already carries heat statically.
 #
 # openstack-heat-ui, the Horizon dashboard plugin, is deliberately no longer
 # installed: Horizon imports it and Horizon still runs on the system python 3.9,

--- a/core/heat/openstack-heat-all.service
+++ b/core/heat/openstack-heat-all.service
@@ -1,0 +1,19 @@
+[Unit]
+# NOT enabled by CubeCOS. heat-all runs api + api-cfn + engine in a single
+# process; hex_config drives the three separate units instead (see
+# HeatService() in core/modules/config_heat.cpp). The unit is shipped only to
+# keep the file layout aligned with the RDO packaging, which keeps the next
+# release hop's diff cheap -- same reason glance ships openstack-glance-scrubber.
+Description=OpenStack Heat All-in-One Service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=heat
+# See openstack-heat-api.service for why only /etc/heat/heat.conf is loaded.
+ExecStart=/usr/bin/heat-all --config-file /etc/heat/heat.conf
+Restart=on-failure
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/core/heat/openstack-heat-api-cfn.service
+++ b/core/heat/openstack-heat-api-cfn.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenStack Heat CloudFormation API Service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=heat
+# See openstack-heat-api.service for why only /etc/heat/heat.conf is loaded.
+ExecStart=/usr/bin/heat-api-cfn --config-file /etc/heat/heat.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/core/heat/openstack-heat-api.service
+++ b/core/heat/openstack-heat-api.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=OpenStack Heat API Service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=heat
+# heat comes from pip inside /opt/openstack-antelope; /usr/bin/heat-api is the
+# symlink heat.mk creates into that venv. Only /etc/heat/heat.conf is loaded --
+# hex_config generates it in full from heat.conf.def, so there is no
+# distribution-level heat-dist.conf in this layout.
+ExecStart=/usr/bin/heat-api --config-file /etc/heat/heat.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/core/heat/openstack-heat-engine.service
+++ b/core/heat/openstack-heat-engine.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=OpenStack Heat Engine Service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=heat
+# See openstack-heat-api.service for why only /etc/heat/heat.conf is loaded.
+ExecStart=/usr/bin/heat-engine --config-file /etc/heat/heat.conf
+Restart=on-failure
+# Upstream (RDO) sets this so only the main process is signalled; the engine
+# forks workers that manage their own lifecycle.
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/core/heat/oslo-config-generator/heat.conf
+++ b/core/heat/oslo-config-generator/heat.conf
@@ -1,0 +1,22 @@
+[DEFAULT]
+output_file = etc/heat/heat.conf.sample
+wrap_width = 79
+namespace = heat.common.config
+namespace = heat.common.context
+namespace = heat.common.crypt
+namespace = heat.engine.clients.os.keystone.heat_keystoneclient
+namespace = heat.common.wsgi
+namespace = heat.engine.clients
+namespace = heat.engine.notification
+namespace = heat.engine.resources
+namespace = heat.api.aws.ec2token
+namespace = keystonemiddleware.auth_token
+namespace = oslo.messaging
+namespace = oslo.middleware
+namespace = oslo.cache
+namespace = oslo.log
+namespace = oslo.policy
+namespace = oslo.reports
+namespace = oslo.service.service
+namespace = oslo.service.periodic_task
+namespace = oslo.service.sslutils

--- a/core/modules/config_heat.cpp
+++ b/core/modules/config_heat.cpp
@@ -1,6 +1,7 @@
 // CUBE SDK
 
 #include <hex/log.h>
+#include <hex/logrotate.h>
 #include <hex/pidfile.h>
 #include <hex/filesystem.h>
 #include <hex/process.h>
@@ -18,6 +19,8 @@
 
 #include "mysql_util.h"
 #include "include/role_cubesys.h"
+
+static LogRotateConf log_conf("heat", "/var/log/heat/*.log", DAILY, 128, 0, true);
 
 static const char USER[] = "heat";
 static const char GROUP[] = "heat";
@@ -192,6 +195,7 @@ UpdateDbConn(std::string sharedId, std::string password)
         dbconn += "/heat";
 
         cfg["database"]["connection"] = dbconn;
+        cfg["database"]["mysql_wsrep_sync_wait"] = "1";
     }
 
     return true;
@@ -433,6 +437,7 @@ Commit(bool modified, int dryLevel)
         UpdateEndpoint(sharedId, external, s_cubeRegion.newValue());
 
     // 4. Service kickoff
+    WriteLogRotateConf(log_conf);
     HeatService(s_enabled);
 
     return true;

--- a/core/modules/config_heat.cpp
+++ b/core/modules/config_heat.cpp
@@ -126,7 +126,7 @@ SetupHeat(std::string domain, std::string userPass, std::string adminPass)
     HexLogInfo("Setting up heat");
 
     // Populate the heat service database
-    HexUtilSystemF(0, 0, "su -s /bin/sh -c \"heat-manage db_sync\" %s", USER);
+    HexUtilSystemF(0, 0, "su -s /bin/sh -c \"/usr/bin/heat-manage db_sync\" %s", USER);
 
     // prepare env settings
     std::string env = ". " + std::string(OPENRC) + " &&";

--- a/core/nova/nova.mk
+++ b/core/nova/nova.mk
@@ -4,8 +4,39 @@
 # spice html5 proxy doesn't work well, improve in the future
 # $(call PROJ_INSTALL_APT,,dosfstools nova-api nova-conductor nova-consoleauth nova-novncproxy nova-spicehtml5proxy spice-html5 spice-vdagent nova-scheduler nova-placement-api nova-compute)
 
+# libvirt is held at 11.10.0-14.el9. A version in ROOTFS_DNF alone does not hold
+# it: installdnf runs `dnf download --resolve` and then localinstalls whatever
+# landed in RPMS, and python3-libvirt and virt-v2v require the sonames
+# libvirt.so.0 / libvirt-lxc.so.0 rather than a package version. Every release in
+# the repos (-4/-12/-13/-14/-16) provides those sonames identically, so the
+# download pulls -16 for part of the tree next to the -14 the pin asked for.
+# installdnf's duplicate pass then keeps the *newer* file of each pair unless the
+# older one is listed in locked_rpms.txt, i.e. unless it is in LOCKED_DNF -- so
+# the -14 subpackages get deleted and localinstall dies with
+# "cannot install both libvirt-client-11.10.0-16.el9 from @commandline and
+# libvirt-client-11.10.0-14.el9 from appstream".
+#
+# So the whole tree has to be listed, the way core/heavyfs/Makefile does it for
+# qemu and core/pacemaker/pacemaker.mk for pacemaker. ROOTFS_DNF installs, and
+# LOCKED_DNF is what makes the duplicate pass drop -16 instead of -14.
+LIBVIRT_VER := -11.10.0-14.el9
+LIBVIRT_LOCKED_RPMS := libvirt$(LIBVIRT_VER) libvirt-libs$(LIBVIRT_VER) libvirt-devel$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-client$(LIBVIRT_VER) libvirt-client-qemu$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon$(LIBVIRT_VER) libvirt-daemon-common$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-lock$(LIBVIRT_VER) libvirt-daemon-log$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-proxy$(LIBVIRT_VER) libvirt-daemon-plugin-lockd$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-config-network$(LIBVIRT_VER) libvirt-daemon-config-nwfilter$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-interface$(LIBVIRT_VER) libvirt-daemon-driver-network$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-nodedev$(LIBVIRT_VER) libvirt-daemon-driver-nwfilter$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-qemu$(LIBVIRT_VER) libvirt-daemon-driver-secret$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-storage$(LIBVIRT_VER) libvirt-daemon-driver-storage-core$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-storage-disk$(LIBVIRT_VER) libvirt-daemon-driver-storage-iscsi$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-storage-logical$(LIBVIRT_VER) libvirt-daemon-driver-storage-mpath$(LIBVIRT_VER)
+LIBVIRT_LOCKED_RPMS += libvirt-daemon-driver-storage-rbd$(LIBVIRT_VER) libvirt-daemon-driver-storage-scsi$(LIBVIRT_VER)
+LOCKED_DNF += $(LIBVIRT_LOCKED_RPMS)
+
 # Core hypervisor and system dependencies from the Antelope spec
-ROOTFS_DNF += libvirt-11.10.0-14.el9 libvirt-devel-11.10.0-14.el9 dosfstools python3-libvirt ksmtuned virt-v2v qemu-kvm ipmitool openssh-clients rsync xorriso sudo
+ROOTFS_DNF += $(LIBVIRT_LOCKED_RPMS) dosfstools python3-libvirt ksmtuned virt-v2v qemu-kvm ipmitool openssh-clients rsync xorriso sudo
 # handled elsewhere: iptables
 ROOTFS_DNF_NOARCH += iptables-services novnc
 

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -129,7 +129,7 @@ migrate_heat_db()
     fi
 
     if is_control_node ; then
-        su -s /bin/sh -c "heat-manage db_sync" heat
+        su -s /bin/sh -c "/usr/bin/heat-manage db_sync" heat
     fi
 
     touch $STATE_DIR/heat_db_migrated

--- a/git-conventional-commits.yaml
+++ b/git-conventional-commits.yaml
@@ -13,7 +13,7 @@ convention:
   - chore    # Miscellaneous commits e.g. modifying `.gitignore`
   - merge
   - revert
-  commitScopes: ["cinder", "glance", "keystone", "neutron", "nova", "sbom","security","watcher","hex_sdk","cubectl","etcd","keycloak","make","build","new","docker","deps","readme","bump","haproxy","ci","tests","docs","ui","api","ceph","hex_install","app frameworks","rancher","k3s","bootstrap","sec","rc","gpu","git","elk","hex_fixpack_install","terraform","prometheus","kernel","skyline","jail","hex_cli","hex_config","telegraf","mongodb","fixpack_history","cve-2026-21721","pcs","provider","changelog","rolling-upgrade","senlin","appctl","cube_sdk_library","app","kapacitor","httpd","log","appfw","alert","hex_translate","license","ci","pr","oci image","linux","typo"]
+  commitScopes: ["cinder", "glance", "heat", "keystone", "neutron", "nova", "sbom","security","watcher","hex_sdk","cubectl","etcd","keycloak","make","build","new","docker","deps","readme","bump","haproxy","ci","tests","docs","ui","api","ceph","hex_install","app frameworks","rancher","k3s","bootstrap","sec","rc","gpu","git","elk","hex_fixpack_install","terraform","prometheus","kernel","skyline","jail","hex_cli","hex_config","telegraf","mongodb","fixpack_history","cve-2026-21721","pcs","provider","changelog","rolling-upgrade","senlin","appctl","cube_sdk_library","app","kapacitor","httpd","log","appfw","alert","hex_translate","license","ci","pr","oci image","linux","typo"]
 changelog:
   commitTypes:
   - feat


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Upgrades Heat from Yoga to Antelope (`openstack-heat==20.0.1`), moving it off the
CentOS Stream 9 RDO SIG RPMs and onto a pip install inside the Python 3.10 venv
at `/opt/openstack-antelope`, following the skeleton established by keystone
(#1050), glance (#1080), cinder (#1088), nova (#1124) and neutron (#1170).

- **`core/heat/heat.mk`** — the six stacked `rootfs_install::` targets: pip
  install under the venv with the installed-constraints file (DNS opened and
  closed around it), `/usr/bin` symlinks, build dir prepare, staging of the
  checked-in artifacts, install to production paths, ownership/permissions,
  cleanup, and the `heat.conf.def` baseline.
- **Checked-in generated artifacts** — `heat.conf.sample` (from
  `core/heat/oslo-config-generator/heat.conf`, which is kept in the repo for the
  next release hop) plus the four `openstack-heat-*.service` units. The build
  only copies; nothing is generated at build time.
- **`core/modules/config_heat.cpp`** — declares *and* writes the hex
  `LogRotateConf`, sets `database/mysql_wsrep_sync_wait = 1`, and calls
  `/usr/bin/heat-manage` rather than the venv path.
- **`core/sdk_sh/modules/sdk_migrate.sh`** — same `/usr/bin/heat-manage` change
  for `migrate_heat_db()`.
- **`python3-heatclient` stays an RPM under the system python.** `/usr/bin/openstack`
  is `#!/usr/bin/python3` (3.9) and its `orchestration` subcommand is an entry
  point owned by python-heatclient (`[openstack.cli.extension] orchestration =
  heatclient.osc.plugin`); the copy pip puts in the 3.10 venv is invisible to
  that CLI. It used to arrive as an `openstack-heat-*` dependency, so dropping
  those RPMs also dropped it. `hex_sdk`'s `health_heat_check()` runs
  `openstack orchestration service list`, so without it `cluster check` reports
  `Orchestration NG [ heat(3 engine down) ]` while heat-engine is completely
  healthy. keystone, glance, cinder and nova did not hit this because their
  health checks use OSC built-in subcommands; `orchestration` is the only one
  that is a plugin.
- **`core/nova/nova.mk`** — a build fix this PR needs in order to build at all.
  See *Special notes* below.

#### Which issue(s) this PR fixes

Fixes #608

#### Special notes for your reviewer

> **Base branch.** Targets `openstack-develop`. The branch is currently 16
> commits behind it (the neutron line), but the two change sets touch **zero
> files in common**, so the rebase is clean. Verified on a build cut from
> `034567ce`; say the word if you would rather see it rebased and re-verified
> before review.

> **Commits in this PR.** All seven are this PR's own:
>
> | commit | subject |
> |---|---|
> | `0fb65c96` | chore: add heat to conventional commit scopes |
> | `b2c3be53` | feat(heat): let hex_config manage logrotate and wsrep sync for heat |
> | `a1be349b` | feat(heat): resolve heat-manage from the venv symlink |
> | `bc36206c` | feat(heat): add antelope config sample and systemd units |
> | `400ea873` | feat(heat): install heat from pip into the antelope venv |
> | `d90b8771` | fix(nova): lock the whole libvirt tree so the pin actually holds |
> | `af0dae4d` | fix(heat): keep python3-heatclient for the system openstack client |

> **Why `core/nova/nova.mk` is in a heat PR.** It is a `heavyfs` build fix, and
> without it this PR cannot produce an image. libvirt is version-pinned in
> `ROOTFS_DNF`, but a version in that list does not pin anything on its own:
> `hex/scripts/installdnf` runs `dnf download --resolve` into `RPMS`, then walks
> that directory and deletes one file of every same-name pair — keeping the
> **newer** one unless the older is listed in `locked_rpms.txt`, which is fed by
> `LOCKED_DNF`. `python3-libvirt` and `virt-v2v` require the sonames
> `libvirt.so.0` / `libvirt-lxc.so.0` rather than a package version, and every
> release in the repos provides them identically, so the download legitimately
> pulls a newer release for part of the tree next to the pinned one. With no
> libvirt entry in `LOCKED_DNF` the duplicate pass then deleted the pinned half
> of all nine pairs it found and `localinstall` died:
>
> ```
> Error:
>  Problem 1: cannot install both libvirt-client-11.10.0-16.el9.x86_64 from @commandline and libvirt-client-11.10.0-14.el9.x86_64 from appstream
>   - package libvirt-11.10.0-14.el9.x86_64 from @commandline requires libvirt-client = 11.10.0-14.el9, but none of the providers can be installed
>   - conflicting requests
> ```
>
> Whether the download comes out consistent depends on the **entire**
> `ROOTFS_DNF` set, which makes this latent rather than deterministic: the single
> `python3-heatclient` line above was enough to flip it, while the immediately
> preceding build of the same branch had succeeded. So the fix is to list the
> whole libvirt tree in `LOCKED_DNF`, the way `core/heavyfs/Makefile` already
> does for qemu and `core/pacemaker/pacemaker.mk` for pacemaker. Anyone else
> adding a package to `ROOTFS_DNF*` would have hit the same wall, and the error
> points entirely at libvirt with no hint that it relates to your own change —
> which is why it is fixed here rather than deferred.

> **`openstack-heat-ui` is deliberately not installed.** It is the Horizon
> dashboard plugin; Horizon imports it and still runs on the system python 3.9,
> so it cannot follow heat into the 3.10 venv. Restoring the Orchestration panel
> belongs to #609 (Upgrade Horizon from Yoga to Antelope), whose acceptance
> criteria already cover "Ensure other panels are functioning on the dashboard".

> **Four of heat's ten console scripts are left unlinked on purpose:**
> `heat-db-setup` and `heat-keystone-setup{,-domain}` are manual-deployment
> helpers that `hex_config` replaces, `heat-wsgi-api{,-cfn}` are only used when
> heat is hosted under a WSGI server (not the layout here), and `heat` is the
> deprecated python-heatclient CLI, called nowhere in this tree.

#### Verification

Environment: `centos9_cubecos_seki_200.13-1cc`, node `cc1`.

For the requirement "Migrate configs",

```bash
[cc1 ~]# ls -l /etc/heat
total 104
-rw-r----- 1 root heat  4253 Jul 29 17:27 api-paste.ini
drwxr-xr-x 2 root heat  4096 Jul 29 18:26 environment.d
-rw-r----- 1 root heat  1906 Jul 29 18:46 heat.conf
-rw-r----- 1 root root 85199 Jul 29 17:27 heat.conf.def
drwxr-xr-x 2 root heat  4096 Jul 29 18:26 templates

[cc1 ~]# ls -l /usr/bin/heat-*
lrwxrwxrwx 1 root root  4 Mar 15  2022 /usr/bin/heat-3 -> heat
lrwxrwxrwx 1 root root 36 Jul 29 17:27 /usr/bin/heat-all -> /opt/openstack-antelope/bin/heat-all
lrwxrwxrwx 1 root root 36 Jul 29 17:27 /usr/bin/heat-api -> /opt/openstack-antelope/bin/heat-api
lrwxrwxrwx 1 root root 40 Jul 29 17:27 /usr/bin/heat-api-cfn -> /opt/openstack-antelope/bin/heat-api-cfn
lrwxrwxrwx 1 root root 39 Jul 29 17:27 /usr/bin/heat-engine -> /opt/openstack-antelope/bin/heat-engine
lrwxrwxrwx 1 root root 39 Jul 29 17:27 /usr/bin/heat-manage -> /opt/openstack-antelope/bin/heat-manage
lrwxrwxrwx 1 root root 39 Jul 29 17:27 /usr/bin/heat-status -> /opt/openstack-antelope/bin/heat-status

[cc1 ~]# /usr/bin/heat-engine --version
20.0.1

[cc1 ~]# /usr/bin/heat-status upgrade check
+-------------------------------------------+
| Upgrade Check Results                     |
+-------------------------------------------+
| Check: Policy File JSON to YAML Migration |
| Result: Success                           |
| Details: None                             |
+-------------------------------------------+
```

`hex_config` regenerates `/etc/heat/heat.conf` from the `.def` baseline, so the
wsrep setting and the logrotate file are produced by the module rather than
shipped:

```bash
[cc1 ~]# grep -n "^connection\|mysql_wsrep_sync_wait" /etc/heat/heat.conf
65:connection = mysql+pymysql://heat:<redacted>@10.1.0.1/heat
66:mysql_wsrep_sync_wait = 1

[cc1 ~]# cat /etc/logrotate.d/heat
/var/log/heat/*.log {
  daily
  copytruncate
  maxsize 128M
  missingok
  compress
  delaycompress
  notifempty
}
```

For the requirement "Pass health check",

```bash
[cc1 ~]# systemctl is-active openstack-heat-api openstack-heat-api-cfn openstack-heat-engine
active
active
active

[cc1 ~]# openstack orchestration service list
+----------+-------------+--------------------------------------+------+--------+----------------------------+--------+
| Hostname | Binary      | Engine ID                            | Host | Topic  | Updated At                 | Status |
+----------+-------------+--------------------------------------+------+--------+----------------------------+--------+
| cc1      | heat-engine | 9eaf3c99-2b15-4f0f-a2bd-bca2bdba0942 | cc1  | engine | 2026-07-29T11:47:50.000000 | up     |
+----------+-------------+--------------------------------------+------+--------+----------------------------+--------+

[cc1 ~]# hex_cli -v -c boot_mode status
two phase boot... [yes]
standalone services... [ready]
cube services... [ready]
cluster data... [synced]
applying policy... [no]

[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
           IaasDb      ok  [ mysql(v) ]
       InstanceHa      ok  [ masakari(v) ]
            Image      ok  [ glance(v) ]
            LBaaS      ok  [ octavia(v) ]
        Baremetal      ok  [ ironic(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
        HaCluster      ok  [ hacluster(v) ]
           K8SaaS      ok  [ rancher(v) ]
         FileStor      ok  [ manila(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
    Orchestration      ok  [ heat(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
       ObjectStor      ok  [ swift(v) ]
        BlockStor      ok  [ cinder(v) ]
           DNSaaS      ok  [ designate(v) ]
    BusinessLogic      ok  [ watcher(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
          Network      ok  [ neutron(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) ]
```

Beyond the health check, a stack was created from a cross-service template so
that the Antelope heat is shown driving the still-Yoga neutron, and the result
was confirmed **from neutron's side** rather than from heat's own report:

```bash
[cc1 ~]# openstack stack create -t /tmp/heat-verify.yaml --wait heat-verify-608
2026-07-29 11:49:58Z [heat-verify-608]: CREATE_COMPLETE  Stack CREATE completed successfully
+---------------------+----------------------------------------------------------+
| Field               | Value                                                    |
+---------------------+----------------------------------------------------------+
| id                  | 5d8ee43f-e934-409b-9f5d-f20485afd45a                     |
| stack_name          | heat-verify-608                                          |
| description         | cross-service check - Antelope heat driving Yoga neutron |
| creation_time       | 2026-07-29T11:49:55Z                                     |
| updated_time        | None                                                     |
| stack_status        | CREATE_COMPLETE                                          |
| stack_status_reason | Stack CREATE completed successfully                      |
+---------------------+----------------------------------------------------------+

[cc1 ~]# openstack network show heat-verify-608-net -f value -c id -c name -c status
572c3eb4-b8d2-44fe-b2e3-81e8593c846f
heat-verify-608-net
ACTIVE

[cc1 ~]# openstack subnet list --network heat-verify-608-net -f value -c Name -c Subnet
heat-verify-608-subnet-krpvxef6sgcp 192.0.2.0/24
```

The delete path was checked the same way — negative proof, not just a
`DELETE_COMPLETE`:

```bash
[cc1 ~]# openstack stack delete --yes --wait heat-verify-608
2026-07-29 11:50:29Z [heat-verify-608]: DELETE_IN_PROGRESS  Stack DELETE started

[cc1 ~]# openstack stack list -f value -c "Stack Name" | grep -c heat-verify-608
0
[cc1 ~]# openstack network list -f value -c Name | grep -c heat-verify-608-net
0

[cc1 ~]# journalctl -u openstack-heat-engine --since "-10min" | grep -icE "error|traceback"
0
```

For the requirement "Ignore the new features introduced in the new version",
no Antelope-only feature is enabled: `/etc/heat/heat.conf` is regenerated by
`config_heat.cpp` from the checked-in Antelope sample with the same set of
options Yoga configured, and the only behavioural change against Yoga is the
Orchestration dashboard panel, which is out of scope here and tracked by #609.

##### The libvirt build fix, verified separately

The `LOCKED_DNF` change could not be reproduced by running `dnf install` in the
build container — the container's installed package set differs too much from a
fresh rootfs, and a simulated install resolves cleanly there. So it was verified
against the deciding step itself: `installdnf`'s duplicate pass was extracted
verbatim and replayed over the failing build's real `RPMS` directory, restored to
its post-download state (27 pinned-release files + 9 newer ones), with only
`locked_rpms.txt` differing between runs.

| run | `locked_rpms.txt` | files deleted | left for `localinstall` |
|---|---|---|---|
| before | no libvirt entry | the 9 **pinned** files | 18 pinned + 9 newer → conflict |
| after | 27 libvirt entries | the 9 **newer** files | 27 pinned + 0 newer → consistent |

The "before" run reproduced the failing build's `removed_rpms.txt` exactly, which
is what makes the replay trustworthy. The same build also provides a control
group: pacemaker had a newer release downloaded alongside its pinned one and
dropped the **newer** file, because pacemaker *is* in `LOCKED_DNF`.

Confirmed end to end on the resulting image:

```bash
[cc1 ~]# rpm -qa "libvirt*" --qf "%{VERSION}-%{RELEASE}\n" | sort | uniq -c
     26 11.10.0-14.el9

[cc1 ~]# virsh version
Compiled against library: libvirt 11.10.0
Using library: libvirt 11.10.0
Using API: QEMU 11.10.0
Running hypervisor: QEMU 10.1.0

[cc1 ~]# python3 -c "import libvirt; print(libvirt.getVersion())"
11010000

[cc1 ~]# openstack hypervisor list -f value -c "Hypervisor Hostname" -c State
cc1 up
```

The last two matter because `python3-libvirt`'s soname dependency is what made
the resolution free in the first place; it now loads against the pinned tree.

#### Additional documentation

```docs
kb/cubecos/architecture/heat-antelope-pip-packaging.md
kb/cubecos/known-issues/osc-plugin-subcommand-lost-in-venv-migration.md
kb/cubecos/known-issues/rootfs-dnf-version-pin-needs-locked-dnf.md
```
