### PR TITLE
fix(fts): parallel-apply race hardening (ceph, octavia, keycloak, cinder)

### DIFF
--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1493,10 +1493,11 @@ Commit(bool modified, int dryLevel)
             if (HexParseIP(masterIp.c_str(), AF_INET, &v4addr))
                 break;
             else {
-                HexLogWarning("invalid bootstrap ip address, try again");
-                sleep(1);
+                // wait out the master's mon bootstrap (~10 min) instead of failing
+                HexLogWarning("ceph bootstrap mon ip not ready from %s (retry %d), waiting for master's mon", peer.c_str(), retry);
+                sleep(5);
             }
-        } while (retry++ < 10);
+        } while (retry++ < 120);
 
         if (!HexParseIP(masterIp.c_str(), AF_INET, &v4addr)) {
             HexLogError("failed to get ceph monintor bootstrap ip");

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -70,6 +70,7 @@ static const char DBPASS[] = "hhyCDG3IdNmcQaJo";
 CONFIG_GLOBAL_STR_REF(CTRL_IP);
 CONFIG_GLOBAL_STR_REF(SHARED_ID);
 CONFIG_GLOBAL_STR_REF(EXTERNAL);
+CONFIG_GLOBAL_BOOL_REF(IS_MASTER);
 
 // private tunings
 CONFIG_TUNING_BOOL(CINDER_ENABLED, "cinder.enabled", TUNING_UNPUB, "Set to true to enable cinder.", true);
@@ -779,14 +780,16 @@ SetServiceEndpoints(
  * Start Cinder services.
  */
 static void
-StartCinderService(const bool enabled, const bool isHa, const bool isBootstrap)
+StartCinderService(const bool enabled, const bool isHa, const bool isBootstrap, const bool isMaster)
 {
     SystemdCommitService(enabled, API_NAME); // cinder-api
     SystemdCommitService(enabled, SCHL_NAME); // cinder-scheduler
     SystemdCommitService(enabled, BAK_NAME); // cinder-backup
     if (!isHa) {
         SystemdCommitService(enabled, VOL_NAME); // cinder-volume
-    } else if (!isBootstrap) {
+    } else if (!isBootstrap && isMaster) {
+        // cinder-volume is a pacemaker singleton; restart it master-only so
+        // concurrent peers don't race the CIB target-role.
         HexUtilSystemF(0, 0, "pcs resource restart cinder-volume");
     }
 }
@@ -919,7 +922,7 @@ Commit(bool modified, int dryLevel)
     }
 
     // start services
-    StartCinderService(s_enabled, s_ha, IsBootstrap());
+    StartCinderService(s_enabled, s_ha, IsBootstrap(), G(IS_MASTER));
     // wait for services to be up
     std::stringstream enabledHostLine;
     enabledHostLine << BUILTIN_STORAGE_HOST << "@" << BUILTIN_STORAGE_BACKEND;
@@ -961,7 +964,7 @@ RestartMain(int argc, char* argv[])
     if (!IsControl(s_eCubeRole)) {
         return EXIT_SUCCESS;
     }
-    StartCinderService(s_enabled, s_ha, IsBootstrap());
+    StartCinderService(s_enabled, s_ha, IsBootstrap(), G(IS_MASTER));
 
     return EXIT_SUCCESS;
 }

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -287,19 +287,24 @@ updateKeycloak()
         nodeCount = 1;
     }
 
-    const ExecSyncResult r = ExecBashSync(
-        0,
-        false,
-        false,
-        {},
-        std::string()
-            + "/usr/local/bin/helm --kubeconfig=/etc/rancher/k3s/k3s.yaml "
-            + "upgrade --install " + CHART_RELEASE_NAME + " " + KEYCLOAK_CHARTS + " "
-            + "-f " + KEYCLOAK_CHART_VALUES + " "
-            + "-n " + APP_NAMESPACE + " "
-            + "--create-namespace "
-            + "--set replicas=" + std::to_string(nodeCount));
-    return (r.exitCode == 0);
+    const std::string cmd = std::string()
+        + "/usr/local/bin/helm --kubeconfig=/etc/rancher/k3s/k3s.yaml "
+        + "upgrade --install " + CHART_RELEASE_NAME + " " + KEYCLOAK_CHARTS + " "
+        + "-f " + KEYCLOAK_CHART_VALUES + " "
+        + "-n " + APP_NAMESPACE + " "
+        + "--create-namespace "
+        + "--set replicas=" + std::to_string(nodeCount);
+
+    // parallel control-node applies race on the same helm release; retry the
+    // transient "another operation in progress" lock
+    for (int attempt = 0; attempt < 6; attempt++) {
+        const ExecSyncResult r = ExecBashSync(0, false, false, {}, cmd);
+        if (r.exitCode == 0)
+            return true;
+        HexLogWarning("keycloak helm upgrade failed (attempt %d/6); retrying", attempt + 1);
+        sleep(15);
+    }
+    return false;
 }
 
 /**
@@ -483,89 +488,67 @@ Commit(bool modified, int dryLevel)
     bool isKeycloakUpdated = false;
     if ((s_bApplianceModified || !checkKeycloak())
         && isUpdateKeycloakPossible(s_ha, s_hostname, s_ctrlHosts)) {
-        // update keycloak and roll out pods
+        // scale keycloak to one pod per control host + roll out
         HexLogInfo("update keycloak");
-        if (!updateKeycloak()) {
-            HexLogError("failed to update keycloak");
+        if (updateKeycloak()) {
+            HexLogInfo("updated keycloak");
+            isKeycloakUpdated = true;
 
-            // let other modules to commit
-            return true;
-        }
-        HexLogInfo("updated keycloak");
-        isKeycloakUpdated = true;
-
-        // check the roll out status of pods
-        if (!K3sWatchRollOut(APP, APP_NAMESPACE, "3m")) {
-            HexLogError("failed to see all pods rolled out");
+            // check the roll out status of pods
+            if (!K3sWatchRollOut(APP, APP_NAMESPACE, "3m")) {
+                HexLogError("failed to see all pods rolled out");
+            } else {
+                HexLogInfo("keycloak pods were all rolled out");
+            }
         } else {
-            HexLogInfo("keycloak pods were all rolled out");
+            // a lost scale-up race is self-healing (the winner sets replicas);
+            // don't early-return, or we'd skip the metadata gate below
+            HexLogError("failed to update keycloak (scale race?); continuing to saml metadata gate");
         }
     }
 
-    if (isKeycloakUpdated) {
-        // check if the Keycloak endpoint is reachable; an unreachable endpoint is
-        // one way the saml metadata cannot be downloaded, so do not bail out --
-        // defer the cube-groups terraform and fall through to the gate below
-        std::string sharedId = G(SHARED_ID);
-        bool isCubeGroupsApplied = false;
-        if (!checkKeycloakEndpoint(sharedId)) {
-            HexLogError("keycloak endpoint is not ready");
-        } else {
-            // create default cube groups
-            if (!ExecTerraform(
-                    "apply",
-                    "keycloak",
-                    { "cube_controller=" + sharedId },
-                    { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
-                HexLogError("failed to create default cube groups via terraform");
-            }
-            isCubeGroupsApplied = true;
+    // always gate on the SAML metadata file (SSO reads it): the commit must not
+    // report success without it. Needs only keycloak reachable, not this node's
+    // own upgrade. Retry until present, or the operator releases the gate.
+    std::string sharedId = G(SHARED_ID);
+    time_t lastNotify = time(NULL);
+    while (!hasKeycloakSamlMetadataFile()) {
+        if (downloadKeycloakSamlMetadata(sharedId))
+            break;
+        HexLogError("failed to download the saml metadata from keycloak");
+
+        if (access(SAML_METADATA_GATE_RELEASE, F_OK) == 0) {
+            unlink(SAML_METADATA_GATE_RELEASE);
+            HexLogWarning("saml metadata gate released by operator via %s;"
+                          " proceeding without %s (SSO will be degraded)",
+                          SAML_METADATA_GATE_RELEASE, KEYCLOAK_SAML_METADATA_FILE);
+            break;
         }
 
-        // pull down the saml metadata and save it to /etc/keycloak/saml-metadata.xml.
-        // keystone_idp, rancher and the ceph dashboard all configure SSO from this
-        // file, so never proceed without it: retry forever and notify the console
-        // every SAML_METADATA_STUCK_NOTIFY_SECS while stuck. An operator can
-        // release the gate by touching SAML_METADATA_GATE_RELEASE (one-shot).
-        time_t lastNotify = time(NULL);
-        while (!hasKeycloakSamlMetadataFile()) {
-            if (downloadKeycloakSamlMetadata(sharedId))
-                break;
-            HexLogError("failed to download the saml metadata from keycloak");
-
-            if (access(SAML_METADATA_GATE_RELEASE, F_OK) == 0) {
-                unlink(SAML_METADATA_GATE_RELEASE);
-                HexLogWarning("saml metadata gate released by operator via %s;"
-                              " proceeding without %s (SSO will be degraded)",
-                              SAML_METADATA_GATE_RELEASE, KEYCLOAK_SAML_METADATA_FILE);
-                break;
-            }
-
-            if (time(NULL) - lastNotify >= SAML_METADATA_STUCK_NOTIFY_SECS) {
-                HexLogWarning("keycloak saml metadata download is stuck; notified the console");
-                HexSystemF(0,
-                    "echo 'CUBE: setup is waiting for the keycloak SAML metadata"
-                    " (https://%s:%d/auth/realms/master/protocol/saml/descriptor)"
-                    " and cannot proceed until it is downloaded."
-                    " Check keycloak and k3s."
-                    " To skip and continue with degraded SSO, run: touch %s' > /dev/console",
-                    sharedId.c_str(), K3S_INGRESS_HTTPS_PORT, SAML_METADATA_GATE_RELEASE);
-                lastNotify = time(NULL);
-            }
-
-            sleep(10);
+        if (time(NULL) - lastNotify >= SAML_METADATA_STUCK_NOTIFY_SECS) {
+            HexLogWarning("keycloak saml metadata download is stuck; notified the console");
+            HexSystemF(0,
+                "echo 'CUBE: setup is waiting for the keycloak SAML metadata"
+                " (https://%s:%d/auth/realms/master/protocol/saml/descriptor)"
+                " and cannot proceed until it is downloaded."
+                " Check keycloak and k3s."
+                " To skip and continue with degraded SSO, run: touch %s' > /dev/console",
+                sharedId.c_str(), K3S_INGRESS_HTTPS_PORT, SAML_METADATA_GATE_RELEASE);
+            lastNotify = time(NULL);
         }
 
-        // create default cube groups, deferred from above when the endpoint check
-        // failed; a successful metadata download implies the endpoint answers now
-        if (!isCubeGroupsApplied) {
-            if (!ExecTerraform(
-                    "apply",
-                    "keycloak",
-                    { "cube_controller=" + sharedId },
-                    { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
-                HexLogError("failed to create default cube groups via terraform");
-            }
+        sleep(10);
+    }
+
+    // create default cube groups (owned by the node that scaled keycloak),
+    // gated on the endpoint being reachable. Idempotent.
+    if (isKeycloakUpdated && checkKeycloakEndpoint(sharedId)) {
+        if (!ExecTerraform(
+                "apply",
+                "keycloak",
+                { "cube_controller=" + sharedId },
+                { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
+            HexLogError("failed to create default cube groups via terraform");
         }
     }
 

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -703,6 +703,8 @@ ReinitMain(int argc, char* argv[])
     if (G(IS_MASTER)) {
         std::string cidr = GetMgmtCidr(s_mgmtCidr.newValue(), 0);
         HexUtilSystemF(0, 0, HEX_SDK " os_octavia_init %s", cidr.c_str());
+        // cluster_start is master-only; drive per-node octavia init on the peers
+        HexUtilSystemF(0, 0, HEX_SDK " os_octavia_init_peers");
     }
     if (IsCompute(s_eCubeRole)) {
         std::string sharedId = G(SHARED_ID);

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1555,6 +1555,19 @@ os_octavia_init()
     fi
 }
 
+# Master drives reinit_octavia on each other first-three-compute node so the
+# peers create their health-mgr port + o-hm0 (cluster_start is master-only; a
+# non-master reinit skips the master-only network setup). Idempotent.
+os_octavia_init_peers()
+{
+    for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
+        [ "$node" = "$(hostname)" ] && continue
+        if remote_run $node hex_sdk is_first_three_compute_node ; then
+            Quiet -n remote_run $node hex_config reinit_octavia
+        fi
+    done
+}
+
 os_octavia_node_init()
 {
     if [ ! -f /run/cube_commit_done  ] ; then


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
On a fresh **HA** first-time setup all control nodes apply policy in parallel, so several cluster-wide / master-only operations race and leave `cluster check` NG until the first `check_repair`. Four fixes, one commit each:

- **ceph** — a peer's apply can start before the master's mon bootstraps; wait it out (mon-IP resolve retry 5s × 120, ~10 min) instead of failing the apply.
- **octavia** — `cluster_start`'s `reinit_octavia` is master-only, so peers never create their health-mgr port + `o-hm0`; the master fans `reinit_octavia` out to each other first-three-compute node (`os_octavia_init_peers`).
- **keycloak** — every control node scales the same helm release, racing the "another operation in progress" lock; retry 6× / 15s, and stop masking a lost race with an early return that skipped the SAML-metadata gate. The gate now always runs (it only needs keycloak reachable), so the commit never reports success without `saml-metadata.xml`.
- **cinder** — concurrent `pcs resource restart cinder-volume` from each peer races the CIB target-role and can strand the singleton disabled; gate the restart on `IS_MASTER`.

#### Which issue(s) this PR fixes

Part of #1195 — the config-history git-init sub-item is **removed** from this PR (see below) and stays open there for a correct fix, so this PR does not close #1195.

#### Special notes for your reviewer

> Validated on the lab (1cc R630 + 3cc sky HA). The git-init changes originally bundled here were dropped: master-only `git_init` doesn't cover HA peers, and the peer `reset --hard` wiped unstaged config drift the git client deliberately preserves. The ceph_mds git NG self-heals per-node via auto-repair; the correct proactive fix is still open in #1195.

#### Additional documentation

```docs
kb/cubecos/architecture/fts-parallel-apply-races.md — the race class and the master-first / fan-out / idempotent-retry patterns behind each fix.
```
