### PR TITLE
fix(ceph): ganesha active/active HA — rados_cluster + per-node nodeid + grace DB

### DIFF
--- a/core/ceph/ganesha.conf
+++ b/core/ceph/ganesha.conf
@@ -45,11 +45,9 @@ NFSv4
 	# able to store it in RADOS is a nice feature that makes it easy to
 	# migrate the daemon to another host.
 	#
-	# For a single-node or active/passive configuration, rados_ng driver
-	# is preferred. For active/active clustered configurations, the
-	# rados_cluster backend can be used instead. See the
-	# ganesha-rados-grace manpage for more information.
-	RecoveryBackend = rados_ng;
+	# Active/active (one ganesha per control node): rados_cluster + a per-node
+	# nodeid + a shared ganesha-rados-grace DB (also fine for a single node).
+	RecoveryBackend = rados_cluster;
 
 	# NFSv4.0 clients do not send a RECLAIM_COMPLETE, so we end up having
 	# to wait out the entire grace period if there are any. Avoid them.
@@ -187,12 +185,9 @@ RADOS_KV
 	# The default is "nfs-ganesha".
 	pool = "cephfs_data";
 
-	# Consider setting a unique nodeid for each running daemon here,
-	# particularly if this daemon could end up migrating to a host with
-	# a different hostname (i.e. if you're running an active/passive cluster
-	# with rados_ng/rados_kv and/or a scale-out rados_cluster). The default
-	# is to use the hostname of the node where ganesha is running.
-	# nodeid = hostname.example.com
+	# Unique per-node id (config_ceph substitutes @NODEID@ = hostname; kept in
+	# sync with the ganesha-rados-grace membership by config_ceph).
+	nodeid = @NODEID@;
 }
 
 # Config block for rados:// URL access. It too uses its own client to access

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -55,6 +55,8 @@ const static char GROUP[] = "ceph";
 const static char CONF[] = "/etc/ceph/ceph.conf";
 const static char ISCSI_GW_CONF[] = "/etc/ceph/iscsi-gateway.cfg";
 const static char NFS_GANESHA_CONF[] = "/etc/ganesha/ganesha.conf";
+// RADOS pool for the ganesha rados_cluster grace DB (matches RADOS_KV pool).
+const static char GANESHA_RECOV_POOL[] = "cephfs_data";
 const static char CONF_DEF[] = "/etc/default/ceph";
 const static char APP_DIR[] = "/var/lib/ceph";
 const static char CLIENT_SOCK[] = "/var/run/ceph/guests/";
@@ -512,6 +514,11 @@ SetupMds(std::string hostname)
     }
     if (HexSystemF(0, "sed -i 's/@BIND_ADDR@/%s/' %s", myIp.c_str(), NFS_GANESHA_CONF) != 0) {
         HexLogError("failed to update %s", NFS_GANESHA_CONF);
+        return false;
+    }
+    // rados_cluster nodeid = hostname (stable across a same-hostname rejoin).
+    if (HexSystemF(0, "sed -i 's/@NODEID@/%s/' %s", hostname.c_str(), NFS_GANESHA_CONF) != 0) {
+        HexLogError("failed to update ganesha nodeid in %s", NFS_GANESHA_CONF);
         return false;
     }
 
@@ -1017,6 +1024,8 @@ RemoveMon(const char* hostname)
 {
     HexUtilSystemF(0, 0, "timeout 60 ceph mon remove %s", hostname);
     RemoveMonData(hostname);
+    // Drop the node from the grace DB on permanent removal (a rejoin re-adds itself in SetupMds).
+    HexUtilSystemF(0, 0, "ganesha-rados-grace -p %s remove %s", GANESHA_RECOV_POOL, hostname);
     HexLogInfo("ceph-mon@%s removed", hostname);
 
     return true;
@@ -1297,6 +1306,8 @@ MountCephfsStore()
         HexSetFileMode("/mnt/cephfs/nova/instances", "nova", "nova", 0755);
 
         HexUtilSystemF(0, 0, "systemctl start ceph-umountfs");
+        // Register this node in the grace DB before ganesha joins (idempotent; also covers a same-hostname rejoin). See #1231.
+        HexUtilSystemF(0, 0, "ganesha-rados-grace -p %s add %s", GANESHA_RECOV_POOL, s_hostname.c_str());
         HexUtilSystemF(0, 0, "systemctl start nfs-ganesha");
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

CubeCOS runs one `nfs-ganesha` per control node (active/active), but `core/ceph/ganesha.conf` used the **active/passive** `rados_ng` recovery backend with no `nodeid`, so all daemons shared one recovery object (`node0_recov`) and raced the NFSv4 grace/callback machinery (observed `SIGABRT` in `libntirpc svc_fd_ncreatef`). Switch to `rados_cluster` + per-node `nodeid` (= hostname) + managed `ganesha-rados-grace` membership. Uniform for single-node, active/active, and same-hostname control rejoin.

#### Which issue(s) this PR fixes

Fixes #1231

#### Special notes for your reviewer

- `config_ceph` substitutes `@NODEID@` (= hostname) in `SetupMds`, self-adds to the grace DB before starting ganesha (idempotent → also covers a same-hostname rejoin), and removes on permanent node removal (`RemoveMon`).
- **Assumption to confirm:** `RemoveMon` is the permanent-removal path only (rejoin uses `ceph_mon_map_renew`).
- Validated on a 3-node HA lab: 3-member grace DB, per-node recovery objects, 270 NFSv4.1 mount/session/callback cycles → 0 crashes, `NRestarts=0`.

#### Additional documentation

```docs
Handbook known-issue: bigstack-oss/bigstack-handbook#234
```
