### PR TITLE
feat(gpu): MIG-backed vGPU resource-set infra (#905)

### DIFF
--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -164,9 +164,10 @@ ApplySriovVgpu(const std::string& pciAddress, const json11::Json& profiles)
 }
 
 // A PF counts as applied when its VFs are enabled and at least one VF
-// already carries a vGPU type.
+// already carries a vGPU type. Shared by sriovVgpu and migBackedVgpu - both
+// end up in the same VF/current_vgpu_type sysfs shape once carved.
 static bool
-SriovVgpuApplied(const std::string& sysfsAddr)
+VfVgpuApplied(const std::string& sysfsAddr)
 {
     std::ifstream numvfsStream(std::string(PCI_DEVICES_DIR) + "/" + sysfsAddr + "/sriov_numvfs");
     long numvfs = 0;
@@ -254,7 +255,353 @@ ProfileAlias(const std::string& fullName, int profileId)
     return alias + std::to_string(profileId);
 }
 
-struct SriovVf {
+// A MIG-backed vGPU type as `nvidia-smi vgpu -s -v` reports it, keyed by its
+// vGPU Type ID - what current_vgpu_type expects, and what migBackedVgpu profile
+// ids now carry (gpu_vgpu_profile_list reports one entry per type rather than
+// per GPU instance profile; see spec.md §5b).
+//
+// giProfileId is still needed because `mig -cgi` carves partitions by GPU
+// Instance Profile ID, not by vGPU type. The mapping is only a function in this
+// direction: a type belongs to exactly one GI profile, while one GI profile
+// exposes many types (47 exposes 19 on cn13's RTX PRO 6000 Blackwell). Keying
+// the other way round is what made the old list unable to express which
+// framebuffer size or mode the operator asked for.
+struct MigVgpuType {
+    int typeId;
+    std::string name;   // full name, for the Nova alias - same as the SR-IOV path
+    int giProfileId;
+    long fbMiB;         // this type's framebuffer; the grouping key for GI budgeting
+    long perGi;         // Max Instances Per GI
+    long maxInstances;  // how many of this type the whole card can host
+};
+
+// How many GPU instances of this type's profile the card allows, derived from
+// the driver's own two numbers instead of parsing `mig -lgip` separately:
+// Max Instances = Max Instances Per GI x GI Instances Total. Verified to hold
+// for all 43 MIG-backed types on cn13 2026-08-04 (R6 in
+// ../feat-905-mig-vgpu-infra/execution-log-cn13-mixed-fb.md).
+static long
+MigGiInstancesTotal(const MigVgpuType& type)
+{
+    return (type.perGi > 0) ? type.maxInstances / type.perGi : 0;
+}
+
+// Records a parsed block, but only once every field the apply and validation
+// paths need is present. Anything incomplete is dropped rather than guessed at:
+// SR-IOV time-sliced types share this output and legitimately lack a GPU
+// instance profile, so "incomplete" is the normal case, not an error.
+static void
+AddMigVgpuType(std::map<int, MigVgpuType>& types, const MigVgpuType& type)
+{
+    if (type.typeId >= 0 && !type.name.empty() && type.giProfileId >= 0 &&
+        type.fbMiB > 0 && type.perGi > 0 && type.maxInstances > 0) {
+        types[type.typeId] = type;
+    }
+}
+
+// Parses `nvidia-smi vgpu -s -v` output into a map of vGPU Type ID -> that
+// type's MIG geometry. Blocks look like (mirroring ParseVgpuTypeNames, plus the
+// fields only MIG-backed types populate):
+//   vGPU Type ID                      : 0x619
+//       Name                          : NVIDIA RTX Pro 6000 Blackwell DC-1-24Q
+//       GPU Instance Profile ID       : 47
+//       Max Instances Per VM          : 1
+//       Max Instances Per GI          : 1
+//       Max Instances                 : 4
+//       FB Memory                     : 24576 MiB
+static std::map<int, MigVgpuType>
+ParseMigVgpuTypes(const std::string& smiOutput)
+{
+    std::map<int, MigVgpuType> types;
+    std::istringstream stream(smiOutput);
+    std::string line;
+
+    MigVgpuType current = MigVgpuType { -1, "", -1, 0, 0, 0 };
+
+    while (std::getline(stream, line)) {
+        const size_t colon = line.find(':');
+        if (colon == std::string::npos) {
+            continue;
+        }
+
+        std::string key = line.substr(0, colon);
+        key.erase(0, key.find_first_not_of(" \t"));
+        key.erase(key.find_last_not_of(" \t") + 1);
+
+        std::string value = line.substr(colon + 1);
+        value.erase(0, value.find_first_not_of(" \t"));
+        value.erase(value.find_last_not_of(" \t\r") + 1);
+
+        if (key == "vGPU Type ID") {
+            // A new block starts here, so the previous one is complete.
+            AddMigVgpuType(types, current);
+            current = MigVgpuType { (int)strtol(value.c_str(), NULL, 16), "", -1, 0, 0, 0 };
+        } else if (key == "Name") {
+            current.name = value;
+        } else if (key == "GPU Instance Profile ID") {
+            // Real hardware prints "N/A" here for SR-IOV time-sliced types: the
+            // field is always present, contrary to the earlier assumption that
+            // only MIG-backed types carried it (all 24 SR-IOV types on cn13
+            // report N/A, 2026-08-04). strtol("N/A") is 0 and 0 is a real GI
+            // profile id (MIG 4g.96gb), so accepting it fabricated a mapping
+            // for a type with no partition behind it - and one that passed
+            // validation, because 0 really is in the profile list. Leaving the
+            // field unset instead makes AddMigVgpuType drop the whole block.
+            if (!value.empty() && value.find_first_not_of("0123456789") == std::string::npos) {
+                current.giProfileId = (int)strtol(value.c_str(), NULL, 10);
+            }
+        } else if (key == "Max Instances Per GI") {
+            current.perGi = strtol(value.c_str(), NULL, 10);
+        } else if (key == "Max Instances") {
+            // Exact key match, so this cannot pick up "Max Instances Per VM" or
+            // "Max Instances Per GI" - both contain this string.
+            current.maxInstances = strtol(value.c_str(), NULL, 10);
+        } else if (key == "FB Memory") {
+            // "24576 MiB" - strtol stops at the space.
+            current.fbMiB = strtol(value.c_str(), NULL, 10);
+        }
+    }
+
+    AddMigVgpuType(types, current);
+
+    return types;
+}
+
+// The GPU instances a migBackedVgpu request needs, keyed by
+// (GPU Instance Profile ID, framebuffer size) -> how many instances of that
+// partition shape have to exist.
+//
+// Both halves of the key matter, per the placement rules measured on cn13
+// 2026-08-04 (R1-R4 in
+// ../feat-905-mig-vgpu-infra/execution-log-cn13-mixed-fb.md): a GI only ever
+// hosts one framebuffer size, though the Q/A/B/C mode may differ (DC-1-3Q and
+// DC-1-3A coexisted in one GI, rc=0, while writing a 6144 MiB type into that
+// same GI was refused); the same size may span several GIs; and a GI holds at
+// most perGi of them. Two types can also share a framebuffer size while
+// belonging to different GI profiles - 24576 MiB exists under profiles 47, 35
+// and 32 on that card - and those are physically different partitions that
+// cannot share one instance.
+//
+// So the instance count is per group: ceil(that group's total / perGi). Not one
+// per requested vGPU (which over-carves whenever the type is smaller than its
+// partition) and not one per profile (which under-carves past perGi).
+static std::map<std::pair<int, long>, long>
+BuildMigInstanceNeeds(const json11::Json& profiles, const std::map<int, MigVgpuType>& typesByTypeId)
+{
+    std::map<std::pair<int, long>, long> requested;  // group -> vGPUs asked for
+    std::map<std::pair<int, long>, long> perGiOf;
+
+    for (const json11::Json& profile : profiles.array_items()) {
+        const std::map<int, MigVgpuType>::const_iterator typeIt =
+            typesByTypeId.find((int)profile["id"].number_value());
+        if (typeIt == typesByTypeId.end()) {
+            // Callers reject unknown ids before planning; nothing to plan here.
+            continue;
+        }
+
+        const std::pair<int, long> group(typeIt->second.giProfileId, typeIt->second.fbMiB);
+        requested[group] += (long)profile["count"].number_value();
+        // perGi is a property of the type, and every type in a group shares the
+        // framebuffer size it is derived from, so any of them gives the same value.
+        perGiOf[group] = typeIt->second.perGi;
+    }
+
+    std::map<std::pair<int, long>, long> needs;
+    for (std::map<std::pair<int, long>, long>::const_iterator it = requested.begin();
+         it != requested.end(); ++it) {
+        // perGi is guaranteed positive: AddMigVgpuType drops types without it.
+        const long perGi = perGiOf[it->first];
+        needs[it->first] = (it->second + perGi - 1) / perGi;
+    }
+
+    return needs;
+}
+
+// Flattens BuildMigInstanceNeeds into one GPU Instance Profile ID per
+// `mig -cgi` call to make.
+static std::vector<int>
+BuildMigInstancePlan(const json11::Json& profiles, const std::map<int, MigVgpuType>& typesByTypeId)
+{
+    const std::map<std::pair<int, long>, long> needs = BuildMigInstanceNeeds(profiles, typesByTypeId);
+
+    std::vector<int> plan;
+    for (std::map<std::pair<int, long>, long>::const_iterator it = needs.begin();
+         it != needs.end(); ++it) {
+        for (long i = 0; i < it->second; i++) {
+            plan.push_back(it->first.first);
+        }
+    }
+
+    return plan;
+}
+
+// Whether MIG mode is on right now, read before an apply enables it so a
+// failed apply can put the card back the way it found it instead of forcing
+// MIG off. Treats an unreadable answer as "already enabled", which is the
+// conservative direction here: it makes the teardown leave MIG alone rather
+// than turn off a mode this apply may not have been the one to enable.
+static bool
+MigModeEnabled(const std::string& gpuId)
+{
+    const std::string output = HexUtilPOpen(
+        "%s --query-gpu=mig.mode.current --format=csv,noheader -i %s", NVIDIA_SMI, gpuId.c_str());
+
+    return output.find("Disabled") == std::string::npos;
+}
+
+// Best-effort teardown after a failed MIG-backed apply: release the VFs
+// (same as the SR-IOV path), destroy whatever GPU/compute instances this
+// attempt created, then undo the MIG-mode enable if this attempt is what
+// turned it on - so no half-configured GPU is left behind.
+//
+// sriov-manage -d rebinds the driver, which on its own already destroys
+// every GPU instance on the card (confirmed on cn13 2026-08-04 - the same
+// side effect that made the original apply ordering fail, see ApplyMigVgpu).
+// The explicit -dci/-dgi calls that follow are therefore usually no-ops;
+// they are kept as a safety net in case a driver version releases VFs
+// without wiping instances. Releasing the consumers (VFs) before the
+// resources (instances) is also the safer order - a VF holding a live vGPU
+// backed by an instance can refuse that instance's destruction. Compute
+// instances must be destroyed before their GPU instances.
+//
+// The MIG-mode undo is what keeps a failed apply recoverable. MIG mode is
+// persistent state, and config.json only gains its migBackedVgpu entry after
+// ApplyMigVgpu returns true - so on failure gpu_unset_current_type's
+// `current_type = migBackedVgpu` branch, the only place that runs `-mig 0`,
+// can never fire. Without this the card stays MIG-enabled with no product
+// path back: a later switch to sriovVgpu writes a time-sliced type into a VF
+// that cannot offer it and fails, exactly the dead end 48f96531 removed for
+// the successful-apply case. It runs after TeardownSriov because the driver
+// refuses `-mig 0` while VFs are enabled ("In use by another client",
+// cn13 2026-08-04) - the same ordering that fix established.
+//
+// Only this attempt's own enable is undone. On the boot-time Commit()
+// re-apply path MIG mode survived the reboot while the VFs and instances did
+// not, so migWasEnabled is true there and a failed re-apply leaves the mode
+// alone for the next Commit() to retry against.
+static void
+TeardownMigVgpu(const std::string& gpuId, const std::string& sysfsAddr, size_t createdInstances,
+                bool migWasEnabled)
+{
+    TeardownSriov(sysfsAddr);
+
+    if (createdInstances > 0) {
+        HexUtilSystemF(0, 0, "%s mig -i %s -dci", NVIDIA_SMI, gpuId.c_str());
+        HexUtilSystemF(0, 0, "%s mig -i %s -dgi", NVIDIA_SMI, gpuId.c_str());
+    }
+
+    if (!migWasEnabled) {
+        HexUtilSystemF(0, 0, "%s -i %s -mig 0", NVIDIA_SMI, gpuId.c_str());
+    }
+}
+
+// Enables MIG mode, enables the PF's VFs, carves one GPU+compute instance
+// per requested profile (nvidia-smi mig -cgi <id> -C), then writes each
+// instance's vGPU type into a VF's current_vgpu_type. profiles must already
+// be validated (ids are GPU Instance Profile IDs).
+//
+// The VF step MUST come before instance creation. sriov-manage goes through
+// the driver's unbindLock and rebinds the GPU, which wipes every GPU
+// instance on the card - MIG mode itself is persistent state and survives,
+// but the instances are runtime state and do not. Creating instances first
+// (the original shape of this function, mirroring ApplySriovVgpu) left the
+// card with zero instances by the time the VFs came up, so the driver had
+// no MIG-backed vGPU type to offer: every VF's creatable_vgpu_types stayed
+// empty and the current_vgpu_type write below failed with EIO
+// (NVRM: Failed to add vgpu create request: 0x38). Verified on cn13
+// 2026-08-04, both directions - see
+// ../feat-905-mig-vgpu-infra/execution-log-cn13-vgpud-restart.md.
+//
+// Which instance each VF ends up serving is the driver's decision, not this
+// function's: virtfnN/nvidia/gpu_instance_id and placement_id are outputs the
+// driver fills in (they read ENXIO until a vGPU exists), so nothing here writes
+// them. They are, however, trustworthy for reading the binding back - a VF's
+// gpu_instance_id matched the instance actually carved in every case on cn13
+// 2026-08-04, which also means the binding can be inspected without booting a
+// VM. An earlier comment here claimed otherwise, on the strength of
+// `nvidia-smi vgpu -q` reporting GPU Instance ID 3 for a vGPU whose Placement
+// ID 6 "belongs to instance 5". That comparison was invalid: vgpu -q's
+// Placement ID is the vGPU's offset *inside* its GI, while `mig -lgi`'s
+// Placement Start is the GI's position on the card - two different coordinate
+// systems, so the driver was never contradicting itself.
+static bool
+ApplyMigVgpu(const std::string& gpuId, const std::string& pciAddress, const json11::Json& profiles)
+{
+    const std::string sysfsAddr = SysfsPciAddr(pciAddress);
+
+    // Everything that can fail without touching the card runs first, so a bad
+    // request leaves no state behind at all. `vgpu -s -v` lists the statically
+    // supported types and works with MIG mode still off (verified on cn13
+    // 2026-08-04), so resolution does not need `-mig 1` to have run.
+    const std::map<int, MigVgpuType> typesByTypeId =
+        ParseMigVgpuTypes(HexUtilPOpen("%s vgpu -s -v -i %s", NVIDIA_SMI, gpuId.c_str()));
+
+    // One entry per requested vGPU: these are the types written to the VFs.
+    const std::vector<int> vgpuTypePlan = BuildVfAssignmentPlan(profiles);
+
+    for (size_t i = 0; i < vgpuTypePlan.size(); i++) {
+        if (typesByTypeId.find(vgpuTypePlan[i]) == typesByTypeId.end()) {
+            HexLogError("gpu_resource_set: vGPU type %d is not a MIG-backed type on GPU %s",
+                        vgpuTypePlan[i], gpuId.c_str());
+            return false;
+        }
+    }
+
+    // The partitions those vGPUs need - far fewer than one per vGPU whenever the
+    // chosen type is smaller than the partition it lives in.
+    const std::vector<int> giProfilePlan = BuildMigInstancePlan(profiles, typesByTypeId);
+    if (giProfilePlan.empty()) {
+        HexLogError("gpu_resource_set: could not plan any GPU instance for the request on GPU %s",
+                    gpuId.c_str());
+        return false;
+    }
+
+    // Sampled before the enable below so the teardown can tell this attempt's
+    // own MIG-mode change apart from one that was already in place.
+    const bool migWasEnabled = MigModeEnabled(gpuId);
+
+    if (HexUtilSystemF(0, 0, "%s -i %s -mig 1", NVIDIA_SMI, gpuId.c_str()) != 0) {
+        HexLogError("gpu_resource_set: failed to enable MIG mode on GPU %s", gpuId.c_str());
+        return false;
+    }
+
+    // Every failure from here on has to go through the teardown: MIG mode is
+    // now on, and if it stays on with no config.json entry recording it the
+    // card has no product path back to another resource type.
+    if (!RunSriovManageWithRetry("-e", sysfsAddr)) {
+        TeardownMigVgpu(gpuId, sysfsAddr, 0, migWasEnabled);
+        return false;
+    }
+
+    size_t created = 0;
+    for (; created < giProfilePlan.size(); created++) {
+        if (HexUtilSystemF(0, 0, "%s mig -i %s -cgi %d -C", NVIDIA_SMI, gpuId.c_str(), giProfilePlan[created]) != 0) {
+            HexLogError("gpu_resource_set: failed to create a GPU instance (profile %d) on GPU %s",
+                        giProfilePlan[created], gpuId.c_str());
+            TeardownMigVgpu(gpuId, sysfsAddr, created, migWasEnabled);
+            return false;
+        }
+    }
+
+    for (size_t vf = 0; vf < vgpuTypePlan.size(); vf++) {
+        const std::string typePath = std::string(PCI_DEVICES_DIR) + "/" + sysfsAddr +
+            "/virtfn" + std::to_string(vf) + "/nvidia/current_vgpu_type";
+
+        if (!WriteSysfs(typePath, std::to_string(vgpuTypePlan[vf]))) {
+            HexLogError("gpu_resource_set: failed to set MIG-backed vGPU type %d on %s/virtfn%d",
+                        vgpuTypePlan[vf], sysfsAddr.c_str(), (int)vf);
+            TeardownMigVgpu(gpuId, sysfsAddr, created, migWasEnabled);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// A passthrough-eligible VF, regardless of which vGPU flavor (SR-IOV
+// time-sliced or MIG-backed) it was carved for - Nova only cares that it's
+// a type-VF PCI device, not how its vGPU type was assigned.
+struct PciVf {
     std::string address;    // sysfs form, e.g. 0001:c8:00.2
     std::string vendorId;   // e.g. 10de
     std::string productId;  // e.g. 2bb5
@@ -282,7 +629,7 @@ ReadSysfsId(const std::string& path)
 // virtfnN symlink) plus vendor/product ids read from the VF itself (not
 // hardcoded - VF ids are device specific).
 static bool
-GetSriovVfs(const std::string& sysfsAddr, size_t count, std::vector<SriovVf>* vfs)
+GetPciVfs(const std::string& sysfsAddr, size_t count, std::vector<PciVf>* vfs)
 {
     for (size_t i = 0; i < count; i++) {
         const std::string link = std::string(PCI_DEVICES_DIR) + "/" + sysfsAddr +
@@ -301,7 +648,7 @@ GetSriovVfs(const std::string& sysfsAddr, size_t count, std::vector<SriovVf>* vf
             address = address.substr(slash + 1);
         }
 
-        SriovVf vf;
+        PciVf vf;
         vf.address = address;
         vf.vendorId = ReadSysfsId(std::string(PCI_DEVICES_DIR) + "/" + address + "/vendor");
         vf.productId = ReadSysfsId(std::string(PCI_DEVICES_DIR) + "/" + address + "/device");
@@ -315,31 +662,40 @@ GetSriovVfs(const std::string& sysfsAddr, size_t count, std::vector<SriovVf>* vf
     return true;
 }
 
+// A truth-file entry is backed by a passthrough VF - and therefore belongs
+// in the Nova drop-in - regardless of whether its vGPU type came from
+// SR-IOV time-slicing or a MIG GPU instance.
+static bool
+IsVfBackedType(const json11::Json& type)
+{
+    return type.is_string() && (type.string_value() == "sriovVgpu" || type.string_value() == "migBackedVgpu");
+}
+
 // Builds the /etc/nova/nova.d/gpu.conf content from config.json entries:
 // one [pci] alias per profile and one passthrough_whitelist per assigned VF
-// of every sriovVgpu GPU. Regenerating everything from the truth file means
-// entries for GPUs switched away from sriovVgpu disappear without any
-// dedicated cleanup logic.
+// of every sriovVgpu/migBackedVgpu GPU. Regenerating everything from the
+// truth file means entries for GPUs switched away from either type
+// disappear without any dedicated cleanup logic.
 static std::string
 BuildNovaGpuConfContent(const json11::Json& gpuConfig,
-                        const std::map<std::string, std::vector<SriovVf>>& vfsByGpuId)
+                        const std::map<std::string, std::vector<PciVf>>& vfsByGpuId)
 {
     std::string content =
         "# Generated by hex_config (gpu_resource_set / gpu Commit). Do not edit.\n"
         "[pci]\n";
 
     for (const json11::Json& entry : gpuConfig.array_items()) {
-        if (!entry["type"].is_string() || entry["type"].string_value() != "sriovVgpu") {
+        if (!IsVfBackedType(entry["type"])) {
             continue;
         }
 
-        const std::map<std::string, std::vector<SriovVf>>::const_iterator vfsIt =
+        const std::map<std::string, std::vector<PciVf>>::const_iterator vfsIt =
             vfsByGpuId.find(entry["id"].string_value());
         if (vfsIt == vfsByGpuId.end() || vfsIt->second.empty()) {
             continue;
         }
 
-        const std::vector<SriovVf>& vfs = vfsIt->second;
+        const std::vector<PciVf>& vfs = vfsIt->second;
 
         for (const json11::Json& profile : entry["profiles"].array_items()) {
             if (!profile["alias"].is_string()) {
@@ -377,17 +733,18 @@ WriteNovaGpuConf(void)
         return false;
     }
 
-    std::map<std::string, std::vector<SriovVf>> vfsByGpuId;
+    std::map<std::string, std::vector<PciVf>> vfsByGpuId;
 
     for (const json11::Json& entry : gpuConfig.array_items()) {
-        if (!entry["type"].is_string() || entry["type"].string_value() != "sriovVgpu") {
+        if (!IsVfBackedType(entry["type"])) {
             continue;
         }
 
         const std::string gpuId = entry["id"].string_value();
+        const std::string type = entry["type"].string_value();
 
         if (!entry["pciAddress"].is_string() || entry["pciAddress"].string_value().empty()) {
-            HexLogError("GPU %s has type sriovVgpu but no recorded pciAddress", gpuId.c_str());
+            HexLogError("GPU %s has type %s but no recorded pciAddress", gpuId.c_str(), type.c_str());
             return false;
         }
 
@@ -396,8 +753,8 @@ WriteNovaGpuConf(void)
             assigned += (size_t)profile["count"].number_value();
         }
 
-        std::vector<SriovVf> vfs;
-        if (!GetSriovVfs(SysfsPciAddr(entry["pciAddress"].string_value()), assigned, &vfs)) {
+        std::vector<PciVf> vfs;
+        if (!GetPciVfs(SysfsPciAddr(entry["pciAddress"].string_value()), assigned, &vfs)) {
             HexLogError("Failed to resolve VFs of GPU %s for %s", gpuId.c_str(), NOVA_GPU_CONF);
             return false;
         }
@@ -458,15 +815,51 @@ FindGpuDevice(const char* gpuId)
     return json11::Json();
 }
 
+// Total device framebuffer, for the MIG capacity check below. Returns 0 when
+// nvidia-smi reports nothing parseable; the caller treats that as a failed
+// check rather than an unlimited budget.
+static long
+GetGpuTotalVramMiB(const char* gpuId)
+{
+    const std::string output = HexUtilPOpen(
+        "%s --query-gpu=memory.total --format=csv,noheader,nounits -i %s", NVIDIA_SMI, gpuId);
+    return strtol(output.c_str(), NULL, 10);
+}
+
 // Validates the profiles argument for sriovVgpu/migBackedVgpu:
 // - format: a non-empty JSON array of { id, count } objects with unique
 //   non-negative-integer ids and positive-integer counts
 // - existence: every id must be an available profile of the requested type
 //   on this GPU, as reported by gpu_vgpu_profile_list
-// - capacity (SR-IOV only): each vGPU instance occupies one VF, so the
-//   total requested count must fit within the PF's sriov_totalvfs
+// - capacity (SR-IOV): each vGPU instance occupies one VF, so the total
+//   requested count must fit within the PF's sriov_totalvfs
+// - capacity (MIG-backed), three rules:
+//     1. each type's requested count must fit within its own vmCountLimit
+//        (Max Instances - how many of that type the whole card can host)
+//     2. the combined vramMiB*count of the request must fit within the
+//        device's total framebuffer
+//     3. the GPU instances the request needs must fit within the number the
+//        card can create. Rules 1 and 2 can both pass on a request the driver
+//        then refuses: one vGPU each of five different memory sizes on cn13
+//        uses a quarter of the card's memory, yet needs five partitions where
+//        only four exist. See BuildMigInstanceNeeds and spec.md §5c.
+//   Rule 3 does not model cross-profile slice coupling (R7: 1g/2g/4g partitions
+//   draw on one shared pool, so mixing partition *shapes* can run out of slices
+//   even when each shape's own instance count is fine). nvidia-smi mig -cgi
+//   enforces that at apply time and ApplyMigVgpu is fail-fast, matching how the
+//   SR-IOV homogeneous-mode restriction (discovered only via cn13 hardware
+//   testing, see spec.md §4b/§8) was handled: apply-time rejection first,
+//   tighten validation later if real hardware shows it's worth pre-checking.
+//
+// migTypes is the parsed `nvidia-smi vgpu -s -v` geometry, supplied by the
+// caller so the same output serves validation and persistence; it is empty for
+// non-MIG requests. Rule 3 needs the driver's own Max Instances Per GI rather
+// than a memory division: a 1g.24gb partition reports 23.12 GiB usable but the
+// driver budgets vGPUs against the profile's nominal 24576 MiB, so eight
+// 3072 MiB vGPUs fit where 23674/3072 would have allowed only seven (cn13 R4).
 static bool
-ValidateVgpuProfiles(const char* gpuId, const char* newType, const char* profiles, const std::string& pciAddress)
+ValidateVgpuProfiles(const char* gpuId, const char* newType, const char* profiles,
+                     const std::string& pciAddress, const std::map<int, MigVgpuType>& migTypes)
 {
     std::string jsonError;
     const json11::Json parsed = json11::Json::parse(profiles, jsonError);
@@ -549,8 +942,114 @@ ValidateVgpuProfiles(const char* gpuId, const char* newType, const char* profile
         }
     }
 
-    // TODO(#905): validate MIG-backed capacity constraints (per-profile
-    // vmCountLimit and the device VRAM budget).
+    if (strcmp(newType, "migBackedVgpu") == 0) {
+        std::map<int, double> vramMiBById;
+        std::map<int, long> vmCountLimitById;
+
+        for (const json11::Json& profile : profileList[listKey].array_items()) {
+            if (!profile["id"].is_number()) {
+                continue;
+            }
+            const int id = (int)profile["id"].number_value();
+            vramMiBById[id] = profile["vramMiB"].number_value();
+            vmCountLimitById[id] = profile["vmCountLimit"].is_number() ?
+                (long)profile["vmCountLimit"].number_value() : -1;
+        }
+
+        double requestedVramMiB = 0;
+
+        for (const json11::Json& profile : parsed.array_items()) {
+            const int id = (int)profile["id"].number_value();
+            const long count = (long)profile["count"].number_value();
+
+            const std::map<int, long>::const_iterator limitIt = vmCountLimitById.find(id);
+            if (limitIt != vmCountLimitById.end() && limitIt->second >= 0 && count > limitIt->second) {
+                HexLogError("gpu_resource_set: requested %ld instance(s) of profile %d exceeds the %ld "
+                            "instance(s) available on GPU %s", count, id, limitIt->second, gpuId);
+                return false;
+            }
+
+            requestedVramMiB += vramMiBById[id] * count;
+        }
+
+        // Rule 2 fails closed for the same reason rule 3 below does: an
+        // unreadable budget is not a confirmation that the request fits, and
+        // skipping the rule lets the request reach ApplyMigVgpu and mutate the
+        // card before anything notices. This is the shape PR #1141 flagged as a
+        // silent bypass of capacity validation on the SR-IOV check above, fixed
+        // there in 79734b07 - the MIG rules follow the same contract.
+        const long totalVramMiB = GetGpuTotalVramMiB(gpuId);
+        if (totalVramMiB <= 0) {
+            HexLogError("gpu_resource_set: could not read the total framebuffer of GPU %s; "
+                        "cannot verify the request fits", gpuId);
+            return false;
+        }
+
+        if (requestedVramMiB > totalVramMiB) {
+            HexLogError("gpu_resource_set: requested %.0f MiB of MIG-backed vGPU memory exceeds the %ld MiB "
+                        "available on GPU %s", requestedVramMiB, totalVramMiB, gpuId);
+            return false;
+        }
+
+        // Rule 3 needs the driver's partition geometry. Refuse rather than skip
+        // the rule if it is unavailable: a request that reaches ApplyMigVgpu
+        // unchecked mutates the card before failing.
+        if (migTypes.empty()) {
+            HexLogError("gpu_resource_set: could not read the MIG-backed vGPU types of GPU %s; "
+                        "cannot verify the request fits", gpuId);
+            return false;
+        }
+
+        for (const int id : requestedIds) {
+            if (migTypes.find(id) == migTypes.end()) {
+                HexLogError("gpu_resource_set: vGPU type %d is not a MIG-backed type on GPU %s", id, gpuId);
+                return false;
+            }
+        }
+
+        // Each distinct (partition shape, vGPU memory size) pair needs its own
+        // GPU instances; sum them per profile and compare with what the card can
+        // create. Grouped this way so the two ways of getting it wrong are both
+        // excluded: one instance per requested vGPU over-carves, one per
+        // selected type under-carves past Max Instances Per GI.
+        std::map<int, long> neededByGiProfile;
+        const std::map<std::pair<int, long>, long> needs = BuildMigInstanceNeeds(parsed, migTypes);
+        for (std::map<std::pair<int, long>, long>::const_iterator it = needs.begin();
+             it != needs.end(); ++it) {
+            neededByGiProfile[it->first.first] += it->second;
+        }
+
+        for (std::map<int, long>::const_iterator it = neededByGiProfile.begin();
+             it != neededByGiProfile.end(); ++it) {
+            long available = 0;
+            for (std::map<int, MigVgpuType>::const_iterator typeIt = migTypes.begin();
+                 typeIt != migTypes.end(); ++typeIt) {
+                if (typeIt->second.giProfileId == it->first) {
+                    available = MigGiInstancesTotal(typeIt->second);
+                    break;
+                }
+            }
+
+            // Max Instances = Max Instances Per GI x GI Instances Total, so this
+            // is positive for every type the driver reports (verified for all 43
+            // MIG-backed types on cn13 2026-08-04, R6). A zero here means that
+            // invariant did not hold, which is exactly when the budget must not
+            // be assumed sufficient.
+            if (available <= 0) {
+                HexLogError("gpu_resource_set: could not determine how many GPU instance(s) of profile %d "
+                            "GPU %s allows; cannot verify the request fits", it->first, gpuId);
+                return false;
+            }
+
+            if (it->second > available) {
+                HexLogError("gpu_resource_set: the request needs %ld GPU instance(s) of profile %d on GPU %s "
+                            "but only %ld can exist; every distinct vGPU memory size needs its own instance, "
+                            "so select fewer sizes or fewer of the larger ones",
+                            it->second, it->first, gpuId, available);
+                return false;
+            }
+        }
+    }
 
     return true;
 }
@@ -632,12 +1131,21 @@ ResourceSetMain(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
+    // Read once here rather than inside each consumer: the same `vgpu -s -v`
+    // output drives the capacity check's GPU-instance rule and the name/alias
+    // enrichment further down. It has to come after the vfio-pci release above,
+    // since a pgpu is invisible to nvidia-smi while bound to vfio-pci.
+    const std::map<int, MigVgpuType> migTypes =
+        (strcmp(newType, "migBackedVgpu") == 0)
+            ? ParseMigVgpuTypes(HexUtilPOpen("%s vgpu -s -v -i %s", NVIDIA_SMI, gpuId))
+            : std::map<int, MigVgpuType>();
+
     // Both checks run before gpu_unset_current_type below so that a bad
     // request cannot tear down the GPU's existing configuration.
     const bool preChecksPassed =
         HexUtilSystemF(0, 0, HEX_SDK " gpu_resource_set_check %s %s %s", gpuId, newType, profiles) == 0 &&
         (strcmp(newType, "pgpu") == 0 ||
-         ValidateVgpuProfiles(gpuId, newType, profiles, pciAddress));
+         ValidateVgpuProfiles(gpuId, newType, profiles, pciAddress, migTypes));
 
     if (!preChecksPassed) {
         HexLogError("gpu_resource_set: pre-condition check failed for GPU %s", gpuId);
@@ -778,7 +1286,76 @@ ResourceSetMain(int argc, char* argv[])
         HexLogInfo("gpu_resource_set: successfully updated GPU %s to sriovVgpu", gpuId);
         return EXIT_SUCCESS;
     } else if (strcmp(newType, "migBackedVgpu") == 0) {
-        // TODO(#905)
+        // Existence of every requested id (a vGPU Type ID) was confirmed by
+        // ValidateVgpuProfiles above; parse cannot fail here.
+        std::string jsonError;
+        const json11::Json requested = json11::Json::parse(profiles, jsonError);
+
+        // Enrich the requested {id, count} pairs with name/alias for
+        // persistence (#894 schema: {id, name, count, alias}). id is the vGPU
+        // Type ID throughout, the same as the SR-IOV path - so both vGPU
+        // flavours now derive their Nova alias from the same kind of id, and
+        // count means the same thing in both (vGPUs, not partitions). The GPU
+        // Instance Profile ID each type needs stays internal to ApplyMigVgpu.
+        json11::Json::array persistedProfiles;
+        for (const json11::Json& profile : requested.array_items()) {
+            const int id = (int)profile["id"].number_value();
+
+            const std::map<int, MigVgpuType>::const_iterator typeIt = migTypes.find(id);
+            if (typeIt == migTypes.end()) {
+                HexLogError("gpu_resource_set: failed to resolve MIG-backed vGPU type %d on GPU %s",
+                            id, gpuId);
+                return EXIT_FAILURE;
+            }
+
+            persistedProfiles.push_back(json11::Json::object {
+                { "id", id },
+                { "name", typeIt->second.name },
+                { "count", (int)profile["count"].number_value() },
+                { "alias", ProfileAlias(typeIt->second.name, id) },
+            });
+        }
+
+        if (!ApplyMigVgpu(gpuId, pciAddress, requested)) {
+            HexLogError("gpu_resource_set: failed to apply MIG-backed vGPU partitioning on GPU %s", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        HexTempFile tmpFile;
+        if (tmpFile.fd() < 0) {
+            HexLogError("gpu_resource_set: failed to create a temporary file");
+            return EXIT_FAILURE;
+        }
+        tmpFile.close();
+
+        const std::string profilesDump = json11::Json(persistedProfiles).dump();
+
+        if (HexUtilSystemF(0, 0,
+                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" --argjson profiles '%s' "
+                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"migBackedVgpu\", pciAddress:$pciAddress, profiles:$profiles}]' %s > %s",
+                gpuId, name.c_str(), pciAddress.c_str(), profilesDump.c_str(),
+                GPU_CONFIG_FILE, tmpFile.path()) != 0) {
+            HexLogError("gpu_resource_set: failed to build updated GPU config for %s", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        if (HexUtilSystemF(0, 0, "mv %s %s", tmpFile.path(), GPU_CONFIG_FILE) != 0) {
+            HexLogError("gpu_resource_set: failed to persist GPU %s config", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        if (!WriteNovaGpuConf()) {
+            HexLogError("gpu_resource_set: failed to regenerate %s for GPU %s", NOVA_GPU_CONF, gpuId);
+            return EXIT_FAILURE;
+        }
+
+        if (HexUtilSystemF(0, 0, HEX_CFG " restart_nova") != 0) {
+            HexLogError("gpu_resource_set: failed to restart nova services for GPU %s", gpuId);
+            return EXIT_FAILURE;
+        }
+
+        HexLogInfo("gpu_resource_set: successfully updated GPU %s to migBackedVgpu", gpuId);
+        return EXIT_SUCCESS;
     }
 
     HexLogError("gpu_resource_set: unhandled type %s", newType);
@@ -828,7 +1405,7 @@ Commit(bool modified, int dryLevel)
         return false;
     }
 
-    bool hasSriovVgpu = false;
+    bool hasVfBackedVgpu = false;
 
     for (const json11::Json& entry : gpuConfig.array_items()) {
         if (!entry["id"].is_string() || !entry["type"].is_string()) {
@@ -854,43 +1431,49 @@ Commit(bool modified, int dryLevel)
                 HexLogError("Failed to re-apply pgpu passthrough binding for GPU %s", id.c_str());
                 return false;
             }
-        } else if (type == "sriovVgpu") {
+        } else if (type == "sriovVgpu" || type == "migBackedVgpu") {
             // GPU is optional hardware: a single card's sysfs state being
             // unreadable or an apply hiccup should not fail Commit() for
             // the whole node and force a reboot. Log and move on to the
             // next entry instead.
             if (!entry["pciAddress"].is_string() || entry["pciAddress"].string_value().empty()) {
-                HexLogError("GPU %s has type sriovVgpu but no recorded pciAddress; cannot re-apply partitioning", id.c_str());
+                HexLogError("GPU %s has type %s but no recorded pciAddress; cannot re-apply partitioning",
+                            id.c_str(), type.c_str());
                 continue;
             }
 
             const std::string pciAddress = entry["pciAddress"].string_value();
 
-            // VF enablement and per-VF vGPU types are sysfs state and do
-            // not survive a reboot. Skip GPUs that still carry an applied
-            // layout - this also keeps runtime commits from disturbing
-            // vGPUs attached to running VMs.
-            if (!SriovVgpuApplied(SysfsPciAddr(pciAddress))) {
-                if (!ApplySriovVgpu(pciAddress, entry["profiles"])) {
-                    HexLogError("Failed to re-apply sriovVgpu partitioning for GPU %s", id.c_str());
+            // VF enablement, GPU/compute instances (MIG-backed only), and
+            // per-VF vGPU types are runtime state and do not survive a
+            // reboot. Skip GPUs that still carry an applied layout - this
+            // also keeps runtime commits from disturbing vGPUs attached to
+            // running VMs.
+            if (!VfVgpuApplied(SysfsPciAddr(pciAddress))) {
+                const bool applied = (type == "sriovVgpu")
+                    ? ApplySriovVgpu(pciAddress, entry["profiles"])
+                    : ApplyMigVgpu(id, pciAddress, entry["profiles"]);
+
+                if (!applied) {
+                    HexLogError("Failed to re-apply %s partitioning for GPU %s", type.c_str(), id.c_str());
                     continue;
                 }
             }
 
-            hasSriovVgpu = true;
+            hasVfBackedVgpu = true;
         }
-        // TODO(#905): re-apply migBackedVgpu once gpu_resource_set supports it.
     }
 
     // The drop-in's content derives solely from config.json, which does not
     // change across reboots, so no nova restart is needed here -
     // regeneration is self-healing only (e.g. after a lost/stale gpu.conf).
-    // Also regenerate when a drop-in exists but no sriovVgpu entry remains,
-    // so entries of cards switched away from sriovVgpu don't linger.
+    // Also regenerate when a drop-in exists but no sriovVgpu/migBackedVgpu
+    // entry remains, so entries of cards switched away from either don't
+    // linger.
     //
     // A regen failure here means Nova's GPU scheduling info may be stale,
     // not that the node's policy apply should fail and force a reboot.
-    if ((hasSriovVgpu || access(NOVA_GPU_CONF, F_OK) == 0) && !WriteNovaGpuConf()) {
+    if ((hasVfBackedVgpu || access(NOVA_GPU_CONF, F_OK) == 0) && !WriteNovaGpuConf()) {
         HexLogError("Failed to regenerate %s", NOVA_GPU_CONF);
     }
 

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -561,9 +561,20 @@ gpu_vgpu_profile_list()
     # SR-IOV vGPU profiles
     local sriov_profiles="[]"
 
-    # Maps a MIG GPU Instance Profile ID -> MIG-backed vGPU type name ("XX-YY-ZZ"),
-    # used below to name the corresponding mig -lgip profile.
-    local mig_profile_name_map="{}"
+    # MIG-backed vGPU profiles - one entry per vGPU *type*, not per GPU instance
+    # profile. Both lists are therefore built from the same `vgpu -s -v` output
+    # and mean the same thing field for field.
+    #
+    # This list used to be built from `mig -lgip` and keyed by GPU Instance
+    # Profile ID, which cannot express what the operator actually picks: one GI
+    # profile exposes many vGPU types (47 exposes 19 on cn13's RTX PRO 6000
+    # Blackwell, DC-1-2Q through DC-1-24C), so a single id left the type - and
+    # with it the framebuffer size and the Q/A/B/C mode - undetermined, and the
+    # code picked one on the operator's behalf. `mig -lgip` also lists partition
+    # shapes that have no MIG-backed vGPU type at all (8 of the 11 it reports on
+    # that card), so the list offered choices that could never be applied.
+    # Verified on cn13 2026-08-04; see spec.md §2c/§5b (#905).
+    local mig_profiles="[]"
 
     local vgpu_output
     vgpu_output=$($NVIDIA_SMI vgpu -s -v -i "$gpu_id" 2>/dev/null)
@@ -575,25 +586,29 @@ gpu_vgpu_profile_list()
         local decimal_id
         decimal_id=$(awk -v v="$vgpu_type_id_hex" 'BEGIN{print strtonum(v)}')
 
-        local block profile_name fb_memory_mib gpu_instance_profile_id
+        local block profile_name fb_memory_mib max_instances
         block=$(echo "$vgpu_output" | grep -A 20 "vGPU Type ID *: $vgpu_type_id_hex\$")
         # `Name                              : NVIDIA RTX Pro 6000 Blackwell DC-1-24Q`
         profile_name=$(echo "$block" | grep "Name" | head -1 | awk '{print $NF}')
         # `FB Memory                         : 24576 MiB`
         fb_memory_mib=$(echo "$block" | grep "FB Memory" | head -1 | awk '{print $4}')
-        # `GPU Instance Profile ID           : 47`
-        # This column is present only for MIG-backed vGPUs and does not exist for SR-IOV vGPUs.
-        gpu_instance_profile_id=$(echo "$block" | grep "GPU Instance Profile ID" | head -1 | awk '{print $NF}')
+        # `Max Instances                     : 4` - how many of this type the
+        # whole card can host. Anchored on the colon so it cannot match
+        # `Max Instances Per VM` or `Max Instances Per GI`, which both contain
+        # this string. Absent on SR-IOV types, which carry no such limit.
+        max_instances=$(echo "$block" | \
+            grep -E "^[[:space:]]*Max Instances[[:space:]]*:" | head -1 | awk '{print $NF}')
+        [ -z "$max_instances" ] && max_instances="null"
 
-        # MIG-backed vGPU types (name "XX-YY-ZZ") are already covered by the `mig -lgip` command below.
-        # Record their name for later use and skip.
+        # MIG-backed type names carry a slice count ("DC-1-3Q"); SR-IOV
+        # time-sliced ones do not ("DC-3Q").
         if echo "$profile_name" | grep -qE "$MIG_PROFILE_NAME_REGEX"; then
-            if [ -n "$gpu_instance_profile_id" ]; then
-                mig_profile_name_map=$(echo "$mig_profile_name_map" | jq -c \
-                    --arg id "$gpu_instance_profile_id" \
-                    --arg name "$profile_name" \
-                    '. + {($id): $name}')
-            fi
+            mig_profiles=$(echo "$mig_profiles" | jq -c \
+                --argjson id "$decimal_id" \
+                --arg name "$profile_name" \
+                --argjson vram_mib "$fb_memory_mib" \
+                --argjson vmCountLimit "$max_instances" \
+                '. + [{ id: $id, name: $name, vramMiB: $vram_mib, vmCountLimit: $vmCountLimit }]')
             continue
         fi
         if ! echo "$profile_name" | grep -qE "$SRIOV_PROFILE_NAME_REGEX"; then
@@ -607,34 +622,6 @@ gpu_vgpu_profile_list()
             --argjson vram_mib "$fb_memory_mib" \
             '. + [{ id: $id, name: $name, vramMiB: $vram_mib, vmCountLimit: null }]')
     done
-
-    # MIG GPU instance profiles
-    local mig_profiles="[]"
-    local mig_output
-    mig_output=$($NVIDIA_SMI mig -lgip -i "$gpu_id" 2>/dev/null)
-
-    while read -r _gpu_idx _mig_text profile_name profile_id instances memory_gib _rest; do
-        [ -z "$profile_id" ] && continue
-
-        local instances_total
-        instances_total=${instances#*/}
-
-        local vram_mib
-        vram_mib=$(awk -v g="$memory_gib" 'BEGIN{printf "%.2f", g * 1024}')
-
-        local name
-        name=$(echo "$mig_profile_name_map" | jq -r \
-            --arg id "$profile_id" \
-            --arg fallback "MIG $profile_name" \
-            '.[$id] // $fallback')
-
-        mig_profiles=$(echo "$mig_profiles" | jq -c \
-            --argjson id "$profile_id" \
-            --arg name "$name" \
-            --argjson vram "$vram_mib" \
-            --argjson vmCountLimit "$instances_total" \
-            '. + [{ id: $id, name: $name, vramMiB: $vram, vmCountLimit: $vmCountLimit }]')
-    done <<< "$(echo "$mig_output" | grep -E '^\|\s+[0-9]+\s+MIG\s+[0-9]+g\.' | tr -d '|')"
 
     jq -c -n \
         --argjson sriovProfiles "$sriov_profiles" \

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -726,6 +726,63 @@ gpu_resource_set_check()
 # according to the config file, so it is free to be reconfigured.
 # This function does nothing if the target GPU is currently configured
 # as pGPU.
+# Releases one PF's SR-IOV VFs through sriov-manage, retrying briefly on
+# unbindLock contention. Returns 0 on success, 1 on failure.
+#
+# Zeroing sriov_numvfs by writing to the sysfs file directly (even with each
+# VF's vGPU type pre-cleared) is rejected by the driver - confirmed on cn13
+# hardware: "write error: No such file or directory" every time, regardless of
+# VF state. Disabling VFs requires going through sriov-manage, which requests
+# the driver's unbindLock (temporarily detaches/reattaches the PF's own driver
+# binding) before touching sriov_numvfs - a raw sysfs write skips that
+# handshake and the driver refuses it. sriov-manage -d also clears each VF's
+# vGPU type internally, so no separate cleanup loop is needed.
+#
+# sriov-manage can transiently fail to obtain that unbindLock if another NVML
+# client (e.g. cube-cos-api's GPU status API) holds the device open at that
+# exact moment - retry briefly to absorb that race. A failure that isn't this
+# specific message is not retried and fails immediately.
+#
+# Unlike gpu_vf_disable() near the top of this file, this touches only the
+# given PF: it never rebinds anything to vfio-pci and never writes
+# modprobe.d persistence.
+gpu_sriov_disable_vfs()
+{
+    local pci_addr="$1"
+
+    local attempt output rc
+    for attempt in 1 2 3 4 5; do
+        output=$($NVIDIA_SRIOV -d "$pci_addr" 2>&1)
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            return 0
+        fi
+        if ! echo "$output" | grep -q "Cannot obtain unbindLock"; then
+            echo "Error: failed to disable SR-IOV VFs on $pci_addr: $output" >&2
+            return 1
+        fi
+        if [ "$attempt" = "5" ]; then
+            echo "Error: failed to disable SR-IOV VFs on $pci_addr: unbindLock still busy after 5 attempts" >&2
+            return 1
+        fi
+        echo "Warning: unbindLock busy for $pci_addr, retrying ($attempt/5)" >&2
+        sleep 1
+    done
+
+    return 1
+}
+
+# Renders the sysfs form of a GPU's PCI address: nvidia-smi reports an 8-char
+# domain in uppercase hex (00000000:BB:SS.F) but the sysfs directory name uses
+# a 4-char lowercase one (0000:bb:ss.f).
+gpu_sysfs_pci_addr()
+{
+    local gpu_id="$1"
+
+    $NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null \
+        | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]'
+}
+
 gpu_unset_current_type()
 {
     local gpu_id="$1"
@@ -736,50 +793,36 @@ gpu_unset_current_type()
         "$GPU_CONFIG_FILE_PATH" 2>/dev/null)
 
     if [ "$current_type" = "sriovVgpu" ]; then
-        local pci_bus_id
-        pci_bus_id=$($NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null)
-
-        # nvidia-smi uses 8-char domain (00000000:bb:ss.f); sysfs uses 4-char
-        # lowercase (0000:bb:ss.f) - the uppercase hex nvidia-smi reports
-        # doesn't match the (lowercase) sysfs directory name.
         local pci_addr
-        pci_addr=$(echo "$pci_bus_id" | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]')
+        pci_addr=$(gpu_sysfs_pci_addr "$gpu_id")
 
-        # Zeroing sriov_numvfs by writing to the sysfs file directly (even
-        # with each VF's vGPU type pre-cleared) is rejected by the driver -
-        # confirmed on cn13 hardware: "write error: No such file or
-        # directory" every time, regardless of VF state. Disabling VFs
-        # requires going through sriov-manage, which requests the driver's
-        # unbindLock (temporarily detaches/reattaches the PF's own driver
-        # binding) before touching sriov_numvfs - a raw sysfs write skips
-        # that handshake and the driver refuses it. sriov-manage -d also
-        # clears each VF's vGPU type internally, so no separate cleanup
-        # loop is needed here.
-        #
-        # sriov-manage can transiently fail to obtain that unbindLock if
-        # another NVML client (e.g. cube-cos-api's GPU status API) holds the
-        # device open at that exact moment - retry briefly to absorb that
-        # race. A failure that isn't this specific message is not retried
-        # and fails immediately.
-        local attempt output rc
-        for attempt in 1 2 3 4 5; do
-            output=$($NVIDIA_SRIOV -d "$pci_addr" 2>&1)
-            rc=$?
-            if [ $rc -eq 0 ]; then
-                break
-            fi
-            if ! echo "$output" | grep -q "Cannot obtain unbindLock"; then
-                echo "Error: failed to disable SR-IOV VFs on $pci_addr: $output" >&2
-                exit 1
-            fi
-            if [ "$attempt" = "5" ]; then
-                echo "Error: failed to disable SR-IOV VFs on $pci_addr: unbindLock still busy after 5 attempts" >&2
-                exit 1
-            fi
-            echo "Warning: unbindLock busy for $pci_addr, retrying ($attempt/5)" >&2
-            sleep 1
-        done
+        if ! gpu_sriov_disable_vfs "$pci_addr"; then
+            exit 1
+        fi
     elif [ "$current_type" = "migBackedVgpu" ]; then
+        # A MIG-backed card carries the same VF/current_vgpu_type shape as an
+        # SR-IOV one, so its VFs are released the same way - and they must be
+        # released *first*. With VFs still enabled the driver refuses to turn
+        # MIG mode off ("Unable to disable MIG Mode for GPU ...: In use by
+        # another client", confirmed on cn13 2026-08-04), which left a
+        # MIG-backed card permanently stuck on its first configuration: no
+        # re-carve, no switch back to pgpu/sriovVgpu.
+        #
+        # sriov-manage -d rebinds the driver, and that also destroys every GPU
+        # instance on the card, so no explicit -dci/-dgi pass is needed before
+        # -mig 0.
+        local mig_pci_addr
+        mig_pci_addr=$(gpu_sysfs_pci_addr "$gpu_id")
+
+        if [ -z "$mig_pci_addr" ]; then
+            echo "Error: GPU $gpu_id has type migBackedVgpu but nvidia-smi reported no PCI address" >&2
+            exit 1
+        fi
+
+        if ! gpu_sriov_disable_vfs "$mig_pci_addr"; then
+            exit 1
+        fi
+
         if ! $NVIDIA_SMI -i "$gpu_id" -mig 0; then
             echo "Error: failed to disable MIG mode for GPU $gpu_id" >&2
             exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Implements MIG-backed vGPU support for `hex_config gpu_resource_set`, filling
in the `migBackedVgpu` branches left as `TODO(#905)` in #904. An operator can
now carve a MIG-capable GPU into MIG-backed vGPUs and hand them to VMs, not
just SR-IOV time-sliced ones.

- Rebuilds `gpu_vgpu_profile_list`'s `migBacked` list from `nvidia-smi vgpu -s
  -v` with **one entry per vGPU type** instead of per GPU instance profile.
  Keying by GI profile could not express what an operator picks: profile 47
  exposes 19 types on cn13's RTX PRO 6000 Blackwell, so the id left the
  framebuffer size and the Q/A/B/C mode undetermined. It also offered 8 of 11
  partition shapes that have no MIG-backed vGPU type at all and could never be
  applied. `id`/`vramMiB`/`count` now mean field for field what the `sriov`
  list already meant, matching what cube-cos-openapi has documented since the
  schema was written.
- Fixes `vmCountLimit`, which reported the partition count (a flat 4) where the
  contract wants how many of that type the card can host (48 for `DC-1-2Q`). A
  request for 8 `DC-1-3Q` — perfectly legal — used to be rejected.
- Derives partitions rather than requesting them: the instance count is
  `ceil(group total / Max Instances Per GI)` per (GI profile, framebuffer size)
  group. Eight `DC-1-3Q` carve **one** partition, not eight — carving eight
  would have exhausted profile 47's budget of four and failed on the fifth.
- Validates capacity with three rules — per-type `vmCountLimit`, the device
  framebuffer budget, and the GPU-instance budget — **all failing closed** when
  their input is unreadable. The third rule catches what the other two miss:
  one vGPU of each of five sizes uses a quarter of the card's memory and stays
  under every per-type limit, yet needs five partitions where only four exist.
- Applies in a load-bearing order: resolve types (no hardware touched) → MIG
  mode → the PF's VFs → the GPU instances → per-VF `current_vgpu_type`.
  `sriov-manage` rebinds the driver and wipes every GPU instance, so creating
  instances before enabling VFs left the card with none by the time the VFs
  came up.
- Tears down completely on any failure, including turning MIG mode back off if
  this attempt is what turned it on. Without that last step a failed apply left
  the card MIG-enabled with no product path back, because `config.json` only
  gains its `migBackedVgpu` entry on success and `gpu_unset_current_type`'s
  `-mig 0` branch keys off that entry.
- Persists `config.json`, regenerates the Nova PCI drop-in, restarts
  `nova-compute`, and re-applies on node boot via `Commit()` — reusing the
  SR-IOV path's helpers, which are generalised from `Sriov*` to `Vf*`/`Pci*`
  naming since both vGPU flavours end up in the same VF/`current_vgpu_type`
  sysfs shape.
- Fixes a latent bug in `gpu_unset_current_type` (first commit): its
  `migBackedVgpu` branch went straight to `nvidia-smi -mig 0`, which the driver
  refuses while VFs are still enabled. The branch is unreachable on `develop`
  today because carving such a card is a stub, so this is a pre-existing defect
  the feature would hit immediately — separated out so the feature commit is
  about the feature.

#### Which issue(s) this PR fixes

Fixes #905

#### Special notes for your reviewer

**Paired change in `cube-cos-api` — please read before merging.**
`cube-cos-api` PR bigstack-oss/cube-cos-api#625 removes the MIG-only "vGPU Type ID → GPU
Instance Profile ID" reverse lookup, which only existed because hex used to
report GI profile ids.

There is **no hard merge order**: `migBackedVgpu` was a `TODO(#905)` stub on
`develop`, so carving a MIG-backed card was not possible at all and neither
half-deployed combination breaks behaviour that previously worked — new hex +
old API leaves `attachedInstances` empty for MIG-backed cards, old hex + new
API fails to resolve the alias, and both are what happens today anyway. For a
**live node** the two binaries should still go on together, since a mismatched
pair reports MIG-backed cards without instance aliases rather than failing
loudly. `cube-cos-openapi` needs no change (no new fields).

**AC verification status** (cn13, NYCU GPU node, RTX PRO 6000 Blackwell Server
Edition, host driver 580.105.06; unit harness 113/113 green):

- ✅ **AC1** (`config.json` updated on success): confirmed end-to-end. `count`
  is a number of vGPUs and the Nova alias is keyed on the vGPU Type ID, so both
  vGPU flavours now derive it the same way.
- ✅ **AC2** (log error when the target GPU is in-use by a VM): verified with a
  live VM actually attached to a MIG-backed vGPU — the rejection left the GI
  count, `config.json` and the VM completely unchanged. This is a stronger pass
  than #904's, which was a code read.
- ⏳ **AC3** (re-apply config after reboot): the mechanism is verified, a real
  reboot is not. `sriov-manage -d` clears the runtime state (VFs, GPU
  instances) while MIG mode persists — which is exactly the post-reboot
  condition — and a scoped `hex_config commit` then rebuilt 48 VFs, both GPU
  instances, the per-VF types and the Nova drop-in. That is strong evidence the
  mechanism works, **not** a substitute for AC3: it does not cover
  power-cycle persistence, driver reload, or the boot-time policy-apply flow.
  cn13 has no BMC/console, so an actual reboot needs a separate go/no-go. Same
  explicit deferral as #904.

**Known residual gaps** (disclosed, not blocking):

- **Cross-profile slice coupling is not modelled** in the capacity check —
  1g/2g/4g partitions draw on one shared pool, so mixing partition *shapes* can
  exhaust slices even when each shape's own instance budget is fine.
  `nvidia-smi mig -cgi` enforces it at apply time and `ApplyMigVgpu` is
  fail-fast, the same approach #904 took for the SR-IOV homogeneous-mode
  restriction. This is now the tested failure path rather than a theoretical
  one — see the QA notes.
- **A `sriov-manage -e` failure is not hardware-exercised.** Triggering it needs
  either a replaced vendor `sriov-manage` or a long-lived NVML holder on a
  shared node. It reaches the same `TeardownMigVgpu` with nothing created, so it
  differs from the tested paths only in skipping `-dci`/`-dgi`; the harness
  covers the call site in both MIG-mode directions.
- **`config.json`'s read-modify-write still has no locking.** `gpu_resource_set`
  is registered `CONFIG_COMMAND`, not `CONFIG_COMMAND_WITH_SETTINGS`, so nothing
  serializes concurrent invocations. This shape pre-dates the branch — the
  `pgpu` and `sriovVgpu` branches have it too — and was already agreed as a
  separate ticket during #1141 review. This PR adds a third instance of an
  existing gap rather than introducing one.
- **A hex rejection surfaces as HTTP 500** via `nodes.go:439` →
  `handlers.go:355`'s `default:` (the API's own guard returns 409). The
  rejection messages here are deliberately written as sentences an end user can
  act on, since they reach the frontend verbatim, but changing the status
  mapping is out of scope for this ticket.

#### Additional documentation

```docs
Testing performed (cn13, NYCU GPU node — GPU 0 =
GPU-29f1b0ad-ada5-c5fb-ac9c-8d8832d6741b @ 0000:42:00.0 throughout.
GPU 3 stayed pgpu and was never touched: it backs a Grafana dashboard on
this shared node.)

1. Unit harness (Mac, no GPU needed): `bash harness/run.sh` under
   .claude/scratch/feat-905-mig-vgpu-infra/ — 113/113 passed. Covers
   `nvidia-smi vgpu -s -v` parsing, the per-type profile list, the
   GI-count arithmetic, all three capacity rules in both directions, and
   the apply/teardown call sequence via a command log. Includes three
   regression guards: `sriov-manage -e` must precede every `-cgi`, no
   entry may ever be keyed on GI profile 0, and each teardown path both
   undoes its own MIG-mode enable and leaves a pre-existing one alone.

2. Per-type profile list, real hardware (2026-08-05): the migBacked list
   went from 11 entries (partition shapes, 8 of them unusable) to 43
   (real vGPU types). Every framebuffer level's type count and
   `vmCountLimit` matched the values measured directly from
   `nvidia-smi vgpu -s -v` — profile 47 accounts for 19 of the 43.

3. Rejection cases, real hardware (2026-08-05) — hardware untouched in
   all four, errors read via `journalctl -t hex_config` since hex_config
   logs there rather than to stdout:
   - five different framebuffer sizes, one vGPU each -> rc=1, "needs 5
     GPU instance(s) of profile 47 ... but only 4 can exist". Rules 1
     and 2 both pass this request; only the third catches it.
   - 33 x DC-1-3Q -> rc=1 against the corrected limit of 32 (the old
     list would have wrongly rejected at 4).
   - an SR-IOV type id used as migBackedVgpu -> rc=1.
   - `id: 0` -> rc=1. Real hardware prints "GPU Instance Profile ID :
     N/A" for SR-IOV types and strtol("N/A") is 0, which is a real GI
     profile id — so a naive parser fabricated an entry that then passed
     validation. Blocks are now recorded only when every field the apply
     path needs is present.

4. Apply path, real hardware (2026-08-05):
   `hex_config gpu_resource_set <gpu0> migBackedVgpu '[{"id":1549,"count":8}]'`
   -> rc=0, and critically GI count = 1, not 8: eight 3072 MiB vGPUs
   share one 1g.24gb+gfx partition, with virtfn0..7 all carrying type
   1549 and gpu_instance_id 3. config.json recorded count 8 with the
   alias derived from the vGPU Type ID, and the Nova drop-in got 1 alias
   + 8 passthrough_whitelist entries. This is AC1's hardware evidence.
   Mixing sizes was checked in the same session: 8 x 1549 + 2 x 1553 ->
   10 vGPUs across 2 partitions, virtfn0..7 in one and virtfn8..9 in the
   other.

5. Flavor + VM attach + API, real hardware (2026-08-05): created a
   flavor with `pci_passthrough:alias=<alias-from-config.json>:1`, booted
   a VM -> ACTIVE. `nvidia-smi vgpu -q` reported vGPU Type 1549 — the
   same id hex records, which is what makes the cube-cos-api reverse
   lookup removable. `GET /api/v1/datacenters/RegionOne/nodes/cn13/gpuCards`
   then returned resourceType migBackedVgpu, migProfileCount 43, and an
   attachedInstances entry whose id equals the `openstack server create`
   id with profileAlias resolved and totalMiB 3072. Unlike #904, the
   flavor/VM run and the hex_config apply were the same pass.

6. AC2, real hardware (2026-08-05): with that VM still ACTIVE,
   `gpu_resource_set <gpu0> migBackedVgpu '[{"id":1549,"count":4}]'`
   -> rc=1, "GPU ... is in-use". GI count, config.json's count of 8 and
   the VM were all unchanged afterwards.

7. AC3 mechanism, real hardware (2026-08-05): `sriov-manage -d` to clear
   runtime state while leaving MIG mode and config.json intact (the
   post-reboot condition), then `hex_config commit /etc/settings.txt gpu`
   -> numvfs 0->48, 0->2 GPU instances, per-VF types restored, gpu.conf
   regenerated with 10 whitelist entries. settings.txt was fed to itself
   deliberately and its sha256 was identical before and after, so the
   scoped commit did not pollute persisted settings.

8. Resource-type switching matrix, real hardware (2026-08-06): every
   ordered transition among pgpu, sriovVgpu and migBackedVgpu, plus both
   re-carves and unset as a starting point — 10 transitions, all rc=0.
   After each one, mig.mode / sriov_numvfs / GPU-instance count / bound
   driver / config.json / the Nova drop-in were all checked against the
   shape that state should have. The migBackedVgpu -> sriovVgpu direction
   is the one the teardown fix below makes possible.

9. Apply-time failure paths, real hardware (2026-08-06). Triggered
   naturally, with no system file replaced: this card has four 1g slices
   (`mig -lgip`: profile 47 = 1g x4, 35 = 2g x2, 32 = 4g x1), so
   requesting four different framebuffer sizes under profile 47 plus one
   DC-2-12Q under profile 35 passes all three capacity rules (each count
   is 1; sum of framebuffers is 27648 of 98304 MiB; profile 47 needs 4 of
   4 and profile 35 needs 1 of 2) while asking for six slices out of four.
   That is precisely the cross-profile coupling rule 3 leaves to the
   driver.
   - The driver refused the third `-cgi 47` with "Insufficient
     Resources", and the teardown then ran `sriov-manage -d` -> `-dci` ->
     `-dgi` -> `-mig 0`, leaving mig.mode Disabled, numvfs 0 and no GPU
     instances. config.json was untouched, as the apply never reached it.
   - Switching that card to sriovVgpu immediately afterwards succeeded
     (rc=0, numvfs 48, 2 whitelist entries).
   - Repeating the same failing request on a card that was ALREADY
     MIG-enabled left mig.mode Enabled, while still clearing the VFs and
     instances — the boot-time Commit() re-apply case, where the mode
     survived the reboot and this attempt did not set it.
   - As a control for why that `-mig 0` matters, a card was put into the
     un-torn-down state by hand (VFs released, MIG mode left on) and then
     switched to sriovVgpu: rc=1, "failed to set vGPU type 1519 on
     0000:42:00.0/virtfn0", with dmesg showing
     "NVRM: Failed to add vgpu create request: 0x38" and
     "vGPU creation failed on device 0x4202. -5" — the same driver error
     this PR's apply ordering was written against. Leaving MIG mode on is
     therefore not cosmetic: it makes the card unusable for sriovVgpu
     until someone runs `nvidia-smi -mig 0` by hand.

10. Environment restored after every session, reconciled by sha256:
    hex_config, sdk_gpu.sh and cube-cos-api all back to the versions
    found on arrival (with SUID and ownership preserved), all four GPUs
    MIG-disabled with numvfs 0, GPU 3 still pgpu, config.json and
    gpu.conf byte-identical to baseline, /etc/settings.txt unchanged, and
    no leftover VMs, flavors or staged artifacts. gpu.conf has to be
    regenerated through `hex_config commit` rather than copied back — it
    is a derived file, and a stale copy would keep Nova advertising
    aliases that no longer exist.

Not tested / explicitly deferred:

- AC3 as a real reboot: cn13 has no BMC/console, so a bad bootstrap is
  unrecoverable. Needs a separate go/no-go, same as #904. Item 7 above
  verifies the mechanism, not the reboot.
- A `sriov-manage -e` failure: see "Known residual gaps". Same teardown
  code as item 9, minus the instance-destroy calls.
- Nothing was built on a developer Mac at any point; hex_config was
  compiled x86 on the build node and its identity confirmed by symbols
  that only the new code contains, then matched by sha256 across every
  hop to the test node.
```
