### PR TITLE
feat(ironic): upgrade ironic to openstack antelope

### DIFF
--- a/core/heavyfs/os-antelope-pip-upper-constraints.txt
+++ b/core/heavyfs/os-antelope-pip-upper-constraints.txt
@@ -591,3 +591,4 @@ sphinxcontrib-applehelp===1.0.2
 scikit-learn===1.1.2
 pytest-cov===4.0.0
 setuptools==65.7.0
+networking-baremetal===6.1.1

--- a/core/ironic/inspector-dist.conf
+++ b/core/ironic/inspector-dist.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+log_dir = /var/log/ironic-inspector
+state_path = /var/lib/ironic-inspector
+use_stderr = False

--- a/core/ironic/inspector-rootwrap.conf
+++ b/core/ironic/inspector-rootwrap.conf
@@ -1,0 +1,27 @@
+# Configuration for ironic-inspector-rootwrap
+# This file should be owned by (and only-writeable by) the root user
+
+[DEFAULT]
+# List of directories to load filter definitions from (separated by ',').
+# These directories MUST all be only writeable by root !
+filters_path=/etc/ironic-inspector/rootwrap.d,/usr/share/ironic-inspector/rootwrap
+
+# List of directories to search executables in, in case filters do not
+# explicitly specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writeable by root !
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+
+# Enable logging to syslog
+# Default value is False
+use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, user0, user1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
+syslog_log_level=ERROR

--- a/core/ironic/inspector.conf.sample
+++ b/core/ironic/inspector.conf.sample
@@ -1,0 +1,2046 @@
+[DEFAULT]
+
+#
+# From ironic_inspector
+#
+
+# IP to listen on. (string value)
+#listen_address = ::
+
+# Port to listen on. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#listen_port = 5050
+
+# Unix socket to listen on. Disables listen_address and listen_port.
+# (string value)
+#listen_unix_socket = <None>
+
+# File mode (an octal number) of the unix socket to listen on. Ignored
+# if listen_unix_socket is not set. (integer value)
+#listen_unix_socket_mode = <None>
+
+# Name of this node. This can be an opaque identifier. It is not
+# necessarily a hostname, FQDN, or IP address. However, the node name
+# must be valid within an AMQP key, and if using ZeroMQ, a valid
+# hostname, FQDN, or IP address. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#host = localhost
+
+# Authentication method used on the ironic-inspector API. "noauth",
+# "keystone" or "http_basic" are valid options. "noauth" will disable
+# all authentication. (string value)
+# Possible values:
+# noauth - no authentication
+# keystone - use the Identity service for authentication
+# http_basic - HTTP basic authentication
+#auth_strategy = keystone
+
+# Path to Apache format user authentication file used when
+# auth_strategy=http_basic (string value)
+#http_basic_auth_user_file = /etc/ironic-inspector/htpasswd
+
+# Timeout after which introspection is considered failed, set to 0 to
+# disable. (integer value)
+# Maximum value: 315576000
+#timeout = 3600
+
+# Amount of time in seconds, after which repeat clean up of timed out
+# nodes and old nodes status information. WARNING: If set to a value
+# of 0, then the periodic task is disabled and inspector will not sync
+# with ironic to complete the internal clean-up process. Not advisable
+# if the deployment uses a PXE filter, and will result in the ironic-
+# inspector ceasing periodic cleanup activities. (integer value)
+# Minimum value: 0
+#clean_up_period = 60
+
+# Interval (in seconds) between leader elections. (integer value)
+#leader_election_interval = 10
+
+# SSL Enabled/Disabled (boolean value)
+#use_ssl = false
+
+# The green thread pool size. (integer value)
+# Minimum value: 2
+#max_concurrency = 1000
+
+# Delay (in seconds) between two introspections. Only applies when
+# boot is managed by ironic-inspector (i.e. manage_boot==True).
+# (integer value)
+#introspection_delay = 5
+
+# Ironic driver_info fields that are equivalent to ipmi_address. (list
+# value)
+#ipmi_address_fields = redfish_address,ilo_address,drac_host,drac_address,ibmc_address
+
+# Path to the rootwrap configuration file to use for running commands
+# as root (string value)
+#rootwrap_config = /etc/ironic-inspector/rootwrap.conf
+
+# Limit the number of elements an API list-call returns (integer
+# value)
+# Minimum value: 1
+#api_max_limit = 1000
+
+# Whether the current installation of ironic-inspector can manage PXE
+# booting of nodes. If set to False, the API will reject introspection
+# requests with manage_boot missing or set to True. (boolean value)
+#can_manage_boot = true
+
+# Whether to enable publishing the ironic-inspector API endpoint via
+# multicast DNS. (boolean value)
+#enable_mdns = false
+
+# Whether to run ironic-inspector as a standalone service. It's
+# EXPERIMENTAL to set to False. (boolean value)
+#standalone = true
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of
+# the default INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# The name of a logging configuration file. This file is appended to
+# any existing logging configuration files. For details about logging
+# configuration files, see the Python logging module documentation.
+# Note that when logging configuration files are used then all logging
+# configuration is set in the configuration file and other logging
+# configuration options are ignored (for example, log-date-format).
+# (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set.
+# (string value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default
+# is set, logging will go to stderr as defined by use_stderr. This
+# option is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths.
+# This option is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is
+# moved or removed this handler will open a new log file with
+# specified path instantaneously. It makes sense only if log_file
+# option is specified and Linux platform is used. This option is
+# ignored if log_config_append is set. (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and
+# will be changed later to honor RFC5424. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_syslog = false
+
+# Enable journald for logging. If running in a systemd environment you
+# may wish to enable journal support. Doing so will use the journal
+# native protocol which includes structured metadata in addition to
+# log messages.This option is ignored if log_config_append is set.
+# (boolean value)
+#use_journal = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Use JSON formatting for logging. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_json = false
+
+# Log output to standard error. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_stderr = false
+
+# Log output to Windows Event Log. (boolean value)
+#use_eventlog = false
+
+# The amount of time before the log files are rotated. This option is
+# ignored unless log_rotation_type is set to "interval". (integer
+# value)
+#log_rotate_interval = 1
+
+# Rotation interval type. The time of the last file change (or the
+# time when the service was started) is used when scheduling the next
+# rotation. (string value)
+# Possible values:
+# Seconds - <No description provided>
+# Minutes - <No description provided>
+# Hours - <No description provided>
+# Days - <No description provided>
+# Weekday - <No description provided>
+# Midnight - <No description provided>
+#log_rotate_interval_type = days
+
+# Maximum number of rotated log files. (integer value)
+#max_logfile_count = 30
+
+# Log file maximum size in MB. This option is ignored if
+# "log_rotation_type" is not set to "size". (integer value)
+#max_logfile_size_mb = 200
+
+# Log rotation type. (string value)
+# Possible values:
+# interval - Rotate logs at predefined time intervals.
+# size - Rotate logs once they reach a predefined size.
+# none - Do not rotate log files.
+#log_rotation_type = none
+
+# Format string to use for log messages with context. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(global_request_id)s %(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined.
+# Used by oslo_log.formatters.ContextFormatter (string value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the
+# message is DEBUG. Used by oslo_log.formatters.ContextFormatter
+# (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_user_identity_format = %(user)s %(project)s %(domain)s %(system_scope)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is
+# ignored if log_config_append is set. (list value)
+#default_log_levels = sqlalchemy=WARNING,iso8601=WARNING,requests=WARNING,urllib3.connectionpool=WARNING,keystonemiddleware=WARNING,keystoneauth=WARNING,ironicclient=WARNING,amqp=WARNING,amqplib=WARNING,oslo.messaging=WARNING,oslo_messaging=WARNING
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message.
+# (string value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message.
+# (string value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval. (integer
+# value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO,
+# WARNING, DEBUG or empty string. Logs with level greater or equal to
+# rate_limit_except_level are not filtered. An empty string means that
+# all levels are filtered. (string value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+#
+# From oslo.messaging
+#
+
+# Size of RPC connection pool. (integer value)
+# Minimum value: 1
+#rpc_conn_pool_size = 30
+
+# The pool size limit for connections expiration policy (integer
+# value)
+#conn_pool_min_size = 2
+
+# The time-to-live in sec of idle connections in the pool (integer
+# value)
+#conn_pool_ttl = 1200
+
+# Size of executor thread pool when executor is threading or eventlet.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_thread_pool_size
+#executor_thread_pool_size = 64
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout = 60
+
+# The network address and optional user credentials for connecting to
+# the messaging backend, in URL format. The expected format is:
+#
+# driver://[user:pass@]host:port[,[userN:passN@]hostN:portN]/virtual_host?query
+#
+# Example: rabbit://rabbitmq:password@127.0.0.1:5672//
+#
+# For full details on the fields in the URL see the documentation of
+# oslo_messaging.TransportURL at
+# https://docs.openstack.org/oslo.messaging/latest/reference/transport.html
+# (string value)
+#transport_url = rabbit://
+
+# The default exchange under which topics are scoped. May be
+# overridden by an exchange name specified in the transport_url
+# option. (string value)
+#control_exchange = openstack
+
+# Add an endpoint to answer to ping calls. Endpoint is named
+# oslo_rpc_server_ping (boolean value)
+#rpc_ping_enabled = false
+
+#
+# From oslo.service.service
+#
+
+# Enable eventlet backdoor.  Acceptable values are 0, <port>, and
+# <start>:<end>, where 0 results in listening on a random tcp port
+# number; <port> results in listening on the specified port number
+# (and not enabling backdoor if that port is in use); and
+# <start>:<end> results in listening on the smallest unused port
+# number within the specified range of port numbers.  The chosen port
+# is displayed in the service's log file. (string value)
+#backdoor_port = <None>
+
+# Enable eventlet backdoor, using the provided path as a unix socket
+# that can receive connections. This option is mutually exclusive with
+# 'backdoor_port' in that only one should be provided. If both are
+# provided then the existence of this option overrides the usage of
+# that option. Inside the path {pid} will be replaced with the PID of
+# the current process. (string value)
+#backdoor_socket = <None>
+
+# Enables or disables logging values of all registered options when
+# starting a service (at DEBUG level). (boolean value)
+#log_options = true
+
+# Specify a timeout after which a gracefully shutdown server will
+# exit. Zero value means endless wait. (integer value)
+#graceful_shutdown_timeout = 60
+
+#
+# From oslo.service.wsgi
+#
+
+# File name for the paste.deploy config for api service (string value)
+#api_paste_config = api-paste.ini
+
+# A python format string that is used as the template to generate log
+# lines. The following values can beformatted into it: client_ip,
+# date_time, request_line, status_code, body_length, wall_seconds.
+# (string value)
+#wsgi_log_format = %(client_ip)s "%(request_line)s" status: %(status_code)s  len: %(body_length)s time: %(wall_seconds).7f
+
+# Sets the value of TCP_KEEPIDLE in seconds for each server socket.
+# Not supported on OS X. (integer value)
+#tcp_keepidle = 600
+
+# Size of the pool of greenthreads used by wsgi (integer value)
+#wsgi_default_pool_size = 100
+
+# Maximum line size of message headers to be accepted. max_header_line
+# may need to be increased when using large tokens (typically those
+# generated when keystone is configured to use PKI tokens with big
+# service catalogs). (integer value)
+#max_header_line = 16384
+
+# If False, closes the client socket connection explicitly. (boolean
+# value)
+#wsgi_keep_alive = true
+
+# Timeout for client connections' socket operations. If an incoming
+# connection is idle for this number of seconds it will be closed. A
+# value of '0' means wait forever. (integer value)
+#client_socket_timeout = 900
+
+# True if the server should send exception tracebacks to the clients
+# on 500 errors. If False, the server will respond with empty bodies.
+# (boolean value)
+#wsgi_server_debug = false
+
+
+[capabilities]
+
+#
+# From ironic_inspector
+#
+
+# Whether to store the boot mode (BIOS or UEFI). (boolean value)
+#boot_mode = false
+
+# Mapping between a CPU flag and a capability to set if this flag is
+# present. (dict value)
+#cpu_flags = aes:cpu_aes,pdpe1gb:cpu_hugepages_1g,pse:cpu_hugepages,smx:cpu_txt,svm:cpu_vt,vmx:cpu_vt
+
+
+[coordination]
+
+#
+# From ironic_inspector
+#
+
+# The backend URL to use for distributed coordination. EXPERIMENTAL.
+# (string value)
+#backend_url = memcached://localhost:11211
+
+
+[cors]
+
+#
+# From oslo.middleware.cors
+#
+
+# Indicate whether this resource may be shared with the domain
+# received in the requests "origin" header. Format:
+# "<protocol>://<host>[:<port>]", no trailing slash. Example:
+# https://horizon.example.com (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user credentials
+# (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API. Defaults to
+# HTTP Simple Headers. (list value)
+#expose_headers =
+
+# Maximum cache age of CORS preflight requests. (integer value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual request. (list
+# value)
+#allow_methods = GET,POST,PUT,HEAD,PATCH,DELETE,OPTIONS
+
+# Indicate which header field names may be used during the actual
+# request. (list value)
+#allow_headers = X-Auth-Token,X-OpenStack-Ironic-Inspector-API-Minimum-Version,X-OpenStack-Ironic-Inspector-API-Maximum-Version,X-OpenStack-Ironic-Inspector-API-Version
+
+
+[database]
+
+#
+# From oslo.db
+#
+
+# If True, SQLite uses synchronous mode. (boolean value)
+#sqlite_synchronous = true
+
+# The back end to use for the database. (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend = sqlalchemy
+
+# The SQLAlchemy connection string to use to connect to the database.
+# (string value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+#connection = <None>
+
+# The SQLAlchemy connection string to use to connect to the slave
+# database. (string value)
+#slave_connection = <None>
+
+# The SQL mode to be used for MySQL sessions. This option, including
+# the default, overrides any server-set SQL mode. To use whatever SQL
+# mode is set by the server configuration, set this to no value.
+# Example: mysql_sql_mode= (string value)
+#mysql_sql_mode = TRADITIONAL
+
+# For Galera only, configure wsrep_sync_wait causality checks on new
+# connections.  Default is None, meaning don't configure any setting.
+# (integer value)
+#mysql_wsrep_sync_wait = <None>
+
+# DEPRECATED: If True, transparently enables support for handling
+# MySQL Cluster (NDB). (boolean value)
+# This option is deprecated for removal since 12.1.0.
+# Its value may be silently ignored in the future.
+# Reason: Support for the MySQL NDB Cluster storage engine has been
+# deprecated and will be removed in a future release.
+#mysql_enable_ndb = false
+
+# Connections which have been present in the connection pool longer
+# than this number of seconds will be replaced with a new one the next
+# time they are checked out from the pool. (integer value)
+#connection_recycle_time = 3600
+
+# Maximum number of SQL connections to keep open in a pool. Setting a
+# value of 0 indicates no limit. (integer value)
+#max_pool_size = 5
+
+# Maximum number of database connection retries during startup. Set to
+# -1 to specify an infinite retry count. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries = 10
+
+# Interval between retries of opening a SQL connection. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval = 10
+
+# If set, use this value for max_overflow with SQLAlchemy. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow = 50
+
+# Verbosity of SQL debugging information: 0=None, 100=Everything.
+# (integer value)
+# Minimum value: 0
+# Maximum value: 100
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug = 0
+
+# Add Python stack traces to SQL as comment strings. (boolean value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace = false
+
+# If set, use this value for pool_timeout with SQLAlchemy. (integer
+# value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout = <None>
+
+# Enable the experimental use of database reconnect on connection
+# lost. (boolean value)
+#use_db_reconnect = false
+
+# Seconds between retries of a database transaction. (integer value)
+#db_retry_interval = 1
+
+# If True, increases the interval between retries of a database
+# operation up to db_max_retry_interval. (boolean value)
+#db_inc_retry_interval = true
+
+# If db_inc_retry_interval is set, the maximum seconds between retries
+# of a database operation. (integer value)
+#db_max_retry_interval = 10
+
+# Maximum retries in case of connection error or deadlock error before
+# error is raised. Set to -1 to specify an infinite retry count.
+# (integer value)
+#db_max_retries = 20
+
+# Optional URL parameters to append onto the connection URL at connect
+# time; specify as param1=value1&param2=value2&... (string value)
+#connection_parameters =
+
+
+[discovery]
+
+#
+# From ironic_inspector
+#
+
+# The name of the Ironic driver used by the enroll hook when creating
+# a new node in Ironic. (string value)
+#enroll_node_driver = fake-hardware
+
+# Additional fields to set on newly discovered nodes. (dict value)
+#enroll_node_fields =
+
+# IP version of BMC address that will be used when enrolling a new
+# node in Ironic. Defaults to "4,6". Could be "4" (use v4 address
+# only), "4,6" (v4 address have higher priority and if both addresses
+# found v6 version is ignored), "6,4" (v6 is desired but fall back to
+# v4 address for BMCs having v4 address, opposite to "4,6"), "6" (use
+# v6 address only and ignore v4 version). (list value)
+#enabled_bmc_address_version = 4,6
+
+
+[dnsmasq_pxe_filter]
+
+#
+# From ironic_inspector
+#
+
+# The MAC address cache directory, exposed to dnsmasq.This directory
+# is expected to be in exclusive control of the driver. (string value)
+#dhcp_hostsdir = /var/lib/ironic-inspector/dhcp-hostsdir
+
+# Purge the hostsdir upon driver initialization. Setting to false
+# should only be performed when the deployment of inspector is such
+# that there are multiple processes executing inside of the same host
+# and namespace. In this case, the Operator is responsible for setting
+# up a custom cleaning facility. (boolean value)
+#purge_dhcp_hostsdir = true
+
+# A (shell) command line to start the dnsmasq service upon filter
+# initialization. Default: don't start. (string value)
+#dnsmasq_start_command =
+
+# A (shell) command line to stop the dnsmasq service upon inspector
+# (error) exit. Default: don't stop. (string value)
+#dnsmasq_stop_command =
+
+
+[extra_hardware]
+
+#
+# From ironic_inspector
+#
+
+# If True, refuse to parse extra data if at least one record is too
+# short. Additionally, remove the incoming "data" even if parsing
+# failed. (boolean value)
+#strict = false
+
+
+[healthcheck]
+
+#
+# From ironic_inspector
+#
+
+# Enable the health check endpoint at /healthcheck. Note that this is
+# unauthenticated. More information is available at
+# https://docs.openstack.org/oslo.middleware/latest/reference/healthcheck_plugins.html.
+# (boolean value)
+#enabled = false
+
+#
+# From oslo.middleware.healthcheck
+#
+
+# DEPRECATED: The path to respond to healtcheck requests on. (string
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#path = /healthcheck
+
+# Show more detailed information as part of the response. Security
+# note: Enabling this option may expose sensitive details about the
+# service being monitored. Be sure to verify that it will not violate
+# your security policies. (boolean value)
+#detailed = false
+
+# Additional backends that can perform health checks and report that
+# information back as part of a request. (list value)
+#backends =
+
+# Check the presence of a file to determine if an application is
+# running on a port. Used by DisableByFileHealthcheck plugin. (string
+# value)
+#disable_by_file_path = <None>
+
+# Check the presence of a file based on a port to determine if an
+# application is running on a port. Expects a "port:path" list of
+# strings. Used by DisableByFilesPortsHealthcheck plugin. (list value)
+#disable_by_file_paths =
+
+
+[iptables]
+
+#
+# From ironic_inspector
+#
+
+# Interface on which dnsmasq listens, the default is for VM's. (string
+# value)
+#dnsmasq_interface = br-ctlplane
+
+# iptables chain name to use. (string value)
+#firewall_chain = ironic-inspector
+
+# List of Ethernet Over InfiniBand interfaces on the Inspector host
+# which are used for physical access to the DHCP network. Multiple
+# interfaces would be attached to a bond or bridge specified in
+# dnsmasq_interface. The MACs of the InfiniBand nodes which are not in
+# desired state are going to be blocked based on the list of neighbor
+# MACs on these interfaces. (list value)
+#ethoib_interfaces =
+
+# The IP version that will be used for iptables filter. Defaults to 4.
+# (string value)
+# Possible values:
+# 4 - IPv4
+# 6 - IPv6
+#ip_version = 4
+
+
+[ironic]
+
+#
+# From ironic_inspector
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [ironic]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying HTTPs
+# connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection errors. If not
+# set, exponential retry starting with 0.5 seconds up to a maximum of
+# 60 seconds is used. (floating point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will be used
+# for both the user and project domain in v3 and ignored in v2
+# authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters. It will
+# be used for both the user and project domain in v3 and ignored in v2
+# authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client. NOTE: The
+# unversioned endpoint should be specified here; to request a
+# particular API version, use the `version`, `min-version`, and/or
+# `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be used as the
+# upper bound of a range with min_version. Mutually exclusive with
+# version. (string value)
+#max_version = <None>
+
+# Maximum number of retries in case of conflict error (HTTP 409).
+# (integer value)
+#max_retries = 30
+
+# The minimum major version of a given API, intended to be used as the
+# lower bound of a range with max_version. Mutually exclusive with
+# version. If min_version is given with no max_version it is as if max
+# version is "latest". (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [ironic]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [ironic]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string value)
+#region_name = <None>
+
+# Interval between retries in case of conflict error (HTTP 409).
+# (integer value)
+#retry_interval = 2
+
+# The default service_name for endpoint URL discovery. (string value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string value)
+#service_type = baremetal
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for retriable
+# HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status codes.
+# If not set, exponential retry starting with 0.5 seconds up to a
+# maximum of 60 seconds is used. (floating point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [ironic]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint URL. (list
+# value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version for
+# endpoint URL discovery. Mutually exclusive with min_version and
+# max_version (string value)
+#version = <None>
+
+
+[keystone_authtoken]
+
+#
+# From keystonemiddleware.auth_token
+#
+
+# Complete "public" Identity API endpoint. This endpoint should not be
+# an "admin" endpoint, as it should be accessible by all end users.
+# Unauthenticated clients are redirected to this endpoint to
+# authenticate. Although this endpoint should ideally be unversioned,
+# client support in the wild varies. If you're using a versioned v2
+# endpoint here, then this should *not* be the same endpoint the
+# service user utilizes for validating tokens, because normal end
+# users may not be able to reach that endpoint. (string value)
+# Deprecated group/name - [keystone_authtoken]/auth_uri
+#www_authenticate_uri = <None>
+
+# DEPRECATED: Complete "public" Identity API endpoint. This endpoint
+# should not be an "admin" endpoint, as it should be accessible by all
+# end users. Unauthenticated clients are redirected to this endpoint
+# to authenticate. Although this endpoint should ideally be
+# unversioned, client support in the wild varies. If you're using a
+# versioned v2 endpoint here, then this should *not* be the same
+# endpoint the service user utilizes for validating tokens, because
+# normal end users may not be able to reach that endpoint. This option
+# is deprecated in favor of www_authenticate_uri and will be removed
+# in the S release. (string value)
+# This option is deprecated for removal since Queens.
+# Its value may be silently ignored in the future.
+# Reason: The auth_uri option is deprecated in favor of
+# www_authenticate_uri and will be removed in the S  release.
+#auth_uri = <None>
+
+# API version of the Identity API endpoint. (string value)
+#auth_version = <None>
+
+# Interface to use for the Identity API endpoint. Valid values are
+# "public", "internal" (default) or "admin". (string value)
+#interface = internal
+
+# Do not handle authorization requests within the middleware, but
+# delegate the authorization decision to downstream WSGI components.
+# (boolean value)
+#delay_auth_decision = false
+
+# Request timeout value for communicating with Identity API server.
+# (integer value)
+#http_connect_timeout = <None>
+
+# How many times are we trying to reconnect when communicating with
+# Identity API Server. (integer value)
+#http_request_max_retries = 3
+
+# Request environment key where the Swift cache object is stored. When
+# auth_token middleware is deployed with a Swift cache, use this
+# option to have the middleware share a caching backend with swift.
+# Otherwise, use the ``memcached_servers`` option instead. (string
+# value)
+#cache = <None>
+
+# Required if identity server requires client certificate (string
+# value)
+#certfile = <None>
+
+# Required if identity server requires client certificate (string
+# value)
+#keyfile = <None>
+
+# A PEM encoded Certificate Authority to use when verifying HTTPs
+# connections. Defaults to system CAs. (string value)
+#cafile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# The region in which the identity server can be found. (string value)
+#region_name = <None>
+
+# Optionally specify a list of memcached server(s) to use for caching.
+# If left undefined, tokens will instead be cached in-process. (list
+# value)
+# Deprecated group/name - [keystone_authtoken]/memcache_servers
+#memcached_servers = <None>
+
+# In order to prevent excessive effort spent validating tokens, the
+# middleware caches previously-seen tokens for a configurable duration
+# (in seconds). Set to -1 to disable caching completely. (integer
+# value)
+#token_cache_time = 300
+
+# (Optional) If defined, indicate whether token data should be
+# authenticated or authenticated and encrypted. If MAC, token data is
+# authenticated (with HMAC) in the cache. If ENCRYPT, token data is
+# encrypted and authenticated in the cache. If the value is not one of
+# these options or empty, auth_token will raise an exception on
+# initialization. (string value)
+# Possible values:
+# None - <No description provided>
+# MAC - <No description provided>
+# ENCRYPT - <No description provided>
+#memcache_security_strategy = None
+
+# (Optional, mandatory if memcache_security_strategy is defined) This
+# string is used for key derivation. (string value)
+#memcache_secret_key = <None>
+
+# (Optional) Number of seconds memcached server is considered dead
+# before it is tried again. (integer value)
+#memcache_pool_dead_retry = 300
+
+# (Optional) Maximum total number of open connections to every
+# memcached server. (integer value)
+#memcache_pool_maxsize = 10
+
+# (Optional) Socket timeout in seconds for communicating with a
+# memcached server. (integer value)
+#memcache_pool_socket_timeout = 3
+
+# (Optional) Number of seconds a connection to memcached is held
+# unused in the pool before it is closed. (integer value)
+#memcache_pool_unused_timeout = 60
+
+# (Optional) Number of seconds that an operation will wait to get a
+# memcached client connection from the pool. (integer value)
+#memcache_pool_conn_get_timeout = 10
+
+# (Optional) Use the advanced (eventlet safe) memcached client pool.
+# (boolean value)
+#memcache_use_advanced_pool = true
+
+# (Optional) Indicate whether to set the X-Service-Catalog header. If
+# False, middleware will not ask for service catalog on token
+# validation and will not set the X-Service-Catalog header. (boolean
+# value)
+#include_service_catalog = true
+
+# Used to control the use and type of token binding. Can be set to:
+# "disabled" to not check token binding. "permissive" (default) to
+# validate binding information if the bind type is of a form known to
+# the server and ignore it if not. "strict" like "permissive" but if
+# the bind type is unknown the token will be rejected. "required" any
+# form of token binding is needed to be allowed. Finally the name of a
+# binding method that must be present in tokens. (string value)
+#enforce_token_bind = permissive
+
+# A choice of roles that must be present in a service token. Service
+# tokens are allowed to request that an expired token can be used and
+# so this check should tightly control that only actual services
+# should be sending this token. Roles here are applied as an ANY check
+# so any role in this list must be present. For backwards
+# compatibility reasons this currently only affects the allow_expired
+# check. (list value)
+#service_token_roles = service
+
+# For backwards compatibility reasons we must let valid service tokens
+# pass that don't pass the service_token_roles check as valid. Setting
+# this true will become the default in a future release and should be
+# enabled if possible. (boolean value)
+#service_token_roles_required = false
+
+# The name or type of the service as it appears in the service
+# catalog. This is used to validate tokens that have restricted access
+# rules. (string value)
+#service_type = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [keystone_authtoken]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options (string
+# value)
+#auth_section = <None>
+
+
+[mdns]
+
+#
+# From ironic_lib.mdns
+#
+
+# Number of attempts to register a service. Currently has to be larger
+# than 1 because of race conditions in the zeroconf library. (integer
+# value)
+# Minimum value: 1
+#registration_attempts = 5
+
+# Number of attempts to lookup a service. (integer value)
+# Minimum value: 1
+#lookup_attempts = 3
+
+# Additional parameters to pass for the registered service. (dict
+# value)
+#params =
+
+# List of IP addresses of interfaces to use for mDNS. Defaults to all
+# interfaces on the system. (list value)
+#interfaces = <None>
+
+
+[oslo_messaging_amqp]
+
+#
+# From oslo.messaging
+#
+
+# Name for the AMQP container. must be globally unique. Defaults to a
+# generated UUID (string value)
+#container_name = <None>
+
+# Timeout for inactive connections (in seconds) (integer value)
+#idle_timeout = 0
+
+# Debug: dump AMQP frames to stdout (boolean value)
+#trace = false
+
+# Attempt to connect via SSL. If no other ssl-related parameters are
+# given, it will use the system's CA-bundle to verify the server's
+# certificate. (boolean value)
+#ssl = false
+
+# CA certificate PEM file used to verify the server's certificate
+# (string value)
+#ssl_ca_file =
+
+# Self-identifying certificate PEM file for client authentication
+# (string value)
+#ssl_cert_file =
+
+# Private key PEM file used to sign ssl_cert_file certificate
+# (optional) (string value)
+#ssl_key_file =
+
+# Password for decrypting ssl_key_file (if encrypted) (string value)
+#ssl_key_password = <None>
+
+# By default SSL checks that the name in the server's certificate
+# matches the hostname in the transport_url. In some configurations it
+# may be preferable to use the virtual hostname instead, for example
+# if the server uses the Server Name Indication TLS extension
+# (rfc6066) to provide a certificate per virtual host. Set
+# ssl_verify_vhost to True if the server's SSL certificate uses the
+# virtual host name instead of the DNS name. (boolean value)
+#ssl_verify_vhost = false
+
+# Space separated list of acceptable SASL mechanisms (string value)
+#sasl_mechanisms =
+
+# Path to directory that contains the SASL configuration (string
+# value)
+#sasl_config_dir =
+
+# Name of configuration file (without .conf suffix) (string value)
+#sasl_config_name =
+
+# SASL realm to use if no realm present in username (string value)
+#sasl_default_realm =
+
+# Seconds to pause before attempting to re-connect. (integer value)
+# Minimum value: 1
+#connection_retry_interval = 1
+
+# Increase the connection_retry_interval by this many seconds after
+# each unsuccessful failover attempt. (integer value)
+# Minimum value: 0
+#connection_retry_backoff = 2
+
+# Maximum limit for connection_retry_interval +
+# connection_retry_backoff (integer value)
+# Minimum value: 1
+#connection_retry_interval_max = 30
+
+# Time to pause between re-connecting an AMQP 1.0 link that failed due
+# to a recoverable error. (integer value)
+# Minimum value: 1
+#link_retry_delay = 10
+
+# The maximum number of attempts to re-send a reply message which
+# failed due to a recoverable error. (integer value)
+# Minimum value: -1
+#default_reply_retry = 0
+
+# The deadline for an rpc reply message delivery. (integer value)
+# Minimum value: 5
+#default_reply_timeout = 30
+
+# The deadline for an rpc cast or call message delivery. Only used
+# when caller does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_send_timeout = 30
+
+# The deadline for a sent notification message delivery. Only used
+# when caller does not provide a timeout expiry. (integer value)
+# Minimum value: 5
+#default_notify_timeout = 30
+
+# The duration to schedule a purge of idle sender links. Detach link
+# after expiry. (integer value)
+# Minimum value: 1
+#default_sender_link_timeout = 600
+
+# Indicates the addressing mode used by the driver.
+# Permitted values:
+# 'legacy'   - use legacy non-routable addressing
+# 'routable' - use routable addresses
+# 'dynamic'  - use legacy addresses if the message bus does not
+# support routing otherwise use routable addressing (string value)
+#addressing_mode = dynamic
+
+# Enable virtual host support for those message buses that do not
+# natively support virtual hosting (such as qpidd). When set to true
+# the virtual host name will be added to all message bus addresses,
+# effectively creating a private 'subnet' per virtual host. Set to
+# False if the message bus supports virtual hosting using the
+# 'hostname' field in the AMQP 1.0 Open performative as the name of
+# the virtual host. (boolean value)
+#pseudo_vhost = true
+
+# address prefix used when sending to a specific server (string value)
+#server_request_prefix = exclusive
+
+# address prefix used when broadcasting to all servers (string value)
+#broadcast_prefix = broadcast
+
+# address prefix when sending to any server in group (string value)
+#group_request_prefix = unicast
+
+# Address prefix for all generated RPC addresses (string value)
+#rpc_address_prefix = openstack.org/om/rpc
+
+# Address prefix for all generated Notification addresses (string
+# value)
+#notify_address_prefix = openstack.org/om/notify
+
+# Appended to the address prefix when sending a fanout message. Used
+# by the message bus to identify fanout messages. (string value)
+#multicast_address = multicast
+
+# Appended to the address prefix when sending to a particular
+# RPC/Notification server. Used by the message bus to identify
+# messages sent to a single destination. (string value)
+#unicast_address = unicast
+
+# Appended to the address prefix when sending to a group of consumers.
+# Used by the message bus to identify messages that should be
+# delivered in a round-robin fashion across consumers. (string value)
+#anycast_address = anycast
+
+# Exchange name used in notification addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_notification_exchange if set
+# else control_exchange if set
+# else 'notify' (string value)
+#default_notification_exchange = <None>
+
+# Exchange name used in RPC addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_rpc_exchange if set
+# else control_exchange if set
+# else 'rpc' (string value)
+#default_rpc_exchange = <None>
+
+# Window size for incoming RPC Reply messages. (integer value)
+# Minimum value: 1
+#reply_link_credit = 200
+
+# Window size for incoming RPC Request messages (integer value)
+# Minimum value: 1
+#rpc_server_credit = 100
+
+# Window size for incoming Notification messages (integer value)
+# Minimum value: 1
+#notify_server_credit = 100
+
+# Send messages of this type pre-settled.
+# Pre-settled messages will not receive acknowledgement
+# from the peer. Note well: pre-settled messages may be
+# silently discarded if the delivery fails.
+# Permitted values:
+# 'rpc-call' - send RPC Calls pre-settled
+# 'rpc-reply'- send RPC Replies pre-settled
+# 'rpc-cast' - Send RPC Casts pre-settled
+# 'notify'   - Send Notifications pre-settled
+#  (multi valued)
+#pre_settled = rpc-cast
+#pre_settled = rpc-reply
+
+
+[oslo_messaging_kafka]
+
+#
+# From oslo.messaging
+#
+
+# Max fetch bytes of Kafka consumer (integer value)
+#kafka_max_fetch_bytes = 1048576
+
+# Default timeout(s) for Kafka consumers (floating point value)
+#kafka_consumer_timeout = 1.0
+
+# DEPRECATED: Pool Size for Kafka Consumers (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#pool_size = 10
+
+# DEPRECATED: The pool size limit for connections expiration policy
+# (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_min_size = 2
+
+# DEPRECATED: The time-to-live in sec of idle connections in the pool
+# (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_ttl = 1200
+
+# Group id for Kafka consumer. Consumers in one group will coordinate
+# message consumption (string value)
+#consumer_group = oslo_messaging_consumer
+
+# Upper bound on the delay for KafkaProducer batching in seconds
+# (floating point value)
+#producer_batch_timeout = 0.0
+
+# Size of batch for the producer async send (integer value)
+#producer_batch_size = 16384
+
+# The compression codec for all data generated by the producer. If not
+# set, compression will not be used. Note that the allowed values of
+# this depend on the kafka version (string value)
+# Possible values:
+# none - <No description provided>
+# gzip - <No description provided>
+# snappy - <No description provided>
+# lz4 - <No description provided>
+# zstd - <No description provided>
+#compression_codec = none
+
+# Enable asynchronous consumer commits (boolean value)
+#enable_auto_commit = false
+
+# The maximum number of records returned in a poll call (integer
+# value)
+#max_poll_records = 500
+
+# Protocol used to communicate with brokers (string value)
+# Possible values:
+# PLAINTEXT - <No description provided>
+# SASL_PLAINTEXT - <No description provided>
+# SSL - <No description provided>
+# SASL_SSL - <No description provided>
+#security_protocol = PLAINTEXT
+
+# Mechanism when security protocol is SASL (string value)
+#sasl_mechanism = PLAIN
+
+# CA certificate PEM file used to verify the server certificate
+# (string value)
+#ssl_cafile =
+
+# Client certificate PEM file used for authentication. (string value)
+#ssl_client_cert_file =
+
+# Client key PEM file used for authentication. (string value)
+#ssl_client_key_file =
+
+# Client key password file used for authentication. (string value)
+#ssl_client_key_password =
+
+
+[oslo_messaging_notifications]
+
+#
+# From oslo.messaging
+#
+
+# The Drivers(s) to handle sending notifications. Possible values are
+# messaging, messagingv2, routing, log, test, noop (multi valued)
+# Deprecated group/name - [DEFAULT]/notification_driver
+#driver =
+
+# A URL representing the messaging driver to use for notifications. If
+# not set, we fall back to the same configuration used for RPC.
+# (string value)
+# Deprecated group/name - [DEFAULT]/notification_transport_url
+#transport_url = <None>
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+# Deprecated group/name - [DEFAULT]/notification_topics
+#topics = notifications
+
+# The maximum number of attempts to re-send a notification message
+# which failed to be delivered due to a recoverable error. 0 - No
+# retry, -1 - indefinite (integer value)
+#retry = -1
+
+
+[oslo_messaging_rabbit]
+
+#
+# From oslo.messaging
+#
+
+# Use durable queues in AMQP. If rabbit_quorum_queue is enabled,
+# queues will be durable and this value will be ignored. (boolean
+# value)
+#amqp_durable_queues = false
+
+# Auto-delete queues in AMQP. (boolean value)
+#amqp_auto_delete = false
+
+# Connect over SSL. (boolean value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_use_ssl
+#ssl = false
+
+# SSL version to use (valid only if SSL enabled). Valid values are
+# TLSv1 and SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be
+# available on some distributions. (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_version
+#ssl_version =
+
+# SSL key file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_keyfile
+#ssl_key_file =
+
+# SSL cert file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_certfile
+#ssl_cert_file =
+
+# SSL certification authority file (valid only if SSL enabled).
+# (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_ca_certs
+#ssl_ca_file =
+
+# Global toggle for enforcing the OpenSSL FIPS mode. This feature
+# requires Python support. This is available in Python 3.9 in all
+# environments and may have been backported to older Python versions
+# on select environments. If the Python executable used does not
+# support OpenSSL FIPS mode, an exception will be raised. (boolean
+# value)
+#ssl_enforce_fips_mode = false
+
+# Run the health check heartbeat thread through a native python thread
+# by default. If this option is equal to False then the health check
+# heartbeat will inherit the execution model from the parent process.
+# For example if the parent process has monkey patched the stdlib by
+# using eventlet/greenlet then the heartbeat will be run through a
+# green thread. This option should be set to True only for the wsgi
+# services. (boolean value)
+#heartbeat_in_pthread = false
+
+# How long to wait (in seconds) before reconnecting in response to an
+# AMQP consumer cancel notification. (floating point value)
+# Minimum value: 0.0
+# Maximum value: 4.5
+#kombu_reconnect_delay = 1.0
+
+# EXPERIMENTAL: Possible values are: gzip, bz2. If not set compression
+# will not be used. This option may not be available in future
+# versions. (string value)
+#kombu_compression = <None>
+
+# How long to wait a missing client before abandoning to send it its
+# replies. This value should not be longer than rpc_response_timeout.
+# (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_reconnect_timeout
+#kombu_missing_consumer_retry_timeout = 60
+
+# Determines how the next RabbitMQ node is chosen in case the one we
+# are currently connected to becomes unavailable. Takes effect only if
+# more than one RabbitMQ node is provided in config. (string value)
+# Possible values:
+# round-robin - <No description provided>
+# shuffle - <No description provided>
+#kombu_failover_strategy = round-robin
+
+# The RabbitMQ login method. (string value)
+# Possible values:
+# PLAIN - <No description provided>
+# AMQPLAIN - <No description provided>
+# EXTERNAL - <No description provided>
+# RABBIT-CR-DEMO - <No description provided>
+#rabbit_login_method = AMQPLAIN
+
+# How frequently to retry connecting with RabbitMQ. (integer value)
+#rabbit_retry_interval = 1
+
+# How long to backoff for between retries when connecting to RabbitMQ.
+# (integer value)
+#rabbit_retry_backoff = 2
+
+# Maximum interval of RabbitMQ connection retries. Default is 30
+# seconds. (integer value)
+#rabbit_interval_max = 30
+
+# Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change
+# this option, you must wipe the RabbitMQ database. In RabbitMQ 3.0,
+# queue mirroring is no longer controlled by the x-ha-policy argument
+# when declaring a queue. If you just want to make sure that all
+# queues (except those with auto-generated names) are mirrored across
+# all nodes, run: "rabbitmqctl set_policy HA '^(?!amq\.).*' '{"ha-
+# mode": "all"}' " (boolean value)
+#rabbit_ha_queues = false
+
+# Use quorum queues in RabbitMQ (x-queue-type: quorum). The quorum
+# queue is a modern queue type for RabbitMQ implementing a durable,
+# replicated FIFO queue based on the Raft consensus algorithm. It is
+# available as of RabbitMQ 3.8.0. If set this option will conflict
+# with the HA queues (``rabbit_ha_queues``) aka mirrored queues, in
+# other words the HA queues should be disabled, quorum queues durable
+# by default so the amqp_durable_queues opion is ignored when this
+# option enabled. (boolean value)
+#rabbit_quorum_queue = false
+
+# Each time a message is redelivered to a consumer, a counter is
+# incremented. Once the redelivery count exceeds the delivery limit
+# the message gets dropped or dead-lettered (if a DLX exchange has
+# been configured) Used only when rabbit_quorum_queue is enabled,
+# Default 0 which means dont set a limit. (integer value)
+#rabbit_quorum_delivery_limit = 0
+
+# By default all messages are maintained in memory if a quorum queue
+# grows in length it can put memory pressure on a cluster. This option
+# can limit the number of messages in the quorum queue. Used only when
+# rabbit_quorum_queue is enabled, Default 0 which means dont set a
+# limit. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_length
+#rabbit_quorum_max_memory_length = 0
+
+# By default all messages are maintained in memory if a quorum queue
+# grows in length it can put memory pressure on a cluster. This option
+# can limit the number of memory bytes used by the quorum queue. Used
+# only when rabbit_quorum_queue is enabled, Default 0 which means dont
+# set a limit. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_bytes
+#rabbit_quorum_max_memory_bytes = 0
+
+# Positive integer representing duration in seconds for queue TTL
+# (x-expires). Queues which are unused for the duration of the TTL are
+# automatically deleted. The parameter affects only reply and fanout
+# queues. (integer value)
+# Minimum value: 1
+#rabbit_transient_queues_ttl = 1800
+
+# Specifies the number of messages to prefetch. Setting to zero allows
+# unlimited messages. (integer value)
+#rabbit_qos_prefetch_count = 0
+
+# Number of seconds after which the Rabbit broker is considered down
+# if heartbeat's keep-alive fails (0 disables heartbeat). (integer
+# value)
+#heartbeat_timeout_threshold = 60
+
+# How often times during the heartbeat_timeout_threshold we check the
+# heartbeat. (integer value)
+#heartbeat_rate = 2
+
+# DEPRECATED: (DEPRECATED) Enable/Disable the RabbitMQ mandatory flag
+# for direct send. The direct send is used as reply, so the
+# MessageUndeliverable exception is raised in case the client queue
+# does not exist.MessageUndeliverable exception will be used to loop
+# for a timeout to lets a chance to sender to recover.This flag is
+# deprecated and it will not be possible to deactivate this
+# functionality anymore (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Mandatory flag no longer deactivable.
+#direct_mandatory_flag = true
+
+# Enable x-cancel-on-ha-failover flag so that rabbitmq server will
+# cancel and notify consumerswhen queue is down (boolean value)
+#enable_cancel_on_failover = false
+
+
+[oslo_policy]
+
+#
+# From oslo.policy
+#
+
+# This option controls whether or not to enforce scope when evaluating
+# policies. If ``True``, the scope of the token used in the request is
+# compared to the ``scope_types`` of the policy being enforced. If the
+# scopes do not match, an ``InvalidScope`` exception will be raised.
+# If ``False``, a message will be logged informing operators that
+# policies are being invoked with mismatching scope. (boolean value)
+#enforce_scope = false
+
+# This option controls whether or not to use old deprecated defaults
+# when evaluating policies. If ``True``, the old deprecated defaults
+# are not going to be evaluated. This means if any existing token is
+# allowed for old defaults but is disallowed for new defaults, it will
+# be disallowed. It is encouraged to enable this flag along with the
+# ``enforce_scope`` flag so that you can get the benefits of new
+# defaults and ``scope_type`` together. If ``False``, the deprecated
+# policy check string is logically OR'd with the new policy check
+# string, allowing for a graceful upgrade experience between releases
+# with new policies, which is the default behavior. (boolean value)
+#enforce_new_defaults = false
+
+# The relative or absolute path of a file that maps roles to
+# permissions for a given service. Relative paths must be specified in
+# relation to the configuration file setting this option. (string
+# value)
+#policy_file = policy.json
+
+# Default rule. Enforced when a requested rule is not found. (string
+# value)
+#policy_default_rule = default
+
+# Directories where policy configuration files are stored. They can be
+# relative to any directory in the search path defined by the
+# config_dir option, or absolute paths. The file defined by
+# policy_file must exist for these directories to be searched.
+# Missing or empty directories are ignored. (multi valued)
+#policy_dirs = policy.d
+
+# Content Type to send and receive data for REST based policy check
+# (string value)
+# Possible values:
+# application/x-www-form-urlencoded - <No description provided>
+# application/json - <No description provided>
+#remote_content_type = application/x-www-form-urlencoded
+
+# server identity verification for REST based policy check (boolean
+# value)
+#remote_ssl_verify_server_crt = false
+
+# Absolute path to ca cert file for REST based policy check (string
+# value)
+#remote_ssl_ca_crt_file = <None>
+
+# Absolute path to client cert for REST based policy check (string
+# value)
+#remote_ssl_client_crt_file = <None>
+
+# Absolute path client key file REST based policy check (string value)
+#remote_ssl_client_key_file = <None>
+
+
+[pci_devices]
+
+#
+# From ironic_inspector
+#
+
+# An alias for PCI device identified by 'vendor_id' and 'product_id'
+# fields. Format: {"vendor_id": "1234", "product_id": "5678", "name":
+# "pci_dev1"} (multi valued)
+#alias =
+
+
+[port_physnet]
+
+#
+# From ironic_inspector
+#
+
+# Mapping of IP subnet CIDR to physical network. When the
+# physnet_cidr_map processing hook is enabled the physical_network
+# property of baremetal ports is populated based on this mapping.
+# (list value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#cidr_map = 10.10.10.0/24:physnet_a,2001:db8::/64:physnet_b
+
+
+[processing]
+
+#
+# From ironic_inspector
+#
+
+# Which MAC addresses to add as ports during introspection. Possible
+# values: all (all MAC addresses), active (MAC addresses of NIC with
+# IP addresses), pxe (only MAC address of NIC node PXE booted from,
+# falls back to "active" if PXE MAC is not supplied by the ramdisk).
+# (string value)
+# Possible values:
+# all - <No description provided>
+# active - <No description provided>
+# pxe - <No description provided>
+# disabled - <No description provided>
+#add_ports = pxe
+
+# Which ports (already present on a node) to keep after introspection.
+# Possible values: all (do not delete anything), present (keep ports
+# which MACs were present in introspection data), added (keep only
+# MACs that we added during introspection). (string value)
+# Possible values:
+# all - <No description provided>
+# present - <No description provided>
+# added - <No description provided>
+#keep_ports = all
+
+# Whether to overwrite existing values in node database. Disable this
+# option to make introspection a non-destructive operation. (boolean
+# value)
+#overwrite_existing = true
+
+# Comma-separated list of default hooks for processing pipeline. Hook
+# 'scheduler' updates the node with the minimum properties required by
+# the Nova scheduler. Hook 'validate_interfaces' ensures that valid
+# NIC data was provided by the ramdisk. Do not exclude these two
+# unless you really know what you're doing. (string value)
+#default_processing_hooks = ramdisk_error,root_disk_selection,scheduler,validate_interfaces,capabilities,pci_devices
+
+# Comma-separated list of enabled hooks for processing pipeline. The
+# default for this is $default_processing_hooks, hooks can be added
+# before or after the defaults like this:
+# "prehook,$default_processing_hooks,posthook". (string value)
+#processing_hooks = $default_processing_hooks
+
+# If set, logs from ramdisk will be stored in this directory. (string
+# value)
+#ramdisk_logs_dir = <None>
+
+# Whether to store ramdisk logs even if it did not return an error
+# message (dependent upon "ramdisk_logs_dir" option being set).
+# (boolean value)
+#always_store_ramdisk_logs = false
+
+# The name of the hook to run when inspector receives inspection
+# information from a node it isn't already aware of. This hook is
+# ignored by default. (string value)
+#node_not_found_hook = <None>
+
+# The storage backend for storing introspection data. Possible values
+# are: 'none', 'database' and 'swift'. If set to 'none', introspection
+# data will not be stored. (string value)
+#store_data = none
+
+# Whether to leave 1 GiB of disk size untouched for partitioning. Only
+# has effect when used with the IPA as a ramdisk, for older ramdisk
+# local_gb is calculated on the ramdisk side. (boolean value)
+#disk_partitioning_spacing = true
+
+# File name template for storing ramdisk logs. The following
+# replacements can be used: {uuid} - node UUID or "unknown", {bmc} -
+# node BMC address or "unknown", {dt} - current UTC date and time,
+# {mac} - PXE booting MAC or "unknown". (string value)
+#ramdisk_logs_filename_format = {uuid}_{dt:%Y%m%d-%H%M%S.%f}.tar.gz
+
+# Whether to power off a node after introspection. Nodes in active or
+# rescue states which submit introspection data will be left on if the
+# feature is enabled via the 'permit_active_introspection'
+# configuration option. (boolean value)
+#power_off = true
+
+# Whether to process nodes that are in running states. (boolean value)
+#permit_active_introspection = false
+
+# Whether to update the pxe_enabled value according to the
+# introspection data. This option has no effect if
+# [processing]overwrite_existing is set to False (boolean value)
+#update_pxe_enabled = true
+
+
+[pxe_filter]
+
+#
+# From ironic_inspector
+#
+
+# PXE boot filter driver to use, possible filters are: "iptables",
+# "dnsmasq" and "noop". Set "noop " to disable the firewall filtering.
+# (string value)
+#driver = iptables
+
+# Amount of time in seconds, after which repeat periodic update of the
+# filter. (integer value)
+# Minimum value: 0
+#sync_period = 15
+
+# By default inspector will open the DHCP server for any node when
+# introspection is active. Opening DHCP for unknown MAC addresses when
+# introspection is active allow for users to add nodes with no ports
+# to ironic and have ironic-inspector enroll ports based on node
+# introspection results. NOTE: If this option is True, nodes must have
+# at least one enrolled port prior to introspection. (boolean value)
+#deny_unknown_macs = false
+
+
+[service_catalog]
+
+#
+# From ironic_inspector
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [service_catalog]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying HTTPs
+# connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection errors. If not
+# set, exponential retry starting with 0.5 seconds up to a maximum of
+# 60 seconds is used. (floating point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will be used
+# for both the user and project domain in v3 and ignored in v2
+# authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters. It will
+# be used for both the user and project domain in v3 and ignored in v2
+# authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client. NOTE: The
+# unversioned endpoint should be specified here; to request a
+# particular API version, use the `version`, `min-version`, and/or
+# `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be used as the
+# upper bound of a range with min_version. Mutually exclusive with
+# version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be used as the
+# lower bound of a range with max_version. Mutually exclusive with
+# version. If min_version is given with no max_version it is as if max
+# version is "latest". (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [service_catalog]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [service_catalog]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string value)
+#region_name = <None>
+
+# The default service_name for endpoint URL discovery. (string value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string value)
+#service_type = baremetal-introspection
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for retriable
+# HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status codes.
+# If not set, exponential retry starting with 0.5 seconds up to a
+# maximum of 60 seconds is used. (floating point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [service_catalog]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint URL. (list
+# value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version for
+# endpoint URL discovery. Mutually exclusive with min_version and
+# max_version (string value)
+#version = <None>
+
+
+[ssl]
+
+#
+# From oslo.service.sslutils
+#
+
+# CA certificate file to use to verify connecting clients. (string
+# value)
+# Deprecated group/name - [DEFAULT]/ssl_ca_file
+#ca_file = <None>
+
+# Certificate file to use when starting the server securely. (string
+# value)
+# Deprecated group/name - [DEFAULT]/ssl_cert_file
+#cert_file = <None>
+
+# Private key file to use when starting the server securely. (string
+# value)
+# Deprecated group/name - [DEFAULT]/ssl_key_file
+#key_file = <None>
+
+# SSL version to use (valid only if SSL enabled). Valid values are
+# TLSv1 and SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be
+# available on some distributions. (string value)
+#version = <None>
+
+# Sets the list of available ciphers. value should be a string in the
+# OpenSSL cipher list format. (string value)
+#ciphers = <None>
+
+
+[swift]
+
+#
+# From ironic_inspector
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [swift]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying HTTPs
+# connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection errors. If not
+# set, exponential retry starting with 0.5 seconds up to a maximum of
+# 60 seconds is used. (floating point value)
+#connect_retry_delay = <None>
+
+# Default Swift container to use when creating objects. (string value)
+#container = ironic-inspector
+
+# Optional domain ID to use with v3 and v2 parameters. It will be used
+# for both the user and project domain in v3 and ignored in v2
+# authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters. It will
+# be used for both the user and project domain in v3 and ignored in v2
+# authentication. (string value)
+#default_domain_name = <None>
+
+# Number of seconds that the Swift object will last before being
+# deleted. (set to 0 to never delete the object). (integer value)
+#delete_after = 0
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client. NOTE: The
+# unversioned endpoint should be specified here; to request a
+# particular API version, use the `version`, `min-version`, and/or
+# `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be used as the
+# upper bound of a range with min_version. Mutually exclusive with
+# version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be used as the
+# lower bound of a range with max_version. Mutually exclusive with
+# version. If min_version is given with no max_version it is as if max
+# version is "latest". (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [swift]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [swift]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string value)
+#region_name = <None>
+
+# The default service_name for endpoint URL discovery. (string value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string value)
+#service_type = object-store
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for retriable
+# HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status codes.
+# If not set, exponential retry starting with 0.5 seconds up to a
+# maximum of 60 seconds is used. (floating point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [swift]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint URL. (list
+# value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version for
+# endpoint URL discovery. Mutually exclusive with min_version and
+# max_version (string value)
+#version = <None>

--- a/core/ironic/ironic-inspector-sudoers
+++ b/core/ironic/ironic-inspector-sudoers
@@ -1,0 +1,2 @@
+Defaults:ironic-inspector !requiretty
+ironic-inspector ALL=(root) NOPASSWD: /usr/bin/ironic-inspector-rootwrap /etc/ironic-inspector/rootwrap.conf *

--- a/core/ironic/ironic-inspector.filters
+++ b/core/ironic/ironic-inspector.filters
@@ -1,0 +1,7 @@
+# This file should be owned by (and only-writeable by) the root user
+
+[Filters]
+# ironic-inspector-rootwrap command filters for firewall manipulation
+# ironic_inspector/pxe_filter/iptables.py
+iptables: CommandFilter, iptables, root
+ip6tables: CommandFilter, ip6tables, root

--- a/core/ironic/ironic-neutron-agent.service
+++ b/core/ironic/ironic-neutron-agent.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=OpenStack Ironic Neutron Agent
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=neutron
+PermissionsStartOnly=true
+TimeoutStartSec=0
+Restart=on-failure
+ExecStart=/usr/bin/ironic-neutron-agent --config-dir /etc/neutron --config-file /etc/neutron/plugins/ml2/ironic_neutron_agent.ini --log-file /var/log/neutron/ironic-neutron-agent.log
+PrivateTmp=true
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+

--- a/core/ironic/ironic-sudoers
+++ b/core/ironic/ironic-sudoers
@@ -1,0 +1,2 @@
+Defaults:ironic !requiretty
+ironic ALL = (root) NOPASSWD: /usr/bin/ironic-rootwrap /etc/ironic/rootwrap.conf *

--- a/core/ironic/ironic-utils.filters
+++ b/core/ironic/ironic-utils.filters
@@ -1,0 +1,7 @@
+# ironic-rootwrap command filters for disk manipulation
+# This file should be owned by (and only-writable by) the root user
+
+[Filters]
+# ironic/common/utils.py
+mount: CommandFilter, mount, root
+umount: CommandFilter, umount, root

--- a/core/ironic/ironic.conf.sample
+++ b/core/ironic/ironic.conf.sample
@@ -1,0 +1,5634 @@
+[DEFAULT]
+
+#
+# From ironic
+#
+
+# Authentication strategy used by ironic-api. "noauth" should
+# not be used in a production environment because all
+# authentication will be disabled. (string value)
+# Possible values:
+# noauth - no authentication
+# keystone - use the Identity service for authentication
+# http_basic - HTTP basic authentication
+#auth_strategy = keystone
+
+# Path to Apache format user authentication file used when
+# auth_strategy=http_basic (string value)
+#http_basic_auth_user_file = /etc/ironic/htpasswd
+
+# Return server tracebacks in the API response for any error
+# responses. WARNING: this is insecure and should not be used
+# in a production environment. (boolean value)
+#debug_tracebacks_in_api = false
+
+# Enable pecan debug mode. WARNING: this is insecure and
+# should not be used in a production environment. (boolean
+# value)
+#pecan_debug = false
+
+# Resource class to use for new nodes when no resource class
+# is provided in the creation request. (string value)
+# Note: This option can be changed without restarting.
+#default_resource_class = <None>
+
+# Specify the list of hardware types to load during service
+# initialization. Missing hardware types, or hardware types
+# which fail to initialize, will prevent the conductor service
+# from starting. This option defaults to a recommended set of
+# production-oriented hardware types. A complete list of
+# hardware types present on your system may be found by
+# enumerating the "ironic.hardware.types" entrypoint. (list
+# value)
+#enabled_hardware_types = ipmi,redfish
+
+# Specify the list of bios interfaces to load during service
+# initialization. Missing bios interfaces, or bios interfaces
+# which fail to initialize, will prevent the ironic-conductor
+# service from starting. At least one bios interface that is
+# supported by each enabled hardware type must be enabled
+# here, or the ironic-conductor service will not start. Must
+# not be an empty list. The default value is a recommended set
+# of production-oriented bios interfaces. A complete list of
+# bios interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.bios"
+# entrypoint. When setting this value, please make sure that
+# every enabled hardware type will have the same set of
+# enabled bios interfaces on every ironic-conductor service.
+# (list value)
+#enabled_bios_interfaces = no-bios,redfish
+
+# Default bios interface to be used for nodes that do not have
+# bios_interface field set. A complete list of bios interfaces
+# present on your system may be found by enumerating the
+# "ironic.hardware.interfaces.bios" entrypoint. (string value)
+#default_bios_interface = <None>
+
+# Specify the list of boot interfaces to load during service
+# initialization. Missing boot interfaces, or boot interfaces
+# which fail to initialize, will prevent the ironic-conductor
+# service from starting. At least one boot interface that is
+# supported by each enabled hardware type must be enabled
+# here, or the ironic-conductor service will not start. Must
+# not be an empty list. The default value is a recommended set
+# of production-oriented boot interfaces. A complete list of
+# boot interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.boot"
+# entrypoint. When setting this value, please make sure that
+# every enabled hardware type will have the same set of
+# enabled boot interfaces on every ironic-conductor service.
+# (list value)
+#enabled_boot_interfaces = ipxe,pxe,redfish-virtual-media
+
+# Default boot interface to be used for nodes that do not have
+# boot_interface field set. A complete list of boot interfaces
+# present on your system may be found by enumerating the
+# "ironic.hardware.interfaces.boot" entrypoint. (string value)
+#default_boot_interface = <None>
+
+# Specify the list of console interfaces to load during
+# service initialization. Missing console interfaces, or
+# console interfaces which fail to initialize, will prevent
+# the ironic-conductor service from starting. At least one
+# console interface that is supported by each enabled hardware
+# type must be enabled here, or the ironic-conductor service
+# will not start. Must not be an empty list. The default value
+# is a recommended set of production-oriented console
+# interfaces. A complete list of console interfaces present on
+# your system may be found by enumerating the
+# "ironic.hardware.interfaces.console" entrypoint. When
+# setting this value, please make sure that every enabled
+# hardware type will have the same set of enabled console
+# interfaces on every ironic-conductor service. (list value)
+#enabled_console_interfaces = no-console
+
+# Default console interface to be used for nodes that do not
+# have console_interface field set. A complete list of console
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.console"
+# entrypoint. (string value)
+#default_console_interface = <None>
+
+# Specify the list of deploy interfaces to load during service
+# initialization. Missing deploy interfaces, or deploy
+# interfaces which fail to initialize, will prevent the
+# ironic-conductor service from starting. At least one deploy
+# interface that is supported by each enabled hardware type
+# must be enabled here, or the ironic-conductor service will
+# not start. Must not be an empty list. The default value is a
+# recommended set of production-oriented deploy interfaces. A
+# complete list of deploy interfaces present on your system
+# may be found by enumerating the
+# "ironic.hardware.interfaces.deploy" entrypoint. When setting
+# this value, please make sure that every enabled hardware
+# type will have the same set of enabled deploy interfaces on
+# every ironic-conductor service. (list value)
+#enabled_deploy_interfaces = direct,ramdisk
+
+# Default deploy interface to be used for nodes that do not
+# have deploy_interface field set. A complete list of deploy
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.deploy"
+# entrypoint. (string value)
+#default_deploy_interface = <None>
+
+# Specify the list of inspect interfaces to load during
+# service initialization. Missing inspect interfaces, or
+# inspect interfaces which fail to initialize, will prevent
+# the ironic-conductor service from starting. At least one
+# inspect interface that is supported by each enabled hardware
+# type must be enabled here, or the ironic-conductor service
+# will not start. Must not be an empty list. The default value
+# is a recommended set of production-oriented inspect
+# interfaces. A complete list of inspect interfaces present on
+# your system may be found by enumerating the
+# "ironic.hardware.interfaces.inspect" entrypoint. When
+# setting this value, please make sure that every enabled
+# hardware type will have the same set of enabled inspect
+# interfaces on every ironic-conductor service. (list value)
+#enabled_inspect_interfaces = no-inspect,redfish
+
+# Default inspect interface to be used for nodes that do not
+# have inspect_interface field set. A complete list of inspect
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.inspect"
+# entrypoint. (string value)
+#default_inspect_interface = <None>
+
+# Specify the list of management interfaces to load during
+# service initialization. Missing management interfaces, or
+# management interfaces which fail to initialize, will prevent
+# the ironic-conductor service from starting. At least one
+# management interface that is supported by each enabled
+# hardware type must be enabled here, or the ironic-conductor
+# service will not start. Must not be an empty list. The
+# default value is a recommended set of production-oriented
+# management interfaces. A complete list of management
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.management"
+# entrypoint. When setting this value, please make sure that
+# every enabled hardware type will have the same set of
+# enabled management interfaces on every ironic-conductor
+# service. (list value)
+#enabled_management_interfaces = <None>
+
+# Default management interface to be used for nodes that do
+# not have management_interface field set. A complete list of
+# management interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.management"
+# entrypoint. (string value)
+#default_management_interface = <None>
+
+# Specify the list of network interfaces to load during
+# service initialization. Missing network interfaces, or
+# network interfaces which fail to initialize, will prevent
+# the ironic-conductor service from starting. At least one
+# network interface that is supported by each enabled hardware
+# type must be enabled here, or the ironic-conductor service
+# will not start. Must not be an empty list. The default value
+# is a recommended set of production-oriented network
+# interfaces. A complete list of network interfaces present on
+# your system may be found by enumerating the
+# "ironic.hardware.interfaces.network" entrypoint. When
+# setting this value, please make sure that every enabled
+# hardware type will have the same set of enabled network
+# interfaces on every ironic-conductor service. (list value)
+#enabled_network_interfaces = flat,noop
+
+# Default network interface to be used for nodes that do not
+# have network_interface field set. A complete list of network
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.network"
+# entrypoint. (string value)
+#default_network_interface = <None>
+
+# Specify the list of power interfaces to load during service
+# initialization. Missing power interfaces, or power
+# interfaces which fail to initialize, will prevent the
+# ironic-conductor service from starting. At least one power
+# interface that is supported by each enabled hardware type
+# must be enabled here, or the ironic-conductor service will
+# not start. Must not be an empty list. The default value is a
+# recommended set of production-oriented power interfaces. A
+# complete list of power interfaces present on your system may
+# be found by enumerating the
+# "ironic.hardware.interfaces.power" entrypoint. When setting
+# this value, please make sure that every enabled hardware
+# type will have the same set of enabled power interfaces on
+# every ironic-conductor service. (list value)
+#enabled_power_interfaces = <None>
+
+# Default power interface to be used for nodes that do not
+# have power_interface field set. A complete list of power
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.power"
+# entrypoint. (string value)
+#default_power_interface = <None>
+
+# Specify the list of raid interfaces to load during service
+# initialization. Missing raid interfaces, or raid interfaces
+# which fail to initialize, will prevent the ironic-conductor
+# service from starting. At least one raid interface that is
+# supported by each enabled hardware type must be enabled
+# here, or the ironic-conductor service will not start. Must
+# not be an empty list. The default value is a recommended set
+# of production-oriented raid interfaces. A complete list of
+# raid interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.raid"
+# entrypoint. When setting this value, please make sure that
+# every enabled hardware type will have the same set of
+# enabled raid interfaces on every ironic-conductor service.
+# (list value)
+#enabled_raid_interfaces = agent,no-raid,redfish
+
+# Default raid interface to be used for nodes that do not have
+# raid_interface field set. A complete list of raid interfaces
+# present on your system may be found by enumerating the
+# "ironic.hardware.interfaces.raid" entrypoint. (string value)
+#default_raid_interface = <None>
+
+# Specify the list of rescue interfaces to load during service
+# initialization. Missing rescue interfaces, or rescue
+# interfaces which fail to initialize, will prevent the
+# ironic-conductor service from starting. At least one rescue
+# interface that is supported by each enabled hardware type
+# must be enabled here, or the ironic-conductor service will
+# not start. Must not be an empty list. The default value is a
+# recommended set of production-oriented rescue interfaces. A
+# complete list of rescue interfaces present on your system
+# may be found by enumerating the
+# "ironic.hardware.interfaces.rescue" entrypoint. When setting
+# this value, please make sure that every enabled hardware
+# type will have the same set of enabled rescue interfaces on
+# every ironic-conductor service. (list value)
+#enabled_rescue_interfaces = no-rescue
+
+# Default rescue interface to be used for nodes that do not
+# have rescue_interface field set. A complete list of rescue
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.rescue"
+# entrypoint. (string value)
+#default_rescue_interface = <None>
+
+# Specify the list of storage interfaces to load during
+# service initialization. Missing storage interfaces, or
+# storage interfaces which fail to initialize, will prevent
+# the ironic-conductor service from starting. At least one
+# storage interface that is supported by each enabled hardware
+# type must be enabled here, or the ironic-conductor service
+# will not start. Must not be an empty list. The default value
+# is a recommended set of production-oriented storage
+# interfaces. A complete list of storage interfaces present on
+# your system may be found by enumerating the
+# "ironic.hardware.interfaces.storage" entrypoint. When
+# setting this value, please make sure that every enabled
+# hardware type will have the same set of enabled storage
+# interfaces on every ironic-conductor service. (list value)
+#enabled_storage_interfaces = cinder,noop
+
+# Default storage interface to be used for nodes that do not
+# have storage_interface field set. A complete list of storage
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.storage"
+# entrypoint. (string value)
+#default_storage_interface = noop
+
+# Specify the list of vendor interfaces to load during service
+# initialization. Missing vendor interfaces, or vendor
+# interfaces which fail to initialize, will prevent the
+# ironic-conductor service from starting. At least one vendor
+# interface that is supported by each enabled hardware type
+# must be enabled here, or the ironic-conductor service will
+# not start. Must not be an empty list. The default value is a
+# recommended set of production-oriented vendor interfaces. A
+# complete list of vendor interfaces present on your system
+# may be found by enumerating the
+# "ironic.hardware.interfaces.vendor" entrypoint. When setting
+# this value, please make sure that every enabled hardware
+# type will have the same set of enabled vendor interfaces on
+# every ironic-conductor service. (list value)
+#enabled_vendor_interfaces = ipmitool,redfish,no-vendor
+
+# Default vendor interface to be used for nodes that do not
+# have vendor_interface field set. A complete list of vendor
+# interfaces present on your system may be found by
+# enumerating the "ironic.hardware.interfaces.vendor"
+# entrypoint. (string value)
+#default_vendor_interface = <None>
+
+# Max number of characters of any node
+# last_error/maintenance_reason pushed to database. (integer
+# value)
+#log_in_db_max_size = 4096
+
+# Exponent to determine number of hash partitions to use when
+# distributing load across conductors. Larger values will
+# result in more even distribution of load and less load when
+# rebalancing the ring, but more memory usage. Number of
+# partitions per conductor is (2^hash_partition_exponent).
+# This determines the granularity of rebalancing: given 10
+# hosts, and an exponent of the 2, there are 40 partitions in
+# the ring.A few thousand partitions should make rebalancing
+# smooth in most cases. The default is suitable for up to a
+# few hundred conductors. Configuring for too many partitions
+# has a negative impact on CPU usage. (integer value)
+#hash_partition_exponent = 5
+
+# Time (in seconds) after which the hash ring is considered
+# outdated and is refreshed on the next access. (integer
+# value)
+#hash_ring_reset_interval = 15
+
+# If True, convert backing images to "raw" disk image format.
+# (boolean value)
+# Note: This option can be changed without restarting.
+#force_raw_images = true
+
+# The scale factor used for estimating the size of a raw image
+# converted from compact image formats such as QCOW2. Default
+# is 2.0, must be greater than 1.0. (floating point value)
+# Minimum value: 1.0
+#raw_image_growth_factor = 2.0
+
+# Path to isolinux binary file. (string value)
+#isolinux_bin = /usr/lib/syslinux/isolinux.bin
+
+# Template file for isolinux configuration file. (string
+# value)
+#isolinux_config_template = $pybasedir/common/isolinux_config.template
+
+# GRUB2 configuration file location on the UEFI ISO images
+# produced by ironic. The default value is usually incorrect
+# and should not be relied on. If you use a GRUB2 image from a
+# certain distribution, use a distribution-specific path here,
+# e.g. EFI/ubuntu/grub.cfg (string value)
+#grub_config_path = EFI/BOOT/grub.cfg
+
+# Template file for grub configuration file. (string value)
+#grub_config_template = $pybasedir/common/grub_conf.template
+
+# Path to ldlinux.c32 file. This file is required for syslinux
+# 5.0 or later. If not specified, the file is looked for in
+# "/usr/lib/syslinux/modules/bios/ldlinux.c32" and
+# "/usr/share/syslinux/ldlinux.c32". (string value)
+#ldlinux_c32 = <None>
+
+# Path to EFI System Partition image file. This file is
+# recommended for creating UEFI bootable ISO images
+# efficiently. ESP image should contain a
+# FAT12/16/32-formatted file system holding EFI boot loaders
+# (e.g. GRUB2) for each hardware architecture ironic needs to
+# boot. This option is only used when neither ESP nor ISO
+# deploy image is configured to the node being deployed in
+# which case ironic will attempt to fetch ESP image from the
+# configured location or extract ESP image from UEFI-bootable
+# deploy ISO image. (string value)
+#esp_image = <None>
+
+# DEPRECATED: Run image downloads and raw format conversions
+# in parallel. (boolean value)
+# Note: This option can be changed without restarting.
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use image_download_concurrency
+#parallel_image_downloads = true
+
+# How many image downloads and raw format conversions to run
+# in parallel. Only affects image caches. (integer value)
+# Minimum value: 1
+#image_download_concurrency = 20
+
+# IPv4 address of this host. If unset, will determine the IP
+# programmatically. If unable to do so, will use "127.0.0.1".
+# NOTE: This field does accept an IPv6 address as an override
+# for templates and URLs, however it is recommended that
+# [DEFAULT]my_ipv6 is used along with DNS names for service
+# URLs for dual-stack environments. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#my_ip = 127.0.0.1
+
+# IP address of this host using IPv6. This value must be
+# supplied via the configuration and cannot be adequately
+# programmatically determined like the [DEFAULT]my_ip
+# parameter for IPv4. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#my_ipv6 = 2001:db8::1
+
+# Specifies the minimum level for which to send notifications.
+# If not set, no notifications will be sent. The default is
+# for this option to be unset. (string value)
+# Possible values:
+# debug - "debug" level
+# info - "info" level
+# warning - "warning" level
+# error - "error" level
+# critical - "critical" level
+#notification_level = <None>
+
+#
+# Specifies the topics for the versioned notifications issued
+# by Ironic.
+#
+# The default value is fine for most deployments and rarely
+# needs to be changed.
+# However, if you have a third-party service that consumes
+# versioned
+# notifications, it might be worth getting a topic for that
+# service.
+# Ironic will send a message containing a versioned
+# notification payload to each
+# topic queue in this list.
+#
+# The list of versioned notifications is visible in
+# https://docs.openstack.org/ironic/latest/admin/notifications.html
+#  (list value)
+#versioned_notifications_topics = ironic_versioned_notifications
+
+# Directory where the ironic python module is installed.
+# (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#pybasedir = /usr/lib/python/site-packages/ironic/ironic
+
+# Directory where ironic binaries are installed. (string
+# value)
+#bindir = $pybasedir/bin
+
+# Top-level directory for maintaining ironic's state. (string
+# value)
+#state_path = $pybasedir
+
+# Default mode for portgroups. Allowed values can be found in
+# the linux kernel documentation on bonding:
+# https://www.kernel.org/doc/Documentation/networking/bonding.txt.
+# (string value)
+# Note: This option can be changed without restarting.
+#default_portgroup_mode = active-backup
+
+# Name of this node. This can be an opaque identifier. It is
+# not necessarily a hostname, FQDN, or IP address. However,
+# the node name must be valid within an AMQP key, and if using
+# ZeroMQ (will be removed in the Stein release), a valid
+# hostname, FQDN, or IP address. (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#host = localhost
+
+# Used for rolling upgrades. Setting this option downgrades
+# (or pins) the Bare Metal API, the internal ironic RPC
+# communication, and the database objects to their respective
+# versions, so they are compatible with older services. When
+# doing a rolling upgrade from version N to version N+1, set
+# (to pin) this to N. To unpin (default), leave it unset and
+# the latest versions will be used. (string value)
+# Possible values:
+# zed - "zed" release
+# yoga - "yoga" release
+# antelope - "antelope" release
+# 9.2 - "9.2" release
+# 21.4 - "21.4" release
+# 21.3 - "21.3" release
+# 21.2 - "21.2" release
+# 21.1 - "21.1" release
+# 21.0 - "21.0" release
+# 2023.1 - "2023.1" release
+# 20.2 - "20.2" release
+# 20.1 - "20.1" release
+# 20.0 - "20.0" release
+# 19.0 - "19.0" release
+# 18.2 - "18.2" release
+# 18.1 - "18.1" release
+# 18.0 - "18.0" release
+# 17.0 - "17.0" release
+# 16.2 - "16.2" release
+# 16.1 - "16.1" release
+# 16.0 - "16.0" release
+# 15.1 - "15.1" release
+# 15.0 - "15.0" release
+# 14.0 - "14.0" release
+# 13.0 - "13.0" release
+# 12.2 - "12.2" release
+# 12.1 - "12.1" release
+# 12.0 - "12.0" release
+# 11.1 - "11.1" release
+# 11.0 - "11.0" release
+# 10.1 - "10.1" release
+# 10.0 - "10.0" release
+# Note: This option can be changed without restarting.
+#pin_release_version = <None>
+
+# Which RPC transport implementation to use between conductor
+# and API services (string value)
+# Possible values:
+# oslo - use oslo.messaging transport
+# json-rpc - use JSON RPC transport
+# none - No RPC, only use local conductor
+#rpc_transport = oslo
+
+# Setting to govern if Ironic should only warn instead of
+# attempting to hold back the request in order to prevent the
+# exhaustion of system memory. (boolean value)
+# Note: This option can be changed without restarting.
+#minimum_memory_warning_only = false
+
+# Minimum memory in MiB for the system to have available prior
+# to starting a memory intensive process on the conductor.
+# (integer value)
+# Note: This option can be changed without restarting.
+#minimum_required_memory = 1024
+
+# Seconds to wait between retries for free memory before
+# launching the process. This, combined with
+# ``memory_wait_retries`` allows the conductor to determine
+# how long we should attempt to directly retry. (integer
+# value)
+# Note: This option can be changed without restarting.
+#minimum_memory_wait_time = 15
+
+# Number of retries to hold onto the worker before failing or
+# returning the thread to the pool if the conductor can
+# automatically retry. (integer value)
+# Note: This option can be changed without restarting.
+#minimum_memory_wait_retries = 6
+
+# Path to the rootwrap configuration file to use for running
+# commands as root. (string value)
+#rootwrap_config = /etc/ironic/rootwrap.conf
+
+# Temporary working directory, default is Python temp dir.
+# (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#tempdir = /tmp
+
+# CA certificates to be used for certificate verification.
+# This can be either a Boolean value or a path to a CA_BUNDLE
+# file.If set to True, the certificates present in the
+# standard path are used to verify the host certificates.If
+# set to False, the conductor will ignore verifying the SSL
+# certificate presented by the host.If it"s a path, conductor
+# uses the specified certificate for SSL verification. If the
+# path does not exist, the behavior is same as when this value
+# is set to True i.e the certificates present in the standard
+# path are used for SSL verification.Defaults to True. (string
+# value)
+# Note: This option can be changed without restarting.
+#webserver_verify_ca = True
+
+# Connection timeout when accessing remote web servers with
+# images. (integer value)
+#webserver_connection_timeout = 60
+
+# Enable elevated access for users with service role belonging
+# to the 'rbac_service_project_name' project when using
+# default policy. The default setting of disabled causes all
+# service role requests to be scoped to the project the
+# service account belongs to. (boolean value)
+#rbac_service_role_elevated_access = false
+
+# The project name utilized for Role Based Access Control
+# checks for the reserved `service` project. This project is
+# utilized for services to have accounts for cross-service
+# communication. Often these accounts require higher levels of
+# access, and effectively this permits accounts from the
+# service to not be restricted to project scoping of
+# responses. i.e. The service project user with a `service`
+# role will be able to see nodes across all projects, similar
+# to System scoped access. If not set to a value, and all
+# service role access will be filtered matching an `owner` or
+# `lessee`, if applicable. If an operator wishes to make
+# behavior visible for all service role users across all
+# projects, then a custom policy must be used to override the
+# default "service_role" rule. It should be noted that the
+# value of "service" is a default convention for OpenStack
+# deployments, but the requsite access and details around end
+# configuration are largely up to an operator if they are
+# doing an OpenStack deployment manually. (string value)
+#rbac_service_project_name = service
+
+# Hash function to use when building the hash ring. If running
+# on a FIPS system, do not use md5. WARNING: all ironic
+# services in a cluster MUST use the same algorithm at all
+# times. Changing the algorithm requires an offline update.
+# (string value)
+# Possible values:
+# shake_256 - <No description provided>
+# blake2s - <No description provided>
+# sha256 - <No description provided>
+# sha512 - <No description provided>
+# shake_128 - <No description provided>
+# sha3_224 - <No description provided>
+# sha3_512 - <No description provided>
+# md5 - <No description provided>
+# sha3_384 - <No description provided>
+# sha224 - <No description provided>
+# blake2b - <No description provided>
+# sha3_256 - <No description provided>
+# sha384 - <No description provided>
+# sha1 - <No description provided>
+# Advanced Option: intended for advanced users and not used
+# by the majority of users, and might have a significant
+# effect on stability and/or performance.
+#hash_ring_algorithm = md5
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG
+# instead of the default INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# The name of a logging configuration file. This file is
+# appended to any existing logging configuration files. For
+# details about logging configuration files, see the Python
+# logging module documentation. Note that when logging
+# configuration files are used then all logging configuration
+# is set in the configuration file and other logging
+# configuration options are ignored (for example, log-date-
+# format). (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records.
+# Default: %(default)s . This option is ignored if
+# log_config_append is set. (string value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no
+# default is set, logging will go to stderr as defined by
+# use_stderr. This option is ignored if log_config_append is
+# set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file
+# paths. This option is ignored if log_config_append is set.
+# (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log
+# file is moved or removed this handler will open a new log
+# file with specified path instantaneously. It makes sense
+# only if log_file option is specified and Linux platform is
+# used. This option is ignored if log_config_append is set.
+# (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED
+# and will be changed later to honor RFC5424. This option is
+# ignored if log_config_append is set. (boolean value)
+#use_syslog = false
+
+# Enable journald for logging. If running in a systemd
+# environment you may wish to enable journal support. Doing so
+# will use the journal native protocol which includes
+# structured metadata in addition to log messages.This option
+# is ignored if log_config_append is set. (boolean value)
+#use_journal = false
+
+# Syslog facility to receive log lines. This option is ignored
+# if log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Use JSON formatting for logging. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_json = false
+
+# Log output to standard error. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_stderr = false
+
+# Log output to Windows Event Log. (boolean value)
+#use_eventlog = false
+
+# The amount of time before the log files are rotated. This
+# option is ignored unless log_rotation_type is set to
+# "interval". (integer value)
+#log_rotate_interval = 1
+
+# Rotation interval type. The time of the last file change (or
+# the time when the service was started) is used when
+# scheduling the next rotation. (string value)
+# Possible values:
+# Seconds - <No description provided>
+# Minutes - <No description provided>
+# Hours - <No description provided>
+# Days - <No description provided>
+# Weekday - <No description provided>
+# Midnight - <No description provided>
+#log_rotate_interval_type = days
+
+# Maximum number of rotated log files. (integer value)
+#max_logfile_count = 30
+
+# Log file maximum size in MB. This option is ignored if
+# "log_rotation_type" is not set to "size". (integer value)
+#max_logfile_size_mb = 200
+
+# Log rotation type. (string value)
+# Possible values:
+# interval - Rotate logs at predefined time intervals.
+# size - Rotate logs once they reach a predefined size.
+# none - Do not rotate log files.
+#log_rotation_type = none
+
+# Format string to use for log messages with context. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(global_request_id)s %(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is
+# undefined. Used by oslo_log.formatters.ContextFormatter
+# (string value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level
+# for the message is DEBUG. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. Used
+# by oslo_log.formatters.ContextFormatter (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used
+# in logging_context_format_string. Used by
+# oslo_log.formatters.ContextFormatter (string value)
+#logging_user_identity_format = %(user)s %(project)s %(domain)s %(system_scope)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This
+# option is ignored if log_config_append is set. (list value)
+#default_log_levels = amqp=WARNING,amqplib=WARNING,qpid.messaging=INFO,oslo.messaging=INFO,oslo_messaging=INFO,sqlalchemy=WARNING,stevedore=INFO,eventlet.wsgi.server=INFO,iso8601=WARNING,requests=WARNING,glanceclient=WARNING,urllib3.connectionpool=WARNING,keystonemiddleware.auth_token=INFO,keystoneauth.session=INFO,openstack=WARNING,oslo_policy=WARNING,oslo_concurrency.lockutils=WARNING
+
+# Enables or disables publication of error events. (boolean
+# value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log
+# message. (string value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log
+# message. (string value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer
+# value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval.
+# (integer value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO,
+# WARNING, DEBUG or empty string. Logs with level greater or
+# equal to rate_limit_except_level are not filtered. An empty
+# string means that all levels are filtered. (string value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean
+# value)
+#fatal_deprecations = false
+
+#
+# From oslo.messaging
+#
+
+# Size of RPC connection pool. (integer value)
+# Minimum value: 1
+#rpc_conn_pool_size = 30
+
+# The pool size limit for connections expiration policy
+# (integer value)
+#conn_pool_min_size = 2
+
+# The time-to-live in sec of idle connections in the pool
+# (integer value)
+#conn_pool_ttl = 1200
+
+# Size of executor thread pool when executor is threading or
+# eventlet. (integer value)
+# Deprecated group/name - [DEFAULT]/rpc_thread_pool_size
+#executor_thread_pool_size = 64
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout = 60
+
+# The network address and optional user credentials for
+# connecting to the messaging backend, in URL format. The
+# expected format is:
+#
+# driver://[user:pass@]host:port[,[userN:passN@]hostN:portN]/virtual_host?query
+#
+# Example: rabbit://rabbitmq:password@127.0.0.1:5672//
+#
+# For full details on the fields in the URL see the
+# documentation of oslo_messaging.TransportURL at
+# https://docs.openstack.org/oslo.messaging/latest/reference/transport.html
+# (string value)
+#transport_url = rabbit://
+
+# The default exchange under which topics are scoped. May be
+# overridden by an exchange name specified in the
+# transport_url option. (string value)
+#control_exchange = openstack
+
+# Add an endpoint to answer to ping calls. Endpoint is named
+# oslo_rpc_server_ping (boolean value)
+#rpc_ping_enabled = false
+
+#
+# From oslo.service.periodic_task
+#
+
+# Some periodic tasks can be run in a separate process. Should
+# we run them here? (boolean value)
+#run_external_periodic_tasks = true
+
+#
+# From oslo.service.service
+#
+
+# Enable eventlet backdoor.  Acceptable values are 0, <port>,
+# and <start>:<end>, where 0 results in listening on a random
+# tcp port number; <port> results in listening on the
+# specified port number (and not enabling backdoor if that
+# port is in use); and <start>:<end> results in listening on
+# the smallest unused port number within the specified range
+# of port numbers.  The chosen port is displayed in the
+# service's log file. (string value)
+#backdoor_port = <None>
+
+# Enable eventlet backdoor, using the provided path as a unix
+# socket that can receive connections. This option is mutually
+# exclusive with 'backdoor_port' in that only one should be
+# provided. If both are provided then the existence of this
+# option overrides the usage of that option. Inside the path
+# {pid} will be replaced with the PID of the current process.
+# (string value)
+#backdoor_socket = <None>
+
+# Enables or disables logging values of all registered options
+# when starting a service (at DEBUG level). (boolean value)
+#log_options = true
+
+# Specify a timeout after which a gracefully shutdown server
+# will exit. Zero value means endless wait. (integer value)
+#graceful_shutdown_timeout = 60
+
+
+[agent]
+
+#
+# From ironic
+#
+
+# Whether Ironic will manage booting of the agent ramdisk. If
+# set to False, you will need to configure your mechanism to
+# allow booting the agent ramdisk. (boolean value)
+#manage_agent_boot = true
+
+# The memory size in MiB consumed by agent when it is booted
+# on a bare metal node. This is used for checking if the image
+# can be downloaded and deployed on the bare metal node after
+# booting agent ramdisk. This may be set according to the
+# memory consumed by the agent ramdisk image. (integer value)
+# Note: This option can be changed without restarting.
+#memory_consumed_by_agent = 0
+
+# Whether the agent ramdisk should stream raw images directly
+# onto the disk or not. By streaming raw images directly onto
+# the disk the agent ramdisk will not spend time copying the
+# image to a tmpfs partition (therefore consuming less memory)
+# prior to writing it to the disk. Unless the disk where the
+# image will be copied to is really slow, this option should
+# be set to True. Defaults to True. (boolean value)
+# Note: This option can be changed without restarting.
+#stream_raw_images = true
+
+# Number of times to retry getting power state to check if
+# bare metal node has been powered off after a soft power off.
+# (integer value)
+#post_deploy_get_power_state_retries = 6
+
+# Amount of time (in seconds) to wait between polling power
+# state after trigger soft poweroff. (integer value)
+#post_deploy_get_power_state_retry_interval = 5
+
+# API version to use for communicating with the ramdisk agent.
+# (string value)
+#agent_api_version = v1
+
+# Whether Ironic should collect the deployment logs on
+# deployment failure (on_failure), always or never. (string
+# value)
+# Possible values:
+# always - always collect the logs
+# on_failure - only collect logs if there is a failure
+# never - never collect logs
+# Note: This option can be changed without restarting.
+#deploy_logs_collect = on_failure
+
+# The name of the storage backend where the logs will be
+# stored. (string value)
+# Possible values:
+# local - store the logs locally
+# swift - store the logs in Object Storage service
+# Note: This option can be changed without restarting.
+#deploy_logs_storage_backend = local
+
+# The path to the directory where the logs should be stored,
+# used when the deploy_logs_storage_backend is configured to
+# "local". (string value)
+# Note: This option can be changed without restarting.
+#deploy_logs_local_path = /var/log/ironic/deploy
+
+# The name of the Swift container to store the logs, used when
+# the deploy_logs_storage_backend is configured to "swift".
+# (string value)
+# Note: This option can be changed without restarting.
+#deploy_logs_swift_container = ironic_deploy_logs_container
+
+# Number of days before a log object is marked as expired in
+# Swift. If None, the logs will be kept forever or until
+# manually deleted. Used when the deploy_logs_storage_backend
+# is configured to "swift". (integer value)
+# Note: This option can be changed without restarting.
+#deploy_logs_swift_days_to_expire = 30
+
+# Specifies whether direct deploy interface should try to use
+# the image source directly or if ironic should cache the
+# image on the conductor and serve it from ironic's own http
+# server. (string value)
+# Possible values:
+# swift - IPA ramdisk retrieves instance image from the Object
+# Storage service.
+# http - IPA ramdisk retrieves instance image from HTTP
+# service served at conductor nodes.
+# local - Same as "http", but HTTP images are also cached
+# locally, converted and served from the conductor
+# Note: This option can be changed without restarting.
+#image_download_source = http
+
+# Timeout (in seconds) for IPA commands. (integer value)
+# Note: This option can be changed without restarting.
+#command_timeout = 60
+
+# This is the maximum number of attempts that will be done for
+# IPA commands that fails due to network problems. (integer
+# value)
+#max_command_attempts = 3
+
+# Number of attempts to check for asynchronous commands
+# completion before timing out. (integer value)
+#command_wait_attempts = 100
+
+# Number of seconds to wait for between checks for
+# asynchronous commands completion. (integer value)
+#command_wait_interval = 6
+
+# The number of seconds Neutron agent will wait between
+# polling for device changes. This value should be the same as
+# CONF.AGENT.polling_interval in Neutron configuration.
+# (integer value)
+# Note: This option can be changed without restarting.
+#neutron_agent_poll_interval = 2
+
+# Max number of attempts to validate a Neutron agent status
+# before raising network error for a dead agent. (integer
+# value)
+#neutron_agent_max_attempts = 100
+
+# Wait time in seconds between attempts for validating Neutron
+# agent status. (integer value)
+#neutron_agent_status_retry_interval = 10
+
+# If set to True, callback URLs without https:// will be
+# rejected by the conductor. (boolean value)
+# Note: This option can be changed without restarting.
+#require_tls = false
+
+# Path to store auto-generated TLS certificates used to
+# validate connections to the ramdisk. (string value)
+#certificates_path = /var/lib/ironic/certificates
+
+# Path to the TLS CA to validate connection to the ramdisk.
+# Set to True to use the system default CA storage. Set to
+# False to disable validation. Ignored when automatic TLS
+# setup is used. (string value)
+#verify_ca = True
+
+# Path to the TLS CA that is used to start the bare metal API.
+# In some boot methods this file can be passed to the ramdisk.
+# (string value)
+#api_ca_file = <None>
+
+
+[anaconda]
+
+#
+# From ironic
+#
+
+# kickstart template to use when no kickstart template is
+# specified in the instance_info or the glance OS image.
+# (string value)
+# Note: This option can be changed without restarting.
+#default_ks_template = $pybasedir/drivers/modules/ks.cfg.template
+
+# Option to allow the kickstart configuration to be informed
+# if SSL/TLS certificate verificaiton should be enforced, or
+# not. This option exists largely to facilitate easy testing
+# and use of the ``anaconda`` deployment interface. When this
+# option is set, heartbeat operations, depending on the
+# contents of the utilized kickstart template, may not enfore
+# TLS certificate verification. (boolean value)
+# Note: This option can be changed without restarting.
+#insecure_heartbeat = false
+
+
+[ansible]
+
+#
+# From ironic
+#
+
+# Extra arguments to pass on every invocation of Ansible.
+# (string value)
+#ansible_extra_args = <None>
+
+# Set ansible verbosity level requested when invoking
+# "ansible-playbook" command. 4 includes detailed SSH session
+# logging. Default is 4 when global debug is enabled and 0
+# otherwise. (integer value)
+# Minimum value: 0
+# Maximum value: 4
+#verbosity = <None>
+
+# Path to "ansible-playbook" script. Default will search the
+# $PATH configured for user running ironic-conductor process.
+# Provide the full path when ansible-playbook is not in $PATH
+# or installed in not default location. (string value)
+#ansible_playbook_script = ansible-playbook
+
+# Path to directory with playbooks, roles and local inventory.
+# (string value)
+#playbooks_path = $pybasedir/drivers/modules/ansible/playbooks
+
+# Path to ansible configuration file. If set to empty, system
+# default will be used. (string value)
+#config_file_path = $pybasedir/drivers/modules/ansible/playbooks/ansible.cfg
+
+# Number of times to retry getting power state to check if
+# bare metal node has been powered off after a soft power off.
+# Value of 0 means do not retry on failure. (integer value)
+# Minimum value: 0
+#post_deploy_get_power_state_retries = 6
+
+# Amount of time (in seconds) to wait between polling power
+# state after trigger soft poweroff. (integer value)
+# Minimum value: 0
+#post_deploy_get_power_state_retry_interval = 5
+
+# Extra amount of memory in MiB expected to be consumed by
+# Ansible-related processes on the node. Affects decision
+# whether image will fit into RAM. (integer value)
+#extra_memory = 10
+
+# Skip verifying SSL connections to the image store when
+# downloading the image. Setting it to "True" is only
+# recommended for testing environments that use self-signed
+# certificates. (boolean value)
+#image_store_insecure = false
+
+# Specific CA bundle to use for validating SSL connections to
+# the image store. If not specified, CA available in the
+# ramdisk will be used. Is not used by default playbooks
+# included with the driver. Suitable for environments that use
+# self-signed certificates. (string value)
+#image_store_cafile = <None>
+
+# Client cert to use for SSL connections to image store. Is
+# not used by default playbooks included with the driver.
+# (string value)
+#image_store_certfile = <None>
+
+# Client key to use for SSL connections to image store. Is not
+# used by default playbooks included with the driver. (string
+# value)
+#image_store_keyfile = <None>
+
+# Name of the user to use for Ansible when connecting to the
+# ramdisk over SSH. It may be overridden by per-node
+# 'ansible_username' option in node's 'driver_info' field.
+# (string value)
+#default_username = ansible
+
+# Absolute path to the private SSH key file to use by Ansible
+# by default when connecting to the ramdisk over SSH. Default
+# is to use default SSH keys configured for the user running
+# the ironic-conductor service. Private keys with password
+# must be pre-loaded into 'ssh-agent'. It may be overridden by
+# per-node 'ansible_key_file' option in node's 'driver_info'
+# field. (string value)
+#default_key_file = <None>
+
+# Path (relative to $playbooks_path or absolute) to the
+# default playbook used for deployment. It may be overridden
+# by per-node 'ansible_deploy_playbook' option in node's
+# 'driver_info' field. (string value)
+#default_deploy_playbook = deploy.yaml
+
+# Path (relative to $playbooks_path or absolute) to the
+# default playbook used for graceful in-band shutdown of the
+# node. It may be overridden by per-node
+# 'ansible_shutdown_playbook' option in node's 'driver_info'
+# field. (string value)
+#default_shutdown_playbook = shutdown.yaml
+
+# Path (relative to $playbooks_path or absolute) to the
+# default playbook used for node cleaning. It may be
+# overridden by per-node 'ansible_clean_playbook' option in
+# node's 'driver_info' field. (string value)
+#default_clean_playbook = clean.yaml
+
+# Path (relative to $playbooks_path or absolute) to the
+# default auxiliary cleaning steps file used during the node
+# cleaning. It may be overridden by per-node
+# 'ansible_clean_steps_config' option in node's 'driver_info'
+# field. (string value)
+#default_clean_steps_config = clean_steps.yaml
+
+# Absolute path to the python interpreter on the managed
+# machines. It may be overridden by per-node
+# 'ansible_python_interpreter' option in node's 'driver_info'
+# field. By default, ansible uses /usr/bin/python (string
+# value)
+#default_python_interpreter = <None>
+
+
+[api]
+
+#
+# From ironic
+#
+
+# The IP address or hostname on which ironic-api listens.
+# (host address value)
+#host_ip = 0.0.0.0
+
+# The TCP port on which ironic-api listens. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#port = 6385
+
+# Unix socket to listen on. Disables host_ip and port. (string
+# value)
+#unix_socket = <None>
+
+# File mode (an octal number) of the unix socket to listen on.
+# Ignored if unix_socket is not set. (integer value)
+#unix_socket_mode = <None>
+
+# The maximum number of items returned in a single response
+# from a collection resource. (integer value)
+# Note: This option can be changed without restarting.
+#max_limit = 1000
+
+# Public URL to use when building the links to the API
+# resources (for example, "https://ironic.rocks:6384"). If
+# None the links will be built using the request's host URL.
+# If the API is operating behind a proxy, you will want to
+# change this to represent the proxy's URL. Defaults to None.
+# Ignored when proxy headers parsing is enabled via
+# [oslo_middleware]enable_proxy_headers_parsing option.
+# (string value)
+# Note: This option can be changed without restarting.
+#public_endpoint = <None>
+
+# Number of workers for OpenStack Ironic API service. The
+# default is equal to the number of CPUs available, but not
+# more than 4. One worker is used if the CPU number cannot be
+# detected. (integer value)
+#api_workers = <None>
+
+# Enable the integrated stand-alone API to service requests
+# via HTTPS instead of HTTP. If there is a front-end service
+# performing HTTPS offloading from the service, this option
+# should be False; note, you will want to enable proxy headers
+# parsing with [oslo_middleware]enable_proxy_headers_parsing
+# option or configure [api]public_endpoint option to set URLs
+# in responses to the SSL terminated one. (boolean value)
+#enable_ssl_api = false
+
+# Whether to restrict the lookup API to only nodes in certain
+# states. (boolean value)
+# Note: This option can be changed without restarting.
+#restrict_lookup = true
+
+# Maximum interval (in seconds) for agent heartbeats. (integer
+# value)
+# Note: This option can be changed without restarting.
+#ramdisk_heartbeat_timeout = 300
+
+# Schema for network data used by this deployment. (string
+# value)
+#network_data_schema = $pybasedir/api/controllers/v1/network-data-schema.json
+
+# If a project scoped administrative user is permitted to
+# create/delte baremetal nodes in their project. (boolean
+# value)
+# Note: This option can be changed without restarting.
+#project_admin_can_manage_own_nodes = true
+
+
+[audit]
+
+#
+# From ironic
+#
+
+# Enable auditing of API requests (for ironic-api service).
+# (boolean value)
+#enabled = false
+
+# Path to audit map file for ironic-api service. Used only
+# when API audit is enabled. (string value)
+#audit_map_file = /etc/ironic/api_audit_map.conf
+
+# Comma separated list of Ironic REST API HTTP methods to be
+# ignored during audit logging. For example: auditing will not
+# be done on any GET or POST requests if this is set to
+# "GET,POST". It is used only when API audit is enabled.
+# (string value)
+#ignore_req_list =
+
+
+[audit_middleware_notifications]
+
+#
+# From keystonemiddleware.audit
+#
+
+# Indicate whether to use oslo_messaging as the notifier. If
+# set to False, the local logger will be used as the notifier.
+# If set to True, the oslo_messaging package must also be
+# present. Otherwise, the local will be used instead. (boolean
+# value)
+#use_oslo_messaging = true
+
+# The Driver to handle sending notifications. Possible values
+# are messaging, messagingv2, routing, log, test, noop. If not
+# specified, then value from oslo_messaging_notifications conf
+# section is used. (string value)
+#driver = <None>
+
+# List of AMQP topics used for OpenStack notifications. If not
+# specified, then value from  oslo_messaging_notifications
+# conf section is used. (list value)
+#topics = <None>
+
+# A URL representing messaging driver to use for notification.
+# If not specified, we fall back to the same configuration
+# used for RPC. (string value)
+#transport_url = <None>
+
+
+[cinder]
+
+#
+# From ironic
+#
+
+# Number of retries in the case of a failed action (currently
+# only used when detaching volumes). (integer value)
+#action_retries = 3
+
+# Retry interval in seconds in the case of a failed action
+# (only specific actions are retried). (integer value)
+#action_retry_interval = 5
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [cinder]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [cinder]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [cinder]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# Client retries in the case of a failed request connection.
+# (integer value)
+#retries = 3
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = volumev3
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [cinder]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[conductor]
+
+#
+# From ironic
+#
+
+# The size of the workers greenthread pool. Note that 2
+# threads will be reserved by the conductor itself for
+# handling heart beats and periodic tasks. On top of that,
+# `sync_power_state_workers` will take up to 7 green threads
+# with the default value of 8. (integer value)
+# Minimum value: 3
+#workers_pool_size = 100
+
+# Seconds between conductor heart beats. (integer value)
+#heartbeat_interval = 10
+
+# Maximum time (in seconds) since the last check-in of a
+# conductor. A conductor is considered inactive when this time
+# has been exceeded. (integer value)
+# Maximum value: 315576000
+# Note: This option can be changed without restarting.
+#heartbeat_timeout = 60
+
+# Interval between syncing the node power state to the
+# database, in seconds. Set to 0 to disable syncing. (integer
+# value)
+#sync_power_state_interval = 60
+
+# Interval between checks of provision timeouts, in seconds.
+# Set to 0 to disable checks. (integer value)
+# Minimum value: 0
+#check_provision_state_interval = 60
+
+# Interval (seconds) between checks of rescue timeouts.
+# (integer value)
+# Minimum value: 1
+#check_rescue_state_interval = 60
+
+# Interval between checks of orphaned allocations, in seconds.
+# Set to 0 to disable checks. (integer value)
+# Minimum value: 0
+#check_allocations_interval = 60
+
+# Interval between cleaning up image caches, in seconds. Set
+# to 0 to disable periodic clean-up. (integer value)
+# Minimum value: 0
+#cache_clean_up_interval = 3600
+
+# Timeout (seconds) to wait for a callback from a deploy
+# ramdisk. Set to 0 to disable timeout. (integer value)
+# Minimum value: 0
+#deploy_callback_timeout = 1800
+
+# During sync_power_state, should the hardware power state be
+# set to the state recorded in the database (True) or should
+# the database be updated based on the hardware state (False).
+# (boolean value)
+# Note: This option can be changed without restarting.
+#force_power_state_during_sync = true
+
+# During sync_power_state failures, limit the number of times
+# Ironic should try syncing the hardware node power state with
+# the node power state in DB (integer value)
+#power_state_sync_max_retries = 3
+
+# The maximum number of worker threads that can be started
+# simultaneously to sync nodes power states from the periodic
+# task. (integer value)
+# Minimum value: 1
+#sync_power_state_workers = 8
+
+# Maximum number of worker threads that can be started
+# simultaneously by a periodic task. Should be less than RPC
+# thread pool size. (integer value)
+#periodic_max_workers = 8
+
+# Number of attempts to grab a node lock. (integer value)
+#node_locked_retry_attempts = 3
+
+# Seconds to sleep between node lock attempts. (integer value)
+#node_locked_retry_interval = 1
+
+# When conductors join or leave the cluster, existing
+# conductors may need to update any persistent local state as
+# nodes are moved around the cluster. This option controls how
+# often, in seconds, each conductor will check for nodes that
+# it should "take over". Set it to 0 (or a negative value) to
+# disable the check entirely. (integer value)
+#sync_local_state_interval = 180
+
+# Name of the Swift container to store config drive data. Used
+# when configdrive_use_object_store is True. (string value)
+#configdrive_swift_container = ironic_configdrive_container
+
+# The timeout (in seconds) after which a configdrive temporary
+# URL becomes invalid. Defaults to deploy_callback_timeout if
+# it is set, otherwise to 1800 seconds. Used when
+# configdrive_use_object_store is True. (integer value)
+# Minimum value: 60
+#configdrive_swift_temp_url_duration = <None>
+
+# Timeout (seconds) for waiting for node inspection. 0 -
+# unlimited. (integer value)
+# Minimum value: 0
+#inspect_wait_timeout = 1800
+
+# Enables or disables automated cleaning. Automated cleaning
+# is a configurable set of steps, such as erasing disk drives,
+# that are performed on the node to ensure it is in a baseline
+# state and ready to be deployed to. This is done after
+# instance deletion as well as during the transition from a
+# "manageable" to "available" state. When enabled, the
+# particular steps performed to clean a node depend on which
+# driver that node is managed by; see the individual driver's
+# documentation for details. NOTE: The introduction of the
+# cleaning operation causes instance deletion to take
+# significantly longer. In an environment where all tenants
+# are trusted (eg, because there is only one tenant), this
+# option could be safely disabled. (boolean value)
+# Note: This option can be changed without restarting.
+#automated_clean = true
+
+# Whether to allow nodes to enter or undergo deploy or
+# cleaning when in maintenance mode. If this option is set to
+# False, and a node enters maintenance during deploy or
+# cleaning, the process will be aborted after the next
+# heartbeat. Automated cleaning or making a node available
+# will also fail. If True (the default), the process will
+# begin and will pause after the node starts heartbeating.
+# Moving it from maintenance will make the process continue.
+# (boolean value)
+# Note: This option can be changed without restarting.
+#allow_provisioning_in_maintenance = true
+
+# Timeout (seconds) to wait for a callback from the ramdisk
+# doing the cleaning. If the timeout is reached the node will
+# be put in the "clean failed" provision state. Set to 0 to
+# disable timeout. (integer value)
+# Minimum value: 0
+#clean_callback_timeout = 1800
+
+# Timeout (seconds) to wait for a callback from the rescue
+# ramdisk. If the timeout is reached the node will be put in
+# the "rescue failed" provision state. Set to 0 to disable
+# timeout. (integer value)
+# Minimum value: 0
+#rescue_callback_timeout = 1800
+
+# Timeout (in seconds) of soft reboot and soft power off
+# operation. This value always has to be positive. (integer
+# value)
+# Minimum value: 1
+# Note: This option can be changed without restarting.
+#soft_power_off_timeout = 600
+
+# Number of seconds to wait for power operations to complete,
+# i.e., so that a baremetal node is in the desired power
+# state. If timed out, the power operation is considered a
+# failure. (integer value)
+# Minimum value: 2
+# Note: This option can be changed without restarting.
+#power_state_change_timeout = 60
+
+# Interval (in seconds) between checking the power state for
+# nodes previously put into maintenance mode due to power
+# synchronization failure. A node is automatically moved out
+# of maintenance mode once its power state is retrieved
+# successfully. Set to 0 to disable this check. (integer
+# value)
+# Minimum value: 0
+#power_failure_recovery_interval = 300
+
+# Name of the conductor group to join. Can be up to 255
+# characters and is case insensitive. This conductor will only
+# manage nodes with a matching "conductor_group" field set on
+# the node. (string value)
+#conductor_group =
+
+# Allow deleting nodes which are in state 'available'.
+# Defaults to True. (boolean value)
+# Note: This option can be changed without restarting.
+#allow_deleting_available_nodes = true
+
+# Whether to enable publishing the baremetal API endpoint via
+# multicast DNS. (boolean value)
+#enable_mdns = false
+
+# Glance ID, http:// or file:// URL of the kernel of the
+# default deploy image. (string value)
+# Note: This option can be changed without restarting.
+#deploy_kernel = <None>
+
+# Glance ID, http:// or file:// URL of the initramfs of the
+# default deploy image. (string value)
+# Note: This option can be changed without restarting.
+#deploy_ramdisk = <None>
+
+# Glance ID, http:// or file:// URL of the kernel of the
+# default rescue image. (string value)
+# Note: This option can be changed without restarting.
+#rescue_kernel = <None>
+
+# Glance ID, http:// or file:// URL of the initramfs of the
+# default rescue image. (string value)
+# Note: This option can be changed without restarting.
+#rescue_ramdisk = <None>
+
+# Password hash algorithm to be used for the rescue password.
+# (string value)
+# Possible values:
+# sha256 - <No description provided>
+# sha512 - <No description provided>
+# Note: This option can be changed without restarting.
+#rescue_password_hash_algorithm = sha256
+
+# Option to cause the conductor to not fallback to an un-
+# hashed version of the rescue password, permitting rescue
+# with older ironic-python-agent ramdisks. (boolean value)
+# Note: This option can be changed without restarting.
+#require_rescue_password_hashed = false
+
+# Glance ID, http:// or file:// URL of the EFI system
+# partition image containing EFI boot loader. This image will
+# be used by ironic when building UEFI-bootable ISO out of
+# kernel and ramdisk. Required for UEFI boot from partition
+# images. (string value)
+# Note: This option can be changed without restarting.
+#bootloader = <None>
+
+# Priority to run automated clean steps for both in-band and
+# out of band clean steps, provided in
+# interface.step_name:priority format, e.g.
+# deploy.erase_devices_metadata:123. The option can be
+# specified multiple times to define priorities for multiple
+# steps. If set to 0, this specific step will not run during
+# cleaning. If unset for an inband clean step, will use the
+# priority set in the ramdisk. (dict value)
+#clean_step_priority_override =
+
+# Boolean value, default True, if node event history is to be
+# recorded. Errors and other noteworthy events in relation to
+# a node are journaled to a database table which incurs some
+# additional load. A periodic task does periodically remove
+# entries from the database. Please note, if this is disabled,
+# the conductor will continue to purge entries as long as
+# [conductor]node_history_cleanup_batch_count is not 0.
+# (boolean value)
+# Note: This option can be changed without restarting.
+#node_history = true
+
+# Maximum number of history entries which will be stored in
+# the database per node. Default is 300. This setting excludes
+# the minimum number of days retained using the
+# [conductor]node_history_minimum_days setting. (integer
+# value)
+# Minimum value: 0
+# Note: This option can be changed without restarting.
+#node_history_max_entries = 300
+
+# Interval in seconds at which node history entries can be
+# cleaned up in the database. Setting to 0 disables the
+# periodic task. Defaults to once a day, or 86400 seconds.
+# (integer value)
+# Minimum value: 0
+#node_history_cleanup_interval = 86400
+
+# The target number of node history records to purge from the
+# database when performing clean-up. Deletes are performed by
+# node, and a node with excess records for a node will still
+# be deleted. Defaults to 1000. Operators who find node
+# history building up may wish to lower this threshold and
+# decrease the time between cleanup operations using the
+# ``node_history_cleanup_interval`` setting. (integer value)
+# Minimum value: 0
+#node_history_cleanup_batch_count = 1000
+
+# The minimum number of days to explicitly keep on hand in the
+# database history entries for nodes. This is exclusive from
+# the [conductor]node_history_max_entries setting as users of
+# this setting are anticipated to need to retain history by
+# policy. (integer value)
+# Minimum value: 0
+# Note: This option can be changed without restarting.
+#node_history_minimum_days = 0
+
+# Priority to run automated verify steps provided in
+# interface.step_name:priority format,e.g.
+# management.clear_job_queue:123. The option can be specified
+# multiple times to define priorities for multiple steps. If
+# set to 0, this specific step will not run during
+# verification.  (dict value)
+# Note: This option can be changed without restarting.
+#verify_step_priority_override =
+
+# If the conductor should record the Project ID indicated by
+# Keystone for a requested deployment. Allows rights to be
+# granted to directly access the deployed node as a lessee
+# within the RBAC security model. The conductor does *not*
+# record this value otherwise, and this information is not
+# backfilled for prior instances which have been deployed.
+# (boolean value)
+# Note: This option can be changed without restarting.
+#automatic_lessee = false
+
+# The maximum number of concurrent nodes in deployment which
+# are permitted in this Ironic system. If this limit is
+# reached, new requests will be rejected until the number of
+# deployments in progress is lower than this maximum. As this
+# is a security mechanism requests are not queued, and this
+# setting is a global setting applying to all requests this
+# conductor receives, regardless of access rights. The
+# concurrent deployment limit cannot be disabled. (integer
+# value)
+# Minimum value: 1
+# Note: This option can be changed without restarting.
+#max_concurrent_deploy = 250
+
+# The maximum number of concurrent nodes in cleaning which are
+# permitted in this Ironic system. If this limit is reached,
+# new requests will be rejected until the number of nodes in
+# cleaning is lower than this maximum. As this is a security
+# mechanism requests are not queued, and this setting is a
+# global setting applying to all requests this conductor
+# receives, regardless of access rights. The concurrent clean
+# limit cannot be disabled. (integer value)
+# Minimum value: 1
+# Note: This option can be changed without restarting.
+#max_concurrent_clean = 50
+
+# Security Option to permit an operator to disable file
+# content inspections. Under normal conditions, the conductor
+# will inspect requested image contents which are transferred
+# through the conductor. Disabling this option is not
+# advisable and opens the risk of unsafe images being
+# processed which may allow an attacker to leverage unsafe
+# features in various disk image formats to perform a variety
+# of unsafe and potentially compromising actions. This option
+# is *not* mutable, and requires a service restart to change.
+# (boolean value)
+#disable_deep_image_inspection = false
+
+# Security Option to enable the conductor to *always* inspect
+# the image content of any requested deploy, even if the
+# deployment would have normally bypassed the conductor's
+# cache. When this is set to False, the Ironic-Python-Agent is
+# responsible for any necessary image checks. Setting this to
+# True will result in a higher utilization of resources (disk
+# space, network traffic) as the conductor will evaluate *all*
+# images. This option is *not* mutable, and requires a service
+# restart to change. This option requires
+# [conductor]disable_deep_image_inspection to be set to False.
+# (boolean value)
+#conductor_always_validates_images = false
+
+# The supported list of image formats which are permitted for
+# deployment with Ironic. If an image format outside of this
+# list is detected, the image validation logic will fail the
+# deployment process. (list value)
+# Note: This option can be changed without restarting.
+#permitted_image_formats = raw,qcow2,iso
+
+# DEPRECATED: Deprecated Security option: In the default case,
+# image files have their checksums verified before undergoing
+# additional conductor side actions such as image conversion.
+# Enabling this option opens the risk of files being replaced
+# at the source without the user's knowledge. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#disable_file_checksum = false
+
+# Security option: By default Ironic will attempt to retrieve
+# a remote checksum file via HTTP(S) URL in order to validate
+# an image download. This is functionality aligning with
+# ironic-python-agent support for standalone users. Disabling
+# this functionality by setting this option to True will
+# create a more secure environment, however it may break users
+# in an unexpected fashion. (boolean value)
+#disable_support_for_checksum_files = false
+
+
+[console]
+
+#
+# From ironic
+#
+
+# Path to serial console terminal program. Used only by Shell
+# In A Box console. (string value)
+#terminal = shellinaboxd
+
+# Directory containing the terminal SSL cert (PEM) for serial
+# console access. Used only by Shell In A Box console. (string
+# value)
+#terminal_cert_dir = <None>
+
+# Directory for holding terminal pid files. If not specified,
+# the temporary directory will be used. (string value)
+#terminal_pid_dir = <None>
+
+# Timeout (in seconds) for the terminal session to be closed
+# on inactivity. Set to 0 to disable timeout. Used only by
+# Socat console. (integer value)
+# Minimum value: 0
+#terminal_timeout = 600
+
+# Time interval (in seconds) for checking the status of
+# console subprocess. (integer value)
+#subprocess_checking_interval = 1
+
+# Time (in seconds) to wait for the console subprocess to
+# start. (integer value)
+#subprocess_timeout = 10
+
+# Time (in seconds) to wait for the console subprocess to exit
+# before sending SIGKILL signal. (integer value)
+#kill_timeout = 1
+
+# IP address of Socat service running on the host of ironic
+# conductor. Used only by Socat console. (IP address value)
+#socat_address = $my_ip
+
+# A range of ports available to be used for the console proxy
+# service running on the host of ironic conductor, in the form
+# of <start>:<stop>. This option is used by both Shellinabox
+# and Socat console (string value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#port_range = 10000:20000
+
+
+[cors]
+
+#
+# From oslo.middleware.cors
+#
+
+# Indicate whether this resource may be shared with the domain
+# received in the requests "origin" header. Format:
+# "<protocol>://<host>[:<port>]", no trailing slash. Example:
+# https://horizon.example.com (list value)
+#allowed_origin = <None>
+
+# Indicate that the actual request can include user
+# credentials (boolean value)
+#allow_credentials = true
+
+# Indicate which headers are safe to expose to the API.
+# Defaults to HTTP Simple Headers. (list value)
+#expose_headers =
+
+# Maximum cache age of CORS preflight requests. (integer
+# value)
+#max_age = 3600
+
+# Indicate which methods can be used during the actual
+# request. (list value)
+#allow_methods = OPTIONS,GET,HEAD,POST,PUT,DELETE,TRACE,PATCH
+
+# Indicate which header field names may be used during the
+# actual request. (list value)
+#allow_headers =
+
+
+[database]
+
+#
+# From ironic
+#
+
+# MySQL engine to use. (string value)
+#mysql_engine = InnoDB
+
+#
+# From oslo.db
+#
+
+# If True, SQLite uses synchronous mode. (boolean value)
+#sqlite_synchronous = true
+
+# The back end to use for the database. (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend = sqlalchemy
+
+# The SQLAlchemy connection string to use to connect to the
+# database. (string value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+#connection = <None>
+
+# The SQLAlchemy connection string to use to connect to the
+# slave database. (string value)
+#slave_connection = <None>
+
+# The SQL mode to be used for MySQL sessions. This option,
+# including the default, overrides any server-set SQL mode. To
+# use whatever SQL mode is set by the server configuration,
+# set this to no value. Example: mysql_sql_mode= (string
+# value)
+#mysql_sql_mode = TRADITIONAL
+
+# For Galera only, configure wsrep_sync_wait causality checks
+# on new connections.  Default is None, meaning don't
+# configure any setting. (integer value)
+#mysql_wsrep_sync_wait = <None>
+
+# DEPRECATED: If True, transparently enables support for
+# handling MySQL Cluster (NDB). (boolean value)
+# This option is deprecated for removal since 12.1.0.
+# Its value may be silently ignored in the future.
+# Reason: Support for the MySQL NDB Cluster storage engine has
+# been deprecated and will be removed in a future release.
+#mysql_enable_ndb = false
+
+# Connections which have been present in the connection pool
+# longer than this number of seconds will be replaced with a
+# new one the next time they are checked out from the pool.
+# (integer value)
+#connection_recycle_time = 3600
+
+# Maximum number of SQL connections to keep open in a pool.
+# Setting a value of 0 indicates no limit. (integer value)
+#max_pool_size = 5
+
+# Maximum number of database connection retries during
+# startup. Set to -1 to specify an infinite retry count.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries = 10
+
+# Interval between retries of opening a SQL connection.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval = 10
+
+# If set, use this value for max_overflow with SQLAlchemy.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow = 50
+
+# Verbosity of SQL debugging information: 0=None,
+# 100=Everything. (integer value)
+# Minimum value: 0
+# Maximum value: 100
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug = 0
+
+# Add Python stack traces to SQL as comment strings. (boolean
+# value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace = false
+
+# If set, use this value for pool_timeout with SQLAlchemy.
+# (integer value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout = <None>
+
+# Enable the experimental use of database reconnect on
+# connection lost. (boolean value)
+#use_db_reconnect = false
+
+# Seconds between retries of a database transaction. (integer
+# value)
+#db_retry_interval = 1
+
+# If True, increases the interval between retries of a
+# database operation up to db_max_retry_interval. (boolean
+# value)
+#db_inc_retry_interval = true
+
+# If db_inc_retry_interval is set, the maximum seconds between
+# retries of a database operation. (integer value)
+#db_max_retry_interval = 10
+
+# Maximum retries in case of connection error or deadlock
+# error before error is raised. Set to -1 to specify an
+# infinite retry count. (integer value)
+#db_max_retries = 20
+
+# Optional URL parameters to append onto the connection URL at
+# connect time; specify as param1=value1&param2=value2&...
+# (string value)
+#connection_parameters =
+
+
+[deploy]
+
+#
+# From ironic
+#
+
+# ironic-conductor node's HTTP server URL. Example:
+# http://192.1.2.3:8080 (string value)
+#http_url = <None>
+
+# ironic-conductor node's HTTP root path. (string value)
+#http_root = /httpboot
+
+# URL of the ironic-conductor node's HTTP server for boot
+# methods such as virtual media, where images could be served
+# outside of the provisioning network. Does not apply when
+# Swift is used. Defaults to http_url. (string value)
+#external_http_url = <None>
+
+# Agent callback URL of the bare metal API for boot methods
+# such as virtual media, where images could be served outside
+# of the provisioning network. Defaults to the configuration
+# from [service_catalog]. (string value)
+#external_callback_url = <None>
+
+# Whether to support the use of ATA Secure Erase during the
+# cleaning process. Defaults to True. (boolean value)
+# Note: This option can be changed without restarting.
+#enable_ata_secure_erase = true
+
+# Whether to support the use of NVMe Secure Erase during the
+# cleaning process. Currently nvme-cli format command is
+# supported with user-data and crypto modes, depending on
+# device capabilities.Defaults to True. (boolean value)
+# Note: This option can be changed without restarting.
+#enable_nvme_secure_erase = true
+
+# Priority to run in-band erase devices via the Ironic Python
+# Agent ramdisk. If unset, will use the priority set in the
+# ramdisk (defaults to 10 for the GenericHardwareManager). If
+# set to 0, will not run during cleaning. (integer value)
+# Note: This option can be changed without restarting.
+#erase_devices_priority = <None>
+
+# Priority to run in-band clean step that erases metadata from
+# devices, via the Ironic Python Agent ramdisk. If unset, will
+# use the priority set in the ramdisk (defaults to 99 for the
+# GenericHardwareManager). If set to 0, will not run during
+# cleaning. (integer value)
+# Note: This option can be changed without restarting.
+#erase_devices_metadata_priority = <None>
+
+# Priority to run in-band clean step that erases RAID
+# configuration from devices, via the Ironic Python Agent
+# ramdisk. If unset, will use the priority set in the ramdisk
+# (defaults to 0 for the GenericHardwareManager). If set to 0,
+# will not run during cleaning. (integer value)
+# Note: This option can be changed without restarting.
+#delete_configuration_priority = <None>
+
+# Priority to run in-band clean step that creates RAID
+# configuration from devices, via the Ironic Python Agent
+# ramdisk. If unset, will use the priority set in the ramdisk
+# (defaults to 0 for the GenericHardwareManager). If set to 0,
+# will not run during cleaning. (integer value)
+# Note: This option can be changed without restarting.
+#create_configuration_priority = <None>
+
+# During shred, overwrite all block devices N times with
+# random data. This is only used if a device could not be ATA
+# Secure Erased. Defaults to 1. (integer value)
+# Minimum value: 0
+# Note: This option can be changed without restarting.
+#shred_random_overwrite_iterations = 1
+
+# Whether to write zeros to a node's block devices after
+# writing random data. This will write zeros to the device
+# even when deploy.shred_random_overwrite_iterations is 0.
+# This option is only used if a device could not be ATA Secure
+# Erased. Defaults to True. (boolean value)
+# Note: This option can be changed without restarting.
+#shred_final_overwrite_with_zeros = true
+
+# Defines what to do if a secure erase operation (NVMe or ATA)
+# fails during cleaning in the Ironic Python Agent. If False,
+# the cleaning operation will fail and the node will be put in
+# ``clean failed`` state. If True, shred will be invoked and
+# cleaning will continue. (boolean value)
+# Note: This option can be changed without restarting.
+#continue_if_disk_secure_erase_fails = false
+
+# Defines the target pool size used by Ironic Python Agent
+# ramdisk to erase disk devices. The number of threads created
+# to erase disks will not exceed this value or the number of
+# disks to be erased. (integer value)
+# Minimum value: 1
+# Note: This option can be changed without restarting.
+#disk_erasure_concurrency = 4
+
+# Whether to power off a node after deploy failure. Defaults
+# to True. (boolean value)
+# Note: This option can be changed without restarting.
+#power_off_after_deploy_failure = true
+
+# Default boot mode to use when no boot mode is requested in
+# node's driver_info, capabilities or in the `instance_info`
+# configuration. Currently the default boot mode is "uefi",
+# but it was "bios" previously in Ironic. It is recommended to
+# set an explicit value for this option, and if the setting or
+# default differs from nodes, to ensure that nodes are
+# configured specifically for their desired boot mode. (string
+# value)
+# Possible values:
+# uefi - UEFI boot mode
+# bios - Legacy BIOS boot mode
+# Note: This option can be changed without restarting.
+#default_boot_mode = uefi
+
+# Whether to upload the config drive to object store. Set this
+# option to True to store config drive in a swift endpoint.
+# (boolean value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [conductor]/configdrive_use_swift
+#configdrive_use_object_store = false
+
+# The name of subdirectory under ironic-conductor node's HTTP
+# root path which is used to place instance images for the
+# direct deploy interface, when local HTTP service is
+# incorporated to provide instance image instead of swift
+# tempurls. (string value)
+#http_image_subdir = agent_images
+
+# Whether to allow deployment agents to perform lookup,
+# heartbeat operations during initial states of a machine
+# lifecycle and by-pass the normal setup procedures for a
+# ramdisk. This feature also enables power operations which
+# are part of deployment processes to be bypassed if the
+# ramdisk has performed a heartbeat operation using the
+# fast_track_timeout setting. (boolean value)
+# Note: This option can be changed without restarting.
+#fast_track = false
+
+# Seconds for which the last heartbeat event is to be
+# considered valid for the purpose of a fast track sequence.
+# This setting should generally be less than the number of
+# seconds for "Power-On Self Test" and typical ramdisk start-
+# up. This value should not exceed the
+# [api]ramdisk_heartbeat_timeout setting. (integer value)
+# Minimum value: 0
+# Maximum value: 300
+# Note: This option can be changed without restarting.
+#fast_track_timeout = 300
+
+# If the ironic-python-agent should skip read-only devices
+# when running the "erase_devices" clean step where block
+# devices are zeroed out. This requires ironic-python-agent
+# 6.0.0 or greater. By default a read-only device will cause
+# non-metadata based cleaning operations to fail due to the
+# possible operational security risk of data being retained
+# between deployments of the bare metal node. (boolean value)
+# Note: This option can be changed without restarting.
+#erase_skip_read_only = false
+
+# Specifies whether a boot iso image should be served from its
+# own original location using the image source url directly,
+# or if ironic should cache the image on the conductor and
+# serve it from ironic's own http server. (string value)
+# Possible values:
+# http - In case the ramdisk is already a bootable iso, using
+# this option it will be directly provided by an external HTTP
+# service using its full url.
+# local - This is the default behavior. The image is
+# downloaded, prepared and cached locally, to be served from
+# the conductor.
+# swift - Same as "http", but if the image is a Glance UUID,
+# it is exposed via a Swift temporary URL.
+# Note: This option can be changed without restarting.
+#ramdisk_image_download_source = local
+
+# On the ironic-conductor node, directory where master ISO
+# images are stored on disk. Setting to the empty string
+# disables image caching. (string value)
+#iso_master_path = /var/lib/ironic/master_iso_images
+
+# Maximum size (in MiB) of cache for master ISO images,
+# including those in use. (integer value)
+#iso_cache_size = 20480
+
+# Maximum TTL (in minutes) for old master ISO images in cache.
+# (integer value)
+#iso_cache_ttl = 10080
+
+
+[dhcp]
+
+#
+# From ironic
+#
+
+# DHCP provider to use. "neutron" uses Neutron, "dnsmasq" uses
+# the Dnsmasq provider, and "none" uses a no-op provider.
+# (string value)
+#dhcp_provider = neutron
+
+
+[disk_partitioner]
+
+#
+# From ironic_lib.disk_partitioner
+#
+
+# After Ironic has completed creating the partition table, it
+# continues to check for activity on the attached iSCSI device
+# status at this interval prior to copying the image to the
+# node, in seconds (integer value)
+#check_device_interval = 1
+
+# The maximum number of times to check that the device is not
+# accessed by another process. If the device is still busy
+# after that, the disk partitioning will be treated as having
+# failed. (integer value)
+#check_device_max_retries = 20
+
+
+[disk_utils]
+
+#
+# From ironic
+#
+
+# Memory limit for "qemu-img convert" in MiB. Implemented via
+# the address space resource limit. (integer value)
+#image_convert_memory_limit = 2048
+
+# Number of attempts to convert an image. (integer value)
+#image_convert_attempts = 3
+
+#
+# From ironic_lib.disk_utils
+#
+
+# Size of EFI system partition in MiB when configuring UEFI
+# systems for local boot. (integer value)
+#efi_system_partition_size = 200
+
+# Size of BIOS Boot partition in MiB when configuring GPT
+# partitioned systems for local boot in BIOS. (integer value)
+#bios_boot_partition_size = 1
+
+# Block size to use when writing to the nodes disk. (string
+# value)
+#dd_block_size = 1M
+
+# Maximum attempts to detect a newly created partition.
+# (integer value)
+# Minimum value: 1
+#partition_detection_attempts = 3
+
+# Maximum number of attempts to try to read the partition.
+# (integer value)
+#partprobe_attempts = 10
+
+# Memory limit for "qemu-img convert" in MiB. Implemented via
+# the address space resource limit. (integer value)
+#image_convert_memory_limit = 2048
+
+# Number of attempts to convert an image. (integer value)
+#image_convert_attempts = 3
+
+
+[drac]
+
+#
+# From ironic
+#
+
+# Interval (in seconds) between periodic RAID job status
+# checks to determine whether the asynchronous RAID
+# configuration was successfully finished or not. (integer
+# value)
+# Minimum value: 1
+#query_raid_config_job_status_interval = 120
+
+# Maximum amount of time (in seconds) to wait for the boot
+# device configuration job to transition to the correct state
+# to allow a reboot or power on to complete. (integer value)
+# Minimum value: 1
+#boot_device_job_status_timeout = 30
+
+# Maximum number of retries for the configuration job to
+# complete successfully. (integer value)
+# Minimum value: 1
+#config_job_max_retries = 240
+
+# Number of seconds to wait between checking for completed
+# import configuration task (integer value)
+# Minimum value: 0
+#query_import_config_job_status_interval = 60
+
+# Maximum time (in seconds) to wait for factory reset of BIOS
+# settings to complete. (integer value)
+# Minimum value: 1
+#bios_factory_reset_timeout = 600
+
+# Maximum time (in seconds) to wait for RAID job to complete
+# (integer value)
+# Minimum value: 1
+#raid_job_timeout = 300
+
+
+[glance]
+
+#
+# From ironic
+#
+
+# A list of URL schemes that can be downloaded directly via
+# the direct_url.  Currently supported schemes: [file]. (list
+# value)
+#allowed_direct_url_schemes =
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [glance]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# Number of retries when downloading an image from glance.
+# (integer value)
+# Note: This option can be changed without restarting.
+#num_retries = 0
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [glance]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [glance]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = image
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# The account that Glance uses to communicate with Swift. The
+# format is "AUTH_uuid". "uuid" is the UUID for the account
+# configured in the glance-api.conf. For example:
+# "AUTH_a422b2-91f3-2f46-74b7-d7c9e8958f5d30". If not set, the
+# default value is calculated based on the ID of the project
+# used to access Swift (as set in the [swift] section). Swift
+# temporary URL format:
+# "endpoint_url/api_version/account/container/object_id"
+# (string value)
+#swift_account = <None>
+
+# The prefix added to the project uuid to determine the swift
+# account. (string value)
+#swift_account_prefix = AUTH
+
+# The Swift API version to create a temporary URL for.
+# Defaults to "v1". Swift temporary URL format:
+# "endpoint_url/api_version/account/container/object_id"
+# (string value)
+#swift_api_version = v1
+
+# The Swift container Glance is configured to store its images
+# in. Defaults to "glance", which is the default in glance-
+# api.conf. Swift temporary URL format:
+# "endpoint_url/api_version/account/container/object_id"
+# (string value)
+#swift_container = glance
+
+# The "endpoint" (scheme, hostname, optional port) for the
+# Swift URL of the form
+# "endpoint_url/api_version/account/container/object_id". Do
+# not include trailing "/". For example, use
+# "https://swift.example.com". If using RADOS Gateway,
+# endpoint may also contain /swift path; if it does not, it
+# will be appended. Used for temporary URLs, will be fetched
+# from the service catalog, if not provided. (string value)
+#swift_endpoint_url = <None>
+
+# This should match a config by the same name in the Glance
+# configuration file. When set to 0, a single-tenant store
+# will only use one container to store all images. When set to
+# an integer value between 1 and 32, a single-tenant store
+# will use multiple containers to store images, and this value
+# will determine how many containers are created. (integer
+# value)
+#swift_store_multiple_containers_seed = 0
+
+# Whether to cache generated Swift temporary URLs. Setting it
+# to true is only useful when an image caching proxy is used.
+# Defaults to False. (boolean value)
+#swift_temp_url_cache_enabled = false
+
+# The length of time in seconds that the temporary URL will be
+# valid for. Defaults to 20 minutes. If some deploys get a 401
+# response code when trying to download from the temporary
+# URL, try raising this duration. This value must be greater
+# than or equal to the value for
+# swift_temp_url_expected_download_start_delay (integer value)
+#swift_temp_url_duration = 1200
+
+# This is the delay (in seconds) from the time of the deploy
+# request (when the Swift temporary URL is generated) to when
+# the IPA ramdisk starts up and URL is used for the image
+# download. This value is used to check if the Swift temporary
+# URL duration is large enough to let the image download
+# begin. Also if temporary URL caching is enabled this will
+# determine if a cached entry will still be valid when the
+# download starts. swift_temp_url_duration value must be
+# greater than or equal to this option's value. Defaults to 0.
+# (integer value)
+# Minimum value: 0
+#swift_temp_url_expected_download_start_delay = 0
+
+# The secret token given to Swift to allow temporary URL
+# downloads. Required for temporary URLs. For the Swift
+# backend, the key on the service project (as set in the
+# [swift] section) is used by default. (string value)
+#swift_temp_url_key = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [glance]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[healthcheck]
+
+#
+# From ironic
+#
+
+# Enable the health check endpoint at /healthcheck. Note that
+# this is unauthenticated. More information is available at
+# https://docs.openstack.org/oslo.middleware/latest/reference/healthcheck_plugins.html.
+# (boolean value)
+#enabled = false
+
+#
+# From oslo.middleware.healthcheck
+#
+
+# DEPRECATED: The path to respond to healtcheck requests on.
+# (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#path = /healthcheck
+
+# Show more detailed information as part of the response.
+# Security note: Enabling this option may expose sensitive
+# details about the service being monitored. Be sure to verify
+# that it will not violate your security policies. (boolean
+# value)
+#detailed = false
+
+# Additional backends that can perform health checks and
+# report that information back as part of a request. (list
+# value)
+#backends =
+
+# Check the presence of a file to determine if an application
+# is running on a port. Used by DisableByFileHealthcheck
+# plugin. (string value)
+#disable_by_file_path = <None>
+
+# Check the presence of a file based on a port to determine if
+# an application is running on a port. Expects a "port:path"
+# list of strings. Used by DisableByFilesPortsHealthcheck
+# plugin. (list value)
+#disable_by_file_paths =
+
+
+[ilo]
+
+#
+# From ironic
+#
+
+# Timeout (in seconds) for iLO operations (integer value)
+#client_timeout = 60
+
+# Port to be used for iLO operations (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#client_port = 443
+
+# The Swift iLO container to store data. (string value)
+#swift_ilo_container = ironic_ilo_container
+
+# Amount of time in seconds for Swift objects to auto-expire.
+# (integer value)
+#swift_object_expiry_timeout = 900
+
+# Set this to True to use http web server to host floppy
+# images and generated boot ISO. This requires http_root and
+# http_url to be configured in the [deploy] section of the
+# config file. If this is set to False, then Ironic will use
+# Swift to host the floppy images and generated boot_iso.
+# (boolean value)
+#use_web_server_for_images = false
+
+# Priority for reset_ilo clean step. (integer value)
+#clean_priority_reset_ilo = 0
+
+# Priority for reset_bios_to_default clean step. (integer
+# value)
+#clean_priority_reset_bios_to_default = 10
+
+# Priority for reset_secure_boot_keys clean step. This step
+# will reset the secure boot keys to manufacturing defaults.
+# (integer value)
+#clean_priority_reset_secure_boot_keys_to_default = 20
+
+# Priority for clear_secure_boot_keys clean step. This step is
+# not enabled by default. It can be enabled to clear all
+# secure boot keys enrolled with iLO. (integer value)
+#clean_priority_clear_secure_boot_keys = 0
+
+# Priority for reset_ilo_credential clean step. This step
+# requires "ilo_change_password" parameter to be updated in
+# nodes's driver_info with the new password. (integer value)
+#clean_priority_reset_ilo_credential = 30
+
+# Amount of time in seconds to wait in between power
+# operations (integer value)
+#power_wait = 2
+
+# Interval (in seconds) between periodic erase-devices status
+# checks to determine whether the asynchronous out-of-band
+# erase-devices was successfully finished or not. On an
+# average, a 300GB HDD with default pattern "overwrite" would
+# take approximately 9 hours and 300GB SSD with default
+# pattern "block" would take approx. 30 seconds to complete
+# sanitize disk erase. (integer value)
+# Minimum value: 10
+#oob_erase_devices_job_status_interval = 300
+
+# DEPRECATED: CA certificate file to validate iLO. (string
+# value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Its being replaced by new configuration parameter
+# "verify_ca".
+#ca_file = <None>
+
+# CA certificate to validate iLO. This can be either a Boolean
+# value, a path to a CA_BUNDLE file or directory with
+# certificates of trusted CAs. If set to True the driver will
+# verify the host certificates; if False the driver will
+# ignore verifying the SSL certificate. If it's a path the
+# driver will use the specified certificate or one of the
+# certificates in the directory. Defaults to True. (string
+# value)
+#verify_ca = True
+
+# Default boot mode to be used in provisioning when
+# "boot_mode" capability is not provided in the
+# "properties/capabilities" of the node. The default is "auto"
+# for backward compatibility. When "auto" is specified,
+# default boot mode will be selected based on boot mode
+# settings on the system. (string value)
+# Possible values:
+# auto - based on boot mode settings on the system
+# bios - BIOS boot mode
+# uefi - UEFI boot mode
+#default_boot_mode = auto
+
+# File permission for swift-less image hosting with the octal
+# permission representation of file access permissions. This
+# setting defaults to ``644``, or as the octal number
+# ``0o644`` in Python. This setting must be set to the octal
+# number representation, meaning starting with ``0o``.
+# (integer value)
+#file_permission = 420
+
+# Additional kernel parameters to pass down to the instance
+# kernel. These parameters can be consumed by the kernel or by
+# the applications by reading /proc/cmdline. Mind severe
+# cmdline size limit! Can be overridden by
+# `instance_info/kernel_append_params` property. (string
+# value)
+# Note: This option can be changed without restarting.
+#kernel_append_params = nofb nomodeset vga=normal
+
+# On the ironic-conductor node, directory where ilo driver
+# stores the CSR and the cert. (string value)
+#cert_path = /var/lib/ironic/ilo/
+
+
+[inspector]
+
+#
+# From ironic
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [inspector]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# endpoint to use as a callback for posting back introspection
+# data when boot is managed by ironic. Standard keystoneauth
+# options are used by default. (string value)
+#callback_endpoint_override = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# extra kernel parameters to pass to the inspection ramdisk
+# when boot is managed by ironic (not ironic-inspector). Pairs
+# key=value separated by spaces. (string value)
+#extra_kernel_params =
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# whether to power off a node after inspection finishes.
+# Ignored for nodes that have fast track mode enabled.
+# (boolean value)
+#power_off = true
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [inspector]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [inspector]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# require that the in-band inspection boot is fully managed by
+# ironic. Set this to True if your installation of ironic-
+# inspector does not have a separate PXE boot environment.
+# (boolean value)
+#require_managed_boot = false
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = baremetal-introspection
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# period (in seconds) to check status of nodes on inspection
+# (integer value)
+#status_check_period = 60
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [inspector]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[inventory]
+
+#
+# From ironic
+#
+
+# The storage backend for storing introspection data. (string
+# value)
+# Possible values:
+# none - introspection data will not be stored
+# database - introspection data stored in an SQL database
+# swift - introspection data stored in Swift
+#data_backend = database
+
+# The Swift introspection data container to store the
+# inventory data. (string value)
+#swift_data_container = introspection_data_container
+
+
+[ipmi]
+
+#
+# From ironic
+#
+
+# Maximum time in seconds to retry retryable IPMI operations.
+# (An operation is retryable, for example, if the requested
+# operation fails because the BMC is busy.) Setting this too
+# high can cause the sync power state periodic task to hang
+# when there are slow or unresponsive BMCs. (integer value)
+# Note: This option can be changed without restarting.
+#command_retry_timeout = 60
+
+# Minimum time, in seconds, between IPMI operations sent to a
+# server. There is a risk with some hardware that setting this
+# too low may cause the BMC to crash. Recommended setting is 5
+# seconds. (integer value)
+# Note: This option can be changed without restarting.
+#min_command_interval = 5
+
+# When set to True and the parameters are supported by
+# ipmitool, the number of retries and the retry interval are
+# passed to ipmitool as parameters, and ipmitool will do the
+# retries.  When set to False, ironic will retry the ipmitool
+# commands. Recommended setting is False (boolean value)
+#use_ipmitool_retries = false
+
+# Kill `ipmitool` process invoked by ironic to read node power
+# state if `ipmitool` process does not exit after
+# `command_retry_timeout` timeout expires. Recommended setting
+# is True (boolean value)
+# Note: This option can be changed without restarting.
+#kill_on_timeout = true
+
+# Default timeout behavior whether ironic sends a raw IPMI
+# command to disable the 60 second timeout for booting.
+# Setting this option to False will NOT send that command, the
+# default value is True. It may be overridden by per-node
+# 'ipmi_disable_boot_timeout' option in node's 'driver_info'
+# field. (boolean value)
+# Note: This option can be changed without restarting.
+#disable_boot_timeout = true
+
+# Additional errors ipmitool may encounter, specific to the
+# environment it is run in. (multi valued)
+# Note: This option can be changed without restarting.
+#additional_retryable_ipmi_errors =
+
+# Enables all ipmi commands to be executed with an additional
+# debugging output. This is a separate option as ipmitool can
+# log a substantial amount of misleading text when in this
+# mode. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# List of possible cipher suites versions that can be
+# supported by the hardware in case the field `cipher_suite`
+# is not set for the node. (list value)
+#cipher_suite_versions =
+
+
+[irmc]
+
+#
+# From ironic
+#
+
+# Ironic conductor node's "NFS" or "CIFS" root path (string
+# value)
+#remote_image_share_root = /remote_image_share_root
+
+# IP of remote image server (string value)
+#remote_image_server = <None>
+
+# Share type of virtual media (string value)
+# Possible values:
+# CIFS - CIFS (Common Internet File System) protocol
+# NFS - NFS (Network File System) protocol
+#remote_image_share_type = CIFS
+
+# share name of remote_image_server (string value)
+#remote_image_share_name = share
+
+# User name of remote_image_server (string value)
+#remote_image_user_name = <None>
+
+# Password of remote_image_user_name (string value)
+#remote_image_user_password = <None>
+
+# Domain name of remote_image_user_name (string value)
+#remote_image_user_domain =
+
+# Port to be used for iRMC operations (port value)
+# Minimum value: 0
+# Maximum value: 65535
+# Possible values:
+# 443 - port 443
+# 80 - port 80
+#port = 443
+
+# Authentication method to be used for iRMC operations (string
+# value)
+# Possible values:
+# basic - Basic authentication
+# digest - Digest authentication
+#auth_method = basic
+
+# Timeout (in seconds) for iRMC operations (integer value)
+#client_timeout = 60
+
+# Sensor data retrieval method. (string value)
+# Possible values:
+# ipmitool - IPMItool
+# scci - Fujitsu SCCI (ServerView Common Command Interface)
+#sensor_method = ipmitool
+
+# SNMP protocol version (string value)
+# Possible values:
+# v1 - SNMPv1
+# v2c - SNMPv2c
+# v3 - SNMPv3
+#snmp_version = v2c
+
+# SNMP port (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#snmp_port = 161
+
+# SNMP community. Required for versions "v1" and "v2c" (string
+# value)
+#snmp_community = public
+
+# DEPRECATED: SNMP security name. Required for version 'v3'.
+# (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use irmc_snmp_user
+#snmp_security = <None>
+
+# SNMP polling interval in seconds (integer value)
+#snmp_polling_interval = 10
+
+# SNMPv3 message authentication protocol ID. Required for
+# version 'v3'. The valid options are 'sha', 'sha256',
+# 'sha384' and 'sha512', while 'sha' is the only supported
+# protocol in iRMC S4 and S5, and from iRMC S6, 'sha256',
+# 'sha384' and 'sha512' are supported, but 'sha' is not
+# supported any more. (string value)
+# Possible values:
+# sha - Secure Hash Algorithm 1, supported in iRMC S4 and S5.
+# sha256 - Secure Hash Algorithm 2 with 256 bits digest, only
+# supported in iRMC S6.
+# sha384 - Secure Hash Algorithm 2 with 384 bits digest, only
+# supported in iRMC S6.
+# sha512 - Secure Hash Algorithm 2 with 512 bits digest, only
+# supported in iRMC S6.
+#snmp_auth_proto = sha
+
+# SNMPv3 message privacy (encryption) protocol ID. Required
+# for version 'v3'. 'aes' is supported. (string value)
+# Possible values:
+# aes - Advanced Encryption Standard
+#snmp_priv_proto = aes
+
+# Priority for restore_irmc_bios_config clean step. (integer
+# value)
+#clean_priority_restore_irmc_bios_config = 0
+
+# List of vendor IDs and device IDs for GPU device to inspect.
+# List items are in format vendorID/deviceID and separated by
+# commas. GPU inspection will use this value to count the
+# number of GPU device in a node. If this option is not
+# defined, then leave out pci_gpu_devices in capabilities
+# property. Sample gpu_ids value: 0x1000/0x0079,0x2100/0x0080
+# (list value)
+#gpu_ids =
+
+# List of vendor IDs and device IDs for CPU FPGA to inspect.
+# List items are in format vendorID/deviceID and separated by
+# commas. CPU inspection will use this value to find existence
+# of CPU FPGA in a node. If this option is not defined, then
+# leave out CUSTOM_CPU_FPGA in node traits. Sample fpga_ids
+# value: 0x1000/0x0079,0x2100/0x0080 (list value)
+#fpga_ids =
+
+# Interval (in seconds) between periodic RAID status checks to
+# determine whether the asynchronous RAID configuration was
+# successfully finished or not. Foreground Initialization
+# (FGI) will start 5 minutes after creating virtual drives.
+# (integer value)
+# Minimum value: 1
+#query_raid_config_fgi_status_interval = 300
+
+# Additional kernel parameters to pass down to the instance
+# kernel. These parameters can be consumed by the kernel or by
+# the applications by reading /proc/cmdline. Mind severe
+# cmdline size limit! Can be overridden by
+# `instance_info/kernel_append_params` property. (string
+# value)
+# Note: This option can be changed without restarting.
+#kernel_append_params = <None>
+
+
+[ironic_lib]
+
+#
+# From ironic_lib.exception
+#
+
+# Used if there is a formatting error when generating an
+# exception message (a programming error). If True, raise an
+# exception; if False, use the unformatted message. (boolean
+# value)
+#fatal_exception_format_errors = false
+
+#
+# From ironic_lib.utils
+#
+
+# Command that is prefixed to commands that are run as root.
+# If not specified, no commands are run as root. (string
+# value)
+#root_helper = sudo ironic-rootwrap /etc/ironic/rootwrap.conf
+
+
+[json_rpc]
+
+#
+# From ironic_lib.json_rpc
+#
+
+# Authentication strategy used by JSON RPC. Defaults to the
+# global auth_strategy setting. (string value)
+# Possible values:
+# noauth - no authentication
+# keystone - use the Identity service for authentication
+# http_basic - HTTP basic authentication
+#auth_strategy = <None>
+
+# Path to Apache format user authentication file used when
+# auth_strategy=http_basic (string value)
+#http_basic_auth_user_file = /etc/ironic/htpasswd-json-rpc
+
+# The IP address or hostname on which JSON RPC will listen.
+# (host address value)
+#host_ip = ::
+
+# The port to use for JSON RPC (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#port = 8089
+
+# Whether to use TLS for JSON RPC (boolean value)
+#use_ssl = false
+
+# DEPRECATED: Name of the user to use for HTTP Basic
+# authentication client requests. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use username instead
+#http_basic_username = <None>
+
+# DEPRECATED: Password to use for HTTP Basic authentication
+# client requests. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Use password instead
+#http_basic_password = <None>
+
+# List of roles allowed to use JSON RPC (list value)
+#allowed_roles = admin
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [json_rpc]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [json_rpc]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [json_rpc]/tenant_name
+#project_name = <None>
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [json_rpc]/user_name
+#username = <None>
+
+
+[keystone_authtoken]
+
+#
+# From keystonemiddleware.auth_token
+#
+
+# Complete "public" Identity API endpoint. This endpoint
+# should not be an "admin" endpoint, as it should be
+# accessible by all end users. Unauthenticated clients are
+# redirected to this endpoint to authenticate. Although this
+# endpoint should ideally be unversioned, client support in
+# the wild varies. If you're using a versioned v2 endpoint
+# here, then this should *not* be the same endpoint the
+# service user utilizes for validating tokens, because normal
+# end users may not be able to reach that endpoint. (string
+# value)
+# Deprecated group/name - [keystone_authtoken]/auth_uri
+#www_authenticate_uri = <None>
+
+# DEPRECATED: Complete "public" Identity API endpoint. This
+# endpoint should not be an "admin" endpoint, as it should be
+# accessible by all end users. Unauthenticated clients are
+# redirected to this endpoint to authenticate. Although this
+# endpoint should ideally be unversioned, client support in
+# the wild varies. If you're using a versioned v2 endpoint
+# here, then this should *not* be the same endpoint the
+# service user utilizes for validating tokens, because normal
+# end users may not be able to reach that endpoint. This
+# option is deprecated in favor of www_authenticate_uri and
+# will be removed in the S release. (string value)
+# This option is deprecated for removal since Queens.
+# Its value may be silently ignored in the future.
+# Reason: The auth_uri option is deprecated in favor of
+# www_authenticate_uri and will be removed in the S  release.
+#auth_uri = <None>
+
+# API version of the Identity API endpoint. (string value)
+#auth_version = <None>
+
+# Interface to use for the Identity API endpoint. Valid values
+# are "public", "internal" (default) or "admin". (string
+# value)
+#interface = internal
+
+# Do not handle authorization requests within the middleware,
+# but delegate the authorization decision to downstream WSGI
+# components. (boolean value)
+#delay_auth_decision = false
+
+# Request timeout value for communicating with Identity API
+# server. (integer value)
+#http_connect_timeout = <None>
+
+# How many times are we trying to reconnect when communicating
+# with Identity API Server. (integer value)
+#http_request_max_retries = 3
+
+# Request environment key where the Swift cache object is
+# stored. When auth_token middleware is deployed with a Swift
+# cache, use this option to have the middleware share a
+# caching backend with swift. Otherwise, use the
+# ``memcached_servers`` option instead. (string value)
+#cache = <None>
+
+# Required if identity server requires client certificate
+# (string value)
+#certfile = <None>
+
+# Required if identity server requires client certificate
+# (string value)
+#keyfile = <None>
+
+# A PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. Defaults to system CAs. (string value)
+#cafile = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# The region in which the identity server can be found.
+# (string value)
+#region_name = <None>
+
+# Optionally specify a list of memcached server(s) to use for
+# caching. If left undefined, tokens will instead be cached
+# in-process. (list value)
+# Deprecated group/name - [keystone_authtoken]/memcache_servers
+#memcached_servers = <None>
+
+# In order to prevent excessive effort spent validating
+# tokens, the middleware caches previously-seen tokens for a
+# configurable duration (in seconds). Set to -1 to disable
+# caching completely. (integer value)
+#token_cache_time = 300
+
+# (Optional) If defined, indicate whether token data should be
+# authenticated or authenticated and encrypted. If MAC, token
+# data is authenticated (with HMAC) in the cache. If ENCRYPT,
+# token data is encrypted and authenticated in the cache. If
+# the value is not one of these options or empty, auth_token
+# will raise an exception on initialization. (string value)
+# Possible values:
+# None - <No description provided>
+# MAC - <No description provided>
+# ENCRYPT - <No description provided>
+#memcache_security_strategy = None
+
+# (Optional, mandatory if memcache_security_strategy is
+# defined) This string is used for key derivation. (string
+# value)
+#memcache_secret_key = <None>
+
+# (Optional) Number of seconds memcached server is considered
+# dead before it is tried again. (integer value)
+#memcache_pool_dead_retry = 300
+
+# (Optional) Maximum total number of open connections to every
+# memcached server. (integer value)
+#memcache_pool_maxsize = 10
+
+# (Optional) Socket timeout in seconds for communicating with
+# a memcached server. (integer value)
+#memcache_pool_socket_timeout = 3
+
+# (Optional) Number of seconds a connection to memcached is
+# held unused in the pool before it is closed. (integer value)
+#memcache_pool_unused_timeout = 60
+
+# (Optional) Number of seconds that an operation will wait to
+# get a memcached client connection from the pool. (integer
+# value)
+#memcache_pool_conn_get_timeout = 10
+
+# (Optional) Use the advanced (eventlet safe) memcached client
+# pool. (boolean value)
+#memcache_use_advanced_pool = true
+
+# (Optional) Indicate whether to set the X-Service-Catalog
+# header. If False, middleware will not ask for service
+# catalog on token validation and will not set the X-Service-
+# Catalog header. (boolean value)
+#include_service_catalog = true
+
+# Used to control the use and type of token binding. Can be
+# set to: "disabled" to not check token binding. "permissive"
+# (default) to validate binding information if the bind type
+# is of a form known to the server and ignore it if not.
+# "strict" like "permissive" but if the bind type is unknown
+# the token will be rejected. "required" any form of token
+# binding is needed to be allowed. Finally the name of a
+# binding method that must be present in tokens. (string
+# value)
+#enforce_token_bind = permissive
+
+# A choice of roles that must be present in a service token.
+# Service tokens are allowed to request that an expired token
+# can be used and so this check should tightly control that
+# only actual services should be sending this token. Roles
+# here are applied as an ANY check so any role in this list
+# must be present. For backwards compatibility reasons this
+# currently only affects the allow_expired check. (list value)
+#service_token_roles = service
+
+# For backwards compatibility reasons we must let valid
+# service tokens pass that don't pass the service_token_roles
+# check as valid. Setting this true will become the default in
+# a future release and should be enabled if possible. (boolean
+# value)
+#service_token_roles_required = false
+
+# The name or type of the service as it appears in the service
+# catalog. This is used to validate tokens that have
+# restricted access rules. (string value)
+#service_type = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [keystone_authtoken]/auth_plugin
+#auth_type = <None>
+
+# Config Section from which to load plugin specific options
+# (string value)
+#auth_section = <None>
+
+
+[mdns]
+
+#
+# From ironic_lib.mdns
+#
+
+# Number of attempts to register a service. Currently has to
+# be larger than 1 because of race conditions in the zeroconf
+# library. (integer value)
+# Minimum value: 1
+#registration_attempts = 5
+
+# Number of attempts to lookup a service. (integer value)
+# Minimum value: 1
+#lookup_attempts = 3
+
+# Additional parameters to pass for the registered service.
+# (dict value)
+#params =
+
+# List of IP addresses of interfaces to use for mDNS. Defaults
+# to all interfaces on the system. (list value)
+#interfaces = <None>
+
+
+[metrics]
+
+#
+# From ironic
+#
+
+# Backend for the agent ramdisk to use for metrics. Default
+# possible backends are "noop" and "statsd". (string value)
+#agent_backend = noop
+
+# Prepend the hostname to all metric names sent by the agent
+# ramdisk. The format of metric names is
+# [global_prefix.][uuid.][host_name.]prefix.metric_name.
+# (boolean value)
+#agent_prepend_host = false
+
+# Prepend the node's Ironic uuid to all metric names sent by
+# the agent ramdisk. The format of metric names is
+# [global_prefix.][uuid.][host_name.]prefix.metric_name.
+# (boolean value)
+#agent_prepend_uuid = false
+
+# Split the prepended host value by "." and reverse it for
+# metrics sent by the agent ramdisk (to better match the
+# reverse hierarchical form of domain names). (boolean value)
+#agent_prepend_host_reverse = true
+
+# Prefix all metric names sent by the agent ramdisk with this
+# value. The format of metric names is
+# [global_prefix.][uuid.][host_name.]prefix.metric_name.
+# (string value)
+#agent_global_prefix = <None>
+
+#
+# From ironic_lib.metrics
+#
+
+# Backend to use for the metrics system. (string value)
+# Possible values:
+# noop - Do nothing in relation to metrics.
+# statsd - Transmits metrics data to a statsd backend.
+# collector - Collects metrics data and saves it in memory for
+# use by the running application.
+#backend = noop
+
+# Prepend the hostname to all metric names. The format of
+# metric names is
+# [global_prefix.][host_name.]prefix.metric_name. (boolean
+# value)
+#prepend_host = false
+
+# Split the prepended host value by "." and reverse it (to
+# better match the reverse hierarchical form of domain names).
+# (boolean value)
+#prepend_host_reverse = true
+
+# Prefix all metric names with this value. By default, there
+# is no global prefix. The format of metric names is
+# [global_prefix.][host_name.]prefix.metric_name. (string
+# value)
+#global_prefix = <None>
+
+
+[metrics_statsd]
+
+#
+# From ironic
+#
+
+# Host for the agent ramdisk to use with the statsd backend.
+# This must be accessible from networks the agent is booted
+# on. (string value)
+#agent_statsd_host = localhost
+
+# Port for the agent ramdisk to use with the statsd backend.
+# (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#agent_statsd_port = 8125
+
+#
+# From ironic_lib.metrics_statsd
+#
+
+# Host for use with the statsd backend. (string value)
+#statsd_host = localhost
+
+# Port to use with the statsd backend. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#statsd_port = 8125
+
+
+[molds]
+
+#
+# From ironic
+#
+
+# Configuration mold storage location. Supports "swift" and
+# "http". By default "swift". (string value)
+#storage = swift
+
+# User for "http" Basic auth. By default set empty. (string
+# value)
+#user = <None>
+
+# Password for "http" Basic auth. By default set empty.
+# (string value)
+#password = <None>
+
+# Retry attempts for saving or getting configuration molds.
+# (integer value)
+#retry_attempts = 3
+
+# Retry interval for saving or getting configuration molds.
+# (integer value)
+#retry_interval = 3
+
+
+[neutron]
+
+#
+# From ironic
+#
+
+# Option to enable transmission of all ports to neutron when
+# creating ports for provisioning, cleaning, or rescue. This
+# is done without IP addresses assigned to the port, and may
+# be useful in some bonded network configurations. (boolean
+# value)
+# Note: This option can be changed without restarting.
+#add_all_ports = false
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [neutron]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Neutron network UUID or name for the ramdisk to be booted
+# into for cleaning nodes. Required for "neutron" network
+# interface. It is also required if cleaning nodes when using
+# "flat" network interface or "neutron" DHCP provider. If a
+# name is provided, it must be unique among all networks or
+# cleaning will fail. (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [neutron]/cleaning_network_uuid
+#cleaning_network = <None>
+
+# List of Neutron Security Group UUIDs to be applied during
+# cleaning of the nodes. Optional for the "neutron" network
+# interface and not used for the "flat" or "noop" network
+# interfaces. If not specified, default security group is
+# used. (list value)
+# Note: This option can be changed without restarting.
+#cleaning_network_security_groups =
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Number of IPv6 addresses to allocate for ports created for
+# provisioning, cleaning, rescue or inspection on
+# DHCPv6-stateful networks. Different stages of the chain-
+# loading process will request addresses with different
+# CLID/IAID. Due to non-identical identifiers multiple
+# addresses must be reserved for the host to ensure each step
+# of the boot process can successfully lease addresses.
+# (integer value)
+# Note: This option can be changed without restarting.
+#dhcpv6_stateful_address_count = 4
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# Neutron network UUID or name for the ramdisk to be booted
+# into for in-band inspection of nodes. If a name is provided,
+# it must be unique among all networks or inspection will
+# fail. (string value)
+# Note: This option can be changed without restarting.
+#inspection_network = <None>
+
+# List of Neutron Security Group UUIDs to be applied during
+# the node inspection process. Optional for the "neutron"
+# network interface and not used for the "flat" or "noop"
+# network interfaces. If not specified, the default security
+# group is used. (list value)
+# Note: This option can be changed without restarting.
+#inspection_network_security_groups =
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Delay value to wait for Neutron agents to setup sufficient
+# DHCP configuration for port. (integer value)
+# Minimum value: 0
+# Note: This option can be changed without restarting.
+#port_setup_delay = 0
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [neutron]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [neutron]/tenant_name
+#project_name = <None>
+
+# Neutron network UUID or name for the ramdisk to be booted
+# into for provisioning nodes. Required for "neutron" network
+# interface. If a name is provided, it must be unique among
+# all networks or deploy will fail. (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [neutron]/provisioning_network_uuid
+#provisioning_network = <None>
+
+# List of Neutron Security Group UUIDs to be applied during
+# provisioning of the nodes. Optional for the "neutron"
+# network interface and not used for the "flat" or "noop"
+# network interfaces. If not specified, default security group
+# is used. (list value)
+# Note: This option can be changed without restarting.
+#provisioning_network_security_groups =
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# Timeout for request processing when interacting with
+# Neutron. This value should be increased if neutron port
+# action timeouts are observed as neutron performs pre-commit
+# validation prior returning to the API client which can take
+# longer than normal client/server interactions. (integer
+# value)
+# Note: This option can be changed without restarting.
+#request_timeout = 45
+
+# Neutron network UUID or name for booting the ramdisk for
+# rescue mode. This is not the network that the rescue ramdisk
+# will use post-boot -- the tenant network is used for that.
+# Required for "neutron" network interface, if rescue mode
+# will be used. It is not used for the "flat" or "noop"
+# network interfaces. If a name is provided, it must be unique
+# among all networks or rescue will fail. (string value)
+# Note: This option can be changed without restarting.
+#rescuing_network = <None>
+
+# List of Neutron Security Group UUIDs to be applied during
+# the node rescue process. Optional for the "neutron" network
+# interface and not used for the "flat" or "noop" network
+# interfaces. If not specified, the default security group is
+# used. (list value)
+# Note: This option can be changed without restarting.
+#rescuing_network_security_groups =
+
+# DEPRECATED: Client retries in the case of a failed request.
+# (integer value)
+# Note: This option can be changed without restarting.
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Replaced by status_code_retries and
+# status_code_retry_delay.
+#retries = 3
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = network
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [neutron]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[nova]
+
+#
+# From ironic
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [nova]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [nova]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [nova]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# When set to True, it will enable the support for power state
+# change callbacks to nova. This option should be set to False
+# in deployments that do not have the openstack compute
+# service. (boolean value)
+# Note: This option can be changed without restarting.
+#send_power_notifications = true
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = compute
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [nova]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[oslo_concurrency]
+
+#
+# From oslo.concurrency
+#
+
+# Enables or disables inter-process locks. (boolean value)
+#disable_process_locking = false
+
+# Directory to use for lock files.  For security, the
+# specified directory should only be writable by the user
+# running the processes that need locking. Defaults to
+# environment variable OSLO_LOCK_PATH. If external locks are
+# used, a lock path must be set. (string value)
+#lock_path = <None>
+
+
+[oslo_messaging_amqp]
+
+#
+# From oslo.messaging
+#
+
+# Name for the AMQP container. must be globally unique.
+# Defaults to a generated UUID (string value)
+#container_name = <None>
+
+# Timeout for inactive connections (in seconds) (integer
+# value)
+#idle_timeout = 0
+
+# Debug: dump AMQP frames to stdout (boolean value)
+#trace = false
+
+# Attempt to connect via SSL. If no other ssl-related
+# parameters are given, it will use the system's CA-bundle to
+# verify the server's certificate. (boolean value)
+#ssl = false
+
+# CA certificate PEM file used to verify the server's
+# certificate (string value)
+#ssl_ca_file =
+
+# Self-identifying certificate PEM file for client
+# authentication (string value)
+#ssl_cert_file =
+
+# Private key PEM file used to sign ssl_cert_file certificate
+# (optional) (string value)
+#ssl_key_file =
+
+# Password for decrypting ssl_key_file (if encrypted) (string
+# value)
+#ssl_key_password = <None>
+
+# By default SSL checks that the name in the server's
+# certificate matches the hostname in the transport_url. In
+# some configurations it may be preferable to use the virtual
+# hostname instead, for example if the server uses the Server
+# Name Indication TLS extension (rfc6066) to provide a
+# certificate per virtual host. Set ssl_verify_vhost to True
+# if the server's SSL certificate uses the virtual host name
+# instead of the DNS name. (boolean value)
+#ssl_verify_vhost = false
+
+# Space separated list of acceptable SASL mechanisms (string
+# value)
+#sasl_mechanisms =
+
+# Path to directory that contains the SASL configuration
+# (string value)
+#sasl_config_dir =
+
+# Name of configuration file (without .conf suffix) (string
+# value)
+#sasl_config_name =
+
+# SASL realm to use if no realm present in username (string
+# value)
+#sasl_default_realm =
+
+# Seconds to pause before attempting to re-connect. (integer
+# value)
+# Minimum value: 1
+#connection_retry_interval = 1
+
+# Increase the connection_retry_interval by this many seconds
+# after each unsuccessful failover attempt. (integer value)
+# Minimum value: 0
+#connection_retry_backoff = 2
+
+# Maximum limit for connection_retry_interval +
+# connection_retry_backoff (integer value)
+# Minimum value: 1
+#connection_retry_interval_max = 30
+
+# Time to pause between re-connecting an AMQP 1.0 link that
+# failed due to a recoverable error. (integer value)
+# Minimum value: 1
+#link_retry_delay = 10
+
+# The maximum number of attempts to re-send a reply message
+# which failed due to a recoverable error. (integer value)
+# Minimum value: -1
+#default_reply_retry = 0
+
+# The deadline for an rpc reply message delivery. (integer
+# value)
+# Minimum value: 5
+#default_reply_timeout = 30
+
+# The deadline for an rpc cast or call message delivery. Only
+# used when caller does not provide a timeout expiry. (integer
+# value)
+# Minimum value: 5
+#default_send_timeout = 30
+
+# The deadline for a sent notification message delivery. Only
+# used when caller does not provide a timeout expiry. (integer
+# value)
+# Minimum value: 5
+#default_notify_timeout = 30
+
+# The duration to schedule a purge of idle sender links.
+# Detach link after expiry. (integer value)
+# Minimum value: 1
+#default_sender_link_timeout = 600
+
+# Indicates the addressing mode used by the driver.
+# Permitted values:
+# 'legacy'   - use legacy non-routable addressing
+# 'routable' - use routable addresses
+# 'dynamic'  - use legacy addresses if the message bus does
+# not support routing otherwise use routable addressing
+# (string value)
+#addressing_mode = dynamic
+
+# Enable virtual host support for those message buses that do
+# not natively support virtual hosting (such as qpidd). When
+# set to true the virtual host name will be added to all
+# message bus addresses, effectively creating a private
+# 'subnet' per virtual host. Set to False if the message bus
+# supports virtual hosting using the 'hostname' field in the
+# AMQP 1.0 Open performative as the name of the virtual host.
+# (boolean value)
+#pseudo_vhost = true
+
+# address prefix used when sending to a specific server
+# (string value)
+#server_request_prefix = exclusive
+
+# address prefix used when broadcasting to all servers (string
+# value)
+#broadcast_prefix = broadcast
+
+# address prefix when sending to any server in group (string
+# value)
+#group_request_prefix = unicast
+
+# Address prefix for all generated RPC addresses (string
+# value)
+#rpc_address_prefix = openstack.org/om/rpc
+
+# Address prefix for all generated Notification addresses
+# (string value)
+#notify_address_prefix = openstack.org/om/notify
+
+# Appended to the address prefix when sending a fanout
+# message. Used by the message bus to identify fanout
+# messages. (string value)
+#multicast_address = multicast
+
+# Appended to the address prefix when sending to a particular
+# RPC/Notification server. Used by the message bus to identify
+# messages sent to a single destination. (string value)
+#unicast_address = unicast
+
+# Appended to the address prefix when sending to a group of
+# consumers. Used by the message bus to identify messages that
+# should be delivered in a round-robin fashion across
+# consumers. (string value)
+#anycast_address = anycast
+
+# Exchange name used in notification addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_notification_exchange if set
+# else control_exchange if set
+# else 'notify' (string value)
+#default_notification_exchange = <None>
+
+# Exchange name used in RPC addresses.
+# Exchange name resolution precedence:
+# Target.exchange if set
+# else default_rpc_exchange if set
+# else control_exchange if set
+# else 'rpc' (string value)
+#default_rpc_exchange = <None>
+
+# Window size for incoming RPC Reply messages. (integer value)
+# Minimum value: 1
+#reply_link_credit = 200
+
+# Window size for incoming RPC Request messages (integer
+# value)
+# Minimum value: 1
+#rpc_server_credit = 100
+
+# Window size for incoming Notification messages (integer
+# value)
+# Minimum value: 1
+#notify_server_credit = 100
+
+# Send messages of this type pre-settled.
+# Pre-settled messages will not receive acknowledgement
+# from the peer. Note well: pre-settled messages may be
+# silently discarded if the delivery fails.
+# Permitted values:
+# 'rpc-call' - send RPC Calls pre-settled
+# 'rpc-reply'- send RPC Replies pre-settled
+# 'rpc-cast' - Send RPC Casts pre-settled
+# 'notify'   - Send Notifications pre-settled
+#  (multi valued)
+#pre_settled = rpc-cast
+#pre_settled = rpc-reply
+
+
+[oslo_messaging_kafka]
+
+#
+# From oslo.messaging
+#
+
+# Max fetch bytes of Kafka consumer (integer value)
+#kafka_max_fetch_bytes = 1048576
+
+# Default timeout(s) for Kafka consumers (floating point
+# value)
+#kafka_consumer_timeout = 1.0
+
+# DEPRECATED: Pool Size for Kafka Consumers (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#pool_size = 10
+
+# DEPRECATED: The pool size limit for connections expiration
+# policy (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_min_size = 2
+
+# DEPRECATED: The time-to-live in sec of idle connections in
+# the pool (integer value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Driver no longer uses connection pool.
+#conn_pool_ttl = 1200
+
+# Group id for Kafka consumer. Consumers in one group will
+# coordinate message consumption (string value)
+#consumer_group = oslo_messaging_consumer
+
+# Upper bound on the delay for KafkaProducer batching in
+# seconds (floating point value)
+#producer_batch_timeout = 0.0
+
+# Size of batch for the producer async send (integer value)
+#producer_batch_size = 16384
+
+# The compression codec for all data generated by the
+# producer. If not set, compression will not be used. Note
+# that the allowed values of this depend on the kafka version
+# (string value)
+# Possible values:
+# none - <No description provided>
+# gzip - <No description provided>
+# snappy - <No description provided>
+# lz4 - <No description provided>
+# zstd - <No description provided>
+#compression_codec = none
+
+# Enable asynchronous consumer commits (boolean value)
+#enable_auto_commit = false
+
+# The maximum number of records returned in a poll call
+# (integer value)
+#max_poll_records = 500
+
+# Protocol used to communicate with brokers (string value)
+# Possible values:
+# PLAINTEXT - <No description provided>
+# SASL_PLAINTEXT - <No description provided>
+# SSL - <No description provided>
+# SASL_SSL - <No description provided>
+#security_protocol = PLAINTEXT
+
+# Mechanism when security protocol is SASL (string value)
+#sasl_mechanism = PLAIN
+
+# CA certificate PEM file used to verify the server
+# certificate (string value)
+#ssl_cafile =
+
+# Client certificate PEM file used for authentication. (string
+# value)
+#ssl_client_cert_file =
+
+# Client key PEM file used for authentication. (string value)
+#ssl_client_key_file =
+
+# Client key password file used for authentication. (string
+# value)
+#ssl_client_key_password =
+
+
+[oslo_messaging_notifications]
+
+#
+# From oslo.messaging
+#
+
+# The Drivers(s) to handle sending notifications. Possible
+# values are messaging, messagingv2, routing, log, test, noop
+# (multi valued)
+# Deprecated group/name - [DEFAULT]/notification_driver
+#driver =
+
+# A URL representing the messaging driver to use for
+# notifications. If not set, we fall back to the same
+# configuration used for RPC. (string value)
+# Deprecated group/name - [DEFAULT]/notification_transport_url
+#transport_url = <None>
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+# Deprecated group/name - [DEFAULT]/notification_topics
+#topics = notifications
+
+# The maximum number of attempts to re-send a notification
+# message which failed to be delivered due to a recoverable
+# error. 0 - No retry, -1 - indefinite (integer value)
+#retry = -1
+
+
+[oslo_messaging_rabbit]
+
+#
+# From oslo.messaging
+#
+
+# Use durable queues in AMQP. If rabbit_quorum_queue is
+# enabled, queues will be durable and this value will be
+# ignored. (boolean value)
+#amqp_durable_queues = false
+
+# Auto-delete queues in AMQP. (boolean value)
+#amqp_auto_delete = false
+
+# Connect over SSL. (boolean value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_use_ssl
+#ssl = false
+
+# SSL version to use (valid only if SSL enabled). Valid values
+# are TLSv1 and SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may
+# be available on some distributions. (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_version
+#ssl_version =
+
+# SSL key file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_keyfile
+#ssl_key_file =
+
+# SSL cert file (valid only if SSL enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_certfile
+#ssl_cert_file =
+
+# SSL certification authority file (valid only if SSL
+# enabled). (string value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_ssl_ca_certs
+#ssl_ca_file =
+
+# Global toggle for enforcing the OpenSSL FIPS mode. This
+# feature requires Python support. This is available in Python
+# 3.9 in all environments and may have been backported to
+# older Python versions on select environments. If the Python
+# executable used does not support OpenSSL FIPS mode, an
+# exception will be raised. (boolean value)
+#ssl_enforce_fips_mode = false
+
+# Run the health check heartbeat thread through a native
+# python thread by default. If this option is equal to False
+# then the health check heartbeat will inherit the execution
+# model from the parent process. For example if the parent
+# process has monkey patched the stdlib by using
+# eventlet/greenlet then the heartbeat will be run through a
+# green thread. This option should be set to True only for the
+# wsgi services. (boolean value)
+#heartbeat_in_pthread = false
+
+# How long to wait (in seconds) before reconnecting in
+# response to an AMQP consumer cancel notification. (floating
+# point value)
+# Minimum value: 0.0
+# Maximum value: 4.5
+#kombu_reconnect_delay = 1.0
+
+# EXPERIMENTAL: Possible values are: gzip, bz2. If not set
+# compression will not be used. This option may not be
+# available in future versions. (string value)
+#kombu_compression = <None>
+
+# How long to wait a missing client before abandoning to send
+# it its replies. This value should not be longer than
+# rpc_response_timeout. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/kombu_reconnect_timeout
+#kombu_missing_consumer_retry_timeout = 60
+
+# Determines how the next RabbitMQ node is chosen in case the
+# one we are currently connected to becomes unavailable. Takes
+# effect only if more than one RabbitMQ node is provided in
+# config. (string value)
+# Possible values:
+# round-robin - <No description provided>
+# shuffle - <No description provided>
+#kombu_failover_strategy = round-robin
+
+# The RabbitMQ login method. (string value)
+# Possible values:
+# PLAIN - <No description provided>
+# AMQPLAIN - <No description provided>
+# EXTERNAL - <No description provided>
+# RABBIT-CR-DEMO - <No description provided>
+#rabbit_login_method = AMQPLAIN
+
+# How frequently to retry connecting with RabbitMQ. (integer
+# value)
+#rabbit_retry_interval = 1
+
+# How long to backoff for between retries when connecting to
+# RabbitMQ. (integer value)
+#rabbit_retry_backoff = 2
+
+# Maximum interval of RabbitMQ connection retries. Default is
+# 30 seconds. (integer value)
+#rabbit_interval_max = 30
+
+# Try to use HA queues in RabbitMQ (x-ha-policy: all). If you
+# change this option, you must wipe the RabbitMQ database. In
+# RabbitMQ 3.0, queue mirroring is no longer controlled by the
+# x-ha-policy argument when declaring a queue. If you just
+# want to make sure that all queues (except those with auto-
+# generated names) are mirrored across all nodes, run:
+# "rabbitmqctl set_policy HA '^(?!amq\.).*' '{"ha-mode":
+# "all"}' " (boolean value)
+#rabbit_ha_queues = false
+
+# Use quorum queues in RabbitMQ (x-queue-type: quorum). The
+# quorum queue is a modern queue type for RabbitMQ
+# implementing a durable, replicated FIFO queue based on the
+# Raft consensus algorithm. It is available as of RabbitMQ
+# 3.8.0. If set this option will conflict with the HA queues
+# (``rabbit_ha_queues``) aka mirrored queues, in other words
+# the HA queues should be disabled, quorum queues durable by
+# default so the amqp_durable_queues opion is ignored when
+# this option enabled. (boolean value)
+#rabbit_quorum_queue = false
+
+# Each time a message is redelivered to a consumer, a counter
+# is incremented. Once the redelivery count exceeds the
+# delivery limit the message gets dropped or dead-lettered (if
+# a DLX exchange has been configured) Used only when
+# rabbit_quorum_queue is enabled, Default 0 which means dont
+# set a limit. (integer value)
+#rabbit_quorum_delivery_limit = 0
+
+# By default all messages are maintained in memory if a quorum
+# queue grows in length it can put memory pressure on a
+# cluster. This option can limit the number of messages in the
+# quorum queue. Used only when rabbit_quorum_queue is enabled,
+# Default 0 which means dont set a limit. (integer value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_length
+#rabbit_quorum_max_memory_length = 0
+
+# By default all messages are maintained in memory if a quorum
+# queue grows in length it can put memory pressure on a
+# cluster. This option can limit the number of memory bytes
+# used by the quorum queue. Used only when rabbit_quorum_queue
+# is enabled, Default 0 which means dont set a limit. (integer
+# value)
+# Deprecated group/name - [oslo_messaging_rabbit]/rabbit_quroum_max_memory_bytes
+#rabbit_quorum_max_memory_bytes = 0
+
+# Positive integer representing duration in seconds for queue
+# TTL (x-expires). Queues which are unused for the duration of
+# the TTL are automatically deleted. The parameter affects
+# only reply and fanout queues. (integer value)
+# Minimum value: 1
+#rabbit_transient_queues_ttl = 1800
+
+# Specifies the number of messages to prefetch. Setting to
+# zero allows unlimited messages. (integer value)
+#rabbit_qos_prefetch_count = 0
+
+# Number of seconds after which the Rabbit broker is
+# considered down if heartbeat's keep-alive fails (0 disables
+# heartbeat). (integer value)
+#heartbeat_timeout_threshold = 60
+
+# How often times during the heartbeat_timeout_threshold we
+# check the heartbeat. (integer value)
+#heartbeat_rate = 2
+
+# DEPRECATED: (DEPRECATED) Enable/Disable the RabbitMQ
+# mandatory flag for direct send. The direct send is used as
+# reply, so the MessageUndeliverable exception is raised in
+# case the client queue does not exist.MessageUndeliverable
+# exception will be used to loop for a timeout to lets a
+# chance to sender to recover.This flag is deprecated and it
+# will not be possible to deactivate this functionality
+# anymore (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Mandatory flag no longer deactivable.
+#direct_mandatory_flag = true
+
+# Enable x-cancel-on-ha-failover flag so that rabbitmq server
+# will cancel and notify consumerswhen queue is down (boolean
+# value)
+#enable_cancel_on_failover = false
+
+
+[oslo_middleware]
+
+#
+# From oslo.middleware.http_proxy_to_wsgi
+#
+
+# Whether the application is behind a proxy or not. This
+# determines if the middleware should parse the headers or
+# not. (boolean value)
+#enable_proxy_headers_parsing = false
+
+
+[oslo_policy]
+
+#
+# From oslo.policy
+#
+
+# This option controls whether or not to enforce scope when
+# evaluating policies. If ``True``, the scope of the token
+# used in the request is compared to the ``scope_types`` of
+# the policy being enforced. If the scopes do not match, an
+# ``InvalidScope`` exception will be raised. If ``False``, a
+# message will be logged informing operators that policies are
+# being invoked with mismatching scope. (boolean value)
+#enforce_scope = false
+
+# This option controls whether or not to use old deprecated
+# defaults when evaluating policies. If ``True``, the old
+# deprecated defaults are not going to be evaluated. This
+# means if any existing token is allowed for old defaults but
+# is disallowed for new defaults, it will be disallowed. It is
+# encouraged to enable this flag along with the
+# ``enforce_scope`` flag so that you can get the benefits of
+# new defaults and ``scope_type`` together. If ``False``, the
+# deprecated policy check string is logically OR'd with the
+# new policy check string, allowing for a graceful upgrade
+# experience between releases with new policies, which is the
+# default behavior. (boolean value)
+#enforce_new_defaults = false
+
+# The relative or absolute path of a file that maps roles to
+# permissions for a given service. Relative paths must be
+# specified in relation to the configuration file setting this
+# option. (string value)
+#policy_file = policy.json
+
+# Default rule. Enforced when a requested rule is not found.
+# (string value)
+#policy_default_rule = default
+
+# Directories where policy configuration files are stored.
+# They can be relative to any directory in the search path
+# defined by the config_dir option, or absolute paths. The
+# file defined by policy_file must exist for these directories
+# to be searched.  Missing or empty directories are ignored.
+# (multi valued)
+#policy_dirs = policy.d
+
+# Content Type to send and receive data for REST based policy
+# check (string value)
+# Possible values:
+# application/x-www-form-urlencoded - <No description
+# provided>
+# application/json - <No description provided>
+#remote_content_type = application/x-www-form-urlencoded
+
+# server identity verification for REST based policy check
+# (boolean value)
+#remote_ssl_verify_server_crt = false
+
+# Absolute path to ca cert file for REST based policy check
+# (string value)
+#remote_ssl_ca_crt_file = <None>
+
+# Absolute path to client cert for REST based policy check
+# (string value)
+#remote_ssl_client_crt_file = <None>
+
+# Absolute path client key file REST based policy check
+# (string value)
+#remote_ssl_client_key_file = <None>
+
+
+[oslo_reports]
+
+#
+# From oslo.reports
+#
+
+# Path to a log directory where to create a file (string
+# value)
+#log_dir = <None>
+
+# The path to a file to watch for changes to trigger the
+# reports, instead of signals. Setting this option disables
+# the signal trigger for the reports. If application is
+# running as a WSGI application it is recommended to use this
+# instead of signals. (string value)
+#file_event_handler = <None>
+
+# How many seconds to wait between polls when
+# file_event_handler is set (integer value)
+#file_event_handler_interval = 1
+
+
+[profiler]
+
+#
+# From osprofiler
+#
+
+#
+# Enable the profiling for all services on this node.
+#
+# Default value is False (fully disable the profiling
+# feature).
+#
+# Possible values:
+#
+# * True: Enables the feature
+# * False: Disables the feature. The profiling cannot be
+# started via this project
+#   operations. If the profiling is triggered by another
+# project, this project
+#   part will be empty.
+#  (boolean value)
+# Deprecated group/name - [profiler]/profiler_enabled
+#enabled = false
+
+#
+# Enable SQL requests profiling in services.
+#
+# Default value is False (SQL requests won't be traced).
+#
+# Possible values:
+#
+# * True: Enables SQL requests profiling. Each SQL query will
+# be part of the
+#   trace and can the be analyzed by how much time was spent
+# for that.
+# * False: Disables SQL requests profiling. The spent time is
+# only shown on a
+#   higher level of operations. Single SQL queries cannot be
+# analyzed this way.
+#  (boolean value)
+#trace_sqlalchemy = false
+
+#
+# Secret key(s) to use for encrypting context data for
+# performance profiling.
+#
+# This string value should have the following format:
+# <key1>[,<key2>,...<keyn>],
+# where each key is some random string. A user who triggers
+# the profiling via
+# the REST API has to set one of these keys in the headers of
+# the REST API call
+# to include profiling results of this node for this
+# particular project.
+#
+# Both "enabled" flag and "hmac_keys" config options should be
+# set to enable
+# profiling. Also, to generate correct profiling information
+# across all services
+# at least one key needs to be consistent between OpenStack
+# projects. This
+# ensures it can be used from client side to generate the
+# trace, containing
+# information from all possible resources.
+#  (string value)
+#hmac_keys = SECRET_KEY
+
+#
+# Connection string for a notifier backend.
+#
+# Default value is ``messaging://`` which sets the notifier to
+# oslo_messaging.
+#
+# Examples of possible values:
+#
+# * ``messaging://`` - use oslo_messaging driver for sending
+# spans.
+# * ``redis://127.0.0.1:6379`` - use redis driver for sending
+# spans.
+# * ``mongodb://127.0.0.1:27017`` - use mongodb driver for
+# sending spans.
+# * ``elasticsearch://127.0.0.1:9200`` - use elasticsearch
+# driver for sending
+#   spans.
+# * ``jaeger://127.0.0.1:6831`` - use jaeger tracing as driver
+# for sending spans.
+#  (string value)
+#connection_string = messaging://
+
+#
+# Document type for notification indexing in elasticsearch.
+#  (string value)
+#es_doc_type = notification
+
+#
+# This parameter is a time value parameter (for example:
+# es_scroll_time=2m),
+# indicating for how long the nodes that participate in the
+# search will maintain
+# relevant resources in order to continue and support it.
+#  (string value)
+#es_scroll_time = 2m
+
+#
+# Elasticsearch splits large requests in batches. This
+# parameter defines
+# maximum size of each batch (for example:
+# es_scroll_size=10000).
+#  (integer value)
+#es_scroll_size = 10000
+
+#
+# Redissentinel provides a timeout option on the connections.
+# This parameter defines that timeout (for example:
+# socket_timeout=0.1).
+#  (floating point value)
+#socket_timeout = 0.1
+
+#
+# Redissentinel uses a service name to identify a master redis
+# service.
+# This parameter defines the name (for example:
+# ``sentinal_service_name=mymaster``).
+#  (string value)
+#sentinel_service_name = mymaster
+
+#
+# Enable filter traces that contain error/exception to a
+# separated place.
+#
+# Default value is set to False.
+#
+# Possible values:
+#
+# * True: Enable filter traces that contain error/exception.
+# * False: Disable the filter.
+#  (boolean value)
+#filter_error_trace = false
+
+
+[pxe]
+
+#
+# From ironic
+#
+
+# Additional append parameters for baremetal PXE boot. (string
+# value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [pxe]/pxe_append_params
+#kernel_append_params = nofb nomodeset vga=normal
+
+# Default file system format for ephemeral partition, if one
+# is created. (string value)
+# Note: This option can be changed without restarting.
+#default_ephemeral_format = ext4
+
+# On the ironic-conductor node, directory where images are
+# stored on disk. (string value)
+#images_path = /var/lib/ironic/images/
+
+# On the ironic-conductor node, directory where master
+# instance images are stored on disk. Setting to the empty
+# string disables image caching. (string value)
+#instance_master_path = /var/lib/ironic/master_images
+
+# Maximum size (in MiB) of cache for master images, including
+# those in use. (integer value)
+#image_cache_size = 20480
+
+# Maximum TTL (in minutes) for old master images in cache.
+# (integer value)
+#image_cache_ttl = 10080
+
+# On ironic-conductor node, template file for PXE loader
+# configuration. (string value)
+# Note: This option can be changed without restarting.
+#pxe_config_template = $pybasedir/drivers/modules/pxe_config.template
+
+# On ironic-conductor node, template file for iPXE operations.
+# (string value)
+# Note: This option can be changed without restarting.
+#ipxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+
+# On ironic-conductor node, template file for PXE
+# configuration for UEFI boot loader. Generally this is used
+# for GRUB specific templates. (string value)
+# Note: This option can be changed without restarting.
+#uefi_pxe_config_template = $pybasedir/drivers/modules/pxe_grub_config.template
+
+# On ironic-conductor node, template file for PXE
+# configuration per node architecture. For example:
+# aarch64:/opt/share/grubaa64_pxe_config.template (dict value)
+# Note: This option can be changed without restarting.
+#pxe_config_template_by_arch =
+
+# IP address of ironic-conductor node's TFTP server. (string
+# value)
+#tftp_server = $my_ip
+
+# ironic-conductor node's TFTP root path. The ironic-conductor
+# must have read/write access to this path. (string value)
+#tftp_root = /tftpboot
+
+# On ironic-conductor node, directory where master TFTP images
+# are stored on disk. Setting to the empty string disables
+# image caching. (string value)
+#tftp_master_path = /tftpboot/master_images
+
+# The permission that will be applied to the TFTP folders upon
+# creation. This should be set to the permission such that the
+# tftpserver has access to read the contents of the configured
+# TFTP folder. This setting is only required when the
+# operating system's umask is restrictive such that ironic-
+# conductor is creating files that cannot be read by the TFTP
+# server. Setting to <None> will result in the operating
+# system's umask to be utilized for the creation of new tftp
+# folders. The system default umask is masked out on the
+# specified value. It is required that an octal representation
+# is specified. For example: 0o755 (integer value)
+#dir_permission = <None>
+
+# The permission which is used on files created as part of
+# configuration and setup of file assets for PXE based
+# operations. Defaults to a value of 0o644. This value must be
+# specified as an octal representation. For example: 0o644
+# (integer value)
+#file_permission = 420
+
+# Bootfile DHCP parameter. (string value)
+#pxe_bootfile_name = pxelinux.0
+
+# Directory in which to create symbolic links which represent
+# the MAC or IP address of the ports on a node and allow boot
+# loaders to load the PXE file for the node. This directory
+# name is relative to the PXE or iPXE folders. (string value)
+#pxe_config_subdir = pxelinux.cfg
+
+# Bootfile DHCP parameter for UEFI boot mode. (string value)
+#uefi_pxe_bootfile_name = bootx64.efi
+
+# Bootfile DHCP parameter. (string value)
+#ipxe_bootfile_name = undionly.kpxe
+
+# Bootfile DHCP parameter for UEFI boot mode. If you
+# experience problems with booting using it, try ipxe.efi.
+# (string value)
+#uefi_ipxe_bootfile_name = snponly.efi
+
+# Bootfile DHCP parameter per node architecture. For example:
+# aarch64:grubaa64.efi (dict value)
+#pxe_bootfile_name_by_arch =
+
+# Bootfile DHCP parameter per node architecture. For example:
+# aarch64:ipxe_aa64.efi (dict value)
+#ipxe_bootfile_name_by_arch =
+
+# On ironic-conductor node, the path to the main iPXE script
+# file. (string value)
+#ipxe_boot_script = $pybasedir/drivers/modules/boot.ipxe
+
+# File name (e.g. inspector.ipxe) of an iPXE script to fall
+# back to when booting to a MAC-specific script fails. When
+# not set, booting will fail in this case. (string value)
+#ipxe_fallback_script = <None>
+
+# Timeout value (in seconds) for downloading an image via
+# iPXE. Defaults to 0 (no timeout) (integer value)
+#ipxe_timeout = 0
+
+# Timeout (in seconds) after which PXE boot should be retried.
+# Must be less than [conductor]deploy_callback_timeout.
+# Disabled by default. (integer value)
+# Minimum value: 60
+#boot_retry_timeout = <None>
+
+# Interval (in seconds) between periodic checks on PXE boot
+# retry. Has no effect if boot_retry_timeout is not set.
+# (integer value)
+# Minimum value: 1
+#boot_retry_check_interval = 90
+
+# DEPRECATED: The IP version that will be used for PXE
+# booting. Defaults to 4. This option has been a no-op for in-
+# treedrivers since the Ussuri development cycle. (string
+# value)
+# Possible values:
+# 4 - IPv4
+# 6 - IPv6
+# Note: This option can be changed without restarting.
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#ip_version = 4
+
+# Download deploy and rescue images directly from swift using
+# temporary URLs. If set to false (default), images are
+# downloaded to the ironic-conductor node and served over its
+# local HTTP server. Applicable only when 'ipxe' compatible
+# boot interface is used. (boolean value)
+# Note: This option can be changed without restarting.
+#ipxe_use_swift = false
+
+# If True, generate a PXE environment even for nodes that use
+# local boot. This is useful when the driver cannot switch
+# nodes to local boot, e.g. with SNMP or with Redfish on
+# machines that cannot do persistent boot. Mostly useful for
+# standalone ironic since Neutron will prevent incorrect PXE
+# boot. (boolean value)
+# Note: This option can be changed without restarting.
+#enable_netboot_fallback = false
+
+# Dictionary describing the bootloaders to load into conductor
+# PXE/iPXE boot folders values from the host operating system.
+# Formatted as key of destination file name, and value of a
+# full path to a file to be copied. File assets will have
+# [pxe]file_permission applied, if set. If used, the file
+# names should match established bootloader configuration
+# settings for bootloaders. Use example:
+# ipxe.efi:/usr/share/ipxe/ipxe-
+# snponly-x86_64.efi,undionly.kpxe:/usr/share/ipxe/undionly.kpxe
+# (dict value)
+#loader_file_paths =
+
+# On ironic-conductor node, the path to the initial
+# grubconfiguration template for grub network boot. (string
+# value)
+#initial_grub_template = $pybasedir/drivers/modules/initial_grub_cfg.template
+
+
+[redfish]
+
+#
+# From ironic
+#
+
+# Maximum number of attempts to try to connect to Redfish
+# (integer value)
+# Minimum value: 1
+#connection_attempts = 5
+
+# Number of seconds to wait between attempts to connect to
+# Redfish (integer value)
+# Minimum value: 1
+#connection_retry_interval = 4
+
+# Maximum Redfish client connection cache size. Redfish driver
+# would strive to reuse authenticated BMC connections
+# (obtained through Redfish Session Service). This option caps
+# the maximum number of connections to maintain. The value of
+# `0` disables client connection caching completely. (integer
+# value)
+# Minimum value: 0
+#connection_cache_size = 1000
+
+# Redfish HTTP client authentication method. (string value)
+# Possible values:
+# basic - Use HTTP basic authentication
+# session - Use HTTP session authentication
+# auto - Try HTTP session authentication first, fall back to
+# basic HTTP authentication
+#auth_type = auto
+
+# Upload generated ISO images for virtual media boot to Swift,
+# then pass temporary URL to BMC for booting the node. If set
+# to false, images are placed on the ironic-conductor node and
+# served over its local HTTP server. (boolean value)
+# Note: This option can be changed without restarting.
+#use_swift = true
+
+# The Swift container to store Redfish driver data. Applies
+# only when `use_swift` is enabled. (string value)
+# Note: This option can be changed without restarting.
+#swift_container = ironic_redfish_container
+
+# Amount of time in seconds for Swift objects to auto-expire.
+# Applies only when `use_swift` is enabled. (integer value)
+# Note: This option can be changed without restarting.
+#swift_object_expiry_timeout = 900
+
+# Additional kernel parameters to pass down to the instance
+# kernel. These parameters can be consumed by the kernel or by
+# the applications by reading /proc/cmdline. Mind severe
+# cmdline size limit! Can be overridden by
+# `instance_info/kernel_append_params` property. (string
+# value)
+# Note: This option can be changed without restarting.
+#kernel_append_params = nofb nomodeset vga=normal
+
+# File permission for swift-less image hosting with the octal
+# permission representation of file access permissions. This
+# setting defaults to ``644``, or as the octal number
+# ``0o644`` in Python. This setting must be set to the octal
+# number representation, meaning starting with ``0o``.
+# (integer value)
+#file_permission = 420
+
+# Number of seconds to wait between checking for completed
+# firmware update tasks (integer value)
+# Minimum value: 0
+#firmware_update_status_interval = 60
+
+# Number of seconds to wait between checking for failed
+# firmware update tasks (integer value)
+# Minimum value: 0
+#firmware_update_fail_interval = 60
+
+# Specifies how firmware image should be served. Whether from
+# its original location using the firmware source URL
+# directly, or should serve it from ironic's Swift or HTTP
+# server. (string value)
+# Possible values:
+# http - If firmware source URL is also HTTP, then serve from
+# original location, otherwise copy to ironic's HTTP server.
+# Default.
+# local - Download from original location and server from
+# ironic's HTTP server.
+# swift - If firmware source URL is also Swift, serve from
+# original location, otherwise copy to ironic's Swift server.
+# Note: This option can be changed without restarting.
+#firmware_source = http
+
+# Number of seconds to wait between checking for completed
+# raid config tasks (integer value)
+# Minimum value: 0
+#raid_config_status_interval = 60
+
+# Number of seconds to wait between checking for failed raid
+# config tasks (integer value)
+# Minimum value: 0
+#raid_config_fail_interval = 60
+
+
+[sensor_data]
+
+#
+# From ironic
+#
+
+# Enable sending sensor data message via the notification bus.
+# (boolean value)
+# Deprecated group/name - [conductor]/send_sensor_data
+#send_sensor_data = false
+
+# Seconds between conductor sending sensor data message via
+# the notification bus. This was originally for consumption
+# via ceilometer, but the data may also be consumed via a
+# plugin like ironic-prometheus-exporter or any other message
+# bus data collector. (integer value)
+# Minimum value: 1
+# Deprecated group/name - [conductor]/send_sensor_data_interval
+#interval = 600
+
+# The maximum number of workers that can be started
+# simultaneously for send data from sensors periodic task.
+# (integer value)
+# Minimum value: 1
+# Deprecated group/name - [conductor]/send_sensor_data_workers
+#workers = 4
+
+# The time in seconds to wait for send sensors data periodic
+# task to be finished before allowing periodic call to happen
+# again. Should be less than send_sensor_data_interval value.
+# (integer value)
+# Deprecated group/name - [conductor]/send_sensor_data_wait_timeout
+#wait_timeout = 300
+
+# List of comma separated meter types which need to be sent to
+# Ceilometer. The default value, "ALL", is a special value
+# meaning send all the sensor data. This setting only applies
+# to baremetal sensor data being processed through the
+# conductor. (list value)
+# Deprecated group/name - [conductor]/send_sensor_data_types
+#data_types = ALL
+
+# The default for sensor data collection is to only collect
+# data for machines that are deployed, however operators may
+# desire to know if there are failures in hardware that is not
+# presently in use. When set to true, the conductor will
+# collect sensor information from all nodes when sensor data
+# collection is enabled via the send_sensor_data setting.
+# (boolean value)
+# Deprecated group/name - [conductor]/send_sensor_data_for_undeployed_nodes
+#enable_for_undeployed_nodes = false
+
+# If to include sensor metric data for the Conductor process
+# itself in the message payload for sensor data which allows
+# operators to gather instance counts of actions and states to
+# better manage the deployment. (boolean value)
+#enable_for_conductor = true
+
+# If to transmit any sensor data for any nodes under this
+# conductor's management. This option superceeds the
+# ``send_sensor_data_for_undeployed_nodes`` setting. (boolean
+# value)
+#enable_for_nodes = true
+
+
+[service_catalog]
+
+#
+# From ironic
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [service_catalog]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [service_catalog]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [service_catalog]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = baremetal
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [service_catalog]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[snmp]
+
+#
+# From ironic
+#
+
+# Seconds to wait for power action to be completed (integer
+# value)
+#power_timeout = 10
+
+# Time (in seconds) to sleep between when rebooting (powering
+# off and on again) (integer value)
+# Minimum value: 0
+#reboot_delay = 0
+
+# Time (in seconds) to sleep before power on and after
+# powering off. Which may be needed with some PDUs as they may
+# not honor toggling a specific power port in rapid succession
+# without a delay. This option may be useful if the attached
+# physical machine has a substantial power supply to hold it
+# over in the event of a brownout. (integer value)
+# Minimum value: 0
+#power_action_delay = 0
+
+# Response timeout in seconds used for UDP transport. Timeout
+# should be a multiple of 0.5 seconds and is applicable to
+# each retry. (floating point value)
+# Minimum value: 0.0
+#udp_transport_timeout = 1.0
+
+# Maximum number of UDP request retries, 0 means no retries.
+# (integer value)
+# Minimum value: 0
+#udp_transport_retries = 5
+
+
+[ssl]
+
+#
+# From oslo.service.sslutils
+#
+
+# CA certificate file to use to verify connecting clients.
+# (string value)
+# Deprecated group/name - [DEFAULT]/ssl_ca_file
+#ca_file = <None>
+
+# Certificate file to use when starting the server securely.
+# (string value)
+# Deprecated group/name - [DEFAULT]/ssl_cert_file
+#cert_file = <None>
+
+# Private key file to use when starting the server securely.
+# (string value)
+# Deprecated group/name - [DEFAULT]/ssl_key_file
+#key_file = <None>
+
+# SSL version to use (valid only if SSL enabled). Valid values
+# are TLSv1 and SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may
+# be available on some distributions. (string value)
+#version = <None>
+
+# Sets the list of available ciphers. value should be a string
+# in the OpenSSL cipher list format. (string value)
+#ciphers = <None>
+
+
+[swift]
+
+#
+# From ironic
+#
+
+# Authentication URL (string value)
+#auth_url = <None>
+
+# Authentication type to load (string value)
+# Deprecated group/name - [swift]/auth_plugin
+#auth_type = <None>
+
+# PEM encoded Certificate Authority to use when verifying
+# HTTPs connections. (string value)
+#cafile = <None>
+
+# PEM encoded client certificate cert file (string value)
+#certfile = <None>
+
+# Collect per-API call timing information. (boolean value)
+#collect_timing = false
+
+# The maximum number of retries that should be attempted for
+# connection errors. (integer value)
+#connect_retries = <None>
+
+# Delay (in seconds) between two retries for connection
+# errors. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#connect_retry_delay = <None>
+
+# Optional domain ID to use with v3 and v2 parameters. It will
+# be used for both the user and project domain in v3 and
+# ignored in v2 authentication. (string value)
+#default_domain_id = <None>
+
+# Optional domain name to use with v3 API and v2 parameters.
+# It will be used for both the user and project domain in v3
+# and ignored in v2 authentication. (string value)
+#default_domain_name = <None>
+
+# Domain ID to scope to (string value)
+#domain_id = <None>
+
+# Domain name to scope to (string value)
+#domain_name = <None>
+
+# Always use this endpoint URL for requests for this client.
+# NOTE: The unversioned endpoint should be specified here; to
+# request a particular API version, use the `version`, `min-
+# version`, and/or `max-version` options. (string value)
+#endpoint_override = <None>
+
+# Verify HTTPS connections. (boolean value)
+#insecure = false
+
+# PEM encoded client certificate key file (string value)
+#keyfile = <None>
+
+# The maximum major version of a given API, intended to be
+# used as the upper bound of a range with min_version.
+# Mutually exclusive with version. (string value)
+#max_version = <None>
+
+# The minimum major version of a given API, intended to be
+# used as the lower bound of a range with max_version.
+# Mutually exclusive with version. If min_version is given
+# with no max_version it is as if max version is "latest".
+# (string value)
+#min_version = <None>
+
+# User's password (string value)
+#password = <None>
+
+# Domain ID containing project (string value)
+#project_domain_id = <None>
+
+# Domain name containing project (string value)
+#project_domain_name = <None>
+
+# Project ID to scope to (string value)
+# Deprecated group/name - [swift]/tenant_id
+#project_id = <None>
+
+# Project name to scope to (string value)
+# Deprecated group/name - [swift]/tenant_name
+#project_name = <None>
+
+# The default region_name for endpoint URL discovery. (string
+# value)
+#region_name = <None>
+
+# The default service_name for endpoint URL discovery. (string
+# value)
+#service_name = <None>
+
+# The default service_type for endpoint URL discovery. (string
+# value)
+#service_type = object-store
+
+# Log requests to multiple loggers. (boolean value)
+#split_loggers = false
+
+# The maximum number of retries that should be attempted for
+# retriable HTTP status codes. (integer value)
+#status_code_retries = <None>
+
+# Delay (in seconds) between two retries for retriable status
+# codes. If not set, exponential retry starting with 0.5
+# seconds up to a maximum of 60 seconds is used. (floating
+# point value)
+#status_code_retry_delay = <None>
+
+# Maximum number of times to retry a Swift request, before
+# failing. (integer value)
+#swift_max_retries = 2
+
+# Scope for system operations (string value)
+#system_scope = <None>
+
+# Tenant ID (string value)
+#tenant_id = <None>
+
+# Tenant Name (string value)
+#tenant_name = <None>
+
+# Timeout value for http requests (integer value)
+#timeout = <None>
+
+# ID of the trust to use as a trustee use (string value)
+#trust_id = <None>
+
+# User's domain id (string value)
+#user_domain_id = <None>
+
+# User's domain name (string value)
+#user_domain_name = <None>
+
+# User id (string value)
+#user_id = <None>
+
+# Username (string value)
+# Deprecated group/name - [swift]/user_name
+#username = <None>
+
+# List of interfaces, in order of preference, for endpoint
+# URL. (list value)
+#valid_interfaces = internal,public
+
+# Minimum Major API version within a given Major API version
+# for endpoint URL discovery. Mutually exclusive with
+# min_version and max_version (string value)
+#version = <None>
+
+
+[xclarity]
+
+#
+# From ironic
+#
+
+# IP address of the XClarity Controller. Configuration here is
+# deprecated and will be removed in the Stein release. Please
+# update the driver_info field to use "xclarity_manager_ip"
+# instead (string value)
+#manager_ip = <None>
+
+# Username for the XClarity Controller. Configuration here is
+# deprecated and will be removed in the Stein release. Please
+# update the driver_info field to use "xclarity_username"
+# instead (string value)
+#username = <None>
+
+# Password for XClarity Controller username. Configuration
+# here is deprecated and will be removed in the Stein release.
+# Please update the driver_info field to use
+# "xclarity_password" instead (string value)
+#password = <None>
+
+# Port to be used for XClarity Controller connection. (port
+# value)
+# Minimum value: 0
+# Maximum value: 65535
+#port = 443

--- a/core/ironic/ironic.mk
+++ b/core/ironic/ironic.mk
@@ -4,14 +4,137 @@
 IRONIC_CONF_DIR := /etc/ironic
 IRONIC_INSP_CONF_DIR := /etc/ironic-inspector
 
-ROOTFS_DNF += tftp-server
-ROOTFS_DNF_NOARCH += openstack-ironic-api openstack-ironic-conductor openstack-ironic-inspector openstack-ironic-inspector-api openstack-ironic-inspector-conductor openstack-ironic-inspector-dnsmasq openstack-ironic-ui
-ROOTFS_DNF_NOARCH += python3-networking-baremetal python3-ironic-neutron-agent python3-dracclient python3-scciclient python3-sushy syslinux-tftpboot
+# System requirements formerly pulled in by the openstack-ironic RPMs.
+# ipmitool backs enabled_hardware_types=ipmi / enabled_management_interfaces=ipmitool
+# (RDO only listed it as a weak dependency, so pip gives us nothing here);
+# qemu-img, mtools, dosfstools and xorriso are what the conductor shells out to
+# for image conversion and config-drive creation. They used to arrive through
+# other components' RPM sets, which is not something ironic should rely on.
+ROOTFS_DNF += tftp-server ipmitool qemu-img mtools dosfstools xorriso
+ROOTFS_DNF_NOARCH += syslinux-tftpboot
 
+# install ironic and ironic-inspector inside the python 3.10 virtual environment
+# NOTE: networking-baremetal (the 'baremetal' ML2 driver plus the
+# ironic-neutron-agent binary) is pip installed by core/neutron/neutron.mk,
+# because config_neutron.cpp always sets ml2.mechanism_drivers=ovn,baremetal.
+# Do not install it a second time here — only link the binary ironic owns.
 rootfs_install::
-	$(Q)mkdir -p $(ROOTDIR)/tftpboot/pxelinux.cfg $(ROOTDIR)/tftpboot/images
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		ironic==21.4.4 \
+		ironic-inspector==11.4.1"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+	$(Q)# Link binaries
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic /usr/bin/ironic
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-api /usr/bin/ironic-api
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-api-wsgi /usr/bin/ironic-api-wsgi
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-conductor /usr/bin/ironic-conductor
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-dbsync /usr/bin/ironic-dbsync
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-rootwrap /usr/bin/ironic-rootwrap
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-status /usr/bin/ironic-status
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector /usr/bin/ironic-inspector
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-api-wsgi /usr/bin/ironic-inspector-api-wsgi
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-conductor /usr/bin/ironic-inspector-conductor
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-dbsync /usr/bin/ironic-inspector-dbsync
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-migrate-data /usr/bin/ironic-inspector-migrate-data
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-rootwrap /usr/bin/ironic-inspector-rootwrap
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-status /usr/bin/ironic-inspector-status
+	$(Q)# provided by networking-baremetal, installed with neutron
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-neutron-agent /usr/bin/ironic-neutron-agent
+
+# prepare the build directory
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rm -rf /tmp/ironic
+	$(Q)chroot $(ROOTDIR) mkdir -p /tmp/ironic
+
+# stage configuration templates from the core directory
+rootfs_install::
+	$(Q)cp -f $(COREDIR)/ironic/ironic.conf.sample $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/inspector.conf.sample $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/inspector-dist.conf $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/rootwrap.conf $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/inspector-rootwrap.conf $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/ironic-utils.filters $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/ironic-inspector.filters $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/ironic-sudoers $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/ironic-inspector-sudoers $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/openstack-ironic-api.service $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/openstack-ironic-conductor.service $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/openstack-ironic-inspector.service $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/ironic-neutron-agent.service $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/openstack-ironic-file-server.service $(ROOTDIR)/tmp/ironic/
+	$(Q)cp -f $(COREDIR)/ironic/openstack-ironic-inspector-dnsmasq.service $(ROOTDIR)/tmp/ironic/
+
+# install system directories and production files
+rootfs_install::
+	$(Q)# install base configurations
+	$(Q)chroot $(ROOTDIR) install -d -m 755 $(IRONIC_CONF_DIR)
+	$(Q)chroot $(ROOTDIR) install -d -m 755 $(IRONIC_CONF_DIR)/rootwrap.d
+	$(Q)chroot $(ROOTDIR) install -d -m 750 $(IRONIC_INSP_CONF_DIR)
+	$(Q)chroot $(ROOTDIR) install -d -m 755 $(IRONIC_INSP_CONF_DIR)/rootwrap.d
+	$(Q)chroot $(ROOTDIR) cp -f /tmp/ironic/ironic.conf.sample $(IRONIC_CONF_DIR)/ironic.conf
+	$(Q)chroot $(ROOTDIR) cp -f /tmp/ironic/inspector.conf.sample $(IRONIC_INSP_CONF_DIR)/inspector.conf
+	$(Q)# the inspector unit passes this file to --config-file explicitly
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/ironic/inspector-dist.conf $(IRONIC_INSP_CONF_DIR)/inspector-dist.conf
+	$(Q)# install rootwrap configurations
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/ironic/rootwrap.conf $(IRONIC_CONF_DIR)/rootwrap.conf
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/ironic-utils.filters $(IRONIC_CONF_DIR)/rootwrap.d/ironic-utils.filters
+	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/ironic/inspector-rootwrap.conf $(IRONIC_INSP_CONF_DIR)/rootwrap.conf
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/ironic-inspector.filters $(IRONIC_INSP_CONF_DIR)/rootwrap.d/ironic-inspector.filters
+	$(Q)# install security configurations
+	$(Q)chroot $(ROOTDIR) install -p -D -m 440 /tmp/ironic/ironic-sudoers /etc/sudoers.d/ironic
+	$(Q)chroot $(ROOTDIR) install -p -D -m 440 /tmp/ironic/ironic-inspector-sudoers /etc/sudoers.d/ironic-inspector
+	$(Q)# install systemd unit files
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/openstack-ironic-api.service /usr/lib/systemd/system/openstack-ironic-api.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/openstack-ironic-conductor.service /usr/lib/systemd/system/openstack-ironic-conductor.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/openstack-ironic-inspector.service /usr/lib/systemd/system/openstack-ironic-inspector.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/ironic-neutron-agent.service /usr/lib/systemd/system/ironic-neutron-agent.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/openstack-ironic-file-server.service /usr/lib/systemd/system/openstack-ironic-file-server.service
+	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/ironic/openstack-ironic-inspector-dnsmasq.service /usr/lib/systemd/system/openstack-ironic-inspector-dnsmasq.service
+	$(Q)# setup directories
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/lib/ironic
+	$(Q)chroot $(ROOTDIR) install -d -m 750 /var/log/ironic
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/lib/ironic-inspector
+	$(Q)# consumed by the dnsmasq pxe filter; created to stay on par with the RPM layout
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /var/lib/ironic-inspector/dhcp-hostsdir
+	$(Q)chroot $(ROOTDIR) install -d -m 750 /var/log/ironic-inspector
+	$(Q)chroot $(ROOTDIR) install -d -m 750 /var/log/ironic-inspector/ramdisk
+	$(Q)# tftp/pxe server root
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /tftpboot/pxelinux.cfg
+	$(Q)chroot $(ROOTDIR) install -d -m 755 /tftpboot/images
+
+# adjust file ownerships and permissions
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) chown root:ironic $(IRONIC_CONF_DIR)
+	$(Q)chroot $(ROOTDIR) chown root:ironic $(IRONIC_CONF_DIR)/ironic.conf
+	$(Q)chroot $(ROOTDIR) chmod 0640 $(IRONIC_CONF_DIR)/ironic.conf
+	$(Q)chroot $(ROOTDIR) chown root:ironic $(IRONIC_CONF_DIR)/rootwrap.conf
+	$(Q)chroot $(ROOTDIR) chown root:root $(IRONIC_CONF_DIR)/rootwrap.d/ironic-utils.filters
+	$(Q)chroot $(ROOTDIR) chown root:ironic-inspector $(IRONIC_INSP_CONF_DIR)
+	$(Q)chroot $(ROOTDIR) chown root:ironic-inspector $(IRONIC_INSP_CONF_DIR)/inspector.conf
+	$(Q)chroot $(ROOTDIR) chmod 0640 $(IRONIC_INSP_CONF_DIR)/inspector.conf
+	$(Q)chroot $(ROOTDIR) chown root:ironic-inspector $(IRONIC_INSP_CONF_DIR)/inspector-dist.conf
+	$(Q)chroot $(ROOTDIR) chown root:ironic-inspector $(IRONIC_INSP_CONF_DIR)/rootwrap.conf
+	$(Q)chroot $(ROOTDIR) chown root:root $(IRONIC_INSP_CONF_DIR)/rootwrap.d/ironic-inspector.filters
+	$(Q)chroot $(ROOTDIR) chown ironic:ironic /var/lib/ironic
+	$(Q)chroot $(ROOTDIR) chown ironic:ironic /var/log/ironic
+	$(Q)chroot $(ROOTDIR) chown ironic-inspector:ironic-inspector /var/lib/ironic-inspector
+	$(Q)chroot $(ROOTDIR) chown ironic-inspector:ironic-inspector /var/lib/ironic-inspector/dhcp-hostsdir
+	$(Q)chroot $(ROOTDIR) chown ironic-inspector:ironic-inspector /var/log/ironic-inspector
+	$(Q)chroot $(ROOTDIR) chown ironic-inspector:ironic-inspector /var/log/ironic-inspector/ramdisk
 	$(Q)chroot $(ROOTDIR) chown -R ironic /tftpboot
+
+# clean up the build directory
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) rm -rf /tmp/ironic
+
+# install custom files
+rootfs_install::
 	$(Q)cp -f $(ROOTDIR)/$(IRONIC_CONF_DIR)/ironic.conf $(ROOTDIR)/$(IRONIC_CONF_DIR)/ironic.conf.def
 	$(Q)cp -f $(ROOTDIR)/$(IRONIC_INSP_CONF_DIR)/inspector.conf $(ROOTDIR)/$(IRONIC_INSP_CONF_DIR)/inspector.conf.def
-	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/ironic/openstack-ironic-inspector-dnsmasq.service ./lib/systemd/system
-	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/ironic/openstack-ironic-file-server.service ./lib/systemd/system
+
+rootfs_install::
+	$(Q)for ns in $$(find $(ROOTDIR)/usr/lib/systemd/system/*ironic*.service) ; do sed -i /^Timeout*/d $$ns ; done

--- a/core/ironic/openstack-ironic-api.service
+++ b/core/ironic/openstack-ironic-api.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenStack Ironic API service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=ironic
+ExecStart=/usr/bin/ironic-api
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/core/ironic/openstack-ironic-conductor.service
+++ b/core/ironic/openstack-ironic-conductor.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenStack Ironic Conductor service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=ironic
+ExecStart=/usr/bin/ironic-conductor
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/core/ironic/openstack-ironic-inspector.service
+++ b/core/ironic/openstack-ironic-inspector.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hardware introspection service for OpenStack Ironic
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf --config-file /etc/ironic-inspector/inspector.conf
+User=ironic-inspector
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+Alias=openstack-ironic-inspector.service

--- a/core/ironic/oslo-config-generator/inspector-config-generator.conf
+++ b/core/ironic/oslo-config-generator/inspector-config-generator.conf
@@ -1,0 +1,14 @@
+[DEFAULT]
+output_file = example.conf
+namespace = ironic_inspector
+namespace = ironic_lib.mdns
+namespace = keystonemiddleware.auth_token
+namespace = oslo.db
+namespace = oslo.log
+namespace = oslo.messaging
+namespace = oslo.middleware.cors
+namespace = oslo.middleware.healthcheck
+namespace = oslo.policy
+namespace = oslo.service.service
+namespace = oslo.service.sslutils
+namespace = oslo.service.wsgi

--- a/core/ironic/oslo-config-generator/ironic-config-generator.conf
+++ b/core/ironic/oslo-config-generator/ironic-config-generator.conf
@@ -1,0 +1,27 @@
+[DEFAULT]
+output_file = etc/ironic/ironic.conf.sample
+wrap_width = 62
+namespace = ironic
+namespace = ironic_lib.disk_utils
+namespace = ironic_lib.disk_partitioner
+namespace = ironic_lib.exception
+namespace = ironic_lib.json_rpc
+namespace = ironic_lib.mdns
+namespace = ironic_lib.metrics
+namespace = ironic_lib.metrics_statsd
+namespace = ironic_lib.utils
+namespace = oslo.db
+namespace = oslo.messaging
+namespace = oslo.middleware.cors
+namespace = oslo.middleware.healthcheck
+namespace = oslo.middleware.http_proxy_to_wsgi
+namespace = oslo.concurrency
+namespace = oslo.policy
+namespace = oslo.log
+namespace = oslo.reports
+namespace = oslo.service.service
+namespace = oslo.service.periodic_task
+namespace = oslo.service.sslutils
+namespace = osprofiler
+namespace = keystonemiddleware.audit
+namespace = keystonemiddleware.auth_token

--- a/core/ironic/rootwrap.conf
+++ b/core/ironic/rootwrap.conf
@@ -1,0 +1,27 @@
+# Configuration for ironic-rootwrap
+# This file should be owned by (and only writable by) the root user
+
+[DEFAULT]
+# List of directories to load filter definitions from (separated by ',').
+# These directories MUST all be only writable by root !
+filters_path=/etc/ironic/rootwrap.d,/usr/share/ironic/rootwrap
+
+# List of directories to search executables in, in case filters do not
+# explicitly specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writable by root !
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+
+# Enable logging to syslog
+# Default value is False
+use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, user0, user1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
+syslog_log_level=ERROR

--- a/core/modules/config_cube_scan.cpp
+++ b/core/modules/config_cube_scan.cpp
@@ -310,7 +310,9 @@ ParseNew(void)
             return false;
     }
 
-    bool isCtrl = IsControl(s_eCubeRole);
+    // ParseOld() already derives this from the tuning; keep the two symmetric so the
+    // shared id does not silently change shape depending on whether NotifyCube() ran
+    bool isCtrl = IsControl(r);
     bool isMaster = IsMaster(isCtrl, mgmtAddr, s_ctrlAddrs.newValue());
     std::string ctrl = GetController(isCtrl, s_hostname.newValue(), s_controller.newValue());
     std::string ctrlIp = isCtrl ? mgmtAddr : s_controllerIp.newValue();
@@ -427,10 +429,14 @@ Prepare(bool modified, int dryLevel)
 static bool
 Commit(bool modified, int dryLevel)
 {
-    if (IsUndef(s_eCubeRole))
-        return true;
-
+    // read the role straight from the tuning rather than from s_eCubeRole, which is
+    // only ever assigned in NotifyCube() -- and that observer does not fire when the
+    // commit leaves cubesys untouched. Bailing out on the unset static skipped
+    // ParseNew() entirely, so every G(...) below stayed at its compiled-in default.
     CubeRole_e r = GetCubeRole(s_cubeRole.newValue());
+
+    if (IsUndef(r))
+        return true;
 
     if (IfProviderReq(r)) {
         // in case provider interface is disabled in policy

--- a/core/modules/config_ironic.cpp
+++ b/core/modules/config_ironic.cpp
@@ -10,6 +10,7 @@
 #include <hex/config_tuning.h>
 #include <hex/config_global.h>
 #include <hex/dryrun.h>
+#include <hex/logrotate.h>
 
 #include <cube/systemd_util.h>
 #include <cube/config_file.h>
@@ -18,6 +19,9 @@
 
 #include "mysql_util.h"
 #include "include/role_cubesys.h"
+
+static LogRotateConf ironic_log_conf("ironic", "/var/log/ironic/*.log", DAILY, 128, 0, true);
+static LogRotateConf inspector_log_conf("ironic-inspector", "/var/log/ironic-inspector/*.log", DAILY, 128, 0, true);
 
 static const char USER[] = "ironic";
 static const char GROUP[] = "ironic";
@@ -234,8 +238,8 @@ SetupIronic(std::string domain, std::string ironicPass, std::string inspPass)
     HexLogInfo("Setting up ironic");
 
     // Populate the ironic services database
-    HexUtilSystemF(0, 0, "su -s /bin/sh -c \"ironic-dbsync --config-file " CONF " create_schema\" %s", USER);
-    HexUtilSystemF(0, 0, "su -s /bin/sh -c \"ironic-inspector-dbsync --config-file " INSP_CONF " upgrade\" %s", INSP_USER);
+    HexUtilSystemF(0, 0, "su -s /bin/sh -c \"/usr/bin/ironic-dbsync --config-file " CONF " create_schema\" %s", USER);
+    HexUtilSystemF(0, 0, "su -s /bin/sh -c \"/usr/bin/ironic-inspector-dbsync --config-file " INSP_CONF " upgrade\" %s", INSP_USER);
 
     // prepare env settings
     std::string env = ". " + std::string(OPENRC) + " &&";
@@ -302,6 +306,7 @@ UpdateDbConn(std::string sharedId, std::string password, std::string inspPass)
         dbconn += "/ironic";
 
         cfg["database"]["connection"] = dbconn;
+        cfg["database"]["mysql_wsrep_sync_wait"] = "1";
 
         dbconn = "mysql+pymysql://ironic-inspector:";
         dbconn += inspPass;
@@ -310,6 +315,7 @@ UpdateDbConn(std::string sharedId, std::string password, std::string inspPass)
         dbconn += "/ironic_inspector";
 
         inspCfg["database"]["connection"] = dbconn;
+        inspCfg["database"]["mysql_wsrep_sync_wait"] = "1";
     }
 
     return true;
@@ -636,6 +642,9 @@ Commit(bool modified, int dryLevel)
 
     // service kickoff
     IronicService(s_enabled, s_deployEnabled);
+
+    WriteLogRotateConf(ironic_log_conf);
+    WriteLogRotateConf(inspector_log_conf);
 
     return true;
 }

--- a/core/modules/config_ironic.cpp
+++ b/core/modules/config_ironic.cpp
@@ -474,6 +474,30 @@ UpdateCfg(std::string domain, std::string ironicPass, std::string inspPass)
     return true;
 }
 
+// MGMT_ADDR, SHARED_ID and EXTERNAL are published by config_cube_scan's ParseNew(),
+// which only runs when cube_scan itself is being committed -- from its own Commit()
+// or from NotifyCube(). A commit that touches nothing but ironic.enabled leaves
+// cube_scan unmodified, so it is skipped and these globals keep the compiled-in
+// defaults "0.0.0.0" / "0.0.0.0" / "" (config_cube_scan.cpp:36,55,56).
+//
+// ironic is the only OpenStack service that ships disabled, so it is the only one
+// whose first real config write happens after bootstrap -- every other service had
+// its conf written during bootstrap, when the globals were valid, and is not
+// rewritten afterwards. Writing the defaults out would put "@0.0.0.0/ironic" in the
+// database URI and "http://:6385" in the keystone catalog, leaving the conductor in
+// a DB retry loop and the API unreachable.
+//
+// ironic.conf.def carries neither the connection nor the auth URLs -- they are
+// produced here -- so the safe response is to leave the previously written conf and
+// endpoints alone rather than regenerate them from placeholder addresses.
+static bool
+ClusterAddrsResolved(const std::string& myip, const std::string& sharedId, const std::string& external)
+{
+    return !myip.empty() && myip != "0.0.0.0" &&
+           !sharedId.empty() && sharedId != "0.0.0.0" &&
+           !external.empty();
+}
+
 static bool
 IronicService(const bool enabled, const bool deploy)
 {
@@ -611,8 +635,17 @@ Commit(bool modified, int dryLevel)
         MysqlUtilUpdateDbPass(INSP_USER, inspDbPass.c_str());
     }
 
+    // see ClusterAddrsResolved(): every value below is derived from the cluster
+    // addresses, so regenerating them from placeholders would overwrite a working
+    // config with an unusable one
+    bool addrsResolved = ClusterAddrsResolved(myip, sharedId, external);
+    if (!addrsResolved)
+        HexLogWarning("cluster addresses unresolved (mgmt %s, shared %s, external \"%s\"): "
+                      "keeping the existing ironic config and endpoints",
+                      myip.c_str(), sharedId.c_str(), external.c_str());
+
     // update config file
-    if (s_bConfigChanged) {
+    if (s_bConfigChanged && addrsResolved) {
         UpdateCfg(s_cubeDomain.newValue(), ironicPass, inspPass);
         UpdateSharedId(sharedId);
         UpdateMyIp(myip);
@@ -635,7 +668,7 @@ Commit(bool modified, int dryLevel)
     HexUtilSystemF(0, 0, HEX_SDK " migrate_ironic_db");
 
     // configuring openstack end point
-    if (s_bEndpointChanged)
+    if (s_bEndpointChanged && addrsResolved)
         UpdateEndpoint(sharedId, external, s_cubeRegion.newValue());
 
     CronConfigSync(s_deployEnabled);

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -218,8 +218,8 @@ migrate_ironic_db()
     fi
 
     if is_control_node ; then
-        su -s /bin/sh -c "ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade" ironic
-        su -s /bin/sh -c "ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade" ironic-inspector
+        su -s /bin/sh -c "/usr/bin/ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade" ironic
+        su -s /bin/sh -c "/usr/bin/ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade" ironic-inspector
     fi
 
     touch $STATE_DIR/ironic_db_migrated

--- a/git-conventional-commits.yaml
+++ b/git-conventional-commits.yaml
@@ -13,7 +13,7 @@ convention:
   - chore    # Miscellaneous commits e.g. modifying `.gitignore`
   - merge
   - revert
-  commitScopes: ["cinder", "glance", "heat", "keystone", "neutron", "nova", "sbom","security","watcher","hex_sdk","cubectl","etcd","keycloak","make","build","new","docker","deps","readme","bump","haproxy","ci","tests","docs","ui","api","ceph","hex_install","app frameworks","rancher","k3s","bootstrap","sec","rc","gpu","git","elk","hex_fixpack_install","terraform","prometheus","kernel","skyline","jail","hex_cli","hex_config","telegraf","mongodb","fixpack_history","cve-2026-21721","pcs","provider","changelog","rolling-upgrade","senlin","appctl","cube_sdk_library","app","kapacitor","httpd","log","appfw","alert","hex_translate","license","ci","pr","oci image","linux","typo"]
+  commitScopes: ["cinder", "glance", "heat", "ironic", "keystone", "neutron", "nova", "sbom","security","watcher","hex_sdk","cubectl","etcd","keycloak","make","build","new","docker","deps","readme","bump","haproxy","ci","tests","docs","ui","api","ceph","hex_install","app frameworks","rancher","k3s","bootstrap","sec","rc","gpu","git","elk","hex_fixpack_install","terraform","prometheus","kernel","skyline","jail","hex_cli","hex_config","telegraf","mongodb","fixpack_history","cve-2026-21721","pcs","provider","changelog","rolling-upgrade","senlin","appctl","cube_sdk_library","app","kapacitor","httpd","log","appfw","alert","hex_translate","license","ci","pr","oci image","linux","typo"]
 changelog:
   commitTypes:
   - feat


### PR DESCRIPTION
Moves ironic and ironic-inspector off the CentOS Stream 9 RDO SIG RPMs and into
the python 3.10 venv at `/opt/openstack-antelope`, following the layout the
keystone, glance, cinder, nova and neutron upgrades already established.

    ironic            20.x -> 21.4.4    (last 2023.1 revision)
    ironic-inspector  10.x -> 11.4.1    (last 2023.1 revision)

Fixes #610.

## Commits in this PR

| commit | what |
|---|---|
| `58f6ddb0` | add `ironic` to the conventional commit scope list |
| `799f1e27` | lock the whole libvirt tree so the `-14` pin actually holds |
| `815823d3` | pin `networking-baremetal` to the 2023.1 series |
| `f644c09c` | the ironic upgrade itself |
| `1f10a5a6` | keep the existing ironic config when cluster addresses are unresolved |
| `da269581` | derive cube_scan's role from the tuning, not the observer static |

The three fixes are ordered before / after the upgrade deliberately: the scope
entry and the libvirt lock are prerequisites for `f644c09c` to build at all, so
they come first and every commit in the branch builds on its own.

## PR boundary

- **`799f1e27` also exists on the #608 branch** (as `d90b8771`, byte-identical
  patch). Whichever of the two merges first, the other disappears on rebase. It
  is included here because `f644c09c` cannot build without it: adding packages
  to `ROOTFS_DNF` changes the download set, which is what flips the latent
  duplicate-removal bug.
- **`58f6ddb0` touches the same `commitScopes` line as #608's `0fb65c96`**
  (which adds `heat`). Whichever merges second has to re-apply its own entry.
- **`815823d3` fixes something #615 left behind** — `neutron.mk` pip installs
  `networking-baremetal` with no version and the constraints file did not pin
  it. `networking-baremetal 8.0.0` (2026-07-28) requires `neutron>=27.0.0.0rc1`
  against our `neutron==22.2.1`, so pip had to backtrack and the resolved
  version depended on the state of PyPI at build time. It is in this PR because
  that package provides the `ironic-neutron-agent` binary ironic starts.
- **`da269581` touches `core/modules/config_cube_scan.cpp`**, which is outside
  ironic. It is here because ironic is the only service that can reach the bug
  (see below) and because the fix and its evidence belong together. Happy to
  split it out if you would rather review it separately.

## The cube_scan bug, and why only ironic hits it

`cube_scan` publishes `MGMT_ADDR`, `SHARED_ID`, `EXTERNAL` and friends from
`ParseNew()`. `Commit()` gated that call on `s_eCubeRole`, a file-static whose
only assignment is in `NotifyCube()` — an observer on cubesys that does not fire
when the commit leaves cubesys untouched. So a commit that changes only some
other module's tuning left the static unset, `Commit()` returned early,
`ParseNew()` never ran, and every `G(...)` consumer saw the compiled-in defaults
`"0.0.0.0"` / `""`.

**ironic is the only OpenStack service shipping with `enabled=false`**, so it is
the only one whose config is first written *after* bootstrap. Every other
service had its conf written during bootstrap, while the globals were valid, and
is not rewritten afterwards — `config_nova.cpp:321-336` builds its database URI
exactly the same way and is safe only for that reason.

Enabling ironic before the fix wrote `@0.0.0.0/ironic` into `ironic.conf`
(conductor stuck in a DB retry loop) and rewrote the keystone catalog to
`http://0.0.0.0:6385` and `http://:6385` (`EXTERNAL` empty drops the host), so
every baremetal call failed with `No host supplied`. Both were correct until
ironic was enabled.

`1f10a5a6` and `da269581` are complementary rather than alternatives:
`da269581` fixes the full-commit path, while a *scoped* commit
(`hex_config commit <settings> ironic`) never invokes `cube_scan` at all, and
that path stays covered by the guard in `config_ironic.cpp`.

## What was removed, and why

`enabled_hardware_types` is pinned to `ipmi` in `config_ironic.cpp:396` and
rewritten on every `Commit()`, so these had no reachable code path:

- `python3-dracclient`, `python3-scciclient` — Dell iDRAC / Fujitsu irmc drivers
- `openstack-ironic-ui` — a Horizon plugin whose host is still on Yoga
  (deferred to #609)

`sushy` stays: `ironic==21.4.4` requires it directly (`requirements.txt:50`).

Also dropped, with reasons: the RPM's `logrotate` drop-ins (replaced by hex's
`LogRotateConf`), `openstack-ironic.service` (the single-process binary; we run
api + conductor separately), the RDO dnsmasq-tftp-server unit (we ship our own
file-server and inspector-dnsmasq), `openstack-ironic-inspector-conductor.service`
(`standalone = true`), and `ironic-dist.conf` (RDO installs it under
`/usr/share/ironic/` and neither unit references it, so not carrying it is
behaviour-preserving).

Conversely, `ipmitool`, `qemu-img`, `mtools`, `dosfstools` and `xorriso` are now
declared explicitly in `ROOTFS_DNF`. They are what the conductor shells out to
and used to arrive either as RPM weak dependencies (`ipmitool` was only a
`Recommends`) or through other components' RPM sets. `mtools` was not in the
tree at all.

## Changed default that was adopted rather than neutralised

`[conductor]permitted_image_formats` was introduced in 21.4.3 as part of the
**CVE-2024-44082** fixes and defaults to `raw,qcow2,iso`. It is deliberately
left unset here, i.e. the new default is adopted, because those three formats
are the ones the ironic project states as supported and tests against, and
CubeCOS has no existing bare metal usage to stay compatible with. Setting it
back to Yoga behaviour would mean disabling a security fix.

Note for whoever runs bare metal in anger: with `[agent]image_download_source`
at `http` and a glance image, the image goes through the conductor, so the
deep-inspection path applies. Only an `image_source` pointing straight at an
external URL bypasses the conductor cache, and that is what
`[conductor]conductor_always_validates_images` exists for — not enabled here, as
it is a new option that costs extra traffic and disk.

## Verification

Built on `centos9_cubecos_seki_200.13` with `MK_TARGET=distclean iso`,
`RC_BASE=v3.1.10` — `CUBE_3.1.10_20260730-0254_f644c09.iso`.

For the requirement "Migrate configs":

```bash
[cc1 ~]# ls -l /etc/ironic/ /etc/ironic-inspector/
/etc/ironic:            drwxr-xr-x root:ironic
  -rw-r----- root:ironic  ironic.conf          (0640)
  -rw-r----- root:root    ironic.conf.def
  -rw-r----- root:ironic  rootwrap.conf
  rootwrap.d/ironic-utils.filters  0644 root:root
/etc/ironic-inspector:  drwxr-x--- root:ironic-inspector   (0750)
  -rw-r----- root:ironic-inspector  inspector.conf         (0640)
  -rw-r----- root:ironic-inspector  inspector-dist.conf
  -rw-r----- root:ironic-inspector  rootwrap.conf
  rootwrap.d/ironic-inspector.filters  0644 root:root
/etc/sudoers.d/{ironic,ironic-inspector}  0440 root:root

[cc1 ~]# grep -n mysql_wsrep_sync_wait /etc/ironic/ironic.conf /etc/ironic-inspector/inspector.conf
/etc/ironic/ironic.conf:45:mysql_wsrep_sync_wait = 1
/etc/ironic-inspector/inspector.conf:19:mysql_wsrep_sync_wait = 1

[cc1 ~]# cat /etc/logrotate.d/ironic /etc/logrotate.d/ironic-inspector
/var/log/ironic/*.log { daily copytruncate maxsize 128M missingok compress delaycompress notifempty }
/var/log/ironic-inspector/*.log { ... }
```

Database schema is at the 2023.1 head for both — the values match the alembic
heads computed from the sdists (59 and 10 revisions respectively):

```bash
[cc1 ~]# mysql -u root -D ironic -e "select version_num from alembic_version"
4dbec778866e
[cc1 ~]# mysql -u root -D ironic_inspector -e "select version_num from alembic_version"
b55109d5063a
[cc1 ~]# su -s /bin/sh -c "/usr/bin/ironic-status upgrade check" ironic
| Check: Database Index Status               | Result: Success |
| Check: Allocations Name Field Length Check | Result: Success |
| Check: Policy File JSON to YAML Migration  | Result: Success |
```

For the requirement "Adjust service arrangements to fulfill basic
functionalities":

```bash
[cc1 ~]# systemctl is-active openstack-ironic-{api,conductor,inspector} ironic-neutron-agent
active / active / active / active
[cc1 ~]# ss -lntp | grep -E ':6385|:5050'
LISTEN 0.0.0.0:6385  users:(("ironic-api",...))
LISTEN 0.0.0.0:5050  users:(("ironic-inspecto",...))

[cc1 ~]# openstack baremetal driver list
+---------------------+----------------+
| Supported driver(s) | Active host(s) |
| ipmi                | cc1            |
+---------------------+----------------+
[cc1 ~]# openstack baremetal conductor list
| Hostname | Conductor Group | Alive |
| cc1      |                 | True  |

[cc1 ~]# openstack baremetal node create --driver ipmi --name ironic-610-smoke \
           --driver-info ipmi_address=192.0.2.10
ironic-610-smoke  d3580c6e-7a78-44a3-9b82-f4c937ac6abe  enroll
[cc1 ~]# openstack baremetal node show ironic-610-smoke -c driver -c provision_state
ipmi / enroll
[cc1 ~]# openstack baremetal node delete ironic-610-smoke
Deleted node ironic-610-smoke
```

`ipmi` with an RFC 5737 address is used instead of `fake-hardware` on purpose:
`fake_hardware.py:23-32` notes that the fake implementations still have to be
enabled in the configuration, which would mean overriding
`enabled_hardware_types` — a value this module rewrites on every commit. `ipmi`
needs only `ipmi_address` (`ipmitool.py:69-71`), so node CRUD exercises the full
API → conductor → DB path without touching any product setting.

For the requirement "Pass health check":

```bash
[cc1 ~]# hex_cli -v -c boot_mode status
two phase boot... [yes] / standalone services... [ready] / cube services... [ready] / cluster data... [synced]
[cc1 ~]# hex_cli -v -c cluster check
        Baremetal      ok  [ ironic(v) ]
```

The libvirt lock, verified by what the build actually removed:

| | before `799f1e27` | after |
|---|---|---|
| `removed_rpms.txt` (libvirt) | 9 files, all `-14` | 9 files, all `-16` |
| `locked_rpms.txt` (libvirt) | 0 | 27 |
| surviving `RPMS/libvirt*.rpm` | mixed `-14`/`-16` | 27, all `11.10.0-14` |

Image split stays clear of the FAT32 cap — largest `rootfs_0.cgz` is 2.72 GiB of
the 4 GiB limit.

## Not verified here

- Real bare metal enrolment, introspection and provisioning — no hardware
  available. This PR covers packaging and configuration only.
- The Horizon panel (#609) and redfish / iDRAC / irmc hardware types.
- IPA ramdisk build or upgrade — CubeCOS imports the deploy kernel/initramfs.

## Unrelated finding

`cluster check` also reports `Network NG [ neutron(3 metadata not all up) ]` on
this VM. `neutron-ovn-metadata-agent` is crash-looping on
`FailedToDropPrivileges: privsep helper command exited non-zero (1)` because
`/etc/neutron/rootwrap.conf`'s `exec_dirs` has no venv path, so rootwrap resolves
`/usr/bin/privsep-helper` (system python 3.9) for a service running out of the
3.10 venv. That is the same mechanism as #1174, which is still draft and covers
only glance and cinder. Nothing in this branch touches `core/neutron/`.

## Definition of Done

Handbook notes: **bigstack-oss/bigstack-handbook#177** — one architecture topic
for the packaging, plus two known-issues for the bugs this hop exposed
(`cube_scan` globals, and `ROOTFS_DNF` version not being a pin). `handbook
doctor` HIGH=0.
