### PR TITLE
feat(fts): honor hidden repair opt-out marker (validation aid)

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -1244,6 +1244,8 @@ cube_wait_all_committed()
 
 cluster_check_repair_async()
 {
+    # Hidden opt-out: skip the final check_repair if the agent dropped the marker. See #1225.
+    [ -f /etc/appliance/state/cube_repair_optout ] && return 0
     # Run the final cluster check_repair off the caller's critical path so the
     # operator gets their prompt back immediately and can start using the box.
     # The result is popped onto the console device(s) and broadcast (wall) when

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -132,7 +132,8 @@ _health_fail_log()
         # happen without the repair. So increment (and attempt) only when ready.
         # likewise during a roll: nodes are deliberately down and the roll owns
         # service state; repairing fights it
-        if cube_cluster_ready && ! is_cluster_rolling ; then
+        # Hidden opt-out: skip auto_repair if the agent dropped the marker. See #1225.
+        if cube_cluster_ready && ! is_cluster_rolling && [ ! -f /etc/appliance/state/cube_repair_optout ] ; then
             let "count = $count + 1"
             echo "failed count: $count" >> /var/log/health_${srv}_error.log
             echo $count > /tmp/health_${srv}_error.count


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it
Honors a hidden, persistent marker `/etc/appliance/state/cube_repair_optout`: when present, `cluster_check_repair_async` (the final FTS `check_repair`) and the health `_auto_repair` loop **no-op**. Lets the driver/QA iterate on the raw post-set_ready / post-reboot state so real defects stay visible instead of being auto-repaired. Default behavior is unchanged when the marker is absent. The driver **delivers** the marker (cube-cos-driver — separate PR).

#### Which issue(s) this PR fixes
Fixes #1225

#### Special notes for your reviewer
2-file change (`proj_functions` + `sdk_health.sh`). Marker under `/etc/appliance/state/` (per-slot, persists across reboots; cleared on reimage / normal deploy). This is the harness that surfaced the #1195 FTS NGs with auto_repair off.

#### Additional documentation
```docs
Handbook note added under kb/cube-cos-driver/ (repair opt-out for validation).
```
