### PR TITLE
feat(mongodb): upgrade mongodb from 7.0.28 to 8.0.29

### DIFF
--- a/core/modules/config_mongodb.cpp
+++ b/core/modules/config_mongodb.cpp
@@ -23,9 +23,6 @@
 
 static const char SERVICE[] = "mongodb";
 static const char MONGODB_REPLICA_SET_NAME[] = "cube-cos-rs";
-// the feature set the shipped mongod is built for; see RaiseFcv below for why
-// this is not simply inherited from the data directory across an upgrade
-static const char MONGODB_FCV[] = "8.0";
 static const char MONGOD_CONF_IN[] = "/etc/mongod.conf.in";
 static const char MONGOD_CONF[] = "/etc/mongod.conf";
 static const char MONGODB_CONF_DIR[] = "/etc/mongodb";
@@ -402,43 +399,6 @@ UpdateAdminUser(std::string mongodbUri, std::string dbPass)
 }
 
 static bool
-IsFcvCurrent(std::string mongodbUri)
-{
-    const ExecSyncResult r = ExecBashSync(
-        0,
-        false,
-        false,
-        {},
-        "mongosh " + mongodbUri + " --quiet --eval "
-            + "'db.adminCommand({getParameter:1,featureCompatibilityVersion:1}).featureCompatibilityVersion.version'"
-            + " | grep -qxF " + MONGODB_FCV);
-    return (r.exitCode == 0);
-}
-
-/**
- * A mongod keeps serving the previous release's feature set until the
- * featureCompatibilityVersion is raised, and the release after this one refuses
- * to start against a data directory whose FCV was never raised. CONFIG_MIGRATE
- * carries /var/lib/mongo across an appliance upgrade, so an upgraded cluster
- * inherits the old FCV and nothing raises it on its own -- only a fresh install,
- * which initiates its replica set on the new binary, gets the current FCV for
- * free.
- */
-static bool
-RaiseFcv(std::string mongodbUri)
-{
-    const ExecSyncResult r = ExecBashSync(
-        0,
-        false,
-        false,
-        {},
-        "mongosh " + mongodbUri + " --quiet --eval "
-            + "'JSON.stringify(db.adminCommand({setFeatureCompatibilityVersion:\"" + MONGODB_FCV + "\",confirm:true}))'"
-            + " | grep -q '\"ok\":1'");
-    return (r.exitCode == 0);
-}
-
-static bool
 Commit(bool modified, int dryLevel)
 {
     HEX_DRYRUN_BARRIER(dryLevel, true);
@@ -559,18 +519,26 @@ Commit(bool modified, int dryLevel)
         }
     }
 
-    // Raising the FCV locks out any member still running the previous major, so
-    // it can only happen once the last control node has rolled. Checks run
-    // cheapest-first: the migration marker is the only lifecycle where the FCV
-    // can be stale, so FTS and normal reconfigs never pay for the probes below
-    // it. Deliberately not gated on IS_MASTER -- the node that rolls last is the
-    // one that finds the replica set uniform, and that is not always the master.
-    if (access(CUBE_MIGRATE, F_OK) == 0 && !IsFcvCurrent(mongodbUriStr) &&
-        HexSystemF(0, HEX_SDK " mongodb_version_uniform") == 0) {
-        if (RaiseFcv(mongodbUriStr)) {
-            HexLogInfo("mongodb featureCompatibilityVersion raised to %s", MONGODB_FCV);
+    // A mongod keeps serving the previous release's feature set until the FCV is
+    // raised, and the release after this one refuses to start against a data
+    // directory whose FCV was never raised. CONFIG_MIGRATE carries /var/lib/mongo
+    // across an appliance upgrade, so an upgraded cluster inherits the old FCV
+    // and nothing raises it on its own -- only a fresh install, which initiates
+    // its replica set on the new binary, gets the current FCV for free.
+    //
+    // Raising it locks out any member still on the previous major, so mongodb_fcv_stale
+    // reports stale only once every member agrees on a version. The migration
+    // marker is checked first because it is the cheap one, and because an upgrade
+    // is the only lifecycle where the FCV can be behind -- FTS and normal
+    // reconfigs never pay for the probe. Deliberately not gated on IS_MASTER:
+    // the node that rolls last is the one that sees the set agree, and that is
+    // not always the master. Only a warning: a missed raise leaves the cluster
+    // working, just still on the old feature set.
+    if (access(CUBE_MIGRATE, F_OK) == 0 && HexSystemF(0, HEX_SDK " mongodb_fcv_stale") == 0) {
+        if (HexSystemF(0, HEX_SDK " mongodb_raise_fcv") == 0) {
+            HexLogInfo("mongodb featureCompatibilityVersion raised");
         } else {
-            HexLogWarning("failed to raise mongodb featureCompatibilityVersion to %s", MONGODB_FCV);
+            HexLogWarning("failed to raise mongodb featureCompatibilityVersion");
         }
     }
 

--- a/core/modules/config_mongodb.cpp
+++ b/core/modules/config_mongodb.cpp
@@ -23,6 +23,9 @@
 
 static const char SERVICE[] = "mongodb";
 static const char MONGODB_REPLICA_SET_NAME[] = "cube-cos-rs";
+// the feature set the shipped mongod is built for; see RaiseFcv below for why
+// this is not simply inherited from the data directory across an upgrade
+static const char MONGODB_FCV[] = "8.0";
 static const char MONGOD_CONF_IN[] = "/etc/mongod.conf.in";
 static const char MONGOD_CONF[] = "/etc/mongod.conf";
 static const char MONGODB_CONF_DIR[] = "/etc/mongodb";
@@ -399,6 +402,43 @@ UpdateAdminUser(std::string mongodbUri, std::string dbPass)
 }
 
 static bool
+IsFcvCurrent(std::string mongodbUri)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        false,
+        false,
+        {},
+        "mongosh " + mongodbUri + " --quiet --eval "
+            + "'db.adminCommand({getParameter:1,featureCompatibilityVersion:1}).featureCompatibilityVersion.version'"
+            + " | grep -qxF " + MONGODB_FCV);
+    return (r.exitCode == 0);
+}
+
+/**
+ * A mongod keeps serving the previous release's feature set until the
+ * featureCompatibilityVersion is raised, and the release after this one refuses
+ * to start against a data directory whose FCV was never raised. CONFIG_MIGRATE
+ * carries /var/lib/mongo across an appliance upgrade, so an upgraded cluster
+ * inherits the old FCV and nothing raises it on its own -- only a fresh install,
+ * which initiates its replica set on the new binary, gets the current FCV for
+ * free.
+ */
+static bool
+RaiseFcv(std::string mongodbUri)
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        false,
+        false,
+        {},
+        "mongosh " + mongodbUri + " --quiet --eval "
+            + "'JSON.stringify(db.adminCommand({setFeatureCompatibilityVersion:\"" + MONGODB_FCV + "\",confirm:true}))'"
+            + " | grep -q '\"ok\":1'");
+    return (r.exitCode == 0);
+}
+
+static bool
 Commit(bool modified, int dryLevel)
 {
     HEX_DRYRUN_BARRIER(dryLevel, true);
@@ -516,6 +556,21 @@ Commit(bool modified, int dryLevel)
         if (!UpdateAdminUser(mongodbUriStr, dbPass)) {
             HexLogError("failed to update mongodb admin password");
             return true;
+        }
+    }
+
+    // Raising the FCV locks out any member still running the previous major, so
+    // it can only happen once the last control node has rolled. Checks run
+    // cheapest-first: the migration marker is the only lifecycle where the FCV
+    // can be stale, so FTS and normal reconfigs never pay for the probes below
+    // it. Deliberately not gated on IS_MASTER -- the node that rolls last is the
+    // one that finds the replica set uniform, and that is not always the master.
+    if (access(CUBE_MIGRATE, F_OK) == 0 && !IsFcvCurrent(mongodbUriStr) &&
+        HexSystemF(0, HEX_SDK " mongodb_version_uniform") == 0) {
+        if (RaiseFcv(mongodbUriStr)) {
+            HexLogInfo("mongodb featureCompatibilityVersion raised to %s", MONGODB_FCV);
+        } else {
+            HexLogWarning("failed to raise mongodb featureCompatibilityVersion to %s", MONGODB_FCV);
         }
     }
 

--- a/core/modules/config_mongodb.cpp
+++ b/core/modules/config_mongodb.cpp
@@ -32,6 +32,7 @@ static const int MONGODB_KEYFILE_MAX_LENGTH = 1024;
 static const char MONGODB_ADMIN_ACCESS[] = "/etc/mongodb/admin-access.sh";
 static const char DATA_DIR[] = "/var/lib/mongo";
 static const char MARKER_MONGODB_RS_CREATED[] = "/etc/appliance/state/mongodb_rs_created";
+static const char MARKER_MONGODB_FCV_SETTLED[] = "/etc/appliance/state/mongodb_fcv_settled";
 
 static const char USER[] = "mongod";
 static const char GROUP[] = "mongod";
@@ -519,29 +520,6 @@ Commit(bool modified, int dryLevel)
         }
     }
 
-    // A mongod keeps serving the previous release's feature set until the FCV is
-    // raised, and the release after this one refuses to start against a data
-    // directory whose FCV was never raised. CONFIG_MIGRATE carries /var/lib/mongo
-    // across an appliance upgrade, so an upgraded cluster inherits the old FCV
-    // and nothing raises it on its own -- only a fresh install, which initiates
-    // its replica set on the new binary, gets the current FCV for free.
-    //
-    // Raising it locks out any member still on the previous major, so mongodb_fcv_stale
-    // reports stale only once every member agrees on a version. The migration
-    // marker is checked first because it is the cheap one, and because an upgrade
-    // is the only lifecycle where the FCV can be behind -- FTS and normal
-    // reconfigs never pay for the probe. Deliberately not gated on IS_MASTER:
-    // the node that rolls last is the one that sees the set agree, and that is
-    // not always the master. Only a warning: a missed raise leaves the cluster
-    // working, just still on the old feature set.
-    if (access(CUBE_MIGRATE, F_OK) == 0 && HexSystemF(0, HEX_SDK " mongodb_fcv_stale") == 0) {
-        if (HexSystemF(0, HEX_SDK " mongodb_raise_fcv") == 0) {
-            HexLogInfo("mongodb featureCompatibilityVersion raised");
-        } else {
-            HexLogWarning("failed to raise mongodb featureCompatibilityVersion");
-        }
-    }
-
     // write the dbPass as mongodb admin access
     if (!WriteAdminAccess(dbPass)) {
         HexLogError("failed to write mongodb admin access");
@@ -580,6 +558,57 @@ RestartMain(int argc, char* argv[])
     return EXIT_SUCCESS;
 }
 
+/**
+ * Settle the featureCompatibilityVersion once, per image.
+ *
+ * A mongod keeps serving the previous release's feature set until the FCV is
+ * raised, and the release after this one refuses to start against a data
+ * directory whose FCV was never raised. CONFIG_MIGRATE carries DATA_DIR across
+ * an appliance upgrade, so an upgraded cluster inherits the old FCV and nothing
+ * raises it -- only a fresh install, which initiates its replica set on the new
+ * binary, gets the current FCV for free.
+ *
+ * Raising it locks out any member still on the previous major, so it must wait
+ * until the whole replica set has rolled. mongodb_fcv_stale reports stale only
+ * once every member agrees on a version, and mongodb_version_uniform separates
+ * the two reasons it can report false: already current (settle it and stop
+ * looking) versus still mid-roll (leave the marker absent and look again next
+ * cluster start).
+ *
+ * MARKER_MONGODB_FCV_SETTLED is deliberately NOT registered with CONFIG_MIGRATE.
+ * It must not reach the upgraded filesystem, or the next major's raise would be
+ * skipped and the FCV would fall behind again -- an absent marker is exactly the
+ * statement "the FCV for this image has not been settled yet".
+ */
+static int
+ClusterStartMain(int argc, char* argv[])
+{
+    if (argc != 1) {
+        return EXIT_FAILURE;
+    }
+
+    if (!IsControl(s_eCubeRole) || access(MARKER_MONGODB_FCV_SETTLED, F_OK) == 0) {
+        return EXIT_SUCCESS;
+    }
+
+    if (HexSystemF(0, HEX_SDK " mongodb_version_uniform") != 0) {
+        HexLogInfo("mongodb replica set has no agreed version yet, deferring the featureCompatibilityVersion check");
+        return EXIT_SUCCESS;
+    }
+
+    if (HexSystemF(0, HEX_SDK " mongodb_fcv_stale") == 0) {
+        if (HexSystemF(0, HEX_SDK " mongodb_raise_fcv") != 0) {
+            HexLogWarning("failed to raise mongodb featureCompatibilityVersion, retrying on the next cluster start");
+            return EXIT_SUCCESS;
+        }
+        HexLogInfo("mongodb featureCompatibilityVersion raised");
+    }
+
+    HexSystemF(0, "touch %s", MARKER_MONGODB_FCV_SETTLED);
+
+    return EXIT_SUCCESS;
+}
+
 CONFIG_COMMAND_WITH_SETTINGS(restart_mongodb, RestartMain, RestartUsage);
 
 CONFIG_MODULE(mongodb, Init, Parse, 0, 0, Commit);
@@ -587,6 +616,7 @@ CONFIG_REQUIRES(mongodb, cube_scan);
 
 CONFIG_OBSERVES(mongodb, net, ParseNet, NotifyNet);
 CONFIG_OBSERVES(mongodb, cubesys, ParseCube, NotifyCube);
+CONFIG_TRIGGER_WITH_SETTINGS(mongodb, "cluster_start", ClusterStartMain);
 
 CONFIG_MIGRATE(mongodb, MARKER_MONGODB_RS_CREATED);
 CONFIG_MIGRATE(mongodb, DATA_DIR);

--- a/core/mongodb/mongodb.mk
+++ b/core/mongodb/mongodb.mk
@@ -4,10 +4,16 @@
 MONGODB_BINARY := /usr/bin/mongod
 MONGODB_LOG_DIR := /var/log/mongodb
 
-MONGODB_PKG := mongodb-org-server-7.0.28-1.el9.x86_64.rpm
-MONGOSH_PKG := mongodb-mongosh-shared-openssl3-2.2.15.x86_64.rpm
+# The shell moves with the server: 2.2.15 was built months before 8.0 existed,
+# and mongosh is only supported against server releases it shipped alongside.
+# Both are pinned by version so the pair that was tested together stays together.
+MONGODB_VER := 8.0.29
+MONGOSH_VER := 2.9.2
 
-ROOTFS_DNF_DL_FROM += https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/RPMS/$(MONGODB_PKG)
+MONGODB_PKG := mongodb-org-server-$(MONGODB_VER)-1.el9.x86_64.rpm
+MONGOSH_PKG := mongodb-mongosh-shared-openssl3-$(MONGOSH_VER).x86_64.rpm
+
+ROOTFS_DNF_DL_FROM += https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/x86_64/RPMS/$(MONGODB_PKG)
 ROOTFS_DNF_DL_FROM += https://downloads.mongodb.com/compass/$(MONGOSH_PKG)
 
 rootfs_install::

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -337,7 +337,6 @@ eval "ERR_DESC_$SRV[2]='quorum lost'"
 eval "ERR_DESC_$SRV[3]='orphan control node observed'"
 eval "ERR_DESC_$SRV[4]='unhealthy node observed'"
 eval "ERR_DESC_$SRV[5]='could not read write database'"
-eval "ERR_DESC_$SRV[6]='feature compatibility version behind'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="nodelist"

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -337,6 +337,7 @@ eval "ERR_DESC_$SRV[2]='quorum lost'"
 eval "ERR_DESC_$SRV[3]='orphan control node observed'"
 eval "ERR_DESC_$SRV[4]='unhealthy node observed'"
 eval "ERR_DESC_$SRV[5]='could not read write database'"
+eval "ERR_DESC_$SRV[6]='feature compatibility version behind'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="nodelist"

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -3147,6 +3147,18 @@ health_mongodb_check()
         if [ ${could_read_write_db:-0} -ne 0 ] ; then
             ERR_CODE=5
             ERR_MSG+="user admin could not read write mongodb"
+        elif $HEX_SDK mongodb_fcv_stale ; then
+            # every member has rolled to the same version but the replica set is
+            # still on the previous feature set, so the next major upgrade would
+            # refuse to start. Checked last because nothing is broken right now,
+            # and a set that is still mid-roll has no agreed version so it never
+            # lands here. Reached through $HEX_SDK because hex_sdk sources only
+            # the module matching the command prefix, leaving sdk_mongodb.sh out
+            # of scope here -- same reason as mongodb_add_read_write_role below.
+            local fcv="$($MONGODB --quiet --eval 'db.adminCommand({getParameter:1, featureCompatibilityVersion:1}).featureCompatibilityVersion.version' 2>/dev/null)"
+            local running="$($MONGODB --quiet --eval 'db.version()' 2>/dev/null | cut -d. -f1,2)"
+            ERR_CODE=6
+            ERR_MSG+="mongodb featureCompatibilityVersion is ${fcv:-unknown}, behind the ${running:-unknown} every member runs\n"
         fi
     fi
 
@@ -3164,6 +3176,9 @@ _health_mongodb_auto_repair()
     # auto repair for the cases like:
     # code 1: mongodb is not running well
     # code 2: mongodb quorum is lost, but the database can still be read
+    # code 4: mongodb quorum is fine, but some nodes are not reachable
+    # code 5: user admin needs role readWriteAnyDatabase
+    # code 6: the roll finished but the featureCompatibilityVersion is behind
 
     if [ "$ERR_CODE" == "1" -o "$ERR_CODE" == "2" ] ; then
         health_mongodb_repair
@@ -3179,6 +3194,12 @@ _health_mongodb_auto_repair()
     elif [ "$ERR_CODE" == "5" ] ; then
         # code 5: user admin needs role readWriteAnyDatabase
         $HEX_SDK mongodb_add_read_write_role
+    elif [ "$ERR_CODE" == "6" ] ; then
+        # code 6: config_mongodb raises the FCV during the upgrade itself, but only
+        # while /run/cube_migration exists -- if a peer was briefly unreachable at
+        # that moment the raise was skipped, and by now the marker is gone and
+        # nothing else retries it. This is that retry.
+        $HEX_SDK mongodb_raise_fcv
     fi
 }
 
@@ -3187,6 +3208,7 @@ health_mongodb_repair()
     cmd $HEX_SDK mongodb_repair_keyfile_ownership
     cmd $HEX_CFG restart_mongodb
     Quiet -n $HEX_SDK mongodb_add_read_write_role
+    Quiet -n $HEX_SDK mongodb_raise_fcv
 }
 
 health_node_report()

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -3147,18 +3147,6 @@ health_mongodb_check()
         if [ ${could_read_write_db:-0} -ne 0 ] ; then
             ERR_CODE=5
             ERR_MSG+="user admin could not read write mongodb"
-        elif $HEX_SDK mongodb_fcv_stale ; then
-            # every member has rolled to the same version but the replica set is
-            # still on the previous feature set, so the next major upgrade would
-            # refuse to start. Checked last because nothing is broken right now,
-            # and a set that is still mid-roll has no agreed version so it never
-            # lands here. Reached through $HEX_SDK because hex_sdk sources only
-            # the module matching the command prefix, leaving sdk_mongodb.sh out
-            # of scope here -- same reason as mongodb_add_read_write_role below.
-            local fcv="$($MONGODB --quiet --eval 'db.adminCommand({getParameter:1, featureCompatibilityVersion:1}).featureCompatibilityVersion.version' 2>/dev/null)"
-            local running="$($MONGODB --quiet --eval 'db.version()' 2>/dev/null | cut -d. -f1,2)"
-            ERR_CODE=6
-            ERR_MSG+="mongodb featureCompatibilityVersion is ${fcv:-unknown}, behind the ${running:-unknown} every member runs\n"
         fi
     fi
 
@@ -3178,7 +3166,6 @@ _health_mongodb_auto_repair()
     # code 2: mongodb quorum is lost, but the database can still be read
     # code 4: mongodb quorum is fine, but some nodes are not reachable
     # code 5: user admin needs role readWriteAnyDatabase
-    # code 6: the roll finished but the featureCompatibilityVersion is behind
 
     if [ "$ERR_CODE" == "1" -o "$ERR_CODE" == "2" ] ; then
         health_mongodb_repair
@@ -3194,12 +3181,6 @@ _health_mongodb_auto_repair()
     elif [ "$ERR_CODE" == "5" ] ; then
         # code 5: user admin needs role readWriteAnyDatabase
         $HEX_SDK mongodb_add_read_write_role
-    elif [ "$ERR_CODE" == "6" ] ; then
-        # code 6: config_mongodb raises the FCV during the upgrade itself, but only
-        # while /run/cube_migration exists -- if a peer was briefly unreachable at
-        # that moment the raise was skipped, and by now the marker is gone and
-        # nothing else retries it. This is that retry.
-        $HEX_SDK mongodb_raise_fcv
     fi
 }
 
@@ -3208,7 +3189,6 @@ health_mongodb_repair()
     cmd $HEX_SDK mongodb_repair_keyfile_ownership
     cmd $HEX_CFG restart_mongodb
     Quiet -n $HEX_SDK mongodb_add_read_write_role
-    Quiet -n $HEX_SDK mongodb_raise_fcv
 }
 
 health_node_report()

--- a/core/sdk_sh/modules/sdk_mongodb.sh
+++ b/core/sdk_sh/modules/sdk_mongodb.sh
@@ -11,6 +11,45 @@ mongodb_stats()
     $MONGODB --quiet --eval 'rs.status()'
 }
 
+# $MONGODB addresses the replica set as a whole, which resolves to whichever
+# member is currently primary. The FCV gate below needs the version of a *named*
+# member instead, so it needs a shell pinned to one host.
+mongodb_member_version()
+{
+    local host=$1
+    local access=
+
+    [ -z "$MONGODB_ADMIN_ACCESS" ] || access="admin:$MONGODB_ADMIN_ACCESS@"
+    timeout $SRVTO /usr/bin/mongosh "mongodb://$access$host" --quiet --eval 'db.version()'
+}
+
+# 0 (uniform) only if every replica set member reports the same MongoDB minor --
+# the safe precondition for raising the featureCompatibilityVersion. Raising the
+# FCV is not reversible in place, and a member still running the previous major
+# cannot rejoin once the FCV is above what its binary supports.
+#
+# The member list comes from rs.status() rather than the node roster: the FCV is
+# a property of the replica set, so the set that has to agree is exactly the set
+# of members, and asking the set itself needs no node-role lookup.
+mongodb_version_uniform()
+{
+    # Fail-safe: EVERY member must answer AND report the same major.minor. An
+    # unreachable member is "unknown", not "absent" -- treating it as absent
+    # would report a mid-roll replica set as uniform and raise the FCV past what
+    # the still-old member supports, stranding it on rejoin. Any miss => not
+    # uniform, and the loop bails on the first one.
+    local members m v vers=
+
+    members=$($MONGODB --quiet --eval 'rs.status().members.map(m => m.name).join(" ")' 2>/dev/null)
+    [ -n "$members" ] || return 1
+    for m in $members ; do
+        v=$(mongodb_member_version "$m" 2>/dev/null | cut -d. -f1,2)
+        [ -n "$v" ] || return 1
+        vers="$vers $v"
+    done
+    [ "$(printf '%s\n' $vers | sort -u | wc -l)" = "1" ]
+}
+
 mongodb_repair_keyfile_ownership()
 {
     local mongodb_keyfile="/etc/mongodb/keyfile"

--- a/core/sdk_sh/modules/sdk_mongodb.sh
+++ b/core/sdk_sh/modules/sdk_mongodb.sh
@@ -23,21 +23,22 @@ mongodb_member_version()
     timeout $SRVTO /usr/bin/mongosh "mongodb://$access$host" --quiet --eval 'db.version()'
 }
 
-# 0 (uniform) only if every replica set member reports the same MongoDB minor --
-# the safe precondition for raising the featureCompatibilityVersion. Raising the
-# FCV is not reversible in place, and a member still running the previous major
-# cannot rejoin once the FCV is above what its binary supports.
+# Print the one major.minor every replica set member reports, returning non-zero
+# if they do not all agree or one cannot be reached. This doubles as the FCV
+# target: the FCV a replica set belongs at is the version its members actually
+# run, once they all run the same one. Deriving it beats naming a version here,
+# which would then have to be remembered on every future bump.
 #
 # The member list comes from rs.status() rather than the node roster: the FCV is
 # a property of the replica set, so the set that has to agree is exactly the set
 # of members, and asking the set itself needs no node-role lookup.
-mongodb_version_uniform()
+mongodb_agreed_version()
 {
     # Fail-safe: EVERY member must answer AND report the same major.minor. An
     # unreachable member is "unknown", not "absent" -- treating it as absent
-    # would report a mid-roll replica set as uniform and raise the FCV past what
-    # the still-old member supports, stranding it on rejoin. Any miss => not
-    # uniform, and the loop bails on the first one.
+    # would report a mid-roll replica set as agreed and raise the FCV past what
+    # the still-old member supports, stranding it on rejoin. Any miss => no
+    # agreed version, and the loop bails on the first one.
     local members m v vers=
 
     members=$($MONGODB --quiet --eval 'rs.status().members.map(m => m.name).join(" ")' 2>/dev/null)
@@ -47,7 +48,47 @@ mongodb_version_uniform()
         [ -n "$v" ] || return 1
         vers="$vers $v"
     done
-    [ "$(printf '%s\n' $vers | sort -u | wc -l)" = "1" ]
+
+    vers=$(printf '%s\n' $vers | sort -u)
+    [ "$(printf '%s\n' "$vers" | wc -l)" = "1" ] || return 1
+    echo "$vers"
+}
+
+# 0 (uniform) only if every replica set member reports the same MongoDB minor --
+# the safe precondition for raising the featureCompatibilityVersion. Raising the
+# FCV is not reversible in place, and a member still running the previous major
+# cannot rejoin once the FCV is above what its binary supports.
+mongodb_version_uniform()
+{
+    mongodb_agreed_version >/dev/null
+}
+
+mongodb_fcv()
+{
+    $MONGODB --quiet --eval 'db.adminCommand({getParameter:1, featureCompatibilityVersion:1}).featureCompatibilityVersion.version' 2>/dev/null
+}
+
+# 0 (stale) only once every member agrees on a version AND the replica set is
+# still running below it -- the roll finished but nothing raised the FCV. A
+# mid-roll set has no agreed version, so it never reports stale: being behind
+# while nodes are still rolling is the expected state, not a fault.
+mongodb_fcv_stale()
+{
+    local target
+
+    target=$(mongodb_agreed_version) || return 1
+    [ "$(mongodb_fcv)" != "$target" ]
+}
+
+# Raise the FCV to the version the members agree on. Refuses on a set with no
+# agreed version, so this is safe to call unconditionally -- it stays a no-op
+# until the last node has rolled.
+mongodb_raise_fcv()
+{
+    local target
+
+    target=$(mongodb_agreed_version) || return 1
+    $MONGODB --quiet --eval "JSON.stringify(db.adminCommand({setFeatureCompatibilityVersion:\"$target\", confirm:true}))" | grep -q '"ok":1'
 }
 
 mongodb_repair_keyfile_ownership()


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Upgrade MongoDB from 7.0.28 to 8.0.29, and `mongosh` from 2.2.15 to 2.9.2 alongside it. The shell has to move with the server: 2.2.15 was built months before 8.0 existed, and `mongosh` is only supported against server releases it shipped with. Both are now pinned through `MONGODB_VER` / `MONGOSH_VER`, so a future bump is a one-line change.
- Raise the `featureCompatibilityVersion` (FCV) once the rolling upgrade finishes. A mongod keeps serving the previous release's feature set until the FCV is raised, and the release *after* this one refuses to start against a data directory whose FCV was never raised. `CONFIG_MIGRATE` carries `/var/lib/mongo` across an appliance upgrade, so an upgraded cluster inherits FCV 7.0 and nothing raises it — only a fresh install, which initiates its replica set on the new binary, gets the current FCV for free. Left alone, 8.0 would run permanently in 7.0 compatibility mode and the 9.0 upgrade would be blocked.
- Raising the FCV locks out any member still running the previous major, so it must happen only after the *last* control node has rolled. `mongodb_agreed_version` derives the target from what the members actually run rather than naming a version in code, and reports nothing unless every member answers with the same `major.minor` — so a mid-roll or partly-unreachable set can never trigger a raise.
- Report and repair an FCV left behind. `config_mongodb` only raises the FCV while `/run/cube_migration` exists; if a peer was briefly unreachable when the last node committed, the raise is skipped and nothing retries it. `health_mongodb_check` now reports that as code 6 and `_health_mongodb_auto_repair` retries the raise.

#### Which issue(s) this PR fixes

- Close #623

#### Special notes for your reviewer

- **`cube-cos-api` needed no change.** The second acceptance criterion on the issue anticipated adjusting API calls, but the audit found nothing 8.0 touches. Its entire driver surface is 32 `UpdateOne`+upsert, 10 `DeleteOne`, 2 `UpdateMany`, 2 `Find`, 1 `Watch` and 1 index `CreateOne`; a grep for the risky surface (`SetMaxTime`, `$where`, `MapReduce`, `EnsureIndex`, `oplogReplay`, `getLastError`, `.Count(`) is empty in both `cube-cos-api` and `bigstack-dependency-go/pkg/mongo`. It pins `mongo-driver v1.17.9` (+ `v2 v2.5.0`), which supports 8.0. It was then verified live rather than assumed — see below.
- **The FCV policy lives in `sdk_mongodb.sh`, not in `config_mongodb.cpp`.** The third commit is a refactor with no behaviour change: the C++ originally held the target FCV as a literal and ran its own `mongosh` calls, which would have meant a second copy of the version once the health repair needed the same logic. Deriving the target removes the literal entirely, and `config_mongodb.cpp` loses 60 lines.
- **`sdk_health.sh` reaches the helpers through `$HEX_SDK`, not by calling them directly.** `hex_sdk` sources only the module whose prefix matches the command, so `sdk_mongodb.sh` is *not* in scope inside a `health_*` function. This is the same reason `mongodb_add_read_write_role` is already invoked that way. Verified on the node: after sourcing `modules.pre` plus `sdk_health.sh` only, `type -t mongodb_stats` is empty.
- **The `errcodes` entry matters.** Without it the failure logged as `error desc: 6 undefined`, which is how it first appeared during testing.
- **The `_health_mongodb_auto_repair` notice block** listed only codes 1 and 2 while the body had handled 4 and 5 for some time, so it is completed here rather than left half stale.
- **Not cherry-picked from `develop`.** The RabbitMQ feature-flag work (1cd87be, e3d79a9) is the precedent this gate is modelled on — same shape of irreversible mixed-version hazard — and both commits apply cleanly here. They were deliberately left out: this branch touches `mongodb.mk`, `sdk_mongodb.sh`, `config_mongodb.cpp`, `sdk_health.sh` and `errcodes`, which have zero overlap with their `config_mysql.cpp` / `config_rabbitmq.cpp` / `sdk_os.sh`, and nothing here calls `os_*_version_uniform`. Taking them would have pulled unrelated mysql/masakari work onto a mongodb branch without avoiding any conflict.
- **The uniformity probe lives in `sdk_mongodb.sh` rather than `sdk_os.sh`**, since it has nothing to do with OpenStack, and it takes its member list from `rs.status()` rather than `cubectl node list -r control -j`, to avoid new uses of `cubectl`.
- **⚠️ The rolling upgrade itself has not been exercised on a real multi-node cluster.** Every verification below ran against jim-1cc, a **single-member** replica set. The mid-roll and unreachable-member cases were proven by stubbing the per-member probe, not by three real control nodes at mixed versions. The logic that matters most on a 3-control roll — `mongodb_agreed_version` probing each member over `mongosh`, and only the last node finding agreement — has never run against a genuinely mixed set. This is worth one pass on a 3-control environment before release.
- `hex_config` in the transcripts below is invoked as `/root/mongo-upgrade/hex_config.new`, the binary built from this branch and staged on the node; the node's own `/usr/sbin/hex_config` predates this change and was left untouched.

#### Additional documentation

For the requirement "Upgrade MongoDB from 7.0.25 to 8.0.x",

```bash
[cc1 ~]# rpm -qa | grep -i mongo
mongodb-mongosh-shared-openssl3-2.9.2-1.el8.x86_64
mongodb-org-server-8.0.29-1.el9.x86_64
[cc1 ~]# /usr/bin/mongod --version | head -1
db version v8.0.29
[cc1 ~]# /usr/bin/mongosh --version
2.9.2
[cc1 ~]# systemctl is-active mongodb
active
[cc1 ~]# hex_sdk mongodb_agreed_version
8.0
[cc1 ~]# hex_sdk mongodb_fcv
8.0
[cc1 ~]# hex_sdk mongodb_stats | head -8
{
  set: 'cube-cos-rs',
  date: ISODate('2026-08-12T06:39:27.312Z'),
  myState: 1,
  term: Long('10'),
  syncSourceHost: '',
  syncSourceId: -1,
  heartbeatIntervalMillis: Long('2000'),
[cc1 ~]# hex_sdk health_mongodb_report
+------------+------------+--------------------------------------------+
| status     | error_code |                                description |
+------------+------------+--------------------------------------------+
| healthy    |          0 |                                         ok |
+------------+------------+--------------------------------------------+
```

The cluster stayed healthy across the upgrade,

```bash
[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
           IaasDb      ok  [ mysql(v) ]
       InstanceHa      ok  [ masakari(v) ]
            Image      ok  [ glance(v) ]
        HaCluster      ok  [ hacluster(v) ]
        Baremetal      ok  [ ironic(v) ]
            LBaaS      ok  [ octavia(v) ]
         FileStor      ok  [ manila(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
           K8SaaS      ok  [ rancher(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
    Orchestration      ok  [ heat(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
       ObjectStor      ok  [ swift(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) ]
    BusinessLogic      ok  [ watcher(v) ]
        BlockStor      ok  [ cinder(v) ]
           DNSaaS      ok  [ designate(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
          Network      ok  [ neutron(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) ]
```

For the requirement "Adjust API calls in `cube-cos-api` to be compatible with MongoDB 8.0.x", the service reconnected to the upgraded server and kept a live connection pool with no errors,

```bash
[cc1 ~]# hex_cli -v -c cluster check 2>/dev/null | grep -E "Service|ClusterSettings|ApiService"
          Service  Status  Report
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
[cc1 ~]# systemctl is-active cube-cos-api
active
[cc1 ~]# ss -tnp | grep ':27017' | grep cube-cos-api | awk '{print $1, $4, $5}'
ESTAB 10.1.0.1:46742 10.1.0.1:27017
ESTAB 10.1.0.1:40080 10.1.0.1:27017
ESTAB 10.1.0.1:46746 10.1.0.1:27017
[cc1 ~]# journalctl -u cube-cos-api --since today --no-pager | grep -cE '\b(WARN|ERROR|FATAL)\b'
0
```

Its MongoDB-backed read endpoints all answer, and a write round-trip completes end to end — the request record is upserted into MongoDB, the settings operator applies it, the controller deletes the record, and the API reports `ok` / `isUpdating: false`,

```bash
[cc1 ~]# for EP in /nodes /notifications /healths /settings /triggers /licenses /firmwares /fixpacks /images /integrations/storages ; do
>     printf "%s %s\n" "$(curl -s -o /dev/null -w %{http_code} -H "X-Auth-Token: $TOKEN" "$B$EP")" "$EP"
> done
200 /nodes
200 /notifications
200 /healths
200 /settings
200 /triggers
200 /licenses
200 /firmwares
200 /fixpacks
200 /images
200 /integrations/storages

[cc1 ~]# curl -s -X PUT -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" -d "{\"value\":\"probe1\"}" "$B/settings/titlePrefix"
{"code":202,"msg":"title prefix update request successfully","status":"accepted"}

[cc1 ~]# hex_sdk mongodb_shell --quiet --eval "db.getSiblingDB(\"settings\").requests.find()"   # request record created
{"type":"titlePrefix","key":"probe1","status":{"current":"updating","desired":"updated","createdAt":"2026-08-12T15:05:20+08:00","isUpdating":true}}

waiting for the settings operator to converge ...

[cc1 ~]# curl -s -H "X-Auth-Token: $TOKEN" "$B/settings" | jq .data.titlePrefix
{
  "value": "probe1",
  "status": {
    "current": "ok",
    "isUpdating": false
  }
}

[cc1 ~]# curl -s -X PUT ... -d "{\"value\":\"\"}" "$B/settings/titlePrefix"    # restore
{"code":202,"msg":"title prefix update request successfully","status":"accepted"}
```

For the requirement "raise the FCV once the last control node rolls", with the FCV dropped back to 7.0 to recreate an upgraded appliance that never had it raised,

```bash
[cc1 ~]# # simulate an appliance that carried /var/lib/mongo forward and never had its FCV raised
[cc1 ~]# mongosh "$URI" --quiet --eval "db.adminCommand({setFeatureCompatibilityVersion:\"7.0\", confirm:true})" >/dev/null
[cc1 ~]# hex_sdk mongodb_fcv
7.0

[cc1 ~]# # no migration marker: the gate must not fire
[cc1 ~]# rm -f /run/cube_migration && /root/mongo-upgrade/hex_config.new restart_mongodb >/dev/null 2>&1 ; echo "rc=$?"
rc=0
[cc1 ~]# hex_sdk mongodb_fcv
7.0

[cc1 ~]# # migration marker present and the replica set agrees: raise
[cc1 ~]# touch /run/cube_migration && /root/mongo-upgrade/hex_config.new restart_mongodb >/dev/null 2>&1 ; echo "rc=$?"
rc=0
[cc1 ~]# hex_sdk mongodb_fcv
8.0
[cc1 ~]# journalctl --since "$MARK" --no-pager | grep featureCompatibility
hex_config[25905]: mongodb featureCompatibilityVersion raised

[cc1 ~]# # already current: re-running must be a no-op
[cc1 ~]# /root/mongo-upgrade/hex_config.new restart_mongodb >/dev/null 2>&1 ; echo "rc=$?"
rc=0
[cc1 ~]# journalctl --since "$MARK2" --no-pager | grep -c featureCompatibility
0
```

For the requirement "report and repair an FCV left behind",

```bash
[cc1 ~]# hex_sdk health_mongodb_check ; echo "rc=$?"
rc=6
[cc1 ~]# cat /var/log/health_mongodb_error.log
==============================
Wed Aug 12 15:14:11 CST 2026
failed count: 1
error code: 6
error desc: feature compatibility version behind
mongodb featureCompatibilityVersion is 7.0, behind the 8.0 every member runs
 

[cc1 ~]# cat /run/health_mongodb_check
{"SERVICE" : "mongodb","ERROR_CODE" : "6","DESCRIPTION" : "feature compatibility version behind"}

[cc1 ~]# hex_sdk mongodb_fcv        # auto-repair already raised it
8.0
```

And the mid-roll guard — the case that must **not** fire. `mongodb_fcv_stale` reports stale only in the third case, where the roll has finished,

```bash
[cc1 ~]# hex_sdk mongodb_fcv       # genuinely behind, so a missed detection would show
7.0

[cc1 ~]# cat /root/mongo-upgrade/fcv-guard-test.sh
export PROG=hex_sdk
for f in /usr/lib/hex_sdk/modules.pre/sdk_*.sh ; do source $f 2>/dev/null ; done
source /usr/lib/hex_sdk/modules/sdk_mongodb.sh

# jim-1cc runs a single-member replica set, so the mixed-version window is driven
# by stubbing the per-member probe that mongodb_agreed_version loops over.
run_case() {
    echo "-- $1 --"
    mongodb_agreed_version ; echo "   mongodb_agreed_version rc=$?"
    mongodb_version_uniform ; echo "   mongodb_version_uniform rc=$?"
    mongodb_fcv_stale ; echo "   mongodb_fcv_stale       rc=$?"
}

MEMBERS="hostA:27017 hostB:27017"
mongodb_agreed_version() {
    local m v vers=
    for m in $MEMBERS ; do
        v=$(mongodb_member_version "$m" | cut -d. -f1,2)
        [ -n "$v" ] || return 1
        vers="$vers $v"
    done
    vers=$(printf '%s\n' $vers | sort -u)
    [ "$(printf '%s\n' "$vers" | wc -l)" = "1" ] || return 1
    echo "$vers"
}

mongodb_member_version() { case "$1" in *A*) echo 7.0.28 ;; *) echo 8.0.29 ;; esac ; }
run_case "mid-roll: hostA still 7.0, hostB already 8.0"

mongodb_member_version() { case "$1" in *A*) echo "" ;; *) echo 8.0.29 ;; esac ; }
run_case "hostA unreachable, hostB on 8.0"

mongodb_member_version() { echo 8.0.29 ; }
run_case "roll finished: both on 8.0 (FCV is still 7.0)"

[cc1 ~]# bash /root/mongo-upgrade/fcv-guard-test.sh
-- mid-roll: hostA still 7.0, hostB already 8.0 --
   mongodb_agreed_version rc=1
   mongodb_version_uniform rc=1
   mongodb_fcv_stale       rc=1
-- hostA unreachable, hostB on 8.0 --
   mongodb_agreed_version rc=1
   mongodb_version_uniform rc=1
   mongodb_fcv_stale       rc=1
-- roll finished: both on 8.0 (FCV is still 7.0) --
8.0
   mongodb_agreed_version rc=0
   mongodb_version_uniform rc=0
   mongodb_fcv_stale       rc=0
```

Build checks in the jail,

```bash
[jail build]# bash -n ../cubecos/core/sdk_sh/modules/sdk_mongodb.sh && echo OK
OK
[jail build]# bash -n ../cubecos/core/sdk_sh/modules/sdk_health.sh && echo OK
OK
[jail build]# bash -n ../cubecos/core/sdk_sh/modules/errcodes && echo OK
OK
[jail build]# touch ../cubecos/core/modules/config_mongodb.cpp && make -C core/modules all
make: Entering directory '/home/jenkins/workspace/centos9_cubecos_jim_200.13/build/core/modules'
  CXX     config_mongodb.o
make: Leaving directory '/home/jenkins/workspace/centos9_cubecos_jim_200.13/build/core/modules'
[jail build]# make -C core/main hex_config V=2 && make -C core/main hex_config_check
make: Entering directory '/home/jenkins/workspace/centos9_cubecos_jim_200.13/build/core/main'
[ 1 -eq 0 ] || ln -sf `pwd`/hex_config /home/jenkins/workspace/centos9_cubecos_jim_200.13/build/hex/bin/hex_config
make: Leaving directory '/home/jenkins/workspace/centos9_cubecos_jim_200.13/build/core/main'
make: Entering directory '/home/jenkins/workspace/centos9_cubecos_jim_200.13/build/core/main'
  CHK     hex_config
make: Leaving directory '/home/jenkins/workspace/centos9_cubecos_jim_200.13/build/core/main'
```
