### PR TITLE
fix(airgap): bundle rancher/machine into the offline registry

### DIFF
--- a/core/rancher/images.txt
+++ b/core/rancher/images.txt
@@ -7,3 +7,4 @@ docker.io/rancher/system-upgrade-controller:v0.15.2
 docker.io/rancher/kubectl:v1.32.2
 docker.io/rancher/k3s-upgrade:v1.26.6-k3s1
 docker.io/rancher/mirrored-cluster-api-controller:v1.9.5
+docker.io/rancher/machine:v0.15.0-rancher127


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it

`core/rancher/images.txt` (the offline image set seeded into every control node's registry) omits `rancher/machine:v0.15.0-rancher127` — the CAPI docker-machine provisioner Rancher runs to create the App-Framework's RKE2 VMs. Air-gapped `framework_create` therefore stalls: the management cluster's machine-provision pods `ImagePullBackOff` (docker.io unreachable, DNS SERVFAIL), no VMs are created. The v2.11.2 bump to this file fixed the rancher **server** images but missed the provisioner. The registry lives in the heavy rootfs → base rebuild required.

#### Which issue(s) this PR fixes

Fixes #1230

#### Special notes for your reviewer

The offline registry is **per-node** (each control node mirrors `docker.io → its own localhost:5080`), so the image must land on every control node — a VIP-only push seeds just one. Validated on the sky 3cc lab: side-loading this one image to all 3 nodes let a full air-gapped App-Framework + CubeCMP install complete (portal HTTP 200 with the egress block on).

#### Additional documentation

Handbook known-issue `kb/cubecos/known-issues/appfw-airgap-rancher-machine.md` (bigstack-handbook #245).
