### PR TITLE
phone-home-agent: pass --pxe-root to the embedded driver

### DIFF
--- a/core/phone-home-agent/cube-cos-driver.service
+++ b/core/phone-home-agent/cube-cos-driver.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/cube-cos-driver --port 3001 --data-dir /var/lib/cube-cos-driver --export-dir /var/ftpboot
+ExecStart=/usr/local/bin/cube-cos-driver --port 3001 --data-dir /var/lib/cube-cos-driver --export-dir /var/ftpboot --pxe-root /var/ftpboot
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
Add `--pxe-root /var/ftpboot` to `cube-cos-driver.service` ExecStart so the embedded pxeserver driver can enumerate its GRUB images and offer the deploy/inspect image dropdown (cube-cos-driver#23). The appliance driver owns /var/ftpboot locally — air-gap safe. `--advertise` intentionally omitted (single driver; grub `driver_server=` already correct).

#### Which issue(s) this PR fixes

Fixes #1196

#### Special notes for your reviewer

> One-line service change; no build impact.

#### Additional documentation

```docs
N/A (internal service flag)
```