### PR TITLE
docs(github): require a QA Verification section in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -53,6 +53,21 @@ Insert content here.
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
+## QA Verification
+
+> How QA verifies this issue is actually fixed — write **checkable claims**: the exact
+> command or click path plus the expected outcome. "Verify it works" is not a checkable
+> claim. These claims are what the Qase test suite is generated from, so write them for a
+> reader who has not seen the code.
+
+| # | Command / steps | Expected outcome |
+|---|---|---|
+| 1 | `...` | `...` |
+
+- [ ] **QA Status declared at Done** — when this issue reaches `Done`, set the board's
+      `QA Status` field to `Not needed` or `Ready to QA`. Never leave it empty on a Done
+      ticket; `In QA` / `Verified` are QA's own transitions.
+
 ## Output artifacts (Definition of Done)
 
 > Beyond code, docs, and config changes, completing this issue must also deliver:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -69,6 +69,21 @@ Insert content here.
 >- Hardware: [e.g. Dell PowerEdge R630, storage backend NFS/S3/Ceph]
 >- Supporting logs
 
+## QA Verification
+
+> How QA verifies this issue is actually fixed — write **checkable claims**: the exact
+> command or click path plus the expected outcome. "Verify it works" is not a checkable
+> claim. These claims are what the Qase test suite is generated from, so write them for a
+> reader who has not seen the code.
+
+| # | Command / steps | Expected outcome |
+|---|---|---|
+| 1 | `...` | `...` |
+
+- [ ] **QA Status declared at Done** — when this issue reaches `Done`, set the board's
+      `QA Status` field to `Not needed` or `Ready to QA`. Never leave it empty on a Done
+      ticket; `In QA` / `Verified` are QA's own transitions.
+
 ## Output artifacts (Definition of Done)
 
 > Beyond code, docs, and config changes, completing this issue must also deliver:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -42,6 +42,21 @@ Insert content here.
 
 None
 
+## QA Verification
+
+> How QA verifies this feature once it ships — write **checkable claims**: the exact
+> command or click path plus the expected outcome. "Verify it works" is not a checkable
+> claim. These claims are what the Qase test suite is generated from, so write them for a
+> reader who has not seen the code.
+
+| # | Command / steps | Expected outcome |
+|---|---|---|
+| 1 | `...` | `...` |
+
+- [ ] **QA Status declared at Done** — when this issue reaches `Done`, set the board's
+      `QA Status` field to `Not needed` or `Ready to QA`. Never leave it empty on a Done
+      ticket; `In QA` / `Verified` are QA's own transitions.
+
 ## Output artifacts (Definition of Done)
 
 > Beyond code, docs, and config changes, completing this issue must also deliver:

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -31,6 +31,21 @@ As a **[type of user]**, I want **[some goal]** so that **[some reason]**.
 >| 5 | High | High complexity; difficult to implement, requiring significant time and effort.
 >| 8 | Very High | Extreme complexity or high uncertainty. If possible, this should be divided into multiple user stories.
 
+## QA Verification
+
+> How QA verifies this story once it ships — write **checkable claims**: the exact
+> command or click path plus the expected outcome. "Verify it works" is not a checkable
+> claim. These claims are what the Qase test suite is generated from, so write them for a
+> reader who has not seen the code.
+
+| # | Command / steps | Expected outcome |
+|---|---|---|
+| 1 | `...` | `...` |
+
+- [ ] **QA Status declared at Done** — when this issue reaches `Done`, set the board's
+      `QA Status` field to `Not needed` or `Ready to QA`. Never leave it empty on a Done
+      ticket; `In QA` / `Verified` are QA's own transitions.
+
 ## Output artifacts (Definition of Done)
 
 > Beyond code, docs, and config changes, completing this issue must also deliver:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Deliberately scoped to GitHub Actions only. Every other dependency in this
+  # repo (RPM specs, pip requirements, the hex submodule) is version-managed by
+  # the build and release process, not by dependabot.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Git checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Dependency Review
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           comment-summary-in-pr: on-failure
           fail-on-severity: moderate

--- a/.github/workflows/fast-forward-merge.yaml
+++ b/.github/workflows/fast-forward-merge.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Check Out PR Target Branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0 # fetches all history for all branches and tags

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,17 +30,17 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -62,7 +62,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -70,6 +70,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@497990dfed22177a82ba1bbab381bc8f6d27058f # v3.31.6
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind cleanup

#### What this PR does / why we need it

Four commits, paired with **bigstack-oss/hex#151**.

**1. `docs(github)` — bake the handbook's QA-verification requirement into the issue templates**

Adds a `## QA Verification` section to `bug.md`, `bug_report.md`, `feature.md` and
`user-story.md`, encoding two handbook requirements that nothing in the templates asked for:

- [`claude-code-development-flow.md`](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/bigstack/workflows/claude-code-development-flow.md) —
  the Qase test suite is *generated from* the issue's verification claims, so they have to be
  **checkable claims** (command / click path + expected outcome), not prose. The section gives
  that a fixed shape via a steps/outcome table.
- [`scrum-board-ticket-standard.md`](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/bigstack/workflows/scrum-board-ticket-standard.md) —
  `QA Status` is declared by the dev when the ticket reaches `Done` (`Not needed` /
  `Ready to QA`). The retired `needs-qa` label left no reminder anywhere, so it becomes a DoD
  checkbox.

Scoped to the four templates whose ticket types actually carry `QA Status` — Bug, Feature,
User Story. Per the ticket standard, Epic / Task / Spike have no `QA Status` (and a Spike's
deliverable is knowledge, not shippable behavior), so they are untouched.

**2. `ci(actions)` — refresh pinned action versions**

Every pin was stale, by up to three major versions, because nothing was watching them. Each
new pin was verified SHA-to-tag against the action's tag list rather than trusted from the
trailing comment:

| Action | From | To |
|---|---|---|
| `step-security/harden-runner` (×3 workflows) | v2.13.3 | v2.20.0 |
| `actions/checkout` (dependency-review) | v6.0.0 | v7.0.1 |
| `actions/checkout` (fast-forward-merge) | v4.2.2 | v7.0.1 |
| `actions/checkout` (scorecard) | v4.3.1 | v7.0.1 |
| `actions/dependency-review-action` | v4.8.2 | v5.0.0 |
| `ossf/scorecard-action` | v2.4.0 | v2.4.4 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `github/codeql-action/upload-sarif` | v3.31.6 | v4.37.6 |

The three major bumps (dependency-review-action v5, upload-artifact v7, codeql v4) are
node20 → node24 runtime moves with no input or output changes, and GitHub-hosted
`ubuntu-latest` runners already satisfy the runner floor. `checkout` v7.0.1 and
`upload-artifact` v7.0.1 are the same pins hex already runs green.

**3. `ci(dependabot)` — watch GitHub Actions versions**

The drift above happened because cubecos had no dependabot config while hex has had one all
along. Mirrors hex's: `github-actions`, directory `/`, weekly.

Deliberately scoped to `github-actions` **only** — RPM specs, pip requirements and the hex
submodule are version-managed by the build and release process, and dependabot PRs against
those would fight the release flow. The file carries a comment recording that, so the scope
isn't widened by accident.

**4. `chore(hex)` — bump submodule 44b2acb → 466f003**

Picks up hex#151: the same QA Verification section plus hex's backfilled handbook DoD block,
the fixed fast-forward-merge workflow, and a corrected codeql version comment.

#### Which issue(s) this PR fixes

None — process/CI change, no ticket.

#### Special notes for your reviewer

> - **Merge order:** hex#151 should merge first. `466f003` is hex's PR-branch tip, and both
>   repos merge via `fast-forward-merge.yaml` (`git merge --ff-only` on the `done` label), so
>   the SHA survives the merge and this bump needs no re-pointing.
> - The template sections are copy-identical to hex's, so the two repos stay in sync.
> - `bug.md`, `feature.md` and `user-story.md` are mixed-line-ending files (CRLF body, LF
>   handbook block). The inserted block uses LF to match its neighbour, so each diff is a pure
>   15-line insertion rather than a rewrite of the existing block.
> - After the checkout bump, `fast-forward-merge.yaml` is identical to hex's copy except for
>   the harden-runner pin (hex is on v2.13.3, which its dependabot will converge).
> - Worth knowing for the future: hex's `codeql-action` comment claimed v3.29.5 while the SHA
>   was actually v4.37.4 — a dependabot bump had moved the SHA and left the comment behind. Do
>   not read these version comments as authoritative; check the SHA.

#### Additional documentation

```docs

```
