### PR TITLE
feat(jail): bump pinned kernel 6.12.95 → 6.12.96

### DIFF
--- a/jail/jail.ubi9.dockerfile
+++ b/jail/jail.ubi9.dockerfile
@@ -96,7 +96,7 @@ RUN dnf install -y --nobest --allowerasing $HEX_BE $HEX_SDK $HEX_EXTRA $HEX_TEST
 ######## tier3
 FROM tier2_weak_dep_${WEAK_DEP} AS tier3
 # kernel packages
-ARG KER_VER="6.12.95"
+ARG KER_VER="6.12.96"
 ARG KER_REL="1.el9"
 ARG KER_ARC="x86_64"
 ARG HEX_KERNEL="kernel-${KER_VER}-${KER_REL} kernel-core-${KER_VER}-${KER_REL} kernel-modules-${KER_VER}-${KER_REL} kernel-devel-${KER_VER}-${KER_REL}"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it
Bump the pinned kernel `6.12.95 → 6.12.96` in `jail/jail.ubi9.dockerfile` (`KER_VER`). The OS image inherits its kernel from the jail, so this upgrades the shipped CubeCOS kernel.

Forcing function: the CentOS Stream 9 SIG kmods mirror rolls old kernels off, and `6.12.95` is already gone — a clean `make centos9-jail` 404s fetching it. `6.12.96`–`6.12.100` remain; all four `6.12.96-1.el9` RPMs verified present.

Validated locally: clean jail rebuild on 6.12.96 + `pxedeploy` produced `CUBE_3.1.10_20260803-1344_9527eee.pkg`.

#### Which issue(s) this PR fixes

Fixes #1209

#### Special notes for your reviewer

> Kernel **upgrade** — keep in draft until a lab install confirms boot + `cluster check` all-`ok` on 6.12.96 (per #1209 DoD). Recurring risk: the SIG mirror rolls kernels off, so this pin needs periodic bumps (or a local mirror/archive) — tracked as a follow-up in #1209.

#### Additional documentation

```docs
Handbook note (jail kernel pin + SIG mirror-drift gotcha) to land per #1209 DoD.
```
