### PR TITLE
feat(swift): upgrade swift from yoga to antelope

### DIFF
--- a/core/swift/swift.mk
+++ b/core/swift/swift.mk
@@ -1,4 +1,38 @@
 # Cube SDK
 # swift installation
 
-ROOTFS_DNF_NOARCH += python3-swiftclient
+# install the swift client inside the python 3.10 virtual environment.
+# note: the pypi package is python-swiftclient; the "swift" package is the
+# swift *server*, which CubeCOS does not ship (ceph rgw serves object-store).
+#
+# This does not remove yoga's swiftclient (3.13.1) from the image, and cannot
+# yet. Two copies survive in the system python 3.9:
+#
+#   1. the python3-swiftclient rpm, which dnf keeps pulling in as a dependency
+#      of python3-heatclient, python3-troveclient, openstack-ironic-common,
+#      openstack-dashboard and openstack-heat-common. Dropping it from
+#      ROOTFS_DNF_NOARCH here does not uninstall it.
+#   2. a pip-installed copy under /usr/local/lib/python3.9/site-packages,
+#      dragged in by horizon: designate-dashboard, masakari-dashboard and
+#      watcher-dashboard all require horizon 22.1.1, and horizon requires
+#      python-swiftclient, so it is resolved under the yoga constraint. Those
+#      plugins install after swift in HEAVY_COMPONENTS, so they win any race.
+#
+# Remove both once horizon itself moves into the venv. The venv install below
+# still matters meanwhile: cinder's SwiftBackupDriver imports swiftclient from
+# the venv, and installing it here makes that explicit rather than relying on
+# cinder to pull it in transitively.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		python-swiftclient==4.2.0"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+	$(Q)# Link binaries. This overwrites a path owned by the python3-swiftclient
+	$(Q)# rpm, and it does not win PATH: horizon's pip-installed copy owns
+	$(Q)# /usr/local/bin/swift, which precedes /usr/bin, so a bare "swift" is
+	$(Q)# still yoga 3.13.1. Antelope's client is reachable explicitly as
+	$(Q)# /opt/openstack-antelope/bin/swift until horizon leaves python 3.9.
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/swift /usr/bin/swift


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Upgrade Swift from OpenStack Yoga to Antelope

CubeCOS ships **no OpenStack Swift server**, so this upgrade covers the client only. The `object-store` API is served by Ceph RADOS Gateway, and the `swift` component is a Swift-compatible façade over it:

- `config_ceph.cpp` configures `rgw frontends = beast endpoint=<ip>:8888` with keystone v3 auth and `rgw swift account in url = true`
- `config_swift.cpp` starts no daemon at all — it only registers the `object-store` and `s3` keystone service entities and points their endpoints at RGW on `:8888`
- haproxy fronts it as `swift_api` (`:8890`, rewriting URIs to a `/swift` prefix) and `radosgw_proxy` (`:8888`); nginx proxies `/api/openstack/regionone/swift/`
- there is no `openstack-swift-*` package, no `swift-*` systemd unit, and no `/etc/swift` on the image

The only Yoga-versioned artifact in the component was therefore `python-swiftclient` itself. `core/swift/swift.mk` now installs it into the Antelope venv at 4.2.0 instead of pulling the `python3-swiftclient` RPM (3.13.1) into system python, matching how `cinder.mk` and `glance.mk` install their components.

Because there is no Swift server, there is also no `swift.conf`/ring configuration to migrate — the "migrate configurations" acceptance criterion is satisfied vacuously here.

#### Which issue(s) this PR fixes

- Close #618

#### Special notes for your reviewer

**Base branch / what to review.** This branch is stacked on `jim.lin/feat/openstack-a-upgrade-masakari`, which has not landed on `openstack-develop` yet, so the commit list currently shows the whole Antelope stack. The change belonging to this PR is the single commit `feat(swift): upgrade the swift client to openstack antelope`, touching only `core/swift/swift.mk` (+35/-1). It will reduce to that one commit once masakari merges.

**The PyPI package name is a trap.** On PyPI, `swift` is the Swift **server** (versions 2.x, currently 2.38.0) and `python-swiftclient` is the client (4.2.0). Installing `swift` — the intuitive name — would silently put the Swift server into the venv, which is exactly what CubeCOS does not want. `swift.mk` now carries a comment recording this.

**This does not remove Yoga's swiftclient from the image, and cannot yet.** Two copies survive in system python 3.9:

| Copy | Version | Why it stays |
| --- | --- | --- |
| `python3-swiftclient` RPM | 3.13.1 | dnf still pulls it in as a dependency of `python3-heatclient`, `python3-troveclient`, `openstack-ironic-common`, `openstack-dashboard` and `openstack-heat-common`. Dropping it from `ROOTFS_DNF_NOARCH` does not uninstall it. |
| pip copy in `/usr/local/lib/python3.9/site-packages` | 3.13.1 | `designate-dashboard`, `masakari-dashboard` and `watcher-dashboard` all require `horizon` 22.1.1, which requires `python-swiftclient`, so it resolves under the Yoga constraint. Those plugins install *after* `swift` in `HEAVY_COMPONENTS`, so they win any race for the console script. |

Both go away only when horizon itself leaves system python 3.9 — the same knot already documented in `designate.mk` and `masakari.mk`. `swift.mk` records this inline so the next reader does not have to rediscover it.

**The `/usr/bin/swift` symlink does not win `PATH`.** `PATH` is `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin`, and horizon's pip copy owns `/usr/local/bin/swift`, so a bare `swift` remains 3.13.1. The Antelope client is reachable explicitly as `/opt/openstack-antelope/bin/swift`. The symlink also overwrites a path owned by the `python3-swiftclient` RPM. Both facts are commented at the recipe line.

**Why the venv install still earns its place.** The venv already happened to carry 4.2.0, but only because `cinder` pulled it in transitively. `cinder`'s `SwiftBackupDriver` — the default `backup_driver`, and the `cinder.backup.type = cube-swift` tuning — is the one production consumer that imports the library, so this declares the dependency instead of relying on cinder's requirements to keep providing it.

**Note on the "pass health checks" criterion.** `health_swift_check` is `curl :8888` plus `openstack object store account show`, and `python-openstackclient` never imports `swiftclient` (its `object store` commands go through openstacksdk). So the health check passes identically before and after this change and is not by itself evidence for this upgrade. The `swift stat` / `swift list` output from the venv binary below is the direct evidence.

#### Additional documentation

For the requirement "health check",

```bash
[cc1 ~]# hex_cli -v -c boot_mode status
two phase boot... [yes]
standalone services... [ready]
cube services... [ready]
cluster data... [synced]
applying policy... [no]
[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
           IaasDb      ok  [ mysql(v) ]
       InstanceHa      ok  [ masakari(v) ]
            Image      ok  [ glance(v) ]
            LBaaS      ok  [ octavia(v) ]
        Baremetal      ok  [ ironic(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
        HaCluster      ok  [ hacluster(v) ]
         FileStor      ok  [ manila(v) ]
           K8SaaS      ok  [ rancher(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
       ObjectStor      ok  [ swift(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) ]
        BlockStor      ok  [ cinder(v) ]
    Orchestration      ok  [ heat(v) ]
    BusinessLogic      ok  [ watcher(v) ]
           DNSaaS      ok  [ designate(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
          Network      ok  [ neutron(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) ]
[cc1 ~]# /opt/openstack-antelope/bin/swift list
log
[cc1 ~]# /opt/openstack-antelope/bin/swift stat
                                    Account: dc68318e5f6542da82535014c13407cc
                                 Containers: 1
                                    Objects: 2
                                      Bytes: 0
Objects in policy "default-placement-bytes": 0
  Bytes in policy "default-placement-bytes": 0
   Containers in policy "default-placement": 1
      Objects in policy "default-placement": 2
        Bytes in policy "default-placement": 0
                                X-Timestamp: 1785393625.12567
                X-Account-Bytes-Used-Actual: 0
                                 X-Trans-Id: tx0000012c999c897f86260-006a6af1d8-3841-default
                     X-Openstack-Request-Id: tx0000012c999c897f86260-006a6af1d8-3841-default
                              Accept-Ranges: bytes
                               Content-Type: text/plain; charset=utf-8
                                 Connection: Keep-Alive
```

The `X-Trans-Id` / `X-Openstack-Request-Id` values carrying the `-default` suffix and the `default-placement` storage policy lines confirm the request is being served by Ceph RGW rather than a Swift proxy, and that the Antelope 4.2.0 client speaks to it correctly.
