### PR TITLE
fix(fts): green cluster-check on fresh HA FTS — git-init, manila service-net, DB/OVN resilience

### DIFF
--- a/core/manila/openstack-manila-share.service
+++ b/core/manila/openstack-manila-share.service
@@ -5,8 +5,15 @@ After=syslog.target network.target
 [Service]
 Type=simple
 User=manila
+TimeoutStartSec=180
 ExecCondition=/usr/sbin/hex_sdk is_first_three_compute_node
+# First compute node pre-creates exactly one service network before the daemon's
+# workers start (root); other nodes are a no-op. Prevents the lazy-create race.
+ExecStartPre=+/usr/sbin/hex_sdk os_manila_service_network_ensure
 ExecStart=/usr/bin/manila-share --config-file /usr/share/manila/manila-dist.conf --config-file /etc/manila/manila.conf --logfile /var/log/manila/share.log
+# Retry a pre-start that failed because neutron wasn't ready yet.
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -462,6 +462,12 @@ SetDatabaseConnection(
     uri << "mysql+pymysql://cinder:" << dbPass << "@" << sharedId << "/cinder";
 
     config["database"]["connection"] = uri.str();
+    // reconnect on a lost DB connection (survive the set_ready VIP/galera reconfig)
+    config["database"]["use_db_reconnect"] = "true";
+    config["database"]["db_max_retries"] = "-1";
+    config["database"]["db_retry_interval"] = "1";
+    config["database"]["db_inc_retry_interval"] = "true";
+    config["database"]["db_max_retry_interval"] = "10";
 }
 
 /**

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -500,7 +500,7 @@ UpdateCfg(std::string domain, std::string region, std::string password,
         ml2Cfg["ovn"]["ovn_l3_scheduler"] = "leastloaded";
         ml2Cfg["ovn"]["ovn_metadata_enabled"] = "true";
         ml2Cfg["ovn"]["enable_distributed_floating_ip"] = "true";
-        ml2Cfg["ovn"]["ovsdb_probe_interval"] = "600000";
+        ml2Cfg["ovn"]["ovsdb_probe_interval"] = "60000";
         ml2Cfg["ovn"]["ovn_dhcp4_global_options"] = "classless_static_route:{169.254.169.254/32}";
 
         vpnaasCfg["service_providers"]["service_provider"] = "VPN:openswan:neutron_vpnaas.services.vpn.service_drivers.ovn_ipsec.IPsecOvnVPNDriver:default";

--- a/core/sdk_sh/modules.pre/sdk_is.sh
+++ b/core/sdk_sh/modules.pre/sdk_is.sh
@@ -110,6 +110,15 @@ is_first_three_compute_node()
     fi
 }
 
+is_first_compute_node()
+{
+    if cubectl node list -r compute -j | jq -r .[].hostname | head -1 | grep -q $(hostname); then
+        return 0
+    else
+        return 1
+    fi
+}
+
 is_node_repairing()
 {
     if [ -e /run/cube_cluster_repairing ]; then

--- a/core/sdk_sh/modules/sdk_git.sh
+++ b/core/sdk_sh/modules/sdk_git.sh
@@ -49,11 +49,14 @@ _git_server_init()
         mkdir -p $cube_git_dir
         GIT_DIR=$cube_git_dir $GIT init --bare -b $branch
         $GIT config --global user.email "${HOSTNAME}@${ipaddr}"
+        # Disable git auto-maintenance -- it hangs on the /-worktree repo. #1195
+        $GIT config --global maintenance.auto false
         git_ignore_file
 
         Quiet -n pushd /
         Quiet -n git init -b $branch
-        Quiet -n $GIT remote add $project ssh://root@$(shared_ip)${cube_git_dir}
+        # local cephfs path, not ssh://VIP (stalls during set_ready reconfig). #1195
+        Quiet -n $GIT remote add $project ${cube_git_dir}
         if [ -e "/.gitignore" ] ; then
             if ! git log -1 >/dev/null 2>&1 ; then
                 Quiet -n git add -A
@@ -109,11 +112,14 @@ _git_client_init()
     local branch=master
 
     Quiet -n $GIT config --global user.email "${HOSTNAME}@${ipaddr}"
+    # Disable git auto-maintenance -- it hangs on the /-worktree repo. #1195
+    Quiet -n $GIT config --global maintenance.auto false
     Quiet -n git_ignore_file
 
     Quiet -n pushd /
     Quiet -n $GIT init -b $branch
-    Quiet -n $GIT remote add $project ssh://root@$(shared_ip)${cube_git_dir}
+    # local cephfs path, not ssh://VIP (stalls during set_ready reconfig). #1195
+    Quiet -n $GIT remote add $project ${cube_git_dir}
     if [ -e "/.gitignore" ] ; then
         if $GIT fetch ; then
             _git_suid_save

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2564,10 +2564,7 @@ health_manila_check()
 _health_manila_auto_repair()
 {
     if [ $($OPENSTACK network list | grep manila_service_network | wc -l) -gt 1 ] ; then
-        for NID in $($OPENSTACK network list -f value -c ID -c Name | grep manila_service_network | cut -d' ' -f1) ; do
-            $OPENSTACK port list --network $NID -f value -c ID | xargs -i $OPENSTACK port delete {}
-            $OPENSTACK network delete $NID
-        done
+        $HEX_SDK os_manila_service_network_dedup >/dev/null
     fi
     readarray entry_array <<<"$(echo "$ERR_MSG" | awk '/enabled.*down/{print $4" "$6}' | sort)"
     declare -p entry_array > /dev/null

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -24,11 +24,27 @@ migrate_fixpack()
 
 migrate_git()
 {
-    # Init this node's config-history /.git (per-slot root fs) during per-node
-    # bring-up, before it's marked synced, so the first ceph_mds check can't race
-    # the init. Per-slot marker + idempotent git_init => reboots skip. See #1163.
+    # Init this node's config-history /.git, detached, and mark migrated only
+    # after git_init actually works (not on a pre-ready no-op). See #1195.
     [ -f $STATE_DIR/git_migrated ] && return 0
-    $HEX_SDK git_init && touch $STATE_DIR/git_migrated
+    setsid $HEX_SDK _migrate_git_bg </dev/null >/dev/null 2>&1 &
+}
+
+# Retry (detached, bounded ~10 min) until cube_node_ready and git_init works,
+# then set the marker. Never marks on a no-op.
+_migrate_git_bg()
+{
+    local _i
+    for _i in $(seq 1 120) ; do
+        if $HEX_SDK cube_node_ready ; then
+            $HEX_SDK git_init
+            if git -C / log -1 >/dev/null 2>&1 ; then
+                touch $STATE_DIR/git_migrated
+                return 0
+            fi
+        fi
+        sleep 5
+    done
 }
 
 migrate_keystone_db()

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2055,6 +2055,48 @@ os_manila_init()
     #fi
 }
 
+MANILA_SVC_NET=manila_service_network
+
+# Delete all but the oldest manila_service_network (converge to exactly one,
+# never zero). Echoes the surviving id.
+os_manila_service_network_dedup()
+{
+    local oldest ids id
+    ids=$($OPENSTACK network list --name $MANILA_SVC_NET -f value -c ID)
+    oldest=$(for id in $ids ; do
+                echo "$($OPENSTACK network show $id -f value -c created_at) $id"
+             done | sort | head -1 | awk '{print $2}')
+    for id in $ids ; do
+        [ "$id" = "$oldest" ] && continue
+        $OPENSTACK port list --network $id -f value -c ID | xargs -i $OPENSTACK port delete {} 2>/dev/null
+        $OPENSTACK network delete $id 2>/dev/null
+    done
+    echo "$oldest"
+}
+
+# ExecStartPre for openstack-manila-share: the first compute node ensures exactly
+# one service network before the daemon's workers start; other nodes no-op
+# (master-first ordering covers them, so no peer wait). See #1195.
+os_manila_service_network_ensure()
+{
+    is_first_compute_node || return 0
+    local count i
+    # Converge to exactly one: create, then dedup + settle-verify (a create that
+    # times out on the client can still land, so don't trust its exit code).
+    count=$($OPENSTACK network list --name $MANILA_SVC_NET -f value -c ID 2>/dev/null | grep -c .)
+    [ "$count" -gt 1 ] && os_manila_service_network_dedup >/dev/null
+    [ "$count" -eq 0 ] && $OPENSTACK network create $MANILA_SVC_NET >/dev/null 2>&1
+    for i in 1 2 3 ; do
+        sleep 3
+        count=$($OPENSTACK network list --name $MANILA_SVC_NET -f value -c ID 2>/dev/null | grep -c .)
+        [ "$count" -gt 1 ] && os_manila_service_network_dedup >/dev/null
+    done
+    count=$($OPENSTACK network list --name $MANILA_SVC_NET -f value -c ID 2>/dev/null | grep -c .)
+    [ "$count" -eq 1 ] && return 0
+    echo "$MANILA_SVC_NET: not exactly one after converge (count=$count) — retry" >&2
+    return 1
+}
+
 # Create/prune one Manila share type per additional Cinder volume type
 # Manila should serve as a generic-driver backend.
 #


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
Makes a fresh **HA** first-time setup reach a fully green `cluster check` on its own. Three independent FTS defects, validated together:

**1. config-history git-init** (Storage `ceph_mds: git not initialied`). `migrate_git` set the `git_migrated` marker on a *no-op* `git_init` (it ran before `cube_node_ready`), so git was flagged done without being created and every retry was blocked; only a later `auto_repair` recovered it. Fix: retry on the node's own timeline (detached) until `cube_node_ready` **and** `git log` works, then mark — drift-preserving, no `reset --hard`. Also: fetch over the local cephfs path (not `ssh://VIP`, which stalls ~13 min during the set_ready VIP reconfig), and disable git auto-maintenance (hangs on the /-worktree repo).

**2. manila service-network race** (FileStor `manila(share down)`). The generic driver lazy-creates `manila_service_network` from the manila-share daemon on every node; its workers race (neutron lags daemon start ~75 s) and create duplicate networks → `Ambiguous service networks` → crash-loop. Fix: an `ExecStartPre` on the first compute node converges to exactly one network (create + dedup, robust to neutron's read-after-write lag) before the daemon's workers start; other nodes no-op (master-first ordering covers them). Convergent keep-oldest `auto_repair` dedup as backstop.

**3. DB/OVN connection resilience** (BlockStor `cinder backup down`, Network `port create fail`). set_ready's VIP/pacemaker reconfig briefly severs client connections to the HA backends (MySQL, Swift, OVN-NB); cinder-backup and neutron-server don't reconnect → wedged until restarted. Fix: cinder `[database] use_db_reconnect` + retry, and neutron `ovsdb_probe_interval` 600000→60000 (600000 was baked into the initial commit, not a scale decision) so neutron detects the stale OVN-DB connection and reconnects in ~60 s.

#### Which issue(s) this PR fixes
Part of #1195.

#### Special notes for your reviewer
Validated on 3cc sky HA **twice**, with `auto_repair` fully disabled: fresh FTS reaches `cluster check` NG 0 on its own — the connection-sensitive services survive the set_ready transient and the FTS races self-resolve, no repair round needed.

#### Additional documentation
```docs
kb/cubecos/architecture/fts-parallel-apply-races.md updated with the git-init, manila, and DB/OVN-resilience fixes.
```
