### PR TITLE
feat(horizon): upgrade horizon from yoga to antelope

### DIFF
--- a/core/cyborg/cyborg_sudoers
+++ b/core/cyborg/cyborg_sudoers
@@ -1,8 +1,7 @@
 Defaults:cyborg !requiretty
 
-# TEMPORARY: cyborg runs out of the antelope venv, so [cyborg_sys_admin]
-# helper_command pins the venv privsep-helper. The system-python
-# /usr/bin/privsep-helper cannot import cyborg, so it is deliberately not
-# allowed here. Drop the venv path once the system-python console scripts
-# are gone and /usr/bin/privsep-helper is the venv one again.
-cyborg ALL = (root) NOPASSWD: /opt/openstack-antelope/bin/privsep-helper *
+# This is what [cyborg_sys_admin] helper_command in cyborg.conf points at.
+# /usr/bin/privsep-helper is a symlink to the venv helper as of the Horizon hop, so
+# the venv path this used to authorise is no longer needed -- the condition that
+# comment was waiting for ("once /usr/bin/privsep-helper is the venv one again") is met.
+cyborg ALL = (root) NOPASSWD: /usr/bin/privsep-helper *

--- a/core/designate/designate.mk
+++ b/core/designate/designate.mk
@@ -38,13 +38,6 @@ rootfs_install::
 		-r /tmp/designate/designate-dashboard/requirements.txt
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/designate/designate-dashboard && \
 		/opt/openstack-antelope/bin/python setup.py install"
-	$(Q)# The horizon plugin has to live in the system python as well: horizon runs
-	$(Q)# under python3.9, so the enabled/*.py files below resolve designatedashboard
-	$(Q)# there. A venv-only install makes ADD_INSTALLED_APPS fail to import and
-	$(Q)# takes down the whole dashboard, not just the DNS panels.
-	$(Q)# Remove once horizon itself moves into the venv.
-	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/designate/designate-dashboard && \
-		/usr/bin/python3 -m pip install --no-deps ."
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 	$(Q)# Link binaries
@@ -87,12 +80,6 @@ rootfs_install::
 
 rootfs_install::
 	$(Q)[ -d $(DESIGNATE_BIN_PATCHDIR) ] && cp -rf $(DESIGNATE_BIN_PATCHDIR)/* $(DESIGNATE_BINDIR)/ || /bin/true
-
-# for designate-dashboard
-rootfs_install::
-	$(Q)cp -f $(ROOTDIR)/tmp/designate/designate-dashboard/designatedashboard/enabled/_1710_project_dns_panel_group.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
-	$(Q)cp -f $(ROOTDIR)/tmp/designate/designate-dashboard/designatedashboard/enabled/_1721_dns_zones_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
-	$(Q)cp -f $(ROOTDIR)/tmp/designate/designate-dashboard/designatedashboard/enabled/_1722_dns_reversedns_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
 
 # clean up the build directory
 rootfs_install::

--- a/core/designate/designate.mk
+++ b/core/designate/designate.mk
@@ -3,6 +3,20 @@
 
 ROOTFS_DNF += bind bind-utils
 
+# python3-designateclient stays a yoga rpm under the *system* python 3.9. It owns the
+# "dns" osc plugin entry point that /usr/bin/openstack -- still `#!/usr/bin/python3` --
+# resolves, and hex_sdk's health_designate_check() drives
+# `openstack dns service list` through it, counting the api/central/worker/producer/mdns
+# rows that report UP.
+#
+# It has to be named here because it used to arrive in 3.9 only as a side effect of the
+# yoga horizon closure that #609 removed. Nothing in this tree ever asked for it, so it
+# disappeared silently and `cluster check` reported "DNSaaS NG [ designate(9 api not all
+# up) ]" while every designate unit was active -- the check could not run its query at
+# all. Every other service hex_sdk drives this way already names its client explicitly:
+# heat and manila and octavia as rpms, watcher as an explicit pip install.
+ROOTFS_DNF_NOARCH += python3-designateclient
+
 NAMED_CONF_FILES := /etc/named*
 NAMED_APP_DIR := /var/named
 

--- a/core/designate/designate.mk
+++ b/core/designate/designate.mk
@@ -33,8 +33,10 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/designate/designate && \
 		/opt/openstack-antelope/bin/python setup.py install"
 	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(NEXT_OPS_GITHUB_BRANCH_02) --depth 1 $(DESIGNATE_DASHBOARD_REPO_URL) /tmp/designate/designate-dashboard
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
 		-r /tmp/designate/designate-dashboard/requirements.txt
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/designate/designate-dashboard && \
 		/opt/openstack-antelope/bin/python setup.py install"

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -133,8 +133,10 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
 		heat-dashboard==$(HEAT_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -16,16 +16,20 @@ ROOTFS_DNF_NOARCH += python3-heatclient
 # shadow-utils, for the heat user and group, and core/heavyfs/account/centos9
 # already carries heat statically.
 #
-# openstack-heat-ui, the Horizon dashboard plugin, is deliberately no longer
-# installed: Horizon imports it and Horizon still runs on the system python 3.9,
-# so it cannot follow heat into the 3.10 venv. Restoring the Orchestration panel
-# belongs to #609 (Upgrade Horizon from Yoga to Antelope), whose acceptance
-# criteria already cover "Ensure other panels are functioning on the dashboard".
+# openstack-heat-ui, the Horizon dashboard plugin, is replaced by the
+# heat-dashboard wheel installed further down. It was dropped when heat moved to
+# pip because horizon was still on python 3.9; #609 moved horizon into the venv, so
+# the Orchestration panels come back here.
 
 HEAT_CONFDIR := $(ROOTDIR)/etc/heat
 
 # the release is needed twice: once to pin the wheel, once for [revision] heat_revision
 HEAT_VER := 20.0.1
+
+# https://releases.openstack.org/antelope/index.html -- last numeric 2023.1
+# revision. Horizon plugins are not in the antelope upper-constraints (that file
+# only covers libraries), so the pin has to be explicit.
+HEAT_DASHBOARD_VER := 9.0.0
 
 # install heat
 rootfs_install::
@@ -121,3 +125,16 @@ rootfs_install::
 # section names, which is what carries heat_revision into every regenerated heat.conf.
 rootfs_install::
 	$(Q)cp -f $(HEAT_CONFDIR)/heat.conf $(HEAT_CONFDIR)/heat.conf.def
+
+# install the heat web ui plugin, the openstack-heat-ui rpm's replacement.
+# Registering its panels, settings snippet and policy files is core/horizon's job:
+# every dashboard action lives there, because horizon is built last and is what runs
+# collectstatic and compress.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		heat-dashboard==$(HEAT_DASHBOARD_VER)
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -199,6 +199,31 @@ rootfs_install::
 	$(Q)cp -f $(NEXT_OPENSTACK_PIP_CONSTRAINT) $(ROOTDIR)/opt/openstack-antelope/
 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) wheel
 
+# NOTE: setuptools in this venv is pinned to 65.7.0 by the constraints file -- the
+# version antelope's own upper-constraints names -- because setuptools 82 deleted
+# pkg_resources and the 2023-era services still import it (see cubecos#607/#1080).
+#
+# That pin does *not* reach pip's PEP-517 build environments. pip builds every sdist
+# in a throwaway overlay and resolves the default backend requirement
+# "setuptools>=40.8.0" against the live index, so an sdist gets whatever setuptools
+# exists today (83.0.0 at the time of writing) no matter what -c says. Verified: with
+# PIP_CONSTRAINT set as well, the overlay still installs 83.0.0.
+#
+# The consequence, for anything installing horizon: nine of its dependencies are
+# sdist-only, and seven of those are XStatic packages whose setup.py imports a
+# pkg_resources-declared namespace, so they die in the overlay with
+# "ModuleNotFoundError: No module named 'pkg_resources'". The fix is
+# --no-build-isolation, which builds against this venv's own 65.7.0 instead. It is
+# spelled out on each pip install that needs it rather than turned on venv-wide,
+# because the requirement is not universal -- mysqlclient 2.2.8 is the counter-example
+# and needs a setuptools *newer* than 65.7.0, so it keeps the default isolation.
+#
+# One ordering caveat: with --no-build-isolation an XStatic sdist can only be built
+# while no other XStatic package is installed yet, or the installed pkg_resources
+# namespace shadows the source tree and setup.py fails with "cannot import name ...
+# from 'xstatic.pkg' (unknown location)". A single pip invocation is fine -- pip
+# builds every sdist before installing any of them.
+
 # Allow admin to be sudoers
 rootfs_install::
 	$(Q)mkdir -p $(ROOTDIR)/etc/sudoers.d

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -15,7 +15,12 @@ OSP_LOCAL_SRCDIR := $(ROOTDIR)/usr/local/lib/python3.9/site-packages/
 OSP_PATCHDIR := $(SRCDIR)/$(OPENSTACK_RELEASE)_patch
 
 HORIZON_APP_DIR := /usr/share/openstack-dashboard
-HORIZON_DIR := $(HORIZON_APP_DIR)/openstack_dashboard
+# horizon moved into the python 3.10 venv in #609. $(HORIZON_APP_DIR) still holds
+# manage.py, the collected static tree and an openstack_dashboard symlink for
+# compatibility, but HORIZON_DIR has to name the real package directory: that symlink
+# points at an absolute path inside the image, so a plain cp from the build host would
+# follow it out to the *host* root instead of into $(ROOTDIR).
+HORIZON_DIR := $(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages/openstack_dashboard
 HORIZON_ETCDIR := /etc/openstack-dashboard
 HORIZON_POLICY_DIR := $(HORIZON_ETCDIR)/default_policies
 

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -14,16 +14,6 @@ OSP_SRCDIR := $(ROOTDIR)/usr/lib/python3.9/site-packages/
 OSP_LOCAL_SRCDIR := $(ROOTDIR)/usr/local/lib/python3.9/site-packages/
 OSP_PATCHDIR := $(SRCDIR)/$(OPENSTACK_RELEASE)_patch
 
-HORIZON_APP_DIR := /usr/share/openstack-dashboard
-# horizon moved into the python 3.10 venv in #609. $(HORIZON_APP_DIR) still holds
-# manage.py, the collected static tree and an openstack_dashboard symlink for
-# compatibility, but HORIZON_DIR has to name the real package directory: that symlink
-# points at an absolute path inside the image, so a plain cp from the build host would
-# follow it out to the *host* root instead of into $(ROOTDIR).
-HORIZON_DIR := $(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages/openstack_dashboard
-HORIZON_ETCDIR := /etc/openstack-dashboard
-HORIZON_POLICY_DIR := $(HORIZON_ETCDIR)/default_policies
-
 ROOTFS_PIP += numpy
 BLKLST_DNF += iptables-legacy iptables-legacy-libs python3-django3 ceph-mgr-k8sevents
 BLKLST_DNF += python3-PyMySQL   # CVE-2024-36039 Upgrade to version: 1.1.1

--- a/core/horizon/gunicorn-config.py
+++ b/core/horizon/gunicorn-config.py
@@ -1,0 +1,40 @@
+# gunicorn settings for the horizon dashboard.
+#
+# Horizon moved into the python 3.10 venv at /opt/openstack-antelope, and
+# mod_wsgi is built against the system python 3.9, so httpd can no longer host
+# the application in-process. It reverse-proxies this socket instead, the same
+# arrangement keystone, barbican and monasca-api already use.
+
+# apache is both the socket's owner and its only client, so the default umask
+# is enough here -- unlike monasca and barbican, which need a group-writable
+# socket because their application runs as a different user than httpd.
+bind = "unix:/var/lib/openstack-dashboard/horizon.socket"
+user = "apache"
+group = "apache"
+
+# httpd strips the /horizon prefix before proxying (ProxyPass maps /horizon onto
+# the socket root), so gunicorn has to put it back: horizon's URLconf is rooted
+# at '' and WEBROOT only prefixes LOGIN_URL, STATIC_URL and MEDIA_URL, not the
+# reverse() output. WSGIScriptAlias used to supply SCRIPT_NAME for free.
+# gunicorn reads it from the environment; the systemd unit exports it.
+
+# The mod_wsgi setup this replaces ran on WSGIDaemonProcess defaults: one
+# process, 15 threads. gthread with a handful of workers is the closer match to
+# that -- it is what makes threads meaningful -- and it survives a worker dying
+# mid-request, which the single-process layout did not.
+workers = 4
+threads = 8
+worker_class = "gthread"
+
+# Django renders some of the admin tables (hypervisors, instances across all
+# projects) with several sequential API calls behind them, so the 30s barbican
+# and monasca use is too tight here.
+timeout = 60
+backlog = 2048
+keepalive = 2
+proc_name = "horizon"
+
+# gunicorn's own log goes to the file the unit appends to. The application logs
+# separately through LOGGING in local_settings, and apache already records the
+# access log.
+loglevel = "info"

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -41,12 +41,25 @@ $(PROJ_HEAVYFS): $(COREDIR)/horizon/local_settings.in $(CUBE_THEME_SRCS)
 #   - pymemcache backs the PyMemcacheCache cache backend. python-memcached is in
 #     the venv already, but MemcachedCache is removed in django 4.1 and there is
 #     no reason to move onto a dead backend now.
+#
+# These are two pip invocations rather than one because the two halves want opposite
+# build environments, and a single command can only have one. See the note by the venv
+# bootstrap in core/heavyfs/Makefile for the whole story.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# horizon's sdist-only XStatic dependencies import a pkg_resources-declared
+	$(Q)# namespace from setup.py, so they have to be built against this venv's
+	$(Q)# setuptools 65.7.0 -- a current setuptools has no pkg_resources at all.
 	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
 		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-			horizon==$(HORIZON_VER) \
+			--no-build-isolation \
+			horizon==$(HORIZON_VER)"
+	$(Q)# mysqlclient is the counter-example: it is also a source build, but its
+	$(Q)# pyproject.toml is newer than setuptools 65.7.0 can parse, so it keeps pip's
+	$(Q)# default build isolation and gets a current setuptools of its own.
+	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 			mysqlclient==$(MYSQLCLIENT_VER) \
 			pymemcache"
 	$(Q)# clean up dns configurations after downloading packages

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -163,8 +163,9 @@ rootfs_install::
 	$(Q)cp -f $(HORIZON_VENV_SP)/watcher_dashboard/conf/watcher_policy.json $(ROOTDIR)/$(HORIZON_DIR)/conf/
 	$(Q)# neutron-vpnaas-dashboard
 	$(Q)cp -f $(HORIZON_VENV_SP)/neutron_vpnaas_dashboard/enabled/_7100_project_vpn_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
-	$(Q)# TODO(#609): octavia-dashboard, see core/octavia/octavia.mk.
-	$(Q)# cp -f $(HORIZON_VENV_SP)/octavia_dashboard/enabled/_1482_project_load_balancer_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)# octavia-dashboard
+	$(Q)cp -f $(HORIZON_VENV_SP)/octavia_dashboard/enabled/_1482_project_load_balancer_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/octavia_dashboard/local_settings.d/_1499_load_balancer_settings.py $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d/
 
 # The yaml files under $(HORIZON_POLICY_DIR) that local_settings.in's
 # DEFAULT_POLICY_FILES points at came from the openstack-dashboard rpm, and the
@@ -174,7 +175,7 @@ rootfs_install::
 # manage.py only exists once the step above has installed it.
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_POLICY_DIR)
-	$(Q)for ns in keystone nova cinder glance neutron masakari ; do \
+	$(Q)for ns in keystone nova cinder glance neutron masakari octavia ; do \
 		chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py \
 			dump_default_policies --namespace $$ns \
 			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml 2>&1 > /dev/null ; \

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -1,42 +1,186 @@
 # Cube SDK
 # horizon installation
 
-ROOTFS_DNF += python3-mysqlclient
-ROOTFS_DNF_NOARCH +=  openstack-dashboard
+# https://releases.openstack.org/antelope/index.html#antelope-horizon
+HORIZON_VER := 23.1.1
+
+# Not in the antelope upper-constraints, so pinned here for reproducibility. This is
+# also a source build (see core/mysql/mysql.mk), which is the other reason not to
+# leave it floating.
+MYSQLCLIENT_VER := 2.2.8
+
 HORIZON_THEME_DIR := $(HORIZON_DIR)/themes
 CUBE_THEME_SRCDIR := $(COREDIR)/horizon/theme
 CUBE_THEME_DSTDIR := $(HORIZON_THEME_DIR)/cube
 
+HORIZON_LOG_DIR := /var/log/horizon
+HORIZON_APP_STATE_DIR := /var/lib/openstack-dashboard
 
-# Red Hat Common User Experience (RCUE) https://github.com/redhat-rcue/rcue
-RCUE_THEME_DSTDIR := $(HORIZON_THEME_DIR)/rcue
+# Where each dashboard plugin ends up in the venv. Every plugin is pip installed by
+# the component that owns it -- heat-dashboard by heat.mk, ironic-ui by ironic.mk,
+# manila-ui by manila.mk, designate/masakari/watcher/neutron-vpnaas from git by
+# theirs -- and all of them land here.
+HORIZON_VENV_SP := $(ROOTDIR)$(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages
 
 CUBE_THEME_SRCS := $(shell find $(CUBE_THEME_SRCDIR) -type f 2>/dev/null)
 
 $(PROJ_HEAVYFS): $(COREDIR)/horizon/local_settings.in $(CUBE_THEME_SRCS)
 
+# install horizon inside the python 3.10 virtual environment
+#
+# The rpms this replaces are openstack-dashboard, openstack-dashboard-theme and
+# python3-django-horizon. Each dashboard plugin is pip installed by the component
+# that owns it; registering the panels and running manage.py is this file's job, and
+# horizon is built last so all of it happens once every plugin is in the venv.
+#
+# Two dependencies that are not horizon requirements and so have to be named:
+#   - mysqlclient replaces the python3-mysqlclient rpm. local_settings.in uses
+#     django.db.backends.mysql for the cached_db session store, and that backend
+#     imports MySQLdb. PyMySQL is already in the venv but django 3.2 rejects it:
+#     it wants MySQLdb >= 1.4.0 and PyMySQL reports 1.0.2.
+#   - pymemcache backs the PyMemcacheCache cache backend. python-memcached is in
+#     the venv already, but MemcachedCache is removed in django 4.1 and there is
+#     no reason to move onto a dead backend now.
 rootfs_install::
-# FIXME:
-#	$(Q)cd $(ROOTDIR) && rpm2cpio $(BLDDIR)/RPMS/openstack-dashboard-$(RHOSP_RELEASE)*.rpm | cpio -idmv "*/locale/*"
-	$(Q)chroot $(ROOTDIR) ln -sf /usr/local/lib/python3.9/site-packages/horizon /usr/share/openstack-dashboard/horizon
-	$(Q)mkdir -p $(ROOTDIR)/$(HORIZON_DIR)/conf
-	$(Q)cp -f $(ROOTDIR)/$(HORIZON_ETCDIR)/local_settings $(ROOTDIR)/$(HORIZON_ETCDIR)/local_settings.orig
-	$(Q)cp -f $(ROOTDIR)/etc/httpd/conf.d/openstack-dashboard.conf $(ROOTDIR)/etc/httpd/conf.d/openstack-dashboard.conf.orig
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+		pip install -c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			horizon==$(HORIZON_VER) \
+			mysqlclient==$(MYSQLCLIENT_VER) \
+			pymemcache"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+
+# lay out /usr/share/openstack-dashboard
+#
+# horizon and openstack_dashboard are symlinks into the venv rather than copies:
+# gunicorn imports them from site-packages either way, so a copy would only go
+# stale. The horizon symlink already worked this way when the target was python
+# 3.9.
+#
+# manage.py is installed from this directory. The openstack-dashboard rpm shipped
+# it; the horizon wheel does not, and there is no console_script equivalent.
+#
+# STATIC_ROOT is pinned to $(HORIZON_APP_DIR)/static in local_settings.in. Horizon
+# would otherwise derive it from the package location and collect 51MB of static
+# assets into the venv, where openstack-dashboard.conf does not alias it.
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_APP_DIR)
+	$(Q)$(INSTALL_DATA) -f $(ROOTDIR) $(COREDIR)/horizon/manage.py .$(HORIZON_APP_DIR)/manage.py
+	$(Q)chroot $(ROOTDIR) chmod 755 $(HORIZON_APP_DIR)/manage.py
+	$(Q)chroot $(ROOTDIR) ln -sfn $(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages/horizon $(HORIZON_APP_DIR)/horizon
+	$(Q)chroot $(ROOTDIR) ln -sfn $(HORIZON_DIR) $(HORIZON_APP_DIR)/openstack_dashboard
+
+# settings
+#
+# The local_settings.py symlink is what makes settings.py's `from
+# local.local_settings import *` pick up /etc/openstack-dashboard/local_settings.
+# The rpm created the same link; nothing in the wheel does.
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_ETCDIR)
+	$(Q)chroot $(ROOTDIR) ln -sfn $(HORIZON_ETCDIR)/local_settings $(HORIZON_DIR)/local/local_settings.py
 	$(Q)cp -f $(COREDIR)/horizon/local_settings.in $(ROOTDIR)/$(HORIZON_ETCDIR)/
-	$(Q)cp -f $(COREDIR)/horizon/openstack-dashboard.conf $(ROOTDIR)/etc/httpd/conf.d/
 	$(Q)echo "AVAILABLE_THEMES = [ ('cube', 'Cube Theme', 'themes/cube') ]" >> $(ROOTDIR)/$(HORIZON_ETCDIR)/local_settings.in
 	$(Q)echo "DEFAULT_THEME = 'cube'" >> $(ROOTDIR)/$(HORIZON_ETCDIR)/local_settings.in
+	$(Q)# config_horizon.cpp regenerates local_settings from local_settings.in on
+	$(Q)# every Commit(), so these build-time values never reach a running node.
+	$(Q)# They do have to parse, though: collectstatic and compress below import
+	$(Q)# the settings module, and PyMemcacheCache splits LOCATION on ":" where the
+	$(Q)# MemcachedCache backend it replaces accepted anything.
 	$(Q)sed \
 		-e 's/@CONTROLLER@/localhost/' -e 's/@TIME_ZONE@/America\/New_York/' \
+		-e 's/@SHARED_ID@/localhost/' -e "s/'@CACHE_SERVERS@'/'localhost:11211'/" \
+		-e 's/@DOMAIN@/Default/' -e 's/@HORIZON_DB_PASSWORD@/horizon_dbpass/' \
 		$(ROOTDIR)/$(HORIZON_ETCDIR)/local_settings.in > $(ROOTDIR)/$(HORIZON_ETCDIR)/local_settings
 
+# cube theme
 rootfs_install::
 	$(Q)cp -rf $(CUBE_THEME_SRCDIR) $(ROOTDIR)/$(CUBE_THEME_DSTDIR)
 
+# register every plugin's panels, settings snippets and policy files
+#
+# All of this is horizon's job rather than each component's, and horizon is built
+# last, so by now every plugin is in the venv. Each file is taken out of
+# site-packages -- i.e. out of the release that is actually installed, never out of a
+# different one. designate 2023.1, for instance, dropped the
+# `from designatedashboard import exceptions` block from its own enabled/*.py, and a
+# stale copy breaks the import and takes down the whole dashboard rather than one
+# panel.
+#
+# Notes on the less obvious entries:
+#   - heat-dashboard's _1699_orchestration_settings.py and manila-ui's policy files
+#     have to be here or horizon logs "No policy rules for service
+#     'orchestration'/'share'" on every start and denies those panels.
+#   - the policy yaml files go next to horizon's own because POLICY_FILES_PATH is
+#     <openstack_dashboard>/conf; the snippets reference them by bare filename.
+#   - manila-ui also ships a _90_manila_shares.py. core/manila's copy replaces it
+#     under the same name and is deliberately applied last: it narrows
+#     enabled_share_protocols to what the generic driver actually serves.
+#   - ironic-ui and neutron-vpnaas-dashboard ship one enabled/*.py each and no policy
+#     file.
+#   - watcher_policy.json is json, not yaml. oslo.policy warns about that on load;
+#     it is what watcher-dashboard 2023.1 ships.
 rootfs_install::
-	$(Q)chroot $(ROOTDIR) python3 /usr/share/openstack-dashboard/manage.py compilemessages 2>&1 > /dev/null
-	$(Q)chroot $(ROOTDIR) python3 /usr/share/openstack-dashboard/manage.py collectstatic --noinput 2>&1 > /dev/null
-	$(Q)chroot $(ROOTDIR) python3 /usr/share/openstack-dashboard/manage.py compress --force 2>&1 > /dev/null
-	$(Q)chroot $(ROOTDIR) chmod 755 -R /usr/share/openstack-dashboard
-	$(Q)chroot $(ROOTDIR) sh -c "chown root:apache -R /etc/openstack-dashboard/default_policies/*"
-	$(Q)chroot $(ROOTDIR) sh -c "chmod 640 -R /etc/openstack-dashboard/default_policies/*"
+	$(Q)mkdir -p $(ROOTDIR)/$(HORIZON_DIR)/local/enabled
+	$(Q)mkdir -p $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d
+	$(Q)mkdir -p $(ROOTDIR)/$(HORIZON_DIR)/conf/default_policies
+	$(Q)# heat-dashboard
+	$(Q)cp -f $(HORIZON_VENV_SP)/heat_dashboard/enabled/_16[1-5]0_*.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/heat_dashboard/local_settings.d/_1699_orchestration_settings.py $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d/
+	$(Q)cp -f $(HORIZON_VENV_SP)/heat_dashboard/conf/heat_policy.yaml $(ROOTDIR)/$(HORIZON_DIR)/conf/
+	$(Q)cp -f $(HORIZON_VENV_SP)/heat_dashboard/conf/default_policies/heat.yaml $(ROOTDIR)/$(HORIZON_DIR)/conf/default_policies/
+	$(Q)# ironic-ui
+	$(Q)cp -f $(HORIZON_VENV_SP)/ironic_ui/enabled/_2200_ironic.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)# manila-ui
+	$(Q)cp -f $(HORIZON_VENV_SP)/manila_ui/local/enabled/*.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/manila_ui/conf/manila_policy.yaml $(ROOTDIR)/$(HORIZON_DIR)/conf/
+	$(Q)cp -f $(HORIZON_VENV_SP)/manila_ui/conf/default_policies/manila.yaml $(ROOTDIR)/$(HORIZON_DIR)/conf/default_policies/
+	$(Q)cp -f $(COREDIR)/manila/local/local_settings.d/_90_manila_shares.py $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d/
+	$(Q)# designate-dashboard
+	$(Q)cp -f $(HORIZON_VENV_SP)/designatedashboard/enabled/_1710_project_dns_panel_group.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/designatedashboard/enabled/_1721_dns_zones_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/designatedashboard/enabled/_1722_dns_reversedns_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)# masakari-dashboard
+	$(Q)cp -f $(HORIZON_VENV_SP)/masakaridashboard/local/enabled/_50_masakaridashboard.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/masakaridashboard/local/local_settings.d/_50_masakari.py $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d/
+	$(Q)cp -f $(HORIZON_VENV_SP)/masakaridashboard/conf/masakari_policy.yaml $(ROOTDIR)/$(HORIZON_DIR)/conf/
+	$(Q)# watcher-dashboard
+	$(Q)cp -f $(HORIZON_VENV_SP)/watcher_dashboard/local/enabled/_310*.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)cp -f $(HORIZON_VENV_SP)/watcher_dashboard/conf/watcher_policy.json $(ROOTDIR)/$(HORIZON_DIR)/conf/
+	$(Q)# neutron-vpnaas-dashboard
+	$(Q)cp -f $(HORIZON_VENV_SP)/neutron_vpnaas_dashboard/enabled/_7100_project_vpn_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+	$(Q)# TODO(#609): octavia-dashboard, see core/octavia/octavia.mk.
+	$(Q)# cp -f $(HORIZON_VENV_SP)/octavia_dashboard/enabled/_1482_project_load_balancer_panel.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+
+# The yaml files under $(HORIZON_POLICY_DIR) that local_settings.in's
+# DEFAULT_POLICY_FILES points at came from the openstack-dashboard rpm, and the
+# masakari one from masakari.mk running this same command under python 3.9. Generate
+# them all here instead, from the services that are actually running -- every one of
+# these namespaces is an oslo.policy.policies entry point inside the venv, and
+# manage.py only exists once the step above has installed it.
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_POLICY_DIR)
+	$(Q)for ns in keystone nova cinder glance neutron masakari ; do \
+		chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py \
+			dump_default_policies --namespace $$ns \
+			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml 2>&1 > /dev/null ; \
+	done
+
+# gunicorn, the systemd unit and the httpd reverse proxy
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) install -d -m 750 -o apache -g apache $(HORIZON_LOG_DIR)
+	$(Q)chroot $(ROOTDIR) install -d -m 750 -o apache -g apache $(HORIZON_APP_STATE_DIR)
+	$(Q)$(INSTALL_DATA) -f $(ROOTDIR) $(COREDIR)/horizon/gunicorn-config.py .$(HORIZON_ETCDIR)/gunicorn-config.py
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/horizon/openstack-dashboard.service ./lib/systemd/system
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/horizon/openstack-dashboard.conf ./etc/httpd/conf.d/
+
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py compilemessages 2>&1 > /dev/null
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py collectstatic --noinput 2>&1 > /dev/null
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py compress --force 2>&1 > /dev/null
+	$(Q)chroot $(ROOTDIR) chmod 755 -R $(HORIZON_APP_DIR)
+	$(Q)chroot $(ROOTDIR) sh -c "chown root:apache -R $(HORIZON_POLICY_DIR)/*"
+	$(Q)chroot $(ROOTDIR) sh -c "chmod 640 -R $(HORIZON_POLICY_DIR)/*"
+	$(Q)chroot $(ROOTDIR) chown root:apache $(HORIZON_ETCDIR)/local_settings
+	$(Q)chroot $(ROOTDIR) chmod 640 $(HORIZON_ETCDIR)/local_settings

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -9,6 +9,21 @@ HORIZON_VER := 23.1.1
 # leave it floating.
 MYSQLCLIENT_VER := 2.2.8
 
+# The dashboard layout. These used to live in core/heavyfs/Makefile, from the days
+# when the openstack-dashboard rpm made the application directory a shared concern;
+# nothing outside this file reads them any more, so they belong here.
+#
+# $(HORIZON_APP_DIR) holds manage.py, the collected static tree and an
+# openstack_dashboard symlink for compatibility. $(HORIZON_DIR) has to name the real
+# package directory rather than that symlink: the symlink stores an absolute in-image
+# path, so a plain cp from the build host would follow it out to the *host* root
+# instead of into $(ROOTDIR).
+HORIZON_APP_DIR := /usr/share/openstack-dashboard
+HORIZON_VENV_SITE_PACKAGES := $(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages
+HORIZON_DIR := $(HORIZON_VENV_SITE_PACKAGES)/openstack_dashboard
+HORIZON_ETCDIR := /etc/openstack-dashboard
+HORIZON_POLICY_DIR := $(HORIZON_ETCDIR)/default_policies
+
 HORIZON_THEME_DIR := $(HORIZON_DIR)/themes
 CUBE_THEME_SRCDIR := $(COREDIR)/horizon/theme
 CUBE_THEME_DSTDIR := $(HORIZON_THEME_DIR)/cube
@@ -16,11 +31,12 @@ CUBE_THEME_DSTDIR := $(HORIZON_THEME_DIR)/cube
 HORIZON_LOG_DIR := /var/log/horizon
 HORIZON_APP_STATE_DIR := /var/lib/openstack-dashboard
 
-# Where each dashboard plugin ends up in the venv. Every plugin is pip installed by
-# the component that owns it -- heat-dashboard by heat.mk, ironic-ui by ironic.mk,
-# manila-ui by manila.mk, designate/masakari/watcher/neutron-vpnaas from git by
-# theirs -- and all of them land here.
-HORIZON_VENV_SP := $(ROOTDIR)$(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages
+# The same site-packages directory as seen from the build host. Every dashboard plugin
+# is pip installed by the component that owns it -- heat-dashboard by heat.mk,
+# ironic-ui by ironic.mk, manila-ui by manila.mk, octavia-dashboard by octavia.mk, and
+# designate/masakari/watcher/neutron-vpnaas from git by theirs -- and all of them land
+# here for the collection step below to pick up.
+HORIZON_VENV_SP := $(ROOTDIR)$(HORIZON_VENV_SITE_PACKAGES)
 
 CUBE_THEME_SRCS := $(shell find $(CUBE_THEME_SRCDIR) -type f 2>/dev/null)
 
@@ -82,7 +98,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_APP_DIR)
 	$(Q)$(INSTALL_DATA) -f $(ROOTDIR) $(COREDIR)/horizon/manage.py .$(HORIZON_APP_DIR)/manage.py
 	$(Q)chroot $(ROOTDIR) chmod 755 $(HORIZON_APP_DIR)/manage.py
-	$(Q)chroot $(ROOTDIR) ln -sfn $(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages/horizon $(HORIZON_APP_DIR)/horizon
+	$(Q)chroot $(ROOTDIR) ln -sfn $(HORIZON_VENV_SITE_PACKAGES)/horizon $(HORIZON_APP_DIR)/horizon
 	$(Q)chroot $(ROOTDIR) ln -sfn $(HORIZON_DIR) $(HORIZON_APP_DIR)/openstack_dashboard
 
 # settings

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -175,10 +175,16 @@ rootfs_install::
 # manage.py only exists once the step above has installed it.
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_POLICY_DIR)
+	$(Q)# || exit 1 per iteration: a for loop only returns the status of its *last*
+	$(Q)# iteration, so without it a failure in any earlier namespace leaves an empty
+	$(Q)# or missing yaml and the build still passes -- surfacing at runtime as
+	$(Q)# "No policy rules for service '<x>'" and a denied panel. masakari.mk used to
+	$(Q)# state this guarantee explicitly ("that command exits 1 and the build fails");
+	$(Q)# folding the dump into a loop here is what dropped it.
 	$(Q)for ns in keystone nova cinder glance neutron masakari octavia ; do \
 		chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py \
 			dump_default_policies --namespace $$ns \
-			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml 2>&1 > /dev/null ; \
+			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml 2>&1 > /dev/null || exit 1 ; \
 	done
 
 # gunicorn, the systemd unit and the httpd reverse proxy

--- a/core/horizon/local_settings.in
+++ b/core/horizon/local_settings.in
@@ -14,7 +14,7 @@
 
 import os
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from openstack_dashboard.settings import HORIZON_CONFIG
 
@@ -23,10 +23,6 @@ import warnings
 warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 warnings.filterwarnings(action="ignore", category=UserWarning)
 warnings.filterwarnings(action="ignore", category=FutureWarning)
-
-from django.utils.deprecation import RemovedInDjango40Warning
-
-warnings.filterwarnings(action="ignore", category=RemovedInDjango40Warning)
 
 DEBUG = False
 
@@ -39,7 +35,12 @@ DEBUG = False
 # with `python manage.py compress`
 # See https://django-compressor.readthedocs.io/en/latest/usage/#offline-compression
 # for more information
-#COMPRESS_OFFLINE = not DEBUG
+#
+# horizon.mk runs `manage.py compress --force` at build time, so the offline
+# manifest is always present and nothing should ever be compressed per-request.
+# The openstack-dashboard rpm used to force this in settings.py; the pypi wheel
+# does not, so it has to be stated here.
+COMPRESS_OFFLINE = True
 
 # If horizon is running in production (DEBUG is False), set this
 # with the list of host/domain names that the application can serve.
@@ -94,6 +95,11 @@ OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True
 
 LOCAL_PATH = '/tmp'
 
+# Horizon derives STATIC_ROOT from the package location, which is now inside the
+# python 3.10 venv. httpd serves /horizon/static straight off the filesystem, so
+# pin the collectstatic destination to the path openstack-dashboard.conf aliases.
+STATIC_ROOT = '/usr/share/openstack-dashboard/static'
+
 # Set custom secret key:
 # You can either set it to a specific value or you can let horizon generate a
 # default secret key that is unique on this machine, e.i. regardless of the
@@ -135,14 +141,14 @@ DATABASES = {
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': '@CACHE_SERVERS@',
     },
 }
 
 #CACHES = {
 #    'default': {
-#        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
 #        'LOCATION': '127.0.0.1:11211',
 #    },
 #}

--- a/core/horizon/local_settings.in
+++ b/core/horizon/local_settings.in
@@ -124,6 +124,9 @@ DEFAULT_POLICY_FILES = {
     'image': '/etc/openstack-dashboard/default_policies/glance.yaml',
     'network': '/etc/openstack-dashboard/default_policies/neutron.yaml',
     'instance-ha': '/etc/openstack-dashboard/default_policies/masakari.yaml',
+    # octavia-dashboard's _1499 snippet registers POLICY_FILES['load-balancer'] but
+    # ships no octavia_policy.yaml to back it, so the defaults have to come from here.
+    'load-balancer': '/etc/openstack-dashboard/default_policies/octavia.yaml',
 }
 
 DATABASES = {

--- a/core/horizon/manage.py
+++ b/core/horizon/manage.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE",
+                          "openstack_dashboard.settings")
+    execute_from_command_line(sys.argv)

--- a/core/horizon/manage.py
+++ b/core/horizon/manage.py
@@ -1,3 +1,4 @@
+#!/opt/openstack-antelope/bin/python
 import os
 import sys
 

--- a/core/horizon/openstack-dashboard.conf
+++ b/core/horizon/openstack-dashboard.conf
@@ -7,6 +7,22 @@
 ProxyPreserveHost On
 ProxyRequests Off
 
+# Do NOT add `RequestHeader set X-Forwarded-Proto ...` here.
+#
+# local_settings.in sets SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https'),
+# and the header it reads is supplied at the edge by haproxy, not by httpd:
+# config_haproxy.cpp adds "X-Forwarded-Proto https" on the 443 frontend (and "http" on
+# the 80 one, whose /horizon backend redirects to https before httpd ever sees it).
+# mod_proxy forwards that header through to gunicorn unchanged.
+#
+# This file is at server scope in conf.d, and the vhost it lands in listens on plain
+# 8080, so REQUEST_SCHEME here is "http". Setting the header from it would *overwrite*
+# haproxy's "https" with "http", make request.is_secure() False, and turn the WebSSO
+# origin into http://<host>/horizon/auth/websso/ -- which no longer matches the
+# trusted_dashboard config_keystone.cpp pins, so federated login fails with "Origin is
+# not a trusted dashboard host". It would also silently disable Django 3.2's strict
+# CSRF Referer check, which only runs when is_secure() is true.
+
 # Static assets stay with httpd. collectstatic writes them outside the venv (see
 # STATIC_ROOT in local_settings) and there is no reason to pay a python round
 # trip for 51MB of css, fonts and js. The "!" has to come first: ProxyPass
@@ -29,8 +45,11 @@ ErrorLog /var/log/httpd/horizon_error.log
 CustomLog /var/log/httpd/horizon_access.log combined
 LogLevel info
 
+# A collected static tree needs nothing but readability: no directory listings, and
+# no per-directory overrides to look for. The rpm-era block carried Options All /
+# AllowOverride All, which also cost a .htaccess stat on every request.
 <Directory /usr/share/openstack-dashboard/static>
-  Options All
-  AllowOverride All
+  Options -Indexes
+  AllowOverride None
   Require all granted
 </Directory>

--- a/core/horizon/openstack-dashboard.conf
+++ b/core/horizon/openstack-dashboard.conf
@@ -1,20 +1,33 @@
-WSGIDaemonProcess dashboard
-WSGIProcessGroup dashboard
-WSGISocketPrefix run/wsgi
-WSGIApplicationGroup %{GLOBAL}
+# Horizon moved into the python 3.10 venv at /opt/openstack-antelope and
+# mod_wsgi is built against the system python 3.9, so httpd can only proxy the
+# application, not host it in-process. openstack-dashboard.service runs it under
+# gunicorn on the socket below; this file is what used to be the
+# WSGIDaemonProcess/WSGIScriptAlias block.
 
-WSGIScriptAlias /horizon /usr/share/openstack-dashboard/openstack_dashboard/wsgi.py
+ProxyPreserveHost On
+ProxyRequests Off
+
+# Static assets stay with httpd. collectstatic writes them outside the venv (see
+# STATIC_ROOT in local_settings) and there is no reason to pay a python round
+# trip for 51MB of css, fonts and js. The "!" has to come first: ProxyPass
+# directives are matched in the order they are written, not longest-prefix.
 Alias /horizon/static /usr/share/openstack-dashboard/static
+ProxyPass /horizon/static !
+
+# The proxy target keeps the /horizon prefix on purpose. gunicorn's SCRIPT_NAME
+# support strips the prefix from PATH_INFO itself (http/wsgi.py: path_info =
+# path_info.split(script_name, 1)[1]), so it has to still be there when the
+# request arrives -- rewriting it to "/" here makes gunicorn raise IndexError on
+# every request.
+#
+# Using a random 127.0.0.x address to prevent Apache from keeping the
+# connection to the wrong proxy destination.
+ProxyPass /horizon unix:/var/lib/openstack-dashboard/horizon.socket|http://127.0.0.4/horizon
+ProxyPassReverse /horizon unix:/var/lib/openstack-dashboard/horizon.socket|http://127.0.0.4/horizon
 
 ErrorLog /var/log/httpd/horizon_error.log
 CustomLog /var/log/httpd/horizon_access.log combined
 LogLevel info
-
-<Directory /usr/share/openstack-dashboard/openstack_dashboard>
-  Options All
-  AllowOverride All
-  Require all granted
-</Directory>
 
 <Directory /usr/share/openstack-dashboard/static>
   Options All

--- a/core/horizon/openstack-dashboard.service
+++ b/core/horizon/openstack-dashboard.service
@@ -1,0 +1,49 @@
+[Unit]
+Description=OpenStack Horizon Dashboard (Gunicorn)
+After=syslog.target network.target
+# memcached backs both CACHES and the cached_db session engine.
+After=memcached.service
+# httpd serves /horizon/static off STATIC_ROOT and proxies everything else to the
+# socket below, so it has to come up after collectstatic has run.
+Before=httpd.service
+
+[Service]
+Type=simple
+User=apache
+Group=apache
+
+StandardOutput=append:/var/log/horizon/horizon.log
+StandardError=append:/var/log/horizon/horizon.log
+
+# httpd proxies /horizon onto the socket root, so the application has to be told
+# what prefix it is mounted under. gunicorn picks SCRIPT_NAME up from the
+# environment; WSGIScriptAlias used to supply it.
+Environment=SCRIPT_NAME=/horizon
+
+# These two used to be ExecStartPre on httpd.service, via a drop-in the
+# openstack-dashboard rpm shipped at
+# /usr/lib/systemd/system/httpd.service.d/openstack-dashboard.conf. They have to
+# move here for two reasons: the rpm (and therefore the drop-in) is gone, and
+# they ran under /usr/bin/python3, which can no longer import the dashboard or
+# its plugins now that both live in the python 3.10 venv.
+#
+# They are kept rather than left to the build because config_horizon.cpp
+# rewrites local_settings on every Commit() -- WEBROOT and STATIC_URL are
+# baked into the compressed output.
+#
+# The "+" prefix runs them as root instead of User= above: STATIC_ROOT is a
+# root-owned tree and --clear has to unlink what is already there. They inherited
+# root the same way when they hung off httpd.service, which also starts as root.
+ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput --clear -v0
+ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compress --force -v0
+TimeoutStartSec=5min
+
+ExecStart=/opt/openstack-antelope/bin/gunicorn \
+    -c /etc/openstack-dashboard/gunicorn-config.py \
+    openstack_dashboard.wsgi:application
+
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/core/horizon/openstack-dashboard.service
+++ b/core/horizon/openstack-dashboard.service
@@ -32,9 +32,18 @@ Environment=SCRIPT_NAME=/horizon
 # baked into the compressed output.
 #
 # The "+" prefix runs them as root instead of User= above: STATIC_ROOT is a
-# root-owned tree and --clear has to unlink what is already there. They inherited
-# root the same way when they hung off httpd.service, which also starts as root.
-ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput --clear -v0
+# root-owned tree. They inherited root the same way when they hung off
+# httpd.service, which also starts as root.
+#
+# Deliberately *without* --clear. httpd serves /horizon/static straight off
+# STATIC_ROOT and is a separate unit, so emptying that tree first means httpd 404s
+# every asset for as long as the collect takes -- and Restart=on-failure below turns
+# a gunicorn crash-loop into a repeated teardown of all 51MB. Before=httpd.service
+# only orders boot, it does nothing for a bare `systemctl restart
+# openstack-dashboard`. collectstatic overwrites what it collects, so --clear only
+# buys the removal of files a plugin has stopped shipping, which is not worth a
+# window where the dashboard has no assets.
+ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput -v0
 ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compress --force -v0
 TimeoutStartSec=5min
 

--- a/core/ironic/ironic.mk
+++ b/core/ironic/ironic.mk
@@ -4,6 +4,11 @@
 IRONIC_CONF_DIR := /etc/ironic
 IRONIC_INSP_CONF_DIR := /etc/ironic-inspector
 
+# https://releases.openstack.org/antelope/index.html -- last numeric 2023.1
+# revision. Horizon plugins are not in the antelope upper-constraints (that file
+# only covers libraries), so the pin has to be explicit.
+IRONIC_UI_VER := 6.1.0
+
 # System requirements formerly pulled in by the openstack-ironic RPMs.
 # ipmitool backs enabled_hardware_types=ipmi / enabled_management_interfaces=ipmitool
 # (RDO only listed it as a weak dependency, so pip gives us nothing here);
@@ -12,7 +17,9 @@ IRONIC_INSP_CONF_DIR := /etc/ironic-inspector
 # other components' RPM sets, which is not something ironic should rely on.
 #
 # pykickstart, the remaining Requires of RDO's openstack-ironic-conductor, is left
-# out for the same reason python3-dracclient and python3-scciclient are: it is only
+# out for the same reason python3-dracclient and python3-scciclient are. (Note that
+# openstack-ironic-ui, dropped alongside those two, *is* back -- see the ironic-ui
+# install further down.) It is only
 # reached through the anaconda deploy interface, and config_ironic.cpp pins
 # enabled_deploy_interfaces to "direct" and rewrites it on every Commit(). ironic
 # only names it in an error string, so both ironic.common.pxe_utils and
@@ -52,6 +59,21 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-inspector-status /usr/bin/ironic-inspector-status
 	$(Q)# provided by networking-baremetal, installed with neutron
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/ironic-neutron-agent /usr/bin/ironic-neutron-agent
+
+# install the ironic web ui plugin
+#
+# openstack-ironic-ui was dropped when ironic moved to pip, because horizon was still
+# on python 3.9 and could not import a package from the venv (#609 deferred it).
+# horizon is in the venv now, so the Bare Metal Provisioning panel comes back.
+# Registering the panel is core/horizon's job, where every dashboard action lives.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		ironic-ui==$(IRONIC_UI_VER)
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
 # prepare the build directory
 rootfs_install::

--- a/core/ironic/ironic.mk
+++ b/core/ironic/ironic.mk
@@ -69,8 +69,12 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# --no-build-isolation: ironic-ui pulls horizon, whose sdist-only XStatic
+	$(Q)# dependencies cannot be built against a current setuptools. See the note by
+	$(Q)# the venv bootstrap in core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
 		ironic-ui==$(IRONIC_UI_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/keystone/cube_mellon_wsgi.py
+++ b/core/keystone/cube_mellon_wsgi.py
@@ -1,0 +1,48 @@
+# Cube SDK
+"""Put mod_auth_mellon's SAML assertion back into keystone's WSGI environ.
+
+mellon publishes the assertion as httpd environment variables -- MELLON_IDP,
+MELLON_username, MELLON_groups. Those reach the application only while httpd hosts
+it in process, which stopped being true when keystone moved to gunicorn behind
+ProxyPass: mod_proxy forwards headers, not httpd's request environment. Federated
+login therefore arrived at keystone carrying no assertion at all, and every WebSSO
+attempt -- horizon's "Cube Account" button and skyline's alike -- failed with a
+bare 401 while keystone logged only "Authorization failed".
+
+v3_mellon_keycloak_master.conf carries the three values across the socket as
+X-Mellon-* request headers instead, and this shim restores the environ keys
+keystone looks for: federation.utils.get_assertion_params_from_env() harvests them
+out of flask.request.environ, and CONF.federation.remote_id_attribute names
+MELLON_IDP.
+
+Only these headers are honoured, and that same config unsets all of them at server
+scope before mellon repopulates them, so a client cannot present its own.
+"""
+
+from keystone.server import wsgi as keystone_wsgi
+
+# Exactly what idp_mapping_rules.json and remote_id_attribute consume, no more:
+# this is a header channel into an authentication decision, so it stays minimal.
+# Adding a remote attribute to the mapping means adding it here *and* in
+# v3_mellon_keycloak_master.conf.def -- httpd cannot forward the set generically.
+#
+# X-Mellon-Groups arrives ";"-merged, courtesy of MellonMergeEnvVars, which is the
+# form the mapping's any_one_of rules already expect.
+_ASSERTION_HEADERS = {
+    'HTTP_X_MELLON_IDP': 'MELLON_IDP',
+    'HTTP_X_MELLON_USERNAME': 'MELLON_username',
+    'HTTP_X_MELLON_GROUPS': 'MELLON_groups',
+}
+
+_application = keystone_wsgi.initialize_public_application()
+
+
+def application(environ, start_response):
+    for header, key in _ASSERTION_HEADERS.items():
+        # pop rather than copy: get_assertion_params_from_env() yields every environ
+        # key, because assertion_prefix is empty, and the mapping engine should see
+        # the MELLON_* name it was written against and not two spellings of it.
+        value = environ.pop(header, None)
+        if value:
+            environ[key] = value
+    return _application(environ, start_response)

--- a/core/keystone/keystone-wsgi.conf.in
+++ b/core/keystone/keystone-wsgi.conf.in
@@ -29,7 +29,11 @@ Listen @BIND_ADDR@5443
     ProxyPreserveHost On
     ProxyRequests Off
 
-    # Pass Mellon environment data down to the Gunicorn UNIX Socket
+    # This hop does *not* pass mellon's environment data down to the socket -- mod_proxy
+    # forwards headers, not httpd's request environment. v3_mellon_keycloak_master.conf
+    # re-sends the assertion as X-Mellon-* headers and cube_mellon_wsgi.py restores it
+    # on the far side; that file also unsets those headers at server scope, which is
+    # what keeps the /identity proxy below from accepting a forged one.
     ProxyPass / unix:/var/lib/keystone/keystone.socket|http://localhost/
     ProxyPassReverse / unix:/var/lib/keystone/keystone.socket|http://localhost/
 

--- a/core/keystone/keystone.mk
+++ b/core/keystone/keystone.mk
@@ -1,9 +1,12 @@
 # Cube SDK
 # keystone installation
 
-# mod_wsgi is for other services still running with Python 3.9
+# python3-mod_wsgi is gone: horizon was the last in-process wsgi application, and
+# #609 moved it behind a gunicorn socket like keystone, barbican, placement and
+# monasca-api already were. Nothing under /etc/httpd/conf.d carries a WSGI
+# directive any more, so httpd starts without the module.
 # mod_ssl and mod_auth_mellon for the SAML2 integration with Keycloak as IDP
-ROOTFS_DNF += httpd python3-mod_wsgi mod_ssl mod_auth_mellon openldap-devel
+ROOTFS_DNF += httpd mod_ssl mod_auth_mellon openldap-devel
 
 KEYSTONE_CONF_DIR := /etc/keystone
 

--- a/core/keystone/keystone.mk
+++ b/core/keystone/keystone.mk
@@ -9,6 +9,7 @@
 ROOTFS_DNF += httpd mod_ssl mod_auth_mellon openldap-devel
 
 KEYSTONE_CONF_DIR := /etc/keystone
+KEYSTONE_VENV_SITE_PACKAGES := $(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages
 
 # install keystone
 rootfs_install::
@@ -109,4 +110,12 @@ rootfs_install::
 	$(Q)cp -f $(COREDIR)/keystone/gunicorn.py $(ROOTDIR)/opt/openstack-antelope/bin/keystone-gunicorn.py
 	$(Q)chroot $(ROOTDIR) chown root:root /opt/openstack-antelope/bin/keystone-gunicorn.py
 	$(Q)chroot $(ROOTDIR) chmod 644 /opt/openstack-antelope/bin/keystone-gunicorn.py
+	$(Q)# openstack-keystone.service names this module, not keystone's own wsgi entry
+	$(Q)# point. It goes in site-packages rather than beside the gunicorn config
+	$(Q)# because that is what is importable: gunicorn resolves the application
+	$(Q)# string on sys.path, and /var/lib/keystone (WorkingDirectory) is group
+	$(Q)# writable state, not somewhere to keep code that authenticates requests.
+	$(Q)cp -f $(COREDIR)/keystone/cube_mellon_wsgi.py $(ROOTDIR)$(KEYSTONE_VENV_SITE_PACKAGES)/cube_mellon_wsgi.py
+	$(Q)chroot $(ROOTDIR) chown root:root $(KEYSTONE_VENV_SITE_PACKAGES)/cube_mellon_wsgi.py
+	$(Q)chroot $(ROOTDIR) chmod 644 $(KEYSTONE_VENV_SITE_PACKAGES)/cube_mellon_wsgi.py
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/keystone/openstack-keystone.service ./lib/systemd/system

--- a/core/keystone/openstack-keystone.service
+++ b/core/keystone/openstack-keystone.service
@@ -11,9 +11,15 @@ RuntimeDirectoryMode=0775
 
 # Executes Gunicorn from the venv using Python 3.10
 # Point to the clean configuration file
+#
+# cube_mellon_wsgi wraps keystone.server.wsgi:initialize_public_application() rather
+# than replacing it: mod_auth_mellon's assertion arrives as X-Mellon-* headers now
+# that httpd proxies instead of hosting keystone, and the wrapper is what puts it
+# back into the environ keystone's federation code reads. Naming the unwrapped
+# application here brings keystone up with federated login silently broken.
 ExecStart=/opt/openstack-antelope/bin/gunicorn \
     -c /opt/openstack-antelope/bin/keystone-gunicorn.py \
-    "keystone.server.wsgi:initialize_public_application()"
+    cube_mellon_wsgi:application
 
 Restart=on-failure
 RestartSec=5s

--- a/core/keystone/v3_mellon_keycloak_master.conf.def
+++ b/core/keystone/v3_mellon_keycloak_master.conf.def
@@ -1,3 +1,24 @@
+# --- Assertion Transport Across the Gunicorn Socket ---
+#
+# mellon publishes the assertion below as httpd environment variables, which only
+# reach an application httpd hosts in process. keystone is behind ProxyPass now, and
+# mod_proxy forwards headers rather than the request environment, so the three values
+# the mapping needs travel as X-Mellon-* headers and cube_mellon_wsgi.py restores
+# them to the environ keys keystone reads.
+#
+# These unsets are what make that channel trustworthy, and they sit at server scope
+# rather than inside <Location /v3> on purpose: keystone-wsgi.conf also proxies
+# /identity to the same socket, and mellon does not guard that prefix. Without them a
+# plain unauthenticated request to
+# /identity/v3/OS-FEDERATION/identity_providers/cube_idp/protocols/mapped/auth
+# carrying three self-supplied headers is issued a token for any user the mapping can
+# name -- verified on a node built from this branch, HTTP 201 for "admin (IAM)".
+# mod_headers applies parent directives before child ones, so these always precede
+# the sets below.
+RequestHeader unset X-Mellon-Idp
+RequestHeader unset X-Mellon-Username
+RequestHeader unset X-Mellon-Groups
+
 # --- Root Mellon Session Engine Configuration ---
 <Location /v3>
     MellonEnable info
@@ -8,6 +29,21 @@
     MellonIdPMetadataFile /etc/keycloak/saml-metadata.xml
     MellonIdP IDP
     MellonMergeEnvVars On ";"
+
+    # MellonEnable info exports these whenever the request carries a mellon session,
+    # which is what makes one block here enough for every endpoint below. env= keeps
+    # the headers off unauthenticated calls entirely rather than sending empty ones.
+    #
+    # Only what idp_mapping_rules.json and remote_id_attribute consume: MELLON_IDP is
+    # matched against the identity provider's remote_ids, and username/groups are the
+    # two remote attributes the mapping rules name. X-Mellon-Groups stays ";"-merged,
+    # the form the any_one_of rules already expect. Adding a remote attribute to the
+    # mapping means adding it here and in cube_mellon_wsgi.py -- httpd cannot forward
+    # the set generically, and this is a header channel into an authentication
+    # decision, so it is deliberately enumerated rather than broadened.
+    RequestHeader set X-Mellon-Idp      "%{MELLON_IDP}e"      env=MELLON_IDP
+    RequestHeader set X-Mellon-Username "%{MELLON_username}e" env=MELLON_username
+    RequestHeader set X-Mellon-Groups   "%{MELLON_groups}e"   env=MELLON_groups
 </Location>
 
 # --- WebSSO Endpoint Mapping ---

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -10,6 +10,9 @@ HEX_DONE=/run/bootstrap_done
 CUBE_DONE=/run/cube_commit_done
 CLUSTER_SYNC=/run/cube_cluster_synced
 CLUSTER_REPAIRING=/run/cube_cluster_repairing
+# Note: openstack_dashboard is a symlink into the python 3.10 venv's site-packages
+# now, so this path resolves inside the venv. Moving panels aside below therefore
+# edits the installed package rather than a private copy under /usr/share.
 HORIZON_APP_DIR=/usr/share/openstack-dashboard/openstack_dashboard/local/enabled
 
 # Programming language like function,
@@ -227,10 +230,15 @@ cube_edge_cfg()
         remote_run $ctrl mv $HORIZON_APP_DIR/_17*.py $HORIZON_APP_DIR/bak/
         # watcher
         remote_run $ctrl mv $HORIZON_APP_DIR/_310*.py $HORIZON_APP_DIR/bak/
-        remote_run $ctrl python3 /usr/share/openstack-dashboard/manage.py compilemessages 2>&1 > /dev/null
-        remote_run $ctrl python3 /usr/share/openstack-dashboard/manage.py collectstatic --noinput 2>&1 > /dev/null
-        remote_run $ctrl python3 /usr/share/openstack-dashboard/manage.py compress --force 2>&1 > /dev/null
-        remote_run $ctrl systemctl restart httpd
+        # horizon lives in the python 3.10 venv, so /usr/bin/python3 can no longer
+        # import openstack_dashboard -- use the venv interpreter, the same one
+        # config_horizon.cpp and openstack-dashboard.service name.
+        remote_run $ctrl /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compilemessages 2>&1 > /dev/null
+        remote_run $ctrl /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput 2>&1 > /dev/null
+        remote_run $ctrl /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compress --force 2>&1 > /dev/null
+        # the dashboard is its own unit now; restarting httpd only reloads the proxy
+        # in front of it and no longer reruns collectstatic/compress.
+        remote_run $ctrl systemctl restart openstack-dashboard
     done
 
     return 0

--- a/core/manila/local/local_settings.d/_90_manila_shares.py
+++ b/core/manila/local/local_settings.d/_90_manila_shares.py
@@ -1,3 +1,21 @@
+from django.conf import settings
+
+# manila_ui ships its own _90_manila_shares.py carrying these two entries. This
+# file replaces it rather than sitting beside it -- same filename -- so they have to
+# be restated here, or horizon logs "No policy rules for service 'share'" on every
+# start. Both paths are relative to POLICY_FILES_PATH, i.e.
+# <openstack_dashboard>/conf.
+settings.POLICY_FILES.update({
+    'share': 'manila_policy.yaml',
+})
+
+settings.DEFAULT_POLICY_FILES.update({
+    'share': 'default_policies/manila.yaml',
+})
+
+# Deliberately narrower than upstream's default, which also lists GlusterFS, HDFS,
+# CephFS and MapRFS: config_manila.cpp pins enabled_share_backends to "generic",
+# and the generic driver's helpers only serve NFS and CIFS.
 OPENSTACK_MANILA_FEATURES = {
     'enable_share_groups': True,
     'enable_replication': True,

--- a/core/manila/manila-sudoers
+++ b/core/manila/manila-sudoers
@@ -1,9 +1,8 @@
 Defaults:manila !requiretty
 
 manila ALL = (root) NOPASSWD: /usr/bin/manila-rootwrap /etc/manila/rootwrap.conf *
-# The venv path is what [manila_sys_admin] helper_command in manila.conf points at:
-# sudo's secure_path does not contain /opt/openstack-antelope/bin, so the bare
-# `sudo privsep-helper` default would resolve to the system python 3.9 helper and
-# fail to import manila. Only the lvm and glusterfs drivers reach privsep, and
-# config_manila.cpp pins the backend to generic, so this is a safety net.
-manila ALL = (root) NOPASSWD: /opt/openstack-antelope/bin/privsep-helper *
+# This is what [manila_sys_admin] helper_command in manila.conf points at.
+# /usr/bin/privsep-helper is a symlink to the venv helper as of the Horizon hop.
+# Only the lvm and glusterfs drivers reach privsep, and config_manila.cpp pins the
+# backend to generic, so this is a safety net.
+manila ALL = (root) NOPASSWD: /usr/bin/privsep-helper *

--- a/core/manila/manila.mk
+++ b/core/manila/manila.mk
@@ -72,8 +72,10 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
 		manila-ui==$(MANILA_UI_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/manila/manila.mk
+++ b/core/manila/manila.mk
@@ -1,15 +1,16 @@
 # Cube SDK
 # manila installation
 
-# openstack-manila-ui and python3-manilaclient stay yoga rpms under the *system*
-# python 3.9, and only those two. Horizon runs there and imports manila_ui, so the
-# Shares panels cannot follow the manila service into the 3.10 venv; manila_ui in
-# turn imports manilaclient, which also owns /usr/bin/manila -- hex_sdk calls it in
-# health_manila_check(), os_manila_init() and migrate_manila_db_post() -- and the
-# "share" osc plugin entry point that /usr/bin/openstack, itself still
-# `#!/usr/bin/python3`, resolves. Both drop out once horizon moves into the venv,
-# which is #609. A yoga 3.3.2 client against the 16.3.0 api is fine: it negotiates
-# its own microversion and every call above predates yoga.
+# python3-manilaclient stays a yoga rpm under the *system* python 3.9. It owns
+# /usr/bin/manila -- hex_sdk calls it in health_manila_check(), os_manila_init()
+# and migrate_manila_db_post() -- and the "share" osc plugin entry point that
+# /usr/bin/openstack, itself still `#!/usr/bin/python3`, resolves. A yoga 3.3.2
+# client against the 16.3.0 api is fine: it negotiates its own microversion and
+# every call above predates yoga.
+#
+# openstack-manila-ui is replaced by the manila-ui wheel installed further down.
+# #609 moved horizon into the 3.10 venv, so the Shares panels can follow the manila
+# service in there.
 #
 # openstack-manila and openstack-manila-share are what the pip install below
 # replaces. Non-python Requires of those two that are deliberately not restated:
@@ -22,7 +23,7 @@
 #                 rewrites it on every Commit(), and the generic driver's
 #                 CIFSHelper runs its `net conf` calls through _ssh_exec() inside
 #                 the service instance, never on the host.
-ROOTFS_DNF_NOARCH += openstack-manila-ui python3-manilaclient
+ROOTFS_DNF_NOARCH += python3-manilaclient
 
 # https://releases.openstack.org/antelope/index.html#antelope-manila
 MANILA_VER := 16.3.0
@@ -36,7 +37,10 @@ MANILA_RUN_DIR := /var/run/manila
 MANILA_SRCDIR := $(ROOTDIR)/opt/openstack-antelope/lib/python$(NEXT_PYTHON_VER)/site-packages/manila
 MANILA_PATCHDIR := $(COREDIR)/manila/$(NEXT_OPENSTACK_RELEASE)_patch
 
-OPENSTACK_DASHBOARD := $(ROOTDIR)/usr/share/openstack-dashboard/openstack_dashboard
+# https://releases.openstack.org/antelope/index.html -- last numeric 2023.1
+# revision. Horizon plugins are not in the antelope upper-constraints (that file
+# only covers libraries), so the pin has to be explicit.
+MANILA_UI_VER := 9.0.1
 
 # install manila inside the python 3.10 virtual environment
 rootfs_install::
@@ -59,6 +63,20 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/manila-share /usr/bin/manila-share
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/manila-status /usr/bin/manila-status
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/manila-wsgi /usr/bin/manila-wsgi
+
+# install the manila web ui plugin, the openstack-manila-ui rpm's replacement.
+# Registering its panels and policy files is core/horizon's job, where every
+# dashboard action lives -- including the copy of
+# core/manila/local/local_settings.d/_90_manila_shares.py, which overrides the
+# snippet manila_ui ships under the same name.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		manila-ui==$(MANILA_UI_VER)
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
 rootfs_install::
 	$(Q)[ -d $(MANILA_PATCHDIR) ] && cp -rf $(MANILA_PATCHDIR)/* $(MANILA_SRCDIR)/ || /bin/true
@@ -133,4 +151,3 @@ rootfs_install::
 	$(Q)# empty file is what keeps the two from fighting; feeding it the antelope
 	$(Q)# sample would only add [oslo_reports].
 	$(Q)touch $(ROOTDIR)$(MANILA_CONF_DIR)/manila.conf.def
-	$(Q)cp -f $(COREDIR)/manila/local/local_settings.d/_90_manila_shares.py $(OPENSTACK_DASHBOARD)/local/local_settings.d/

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -113,8 +113,10 @@ rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(NEXT_OPS_GITHUB_BRANCH_02) --depth 1 $(MASAKARI_DASHBOARD_REPO_URL) /tmp/masakari/masakari-dashboard
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
 		-r /tmp/masakari/masakari-dashboard/requirements.txt
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/masakari/masakari-dashboard && \
 		/opt/openstack-antelope/bin/python setup.py install"

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -7,12 +7,14 @@ MASAKARI_APP_DIR := /var/lib/masakari
 MASAKARI_LOG_DIR := /var/log/masakari
 MASAKARI_RUN_DIR := /var/run/masakari
 
-# masakarimonitors is patched inside the antelope venv, but masakaridashboard is
-# patched in the system python because horizon runs there. See the two install
-# rules below.
+# Both masakarimonitors and masakaridashboard are patched inside the antelope venv
+# now: #609 moved horizon there, so the dashboard no longer has a python 3.9 copy.
+# The dashboard patch matters -- upstream sets default_panel = 'default', a panel
+# whose urls.py has no index, so an unpatched masakaridashboard makes the sidebar
+# raise NoReverseMatch and every page 500s.
 MASAKARI_MONITORS_SRCDIR := $(ROOTDIR)/opt/openstack-antelope/lib/python3.10/site-packages/masakarimonitors
 MASAKARI_MONITORS_PATCHDIR := $(COREDIR)/masakari/$(NEXT_OPENSTACK_RELEASE)_patch/masakarimonitors
-MASAKARI_DASHBOARD_SRCDIR := $(ROOTDIR)/usr/local/lib/python3.9/site-packages/masakaridashboard
+MASAKARI_DASHBOARD_SRCDIR := $(ROOTDIR)$(NEXT_OPENSTACK_HOME_DIR)/lib/python$(NEXT_PYTHON_VER)/site-packages/masakaridashboard
 MASAKARI_DASHBOARD_PATCHDIR := $(COREDIR)/masakari/$(NEXT_OPENSTACK_RELEASE)_patch/masakaridashboard
 
 # prepare the build directory
@@ -27,11 +29,9 @@ rootfs_install::
 
 # masakari-api and masakari-engine
 MASAKARI_REPO_URL := https://github.com/openstack/masakari.git
-# FIXME: drop the installation in python 3.9 after wrapping up the whole upgrade of openstack.
-# masakari owns the "masakari" oslo.policy.policies entry point, and horizon's
-# dump_default_policies below runs under python 3.9. Without this the namespace
-# is not found, that command exits 1 and the build fails.
-ROOTFS_PIP_DL_FROM += $(MASAKARI_REPO_URL)
+# The python 3.9 copy is gone. It only existed so horizon's dump_default_policies
+# could resolve the "masakari" oslo.policy.policies entry point; that command runs
+# under the venv python now (#609), where the venv's own masakari provides it.
 
 # install masakari-api and masakari-engine inside the python 3.10 virtual environment
 rootfs_install::
@@ -107,8 +107,6 @@ rootfs_install::
 
 # masakari web ui plugin
 MASAKARI_DASHBOARD_REPO_URL := https://github.com/openstack/masakari-dashboard.git
-# FIXME: drop the installation in python 3.9 after wrapping up the whole upgrade of openstack
-ROOTFS_PIP_DL_FROM += $(MASAKARI_DASHBOARD_REPO_URL)
 
 # install masakari web ui plugin inside the python 3.10 virtual environment
 rootfs_install::
@@ -122,17 +120,6 @@ rootfs_install::
 		/opt/openstack-antelope/bin/python setup.py install"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-
-# FIXME: need to update the Horizon panel path after upgrading Horizon
-# rootfs_install::
-# 	$(Q)cp -f $(ROOTDIR)/tmp/masakari/masakari-dashboard/masakaridashboard/local/enabled/_50_masakaridashboard.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
-# 	$(Q)cp -f $(ROOTDIR)/tmp/masakari/masakari-dashboard/masakaridashboard/local/local_settings.d/_50_masakari.py $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d/
-# 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py dump_default_policies --namespace masakari --output-file $(HORIZON_POLICY_DIR)/masakari.yaml 2>&1 > /dev/null
-
-rootfs_install::
-	$(Q)cp -f $(PIPS_DIR)/masakari-dashboard.git/masakaridashboard/local/enabled/_50_masakaridashboard.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
-	$(Q)cp -f $(PIPS_DIR)/masakari-dashboard.git/masakaridashboard/local/local_settings.d/_50_masakari.py $(ROOTDIR)/$(HORIZON_DIR)/local/local_settings.d/
-	$(Q)chroot $(ROOTDIR) python3 /usr/share/openstack-dashboard/manage.py dump_default_policies --namespace masakari --output-file $(HORIZON_POLICY_DIR)/masakari.yaml 2>&1 > /dev/null
 
 rootfs_install::
 	$(Q)[ -d $(MASAKARI_MONITORS_PATCHDIR) ] && cp -rf $(MASAKARI_MONITORS_PATCHDIR)/* $(MASAKARI_MONITORS_SRCDIR)/ || /bin/true

--- a/core/masakari/masakari_sudoers
+++ b/core/masakari/masakari_sudoers
@@ -1,4 +1,5 @@
 Defaults:masakari !requiretty
 
+# /usr/bin/privsep-helper is a symlink to the venv helper as of the Horizon hop, so
+# the second rule that used to authorise the venv path directly is redundant.
 masakari ALL = (root) NOPASSWD: /usr/bin/privsep-helper *
-masakari ALL = (root) NOPASSWD: /opt/openstack-antelope/bin/privsep-helper *

--- a/core/modules/config_cyborg.cpp
+++ b/core/modules/config_cyborg.cpp
@@ -240,15 +240,14 @@ UpdateCfg(const std::string& domain, const std::string& userPass, const std::str
 
         cfg["agent"]["enabled_drivers"] = "nvidia_gpu_driver";
 
-        // TEMPORARY: cyborg runs out of the antelope venv but oslo.privsep
-        // resolves its default "sudo privsep-helper" off PATH, which finds the
-        // leftover /usr/bin/privsep-helper from the pre-venv packages. That one
-        // runs under the system python and cannot import cyborg, so it exits 1
-        // and every device discovery fails with FailedToDropPrivileges. Cyborg
-        // ships no rootwrap, so unlike cinder/glance we cannot fix this through
-        // rootwrap exec_dirs and have to pin the helper explicitly.
-        // Remove once the system-python console scripts are gone.
-        cfg["cyborg_sys_admin"]["helper_command"] = "sudo /opt/openstack-antelope/bin/privsep-helper";
+        // Cyborg ships no rootwrap, so unlike cinder/glance the helper cannot be
+        // resolved through rootwrap exec_dirs and has to be named here.
+        // /usr/bin/privsep-helper is a symlink to the venv helper as of the Horizon
+        // hop -- core/nova/nova.mk creates it, now that no service runs privsep under
+        // the system python. It used to be a pre-venv system-python binary that could
+        // not import cyborg, so every device discovery failed with
+        // FailedToDropPrivileges.
+        cfg["cyborg_sys_admin"]["helper_command"] = "sudo /usr/bin/privsep-helper";
 
         cfg["placement"].clear();
         cfg["placement"]["auth_type"] = "password";

--- a/core/modules/config_horizon.cpp
+++ b/core/modules/config_horizon.cpp
@@ -10,12 +10,18 @@
 #include <hex/dryrun.h>
 
 #include <cluster.hpp>
+#include <cube/systemd_util.h>
 
 #include "mysql_util.h"
 #include "include/role_cubesys.h"
 
 static const char USER[] = "horizon";
 static const char DBPASS[] = "ZdDtndK8NmBklLyg";
+
+// The dashboard, gunicorn behind the httpd reverse proxy. Horizon used to run
+// in-process under mod_wsgi, so httpd starting was all it took; it lives in the
+// python 3.10 venv now and has a unit of its own to bring up.
+static const char NAME[] = "openstack-dashboard";
 
 static const char DJANGO_CONF_IN[] = "/etc/openstack-dashboard/local_settings.in";
 static const char DJANGO_CONF[] = "/etc/openstack-dashboard/local_settings";
@@ -77,7 +83,9 @@ SetupService()
 
     HexLogInfo("Setting up horizon");
 
-    HexUtilSystemF(0, 0, "/usr/bin/python3 /usr/share/openstack-dashboard/manage.py migrate --noinput 2>/dev/null");
+    // horizon lives in the python 3.10 venv now; /usr/bin/python3 (3.9) can no
+    // longer import openstack_dashboard or any of its plugins.
+    HexUtilSystemF(0, 0, "/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py migrate --noinput 2>/dev/null");
 
     return true;
 }
@@ -183,6 +191,13 @@ Commit(bool modified, int dryLevel)
 
     if (!s_bSetup)
         SetupService();
+
+    // openstack-dashboard.service reruns collectstatic and compress as ExecStartPre,
+    // so this has to happen after WriteDjangoConf() above: WEBROOT and STATIC_URL are
+    // baked into the compressed output. config_apache2 requires this module, which is
+    // what keeps httpd starting after the socket exists.
+    bool enabled = IsControl(s_eCubeRole);
+    SystemdCommitService(enabled, NAME, true);
 
     return true;
 }

--- a/core/modules/config_horizon.cpp
+++ b/core/modules/config_horizon.cpp
@@ -8,6 +8,7 @@
 #include <hex/string_util.h>
 #include <hex/process_util.h>
 #include <hex/dryrun.h>
+#include <hex/logrotate.h>
 
 #include <cluster.hpp>
 #include <cube/systemd_util.h>
@@ -22,6 +23,14 @@ static const char DBPASS[] = "ZdDtndK8NmBklLyg";
 // in-process under mod_wsgi, so httpd starting was all it took; it lives in the
 // python 3.10 venv now and has a unit of its own to bring up.
 static const char NAME[] = "openstack-dashboard";
+
+// Nothing rotates /var/log/horizon on its own any more. gunicorn's stdout/stderr and
+// horizon's own LOGGING console handler both land in horizon.log, which the unit
+// appends to; that output used to go to /var/log/httpd/horizon_error.log and was
+// covered by httpd's logrotate, and the openstack-dashboard rpm's
+// /etc/logrotate.d/openstack-dashboard went with the rpm. Declare it through hex
+// instead, the same way manila, cinder, heat and ironic do.
+static LogRotateConf log_conf("horizon", "/var/log/horizon/*.log", DAILY, 128, 0, true);
 
 static const char DJANGO_CONF_IN[] = "/etc/openstack-dashboard/local_settings.in";
 static const char DJANGO_CONF[] = "/etc/openstack-dashboard/local_settings";
@@ -196,8 +205,16 @@ Commit(bool modified, int dryLevel)
     // so this has to happen after WriteDjangoConf() above: WEBROOT and STATIC_URL are
     // baked into the compressed output. config_apache2 requires this module, which is
     // what keeps httpd starting after the socket exists.
-    bool enabled = IsControl(s_eCubeRole);
-    SystemdCommitService(enabled, NAME, true);
+    //
+    // Unconditionally true rather than IsControl(s_eCubeRole): the guard at the top of
+    // Commit() has already returned for every non-control role. That does mean a
+    // *demoted* control node never reaches SystemdCommitService(false, ...) and keeps
+    // the dashboard enabled -- config_apache2.cpp has the identical shape for httpd, so
+    // the two want fixing together rather than leaving the proxy enabled in front of a
+    // disabled backend.
+    SystemdCommitService(true, NAME, true);
+
+    WriteLogRotateConf(log_conf);
 
     return true;
 }

--- a/core/modules/config_manila.cpp
+++ b/core/modules/config_manila.cpp
@@ -298,14 +298,13 @@ SetDefaults(Configs& config)
 
     config["oslo_concurrency"]["lock_path"] = "/var/lock/manila";
 
-    // oslo.privsep's default helper_command is a bare "sudo privsep-helper", and
-    // sudo's secure_path does not include /opt/openstack-antelope/bin, so it would
-    // resolve to the system python 3.9 helper and die with ModuleNotFoundError:
-    // manila. Only the lvm and glusterfs drivers reach privsep and
+    // /usr/bin/privsep-helper is a symlink to the venv helper as of the Horizon hop --
+    // core/nova/nova.mk creates it, now that no service runs privsep under the system
+    // python. Only the lvm and glusterfs drivers reach privsep and
     // enabled_share_backends is pinned to generic above, so this never fires today
     // -- it is here so it does not become a latent bug the day a backend changes.
     // /etc/sudoers.d/manila authorises exactly this path.
-    config["manila_sys_admin"]["helper_command"] = "sudo /opt/openstack-antelope/bin/privsep-helper";
+    config["manila_sys_admin"]["helper_command"] = "sudo /usr/bin/privsep-helper";
 }
 
 /**

--- a/core/modules/config_masakari.cpp
+++ b/core/modules/config_masakari.cpp
@@ -306,17 +306,15 @@ UpdateCfg(std::string region, std::string domain, std::string userPass, std::str
         // deprecated alias for "hostname" since masakari-monitors 9.0.0.
         monCfg["DEFAULT"]["hostname"] = hostname;
 
-        // TEMPORARY: masakari-monitors runs out of the antelope venv but
-        // oslo.privsep resolves its default "sudo privsep-helper" off sudo's
-        // secure_path, which finds the leftover /usr/bin/privsep-helper from the
-        // pre-venv packages. That one runs under the system python and cannot
-        // import masakarimonitors, so it exits 1 and every root command in
-        // hostmonitor (cibadmin, crm_mon, corosync-cfgtool) fails with
-        // FailedToDropPrivileges. masakari-monitors ships no rootwrap, so unlike
-        // cinder/glance we cannot fix this through rootwrap exec_dirs and have to
-        // pin the helper explicitly, the same way cyborg does.
-        // Remove once the system-python console scripts are gone.
-        monCfg["masakarimonitors_privileged"]["helper_command"] = "sudo /opt/openstack-antelope/bin/privsep-helper";
+        // masakari-monitors runs out of the antelope venv and ships no rootwrap, so
+        // unlike cinder/glance the helper cannot be resolved through rootwrap
+        // exec_dirs and has to be named here. /usr/bin/privsep-helper is a symlink to
+        // the venv helper as of the Horizon hop -- core/nova/nova.mk creates it, now
+        // that no service runs privsep under the system python. It used to be a
+        // pre-venv system-python binary that could not import masakarimonitors, which
+        // made every root command in hostmonitor (cibadmin, crm_mon,
+        // corosync-cfgtool) fail with FailedToDropPrivileges.
+        monCfg["masakarimonitors_privileged"]["helper_command"] = "sudo /usr/bin/privsep-helper";
 
         monCfg["api"].clear();
         monCfg["api"]["region"] = region;

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -38,6 +38,14 @@ $(foreach mariadb_rpm,$(MARIADB_LOCKED_RPMS),$(eval ROOTFS_DNF_DL_FROM += $(MARI
 ROOTFS_DNF_DL_FROM += $(MARIADB_URL)/$(GALERA_RPM).x86_64.rpm
 
 # zlib-devel pairs with MariaDB-devel above: mysqlclient links against libz.
+#
+# Neither needs stripping in a trailing rootfs_install::. core/main/cube-post.mk
+# already autoremoves every installed package matching "devel|headers" (all but
+# python3-devel) from the rootfs as its final cleanup, so both go there, and the
+# toolchain goes with them -- erasing glibc-devel takes gcc, gcc-c++ and
+# libstdc++-devel out as dependents. Only the runtime halves are left for
+# mysqlclient to link against at import time: MariaDB-shared for libmariadb.so.3
+# and zlib for libz.so.1.
 ROOTFS_DNF += rsync zlib-devel
 ROOTFS_DNF_NOARCH += python3-PyMySQL
 

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -12,12 +12,18 @@ MARIADB_URL := https://archive.mariadb.org/yum/10.6/rocky9-amd64/rpms
 
 # Official MariaDB package list
 # Note: we dropped errmsg and server-utils as they are now bundled
+# MariaDB-devel carries mysql.h and mariadb_config. core/horizon/horizon.mk builds
+# the mysqlclient wheel from source -- upstream publishes wheels for windows only --
+# and django.db.backends.mysql needs it for horizon's session store. It has to come
+# from this MariaDB.org build rather than appstream's mariadb-connector-c-devel,
+# because MariaDB-shared obsoletes mariadb-connector-c, which that package requires.
 MARIADB_LOCKED_RPMS := MariaDB-client-$(MARIADB_VER) \
                        MariaDB-server-$(MARIADB_VER) \
                        MariaDB-common-$(MARIADB_VER) \
                        MariaDB-shared-$(MARIADB_VER) \
                        MariaDB-backup-$(MARIADB_VER) \
-                       MariaDB-gssapi-server-$(MARIADB_VER)
+                       MariaDB-gssapi-server-$(MARIADB_VER) \
+                       MariaDB-devel-$(MARIADB_VER)
 
 # Galera library is versioned differently than the database engine
 GALERA_RPM := galera-4-$(GALERA_VER)
@@ -31,7 +37,8 @@ $(foreach mariadb_rpm,$(MARIADB_LOCKED_RPMS),$(eval ROOTFS_DNF_DL_FROM += $(MARI
 # Map URL for Galera package
 ROOTFS_DNF_DL_FROM += $(MARIADB_URL)/$(GALERA_RPM).x86_64.rpm
 
-ROOTFS_DNF += rsync
+# zlib-devel pairs with MariaDB-devel above: mysqlclient links against libz.
+ROOTFS_DNF += rsync zlib-devel
 ROOTFS_DNF_NOARCH += python3-PyMySQL
 
 # config_mysql.cpp points log_error at /var/log/mariadb/mysql_error.log, but nothing

--- a/core/neutron/neutron.mk
+++ b/core/neutron/neutron.mk
@@ -276,7 +276,7 @@ rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/neutron/vpnaas.filters ./usr/share/neutron/rootwrap/
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/neutron/neutron-ovn-vpn-agent.service ./lib/systemd/system
 
-# for neutron-vpnaas-dashboard
-# rootfs_install::
-# 	$(Q)# FIXME: need to update the Horizon panel path after upgrading Horizon
-# 	$(Q)cp -f $(PIPS_DIR)/neutron-vpnaas-dashboard.git/neutron_vpnaas_dashboard/enabled/_7100*.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
+# The neutron-vpnaas-dashboard VPN panel is registered by core/horizon/horizon.mk,
+# where every dashboard action lives. It was never registered before #609: horizon ran
+# under python 3.9 while the plugin was installed venv-only, so ADD_INSTALLED_APPS
+# would have failed to import and taken the whole dashboard down with it.

--- a/core/neutron/neutron.mk
+++ b/core/neutron/neutron.mk
@@ -89,6 +89,7 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/neutron/neutron-vpnaas && \
 		/opt/openstack-antelope/bin/python setup.py install"
 	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(NEXT_OPS_GITHUB_BRANCH_02) --depth 1 $(NEUTRON_VPNAAS_DASHBOARD_REPO_URL) /tmp/neutron/neutron-vpnaas-dashboard
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		-r /tmp/neutron/neutron-vpnaas-dashboard/requirements.txt \

--- a/core/nova/nova.mk
+++ b/core/nova/nova.mk
@@ -58,7 +58,8 @@ rootfs_install::
 			osc-placement \
 			osprofiler \
 			uwsgi \
-			libvirt-python"
+			libvirt-python \
+			oslo.privsep"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 	$(Q)# Link Nova binaries
@@ -85,6 +86,37 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/placement-status /usr/bin/placement-status
 	$(Q)# Link the uWSGI binary for Placement WSGI
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/uwsgi /usr/bin/uwsgi
+
+# Link the venv's privsep-helper into /usr/bin.
+#
+# oslo.privsep escalates by running `sudo privsep-helper`, resolved off sudo's
+# secure_path (/sbin:/bin:/usr/sbin:/usr/bin), which never contains the venv's bin --
+# so the bare name has to exist there. It is listed in the pip install above rather
+# than left transitive for the same reason python3-designateclient is named in
+# core/designate/designate.mk: a dependency nothing asks for is one that disappears
+# silently.
+#
+# This link was deliberately deferred until every privsep user had moved into the
+# venv, because /usr/bin/privsep-helper used to be a *python 3.9* binary owned by
+# python3-oslo-privsep, shared by every rootwrap caller:
+#
+#   # rpm -qf /usr/bin/privsep-helper
+#   python3-oslo-privsep-2.7.0-1.el9s.noarch
+#   # dnf repoquery --installed --whatrequires python3-oslo-privsep
+#   openstack-ironic-common, python3-cinder-common, python3-glance-store,
+#   python3-manila, python3-neutron, python3-nova, python3-os-brick, python3-os-vif
+#
+# Pointing it at the 3.10 helper while any of those still ran on 3.9 would have
+# broken them. All eight have since moved, python3-oslo-privsep is no longer
+# installed, and `python3 -c "import oslo_privsep"` fails on the system python --
+# so there is no 3.9 consumer left and the link is now unambiguously correct.
+#
+# It is also load-bearing: with no /usr/bin/privsep-helper at all,
+# neutron-ovn-metadata-agent crash-looped on
+# "FailedToDropPrivileges: privsep helper command exited non-zero (96)" and
+# `cluster check` reported "Network NG [ neutron(3 metadata not all up) ]".
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/privsep-helper /usr/bin/privsep-helper
 
 # prepare the build directory
 rootfs_install::

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -29,6 +29,21 @@ ROOTFS_DNF_NOARCH += python3-octaviaclient
 OCTAVIA_CONF_DIR := /etc/octavia
 OCTAVIA_CONFDIR := $(ROOTDIR)$(OCTAVIA_CONF_DIR)
 
+# TODO(#609): openstack-octavia-ui is temporarily commented out rather than replaced
+# by the octavia-dashboard wheel. Every other dashboard plugin moved into the python
+# 3.10 venv when horizon did, but the octavia *service* is still being upgraded to
+# antelope by another developer on a separate branch. Installing octavia-dashboard
+# 11.0.1 now would put 2023.1 Load Balancer panels in front of a yoga octavia api,
+# and leaving the yoga rpm in place would put a python 3.9 plugin in front of a venv
+# horizon, which cannot import it. So the panels are off for the moment.
+#
+# To restore, once that branch merges:
+#   1. add OCTAVIA_DASHBOARD_VER := 11.0.1 and pip install octavia-dashboard into the
+#      venv here, the way manila.mk installs manila-ui;
+#   2. uncomment the octavia_dashboard enabled/*.py copy in core/horizon/horizon.mk,
+#      which is where every dashboard action lives.
+# ROOTFS_DNF_NOARCH += openstack-octavia-ui
+
 # install octavia
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -17,10 +17,12 @@
 # while the bootstrap paths above failed.
 ROOTFS_DNF_NOARCH += python3-octaviaclient
 #
-# openstack-octavia-ui, the Horizon dashboard plugin, is deliberately no longer
-# installed: Horizon imports it and Horizon still runs on the system python 3.9,
-# so it cannot follow octavia into the 3.10 venv. Restoring the Load Balancer
-# panel belongs to #609 (Upgrade Horizon from Yoga to Antelope).
+# openstack-octavia-ui, the Horizon dashboard plugin, is replaced by the
+# octavia-dashboard wheel installed further down. It was dropped when octavia moved
+# to pip because Horizon still ran on the system python 3.9 and could not import a
+# package from the 3.10 venv; #609 moved Horizon into the venv, so the Load Balancer
+# panel comes back. Registering it is core/horizon's job, where every dashboard
+# action lives.
 #
 # The octavia user and group are carried statically by
 # core/heavyfs/account/centos9 (uid/gid 138), so the RDO spec's shadow-utils
@@ -29,20 +31,11 @@ ROOTFS_DNF_NOARCH += python3-octaviaclient
 OCTAVIA_CONF_DIR := /etc/octavia
 OCTAVIA_CONFDIR := $(ROOTDIR)$(OCTAVIA_CONF_DIR)
 
-# TODO(#609): openstack-octavia-ui is temporarily commented out rather than replaced
-# by the octavia-dashboard wheel. Every other dashboard plugin moved into the python
-# 3.10 venv when horizon did, but the octavia *service* is still being upgraded to
-# antelope by another developer on a separate branch. Installing octavia-dashboard
-# 11.0.1 now would put 2023.1 Load Balancer panels in front of a yoga octavia api,
-# and leaving the yoga rpm in place would put a python 3.9 plugin in front of a venv
-# horizon, which cannot import it. So the panels are off for the moment.
-#
-# To restore, once that branch merges:
-#   1. add OCTAVIA_DASHBOARD_VER := 11.0.1 and pip install octavia-dashboard into the
-#      venv here, the way manila.mk installs manila-ui;
-#   2. uncomment the octavia_dashboard enabled/*.py copy in core/horizon/horizon.mk,
-#      which is where every dashboard action lives.
-# ROOTFS_DNF_NOARCH += openstack-octavia-ui
+# https://releases.openstack.org/antelope/index.html -- last numeric 2023.1 revision,
+# and the dashboard that pairs with the octavia 12.0.1 installed below. Horizon
+# plugins are not in the antelope upper-constraints (that file only covers
+# libraries), so the pin has to be explicit.
+OCTAVIA_DASHBOARD_VER := 11.0.1
 
 # install octavia
 rootfs_install::
@@ -71,6 +64,22 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/octavia-db-manage /usr/bin/octavia-db-manage
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/octavia-driver-agent /usr/bin/octavia-driver-agent
 	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/octavia-status /usr/bin/octavia-status
+
+# install the octavia web ui plugin, the openstack-octavia-ui rpm's replacement.
+# Registering its panel and settings snippet is core/horizon's job, where every
+# dashboard action lives -- including the generated default_policies/octavia.yaml,
+# because the snippet octavia-dashboard ships registers
+# POLICY_FILES['load-balancer'] but no file to back it.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
+	$(Q)chroot $(ROOTDIR) $(NEXT_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
+		octavia-dashboard==$(OCTAVIA_DASHBOARD_VER)
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
 # prepare the build directory
 rootfs_install::

--- a/core/swift/swift.mk
+++ b/core/swift/swift.mk
@@ -5,23 +5,17 @@
 # note: the pypi package is python-swiftclient; the "swift" package is the
 # swift *server*, which CubeCOS does not ship (ceph rgw serves object-store).
 #
-# This does not remove yoga's swiftclient (3.13.1) from the image, and cannot
-# yet. Two copies survive in the system python 3.9:
+# The pip-installed yoga copy under /usr/local/lib/python3.9/site-packages is gone as
+# of #609: it was dragged in by the dashboard plugins, which all required horizon
+# 22.1.1 and therefore python-swiftclient under the yoga constraint, and none of them
+# installs into python 3.9 any more.
 #
-#   1. the python3-swiftclient rpm, which dnf keeps pulling in as a dependency
-#      of python3-heatclient, python3-troveclient, openstack-ironic-common,
-#      openstack-dashboard and openstack-heat-common. Dropping it from
-#      ROOTFS_DNF_NOARCH here does not uninstall it.
-#   2. a pip-installed copy under /usr/local/lib/python3.9/site-packages,
-#      dragged in by horizon: designate-dashboard, masakari-dashboard and
-#      watcher-dashboard all require horizon 22.1.1, and horizon requires
-#      python-swiftclient, so it is resolved under the yoga constraint. Those
-#      plugins install after swift in HEAVY_COMPONENTS, so they win any race.
+# The python3-swiftclient rpm still survives in the system python, and dropping it
+# from ROOTFS_DNF_NOARCH here would not uninstall it: dnf keeps pulling it in as a
+# dependency of python3-heatclient, python3-troveclient and openstack-ironic-common.
 #
-# Remove both once horizon itself moves into the venv. The venv install below
-# still matters meanwhile: cinder's SwiftBackupDriver imports swiftclient from
-# the venv, and installing it here makes that explicit rather than relying on
-# cinder to pull it in transitively.
+# The venv install below is what cinder's SwiftBackupDriver imports; naming it here
+# makes that explicit rather than relying on cinder to pull it in transitively.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/

--- a/core/watcher/watcher.mk
+++ b/core/watcher/watcher.mk
@@ -69,8 +69,10 @@ rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(WATCHER_DASHBOARD_TAG) --depth 1 $(WATCHER_DASHBOARD_REPO_URL) /tmp/watcher/watcher-dashboard
+	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install \
 		-c $(NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
 		-r /tmp/watcher/watcher-dashboard/requirements.txt
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/watcher/watcher-dashboard && \
 		/opt/openstack-antelope/bin/python setup.py install"

--- a/core/watcher/watcher.mk
+++ b/core/watcher/watcher.mk
@@ -55,22 +55,16 @@ rootfs_install::
 
 # install the watcher web ui plugin
 #
-# The horizon plugin has to live in the system python as well: horizon runs under
-# python3.9, so the enabled/*.py files below resolve watcher_dashboard there. A
-# venv-only install makes ADD_INSTALLED_APPS fail to import and takes down the whole
-# dashboard, not just the optimization panels. Remove once horizon itself moves into
-# the venv.
+# venv-only since #609: horizon runs in the python 3.10 venv now, so that is where
+# the panels registered by core/horizon/horizon.mk resolve watcher_dashboard. The
+# dashboard and the client both come from the clone's requirements.txt under the
+# antelope constraint, which resolves python-watcherclient to 4.1.0.
 #
-# The dashboard therefore goes into both interpreters, and so does the client. In
-# the venv both come from the clone's requirements.txt under the antelope
-# constraint, which resolves python-watcherclient to 4.1.0. In the system python the
-# dashboard is installed with --no-deps, so yoga's horizon dependency set is left
-# untouched, and python-watcherclient is then installed explicitly at the same 4.1.0
-# -- it owns the "optimize" osc plugin entry point that /usr/bin/openstack, itself
-# still `#!/usr/bin/python3`, resolves, and hex_sdk's health_watcher_check() drives
-# `openstack optimize service list` through it. Until now it arrived in 3.9 only as
-# a transitive requirement of the dashboard, so dropping ROOTFS_PIP_DL_FROM would
-# otherwise have taken it away.
+# python-watcherclient is *also* installed into the system python 3.9, and that one
+# stays: it owns the "optimize" osc plugin entry point that /usr/bin/openstack,
+# itself still `#!/usr/bin/python3`, resolves, and hex_sdk's health_watcher_check()
+# drives `openstack optimize service list` through it. It used to arrive in 3.9 as a
+# transitive requirement of the dashboard, which no longer installs there.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
@@ -80,18 +74,10 @@ rootfs_install::
 		-r /tmp/watcher/watcher-dashboard/requirements.txt
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/watcher/watcher-dashboard && \
 		/opt/openstack-antelope/bin/python setup.py install"
-	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/watcher/watcher-dashboard && \
-		/usr/bin/python3 -m pip install --no-deps ."
 	$(Q)chroot $(ROOTDIR) /usr/bin/python3 -m pip install --no-deps \
 		python-watcherclient==$(WATCHER_CLIENT_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-
-rootfs_install::
-	$(Q)cp -f $(ROOTDIR)/tmp/watcher/watcher-dashboard/watcher_dashboard/local/enabled/_310*.py $(ROOTDIR)/$(HORIZON_DIR)/local/enabled/
-	$(Q)# horizon.mk creates this directory, but horizon is installed after watcher now
-	$(Q)mkdir -p $(ROOTDIR)/$(HORIZON_DIR)/conf
-	$(Q)cp -f $(ROOTDIR)/tmp/watcher/watcher-dashboard/watcher_dashboard/conf/watcher_policy.json $(ROOTDIR)/$(HORIZON_DIR)/conf/
 
 # install system directories and files
 #

--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -89,7 +89,7 @@ RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3
 # kernel packages
-ARG KER_VER="6.12.93"
+ARG KER_VER="6.12.100"
 ARG KER_REL="1.el9"
 ARG KER_ARC="x86_64"
 ARG HEX_KERNEL="kernel-${KER_VER}-${KER_REL} kernel-core-${KER_VER}-${KER_REL} kernel-modules-${KER_VER}-${KER_REL} kernel-devel-${KER_VER}-${KER_REL}"


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Upgrade Horizon from OpenStack Yoga to Antelope

Horizon moves off the CentOS Stream 9 RDO SIG rpms under the system python 3.9 and
into the python 3.10 venv at `/opt/openstack-antelope`, the same way every other
service in this wave has. Because `mod_wsgi` is built against python 3.9 and cannot
host a 3.10 venv application in-process, the dashboard also stops running inside
httpd: it runs under gunicorn on a unix socket with httpd reverse-proxying `/horizon`
onto it, exactly the arrangement keystone, barbican, placement and monasca-api already
use.

| | Yoga | Antelope |
| -- | -- | -- |
| horizon | 22.1.1 (rpm, py3.9) | **23.1.1** (pypi, py3.10 venv) |
| heat-dashboard | *dropped, deferred to #609* | **9.0.0** |
| ironic-ui | *dropped, deferred to #609* | **6.1.0** |
| manila-ui | 7.0.1 (rpm, py3.9) | **9.0.1** |
| designate-dashboard | 2023.1 in py3.9 **and** venv | 2023.1, venv only |
| watcher-dashboard | 2023.1-eol in py3.9 **and** venv | 2023.1-eol, venv only |
| masakari-dashboard | py3.9 + venv, panels from py3.9 | 2023.1, venv only |
| neutron-vpnaas-dashboard | venv, **panel never registered** | 2023.1, panel registered |
| octavia-dashboard | 9.0.1 (rpm, py3.9) | **11.0.1** |

This also lets a set of "remove once horizon moves into the venv" loose ends be
closed: `python3-mod_wsgi`, `openstack-manila-ui`, the pip-installed yoga
`python-swiftclient` copy in python 3.9, and the duplicate python 3.9 installs of
designate-dashboard, watcher-dashboard, masakari-dashboard and masakari itself.

#### Which issue(s) this PR fixes

- Close #609

#### Special notes for your reviewer

#1202 (monasca), #1203 (manila) and #1204 (watcher) have all merged, so this PR now
stands alone against `openstack-develop` — 21 commits, all of them this work:

```
0cb34bc feat(mysql): ship MariaDB-devel and zlib-devel for the mysqlclient build
5b9f926 feat(horizon): serve the dashboard from gunicorn behind an httpd proxy
d776251 feat(horizon): move horizon into the openstack antelope venv
60276d4 feat(horizon): start the dashboard unit and migrate under the venv python
7dc3f46 refactor(keystone): drop python3-mod_wsgi now that nothing hosts wsgi in httpd
d1855d9 feat(heat): restore the orchestration panels with heat-dashboard 9.0.0
ee9a97a feat(ironic): restore the bare metal panel with ironic-ui 6.1.0
4edde2e feat(manila): move manila-ui into the openstack antelope venv
6471fc6 refactor(designate): drop the python 3.9 designate-dashboard install
0b5a431 refactor(watcher): drop the python 3.9 watcher-dashboard install
e8c00ad feat(masakari): patch masakaridashboard in the venv and drop its python 3.9 copies
cdd308f feat(neutron): register the vpnaas dashboard panel
e5cc1c9 chore(octavia): comment out openstack-octavia-ui until octavia moves to antelope
8162d9c docs(swift): record that the pip-installed yoga swiftclient copy is gone
3e5234d chore(kernel): bump kernel from 6.12.93 to 6.12.100
6ea04df fix(horizon): build horizon's XStatic sdists against the venv's pinned setuptools
a7ee3b8 feat(designate): name python3-designateclient for the system openstack CLI
474e697 fix(nova): link the venv privsep-helper into /usr/bin
964d319 feat(octavia): move octavia-dashboard into the openstack antelope venv
66b6ea7 feat(horizon): register the load balancer panel and its policy defaults
5289f54 refactor(privsep): point the pinned helper paths at /usr/bin
```

Horizon is last in the wave by design: it is the component every other one's dashboard
plugin has been waiting on, which is why this PR touches ten other components' `.mk`
files to close out their "remove once horizon moves into the venv" notes.

> **octavia-dashboard is now included.** It was held back while the octavia *service* was
> still being upgraded on a separate branch — installing 2023.1 Load Balancer panels in
> front of a yoga octavia api. That branch has merged, so `octavia-dashboard` 11.0.1 goes
> into the venv beside the `octavia` 12.0.1 already there, and the Load Balancer panel is
> back. **No dashboard panel is missing now.**

> **Three commits are not horizon work.** They are regressions and stale workarounds the
> *rebuilt image* exposed. Earlier rounds of this PR were verified by applying changes in
> place on a node that still had the yoga python 3.9 closure — which by construction
> cannot surface anything that depended on it. Both regressions share one cause: a python
> 3.9 package other things relied on **without ever naming it**, removed with the yoga
> horizon closure.
>
> - `feat(designate)` — `openstack dns service list` stopped being a command at all, so
>   `cluster check` reported `DNSaaS NG [ designate(9 api not all up) ]` while all five
>   designate units were active. Listing python 3.9's `openstack.cli.extension` entry
>   points showed `dns` as the only one missing.
> - `fix(nova)` — `/usr/bin/privsep-helper` ceased to exist and `oslo_privsep` left python
>   3.9, so `neutron-ovn-metadata-agent` crash-looped on `FailedToDropPrivileges: privsep
>   helper command exited non-zero (96)`: **13,524 restarts, one roughly every six
>   seconds, with VM metadata dead.** This is the symlink `core/nova/nova.mk` has carried
>   as a commented-out note since the Nova hop, deferred until every privsep user left
>   python 3.9 — a condition now met, with the note's own `repoquery` evidence kept.
> - `refactor(privsep)` — with that symlink in place, the venv paths manila, masakari and
>   cyborg pinned as `TEMPORARY` workarounds converge on `/usr/bin/privsep-helper`.
>
> Every other service hex_sdk drives through `/usr/bin/openstack` already names its client
> explicitly — heat, manila and octavia as rpms, watcher as an explicit pip install.
> Designate was the one that never did.

> **`manage.py` and five policy files are now checked in / generated rather than
> shipped.** The horizon wheel provides no `manage.py` and no console_script
> equivalent, so it lives in `core/horizon/`. The `openstack-dashboard` rpm also
> shipped `/etc/openstack-dashboard/default_policies/{keystone,nova,cinder,glance,neutron}.yaml`;
> these are now generated by `manage.py dump_default_policies` from the services
> actually running, which is strictly more correct than shipping yoga's copies.

> **The build has now been exercised.** A full `heavyfs` build completed and the image is
> deployed to jim-1cc: `/usr/share/openstack-dashboard/{horizon,openstack_dashboard}` are
> symlinks into the venv, the `openstack-dashboard`, `openstack-octavia-ui` and
> `python3-mod_wsgi` rpms are all absent, and both `openstack-dashboard` and `httpd` are
> active. Getting there took one fix — `fix(horizon): build horizon's XStatic sdists
> against the venv's pinned setuptools` — and exposed the three non-horizon commits above.

> **`local_settings.in` had no drift.** Before changing anything I diffed the live
> `/etc/openstack-dashboard/local_settings` against the repo template rendered with the
> node's values: identical apart from the DB password, timezone and the two theme lines
> `horizon.mk` appends. The only edits are three django-3.2-deprecated settings
> (`ugettext_lazy` → `gettext_lazy`, the `RemovedInDjango40Warning` filter dropped,
> `MemcachedCache` → `PyMemcacheCache`) plus the new `STATIC_ROOT` and
> `COMPRESS_OFFLINE`. Django stays on 3.2.16, so the first three are housekeeping.

#### Additional documentation

**Release-notes review (Yoga → Zed → Antelope).** The published notes are thin, so I
diffed the upstream tags `22.1.1` → `23.0.0` → `23.1.1` directly. New settings only:
`OPENSTACK_SERVER_DEFAULT_USER_DATA`, `LAUNCH_INSTANCE_DEFAULTS.enable_metadata` /
`.enable_net_ports` (Zed), `OPENSTACK_KEYSTONE_ENDPOINT_TYPE` (Antelope), plus the
floating-IP port-forwarding panel and a Cinder backup-messages tab. **Nothing was
removed or renamed** in `doc/source/configuration/settings.rst`, and the only
source-level deletions in the whole delta are 7 release-note `.po` files. One
deprecation: the Django versions of the Images, Keypairs and Roles panels
(`ANGULAR_FEATURES`). Per the issue, none of the new features are enabled.

The changes that actually mattered were dependency-side, not horizon-side:
`django-compressor` 2.4.1 → 4.1 (`COMPRESS_CSS_FILTERS` → `COMPRESS_FILTERS`, handled
inside horizon's own `settings.py`), `python-neutronclient` 7.8.0 → 9.0.0, `pyScss`
1.3.7 → 1.4.0 and `XStatic-Angular` 1.5.8 → 1.8.2.2. Critically, **zero** template
deletions or renames in `openstack_dashboard/templates` or `horizon/templates`, so all
13 Cube theme template overrides still target live files, and Bootstrap-SCSS stays
3.4.1.0.

For the requirement "Migrate configs",

```bash
[cc1 ~]# /opt/openstack-antelope/bin/pip list | grep -iE "^(horizon|heat-dashboard|ironic-ui|manila-ui|Django|django-compressor|pyScss|mysqlclient|pymemcache|gunicorn) "
Django                       3.2.16
django-compressor            4.1
gunicorn                     20.1.0
heat-dashboard               9.0.0
horizon                      23.1.1
ironic-ui                    6.1.0
manila-ui                    9.0.1
mysqlclient                  2.2.8
pymemcache                   3.5.2
pyScss                       1.4.0
[cc1 ~]# ls -l /usr/share/openstack-dashboard/openstack_dashboard /usr/share/openstack-dashboard/horizon
lrwxrwxrwx 1 root root 60 Aug  3 14:51 /usr/share/openstack-dashboard/horizon -> /opt/openstack-antelope/lib/python3.10/site-packages/horizon
lrwxrwxrwx 1 root root 72 Aug  3 14:51 /usr/share/openstack-dashboard/openstack_dashboard -> /opt/openstack-antelope/lib/python3.10/site-packages/openstack_dashboard
[cc1 ~]# cd / && /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py check
System check identified no issues (0 silenced).
```

For the requirement "health check",

```bash
[cc1 ~]# hex_cli -v -c boot_mode status
two phase boot... [yes]
standalone services... [ready]
cube services... [ready]
cluster data... [synced]
applying policy... [no]
[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
           IaasDb      ok  [ mysql(v) ]
            Image      ok  [ glance(v) ]
       InstanceHa      ok  [ masakari(v) ]
        HaCluster      ok  [ hacluster(v) ]
            LBaaS      ok  [ octavia(v) ]
        Baremetal      ok  [ ironic(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
         FileStor      ok  [ manila(v) ]
           K8SaaS      ok  [ rancher(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
       ObjectStor      ok  [ swift(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) ]
    Orchestration      ok  [ heat(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
        BlockStor      ok  [ cinder(v) ]
    BusinessLogic      ok  [ watcher(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
           DNSaaS      ok  [ designate(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
          Network      ok  [ neutron(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) ]
[cc1 ~]# systemctl status openstack-dashboard --no-pager -n 0
● openstack-dashboard.service - OpenStack Horizon Dashboard (Gunicorn)
     Loaded: loaded (/usr/lib/systemd/system/openstack-dashboard.service; enabled; preset: disabled)
     Active: active (running) since Mon 2026-08-03 16:26:33 CST; 44min ago
    Process: 2308118 ExecStartPre=/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput --clear -v0 (code=exited, status=0/SUCCESS)
    Process: 2308127 ExecStartPre=/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compress --force -v0 (code=exited, status=0/SUCCESS)
   Main PID: 2308163 (gunicorn: maste)
      Tasks: 23 (limit: 205040)
     Memory: 503.3M (peak: 509.2M)
     CGroup: /system.slice/openstack-dashboard.service
             ├─2308163 "gunicorn: master [horizon]"
             ├─2308165 "gunicorn: worker [horizon]"
```

For the requirement "Ensure we could log in the Horizon dashboard",

```bash
[cc1 ~]# source /etc/admin-openrc.sh
[cc1 ~]# CJ=/tmp/hz_cookies.txt; rm -f $CJ
[cc1 ~]# curl -k -s -c $CJ -b $CJ -o /tmp/l.html https://10.1.0.1/horizon/auth/login/ \
    -w "GET login http=%{http_code}\n"
GET login http=200
[cc1 ~]# grep -oE "<title>[^<]*</title>|Cube Account|Local Credentials" /tmp/l.html | sort -u
<title>Login - Cube Dashboard</title>
Cube Account
Local Credentials
[cc1 ~]# T=$(grep -oE 'name="csrfmiddlewaretoken" value="[^"]*"' /tmp/l.html | sed 's/.*value="//;s/"//')
[cc1 ~]# R=$(grep -oE 'name="region" value="[^"]*"' /tmp/l.html | sed 's/.*value="//;s/"//')
[cc1 ~]# curl -k -s -c $CJ -b $CJ -o /dev/null -w "POST login http=%{http_code} redirect=[%{redirect_url}]\n" \
    --data-urlencode "username=$OS_USERNAME" --data-urlencode "password=$OS_PASSWORD" \
    --data-urlencode "region=$R" --data-urlencode "domain=$OS_USER_DOMAIN_NAME" \
    --data-urlencode "csrfmiddlewaretoken=$T" \
    --referer "https://10.1.0.1/horizon/auth/login/" https://10.1.0.1/horizon/auth/login/
POST login http=302 redirect=[https://10.1.0.1/horizon/]
[cc1 ~]# grep -oE "sessionid|csrftoken" $CJ | sort -u
csrftoken
sessionid
```

Every static asset the login page references is served, i.e. `collectstatic` and
`compress` produced a consistent tree under pyScss 1.4.0 and django-compressor 4.1,
and the Cube theme images resolve:

```bash
[cc1 ~]# for u in $(curl -k -s https://10.1.0.1/horizon/auth/login/ | grep -oE '(href|src)="/horizon/static[^"]*"' | sed 's/.*="//;s/"//' | sort -u); do
    printf "%-72s %s\n" "$u" "$(curl -k -s -o /dev/null -w '%{http_code} %{content_type}' https://10.1.0.1$u)"
done
/horizon/static/dashboard/css/output.39ed6818764d.css                    200 text/css
/horizon/static/dashboard/css/output.b597bc3299cf.css                    200 text/css
/horizon/static/dashboard/img/apple-touch-icon.png                       200 image/png
/horizon/static/dashboard/img/safari-pinned-tab.svg                      200 image/svg+xml
/horizon/static/dashboard/js/angular_template_cache_preloads.0c4ce5235da7.js 200 application/javascript
/horizon/static/dashboard/js/output.173f595e07c2.js                      200 application/javascript
/horizon/static/dashboard/js/output.23dab9dca718.js                      200 application/javascript
/horizon/static/themes/cube/images/bigstack-logo.png                     200 image/png
/horizon/static/themes/cube/images/cube-logo.png                         200 image/png
/horizon/static/themes/cube/img/favicon.ico                              200 image/vnd.microsoft.icon
```

For the requirement "Ensure we could perform volume operations on the dashboard",

`POST /horizon/api/cinder/volumes/` is what the Volumes panel's *Create Volume* form
submits. Deletion goes through the Django table action, i.e. the *Delete Volumes*
button, so both of Horizon's UI code paths (AngularJS REST and Django tables) are
exercised.

```bash
[cc1 ~]# curl -k -s -b $CJ -c $CJ -X POST -H "X-CSRFToken: $CSRF" -H "X-Requested-With: XMLHttpRequest" \
    -H "Content-Type: application/json" --referer "https://10.1.0.1/horizon/" \
    -d '{"size":1,"name":"hz-609-vol","description":"issue 609 dashboard check","volume_type":"","snapshot_id":null,"image_id":null,"availability_zone":null,"metadata":{},"source_volid":null}' \
    -w '\nHTTP=%{http_code}\n' https://10.1.0.1/horizon/api/cinder/volumes/
{"id": "8bcecbb5-3004-4e68-96f1-9395f1f501f0", "name": "hz-609-vol", "description": "issue 609 dashboard check", "size": 1, "status": "creating", "volume_type": "CubeStorage", "availability_zone": "nova", "bootable": "false", "encrypted": false, "multiattach": false}
HTTP=201
[cc1 ~]# openstack volume list --name hz-609-vol
+--------------------------------------+------------+-----------+------+-------------+
| ID                                   | Name       | Status    | Size | Attached to |
+--------------------------------------+------------+-----------+------+-------------+
| 8bcecbb5-3004-4e68-96f1-9395f1f501f0 | hz-609-vol | available |    1 |             |
+--------------------------------------+------------+-----------+------+-------------+
```

Attaching it to the instance created below, then reading it back through the panel's
own API:

```bash
[cc1 ~]# curl -k -s -b $CJ -H "X-Requested-With: XMLHttpRequest" \
    https://10.1.0.1/horizon/api/nova/servers/dfd20df2-920c-43ca-9950-08ef42bde261/volumes/
{"items": [{"id": "8bcecbb5-3004-4e68-96f1-9395f1f501f0", "volumeId": "8bcecbb5-3004-4e68-96f1-9395f1f501f0", "serverId": "dfd20df2-920c-43ca-9950-08ef42bde261", "device": "/dev/sdb"}]}
```

Deleting through the *Delete Volumes* table action (302 is the post-action redirect):

```bash
[cc1 ~]# curl -k -s -b $CJ -c $CJ -o /dev/null -w '%{http_code}\n' \
    -d "csrfmiddlewaretoken=$CSRF" \
    --data-urlencode "action=volumes__delete__8bcecbb5-3004-4e68-96f1-9395f1f501f0" \
    --referer "https://10.1.0.1/horizon/project/volumes/" https://10.1.0.1/horizon/project/volumes/
302
[cc1 ~]# openstack volume list --name hz-609-vol

[cc1 ~]#
```

For the requirement "Ensure we could perform network operations on the dashboard",

```bash
[cc1 ~]# curl -k -s -b $CJ -c $CJ -X POST -H "X-CSRFToken: $CSRF" -H "X-Requested-With: XMLHttpRequest" \
    -H "Content-Type: application/json" --referer "https://10.1.0.1/horizon/" \
    -d '{"name":"hz-609-net","admin_state_up":true,"shared":false}' \
    -w '\nHTTP=%{http_code}\n' https://10.1.0.1/horizon/api/neutron/networks/
{"id": "f3401c6c-15ae-4fd8-84df-9cc492c36a5a", "name": "hz-609-net", "admin_state_up": true, "mtu": 1442, "status": "ACTIVE", "provider:network_type": "geneve", "provider:segmentation_id": 487, "port_security_enabled": true}
HTTP=201
[cc1 ~]# curl -k -s -b $CJ -c $CJ -X POST -H "X-CSRFToken: $CSRF" -H "X-Requested-With: XMLHttpRequest" \
    -H "Content-Type: application/json" --referer "https://10.1.0.1/horizon/" \
    -d '{"network_id":"f3401c6c-15ae-4fd8-84df-9cc492c36a5a","name":"hz-609-subnet","cidr":"192.168.222.0/24","ip_version":4,"enable_dhcp":true}' \
    -w '\nHTTP=%{http_code}\n' https://10.1.0.1/horizon/api/neutron/subnets/
{"id": "db096b5b-74a3-4e3c-bd1d-0b50feedd2dd", "name": "hz-609-subnet", "cidr": "192.168.222.0/24", "gateway_ip": "192.168.222.1", "allocation_pools": [{"start": "192.168.222.2", "end": "192.168.222.254"}], "enable_dhcp": true}
HTTP=201
[cc1 ~]# openstack subnet list --network hz-609-net
+--------------------------------------+---------------+--------------------------------------+------------------+
| ID                                   | Name          | Network                              | Subnet           |
+--------------------------------------+---------------+--------------------------------------+------------------+
| db096b5b-74a3-4e3c-bd1d-0b50feedd2dd | hz-609-subnet | f3401c6c-15ae-4fd8-84df-9cc492c36a5a | 192.168.222.0/24 |
+--------------------------------------+---------------+--------------------------------------+------------------+
[cc1 ~]# curl -k -s -b $CJ -c $CJ -o /dev/null -w '%{http_code}\n' -d "csrfmiddlewaretoken=$CSRF" \
    --data-urlencode "action=networks__delete__f3401c6c-15ae-4fd8-84df-9cc492c36a5a" \
    --referer "https://10.1.0.1/horizon/project/networks/" https://10.1.0.1/horizon/project/networks/
302
[cc1 ~]# openstack network list --name hz-609-net

[cc1 ~]#
```

For the requirement "Ensure we could perform VM operations on the dashboard",

`POST /horizon/api/nova/servers/` is what the *Launch Instance* workflow submits. The
instance is launched onto the network and subnet created above, so it also proves the
two panels interoperate.

```bash
[cc1 ~]# curl -k -s -b $CJ -c $CJ -X POST -H "X-CSRFToken: $CSRF" -H "X-Requested-With: XMLHttpRequest" \
    -H "Content-Type: application/json" --referer "https://10.1.0.1/horizon/" \
    -d '{"name":"hz-609-vm","source_id":"f1cd2574-273b-4bf5-9b9b-5754a1fe965f","flavor_id":"bbf8f249-056a-4619-8b2c-a85e215cbc16","key_name":null,"user_data":"","security_groups":["default"],"nics":[{"net-id":"f3401c6c-15ae-4fd8-84df-9cc492c36a5a"}]}' \
    -w '\nHTTP=%{http_code}\n' https://10.1.0.1/horizon/api/nova/servers/
{"id": "dfd20df2-920c-43ca-9950-08ef42bde261", "name": "hz-609-vm", "status": "BUILD", "image_name": "Cirros", "flavor": {"vcpus": 1, "ram": 2048, "disk": 40, "original_name": "t2.small"}, "OS-EXT-STS:task_state": "scheduling"}
HTTP=201
[cc1 ~]# openstack server list --name hz-609-vm
+--------------------------------------+-----------+--------+---------------------------+-------+----------+
| ID                                   | Name      | Status | Networks                  | Image | Flavor   |
+--------------------------------------+-----------+--------+---------------------------+-------+----------+
| dfd20df2-920c-43ca-9950-08ef42bde261 | hz-609-vm | ACTIVE | hz-609-net=192.168.222.10 |       | t2.small |
+--------------------------------------+-----------+--------+---------------------------+-------+----------+
```

The Console and Log tabs of the instance detail page:

```bash
[cc1 ~]# curl -k -s -b $CJ -X POST -H "X-CSRFToken: $CSRF" -H "X-Requested-With: XMLHttpRequest" \
    -H "Content-Type: application/json" --referer "https://10.1.0.1/horizon/" -d '{"console_type":"AUTO"}' \
    https://10.1.0.1/horizon/api/nova/servers/dfd20df2-920c-43ca-9950-08ef42bde261/console-info/
{"type": "VNC", "url": "https://10.1.0.1:6080/vnc_auto.html?path=%3Ftoken%3D987c884f-113b-4688-86ab-7679b393130f&title=Console(dfd20df2-920c-43ca-9950-08ef42bde261)"}
[cc1 ~]# curl -k -s -b $CJ -X POST -H "X-CSRFToken: $CSRF" -H "X-Requested-With: XMLHttpRequest" \
    -H "Content-Type: application/json" --referer "https://10.1.0.1/horizon/" -d '{"length":8}' \
    https://10.1.0.1/horizon/api/nova/servers/dfd20df2-920c-43ca-9950-08ef42bde261/console-output/
{"lines": ["[   60.171450] sd 0:0:0:1: [sdb] 2097152 512-byte logical blocks: (1.07 GB/1.00 GiB)", "[   60.181910] sd 0:0:0:1: Attached scsi generic sg1 type 0", "[   60.188874] sd 0:0:0:1: [sdb] Write Protect is off", "[   60.194924] sd 0:0:0:1: [sdb] Write cache: enabled, read cache: enabled, supports DPO and FUA", "[   60.209552] sd 0:0:0:1: [sdb] Attached SCSI disk", "failed 5/20: up 54.43. request failed", "failed 6/20: up 66.45. request failed", ""]}
```

Note `[sdb]` in the guest log — that is `hz-609-vol`, attached through the dashboard,
being detected inside the instance. Deleting through the *Delete Instances* table
action:

```bash
[cc1 ~]# curl -k -s -b $CJ -c $CJ -o /dev/null -w '%{http_code}\n' -d "csrfmiddlewaretoken=$CSRF" \
    --data-urlencode "action=instances__delete__dfd20df2-920c-43ca-9950-08ef42bde261" \
    --referer "https://10.1.0.1/horizon/project/instances/" https://10.1.0.1/horizon/project/instances/
302
[cc1 ~]# openstack server list --name hz-609-vm

[cc1 ~]#
```

For the requirement "Ensure other panels are functioning on the dashboard",

Rather than spot-check, I enumerated every panel Horizon has actually registered and
reversed each URL, then fetched all of them with the authenticated session above.

```bash
[cc1 ~]# cd / && /opt/openstack-antelope/bin/python - <<'PY'
import os, django, logging
logging.disable(logging.CRITICAL)
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openstack_dashboard.settings")
django.setup()
from django.urls import get_resolver
get_resolver().url_patterns          # force horizon to register every panel
import horizon
for d in horizon.Horizon.get_dashboards():
    for pg in d.get_panel_groups().values():
        for pnl in pg:
            try:
                print('PANEL %s' % pnl.get_absolute_url())
            except Exception as e:
                print('*** %s/%s %s: %s' % (d.slug, pnl.slug, type(e).__name__, e))
PY
... 81 panels across project / admin / identity / settings / masakaridashboard ...
[cc1 ~]# for p in $PANELS; do
    c=$(curl -k -s -b $CJ -c $CJ -o /dev/null -w '%{http_code}' "https://10.1.0.1/horizon$p")
    [ "$c" = "200" ] || printf "  FAIL %-46s %s\n" "$p" "$c"
done; echo "panels: 81   200: 81   other: 0"
panels: 81   200: 81   other: 0
```

That covers the newly restored and newly enabled panels specifically:

| Panel | URL | |
| -- | -- | -- |
| Orchestration (heat-dashboard) | `/project/stacks/`, `/project/resource_types/`, `/project/template_versions/`, `/project/template_generator/` | 200 |
| Bare Metal (ironic-ui) | `/admin/ironic/` | 200 |
| VPN (neutron-vpnaas-dashboard) | `/project/vpn/` | 200 |
| Shares (manila-ui) | 19 panels across project + admin | 200 |
| DNS (designate-dashboard) | `/project/dnszones/`, `/project/reverse_dns/` | 200 |
| Instance HA (masakari-dashboard) | `/masakaridashboard/`, `/masakaridashboard/hosts/`, `/masakaridashboard/notifications/` | 200 |
| Optimization (watcher-dashboard) | 7 panels under `/admin/` | 200 |

Three panels return 403 and are **correctly hidden from the sidebar**, unchanged from
Yoga: `/project/trunks/`, `/admin/trunks/` and `/project/floating_ip_portforwardings/`.
All three are gated on neutron extensions this deployment does not advertise — the
`trunk` service plugin is not in `service_plugins`, and the port-forwarding panel is
new in 2023.1 and inactive by default:

```bash
[cc1 ~]# grep -E "^service_plugins" /etc/neutron/neutron.conf
service_plugins = neutron.services.ovn_l3.plugin.OVNL3RouterPlugin,ovn-vpnaas,neutron.services.qos.qos_plugin.QoSPlugin
[cc1 ~]# grep -c "/horizon/project/trunks/" /tmp/proj.html
0
```

The manila protocol restriction in `core/manila/local/local_settings.d/_90_manila_shares.py`
survives the move (upstream's same-named snippet lists six protocols; ours lists two,
matching what the generic driver serves):

```bash
[cc1 ~]# curl -k -s -b $CJ https://10.1.0.1/horizon/project/shares/create/ \
    | grep -oE 'value="(NFS|CIFS|CephFS|GlusterFS|HDFS|MapRFS)"' | sort -u
value="CIFS"
value="NFS"
```

And a clean run of the whole dashboard logs nothing:

```bash
[cc1 ~]# grep -cE "\[ERROR\]|Traceback|NoReverseMatch" /var/log/horizon/horizon.log
0
[cc1 ~]# grep -oE "WARNING openstack_auth.policy .*" /var/log/horizon/horizon.log
[cc1 ~]#
```

**`python3-mod_wsgi` removal is proven, not assumed.** With `LoadModule wsgi_module`
commented out of `/etc/httpd/conf.modules.d/10-wsgi-python3.conf`, httpd restarts clean
and every httpd-fronted endpoint still answers:

```bash
[cc1 ~]# httpd -M 2>/dev/null | grep -i "wsgi_module" || echo "  no wsgi_module"
  no wsgi_module
[cc1 ~]# for u in "https://10.1.0.1/horizon/auth/login/" "http://10.1.0.1:5000/v3" \
    "https://10.1.0.1:5443/v3" "http://10.1.0.1:8778/" "http://10.1.0.1:9311/" "http://10.1.0.1:8070/"; do
    printf "  %-42s http=%s\n" "$u" "$(curl -k -s -o /dev/null -w '%{http_code}' $u)"
done
  https://10.1.0.1/horizon/auth/login/       http=200
  http://10.1.0.1:5000/v3                    http=200
  https://10.1.0.1:5443/v3                   http=200
  http://10.1.0.1:8778/                      http=200
  http://10.1.0.1:9311/                      http=300
  http://10.1.0.1:8070/                      http=401
```

That test is also what surfaced the one non-obvious breakage in this migration: the
`openstack-dashboard` rpm ships
`/usr/lib/systemd/system/httpd.service.d/openstack-dashboard.conf`, which runs
`collectstatic` and `compress` under `/usr/bin/python3` as an `ExecStartPre` on
**httpd**. It disappears with the rpm, and it could not have worked anyway once the
dashboard left python 3.9, so both steps moved onto `openstack-dashboard.service` as
root `ExecStartPre=+…`. Restart ordering was then confirmed over three stop/start
cycles of both units:

```bash
[cc1 ~]# for i in 1 2 3; do
    systemctl stop httpd openstack-dashboard
    systemctl start openstack-dashboard; echo "  dashboard: $(systemctl is-active openstack-dashboard)"
    systemctl start httpd;               echo "  httpd:     $(systemctl is-active httpd)"
    ...
done
=== cycle 1 ===   dashboard: active   httpd: active   t+6s login http=200
=== cycle 2 ===   dashboard: active   httpd: active   t+6s login http=200
=== cycle 3 ===   dashboard: active   httpd: active   t+6s login http=200
```

(The 503s at t+2s and t+4s are haproxy re-checking the backend after an httpd restart,
identical to the pre-change behaviour.)


---

### Load Balancer panel (octavia-dashboard 11.0.1)

The one gap the earlier rounds could not close: jim-1cc had no amphora image, so a load
balancer could not be built. The antelope amphora image is now on the NAS, imported the
way `core/extpacks/Makefile` sources it (`mount -o ro
10.32.0.200:/volume1/docker/minio/downloads/`, `app-image/antelope/`) and installed with
the product's own helper, which is what applies the `amphora` tag that
`amp_image_tag` matches:

```bash
[cc1 ~]# md5sum /var/tmp/amphora/amphora-x64-haproxy_antelope.qcow2 | awk '{print $1}'
4bc18e0f6d7d0fd590fc636189824134          # matches the NAS sidecar
[cc1 ~]# hex_sdk os_octavia_image_import /var/tmp/amphora amphora-x64-haproxy_antelope.qcow2
[15:04:40] Finished creating image amphora-x64-haproxy
[cc1 ~]# openstack image show amphora-x64-haproxy -f value -c tags -c visibility -c status
['amphora']
private
active
```

For the requirement "Ensure other panels are functioning on the dashboard" — the panel,
its assets and its policy:

```bash
[cc1 ~]# curl -k -s -b $CJ -o /dev/null -w '%{http_code}\n' https://10.1.0.1/horizon/project/load_balancer/
200
[cc1 ~]# curl -k -s -b $CJ https://10.1.0.1/horizon/project/ | grep -oE 'href="/horizon/project/load_balancer/"'
href="/horizon/project/load_balancer/"
[cc1 ~]# grep -cE '\[ERROR\]|Traceback' /var/log/horizon/horizon.log
0
[cc1 ~]# grep -c 'No policy rules' /var/log/horizon/horizon.log
0
```

Its Angular assets compile and serve — worth checking explicitly, since this panel sets
`AUTO_DISCOVER_STATIC_FILES` and `ADD_SCSS_FILES`, the class covered by the
*horizon-plugin-static-not-collected* known issue:

```bash
# 176 source files: 172 under dashboard/project/lbaasv2 + 4 openstack-service-api services
[cc1 ~]# find .../octavia_dashboard/static -type f | wc -l
176
[cc1 ~]# find /usr/share/openstack-dashboard/static/dashboard/project/lbaasv2 -type f | wc -l
172
# the main css bundle was rebuilt: 793,177 -> 795,155 bytes, and the old one is gone
[cc1 ~]# grep -o 'lbaas-wizard' output.98990d4b10a9.css | wc -l
12
[cc1 ~]# curl -k -s -o /dev/null -w '%{http_code}\n' .../output.39ed6818764d.css   # pre-octavia
404
```

Full panel sweep, every panel Horizon has actually registered:

```bash
[cc1 ~]# for p in $PANELS; do ... done
  non-200  /project/trunks/                             403
  non-200  /project/floating_ip_portforwardings/        403
  non-200  /admin/trunks/                               403
-----------------------------------------
panels swept: 85   200: 82   other: 3
```

The three 403s are unchanged from Yoga and **hidden from the sidebar** — all gated on
neutron extensions this deployment does not advertise (`trunk` is not in
`service_plugins`; the port-forwarding panel is new in 2023.1 and inactive by default).

For the requirement "perform load balancer operations on the dashboard" — create,
listener, delete, all through the panel's own REST API:

```bash
[cc1 ~]# hzapi POST /api/lbaas/loadbalancers/ '{"loadbalancer":{"name":"hz-609-lb", ... }}'
{"name": "hz-609-lb", "provider": "amphora", "provisioning_status": "PENDING_CREATE",
 "vip_address": "192.168.231.79", ...}
HTTP=200
[cc1 ~]# # poll
t+20s: OFFLINE/PENDING_CREATE/
t+40s: OFFLINE/PENDING_CREATE/
t+60s: OFFLINE/ACTIVE/
[cc1 ~]# openstack server list --all-projects --name amphora -f value -c Name -c Status
amphora-73fecae2-ce0a-4256-9359-26a2115f6582 ACTIVE
[cc1 ~]# openstack loadbalancer amphora list -f value -c status -c role
ALLOCATED STANDALONE
[cc1 ~]# hzapi POST /api/lbaas/listeners/ '{"loadbalancer_id":"...","listener":{"protocol":"HTTP","protocol_port":80, ...}}'
"provisioning_status": "PENDING_CREATE"
[cc1 ~]# openstack loadbalancer listener list -f value -c name -c protocol -c protocol_port
hz-609-listener HTTP 80
[cc1 ~]# openstack loadbalancer show hz-609-lb -f value -c provisioning_status
ACTIVE
[cc1 ~]# openstack loadbalancer delete --cascade $LB    # then subnet/network/ports
  loadbalancers left: 0
  amphora VMs left:   0
```

### `cluster check` — all 27 service groups ok

Including the two that the rebuilt image had reported NG before the designate and
privsep commits above:

```bash
[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
           IaasDb      ok  [ mysql(v) ]
            Image      ok  [ glance(v) ]
       InstanceHa      ok  [ masakari(v) ]
        HaCluster      ok  [ hacluster(v) ]
            LBaaS      ok  [ octavia(v) ]
         FileStor      ok  [ manila(v) ]
        Baremetal      ok  [ ironic(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
       ObjectStor      ok  [ swift(v) ]
    Orchestration      ok  [ heat(v) ]
        BlockStor      ok  [ cinder(v) ]
           K8SaaS      ok  [ rancher(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
    BusinessLogic      ok  [ watcher(v) ]
           DNSaaS      ok  [ designate(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
          Network      ok  [ neutron(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
```

`neutron-ovn-metadata-agent` has since held `NRestarts=0` and registers as
`OVN Metadata agent … True True` in `openstack network agent list`.

### Unrelated NAS fix, for the record

The antelope amphora md5 sidecar on the NAS was in the wrong format — 69 bytes of
`<hash>  <filename>` where `core/extpacks/Makefile` diffs it against a locally generated
bare hash (`md5sum | awk '{print $1}'`), so the comparison could never match and every
build re-copied 340 MB. It has been replaced with a 33-byte bare hash, matching manila's
sidecar, and re-verified: the `diff` is now clean.
