### PR TITLE
feat(keycloak): upgrade keycloak from 17.0.1-legacy to 18.0.2 quarkus

### DIFF
--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -3,12 +3,17 @@
 include ../../build.mk
 
 # login keycloak helm chart
-CHART_VERSION := 18.1.1
-CHART := keycloak-$(CHART_VERSION).tgz
+# keycloakx is codecentric's chart for the Quarkus distribution. Their plain "keycloak"
+# chart is the WildFly one -- its 18.x versions are chart versions, and every one of them
+# still ships appVersion 17.0.1-legacy -- so moving to Quarkus means changing chart, not
+# just bumping a version. Chart 1.6.0 is the newest one whose appVersion is 18.x.
+CHART_NAME := keycloakx
+CHART_VERSION := 1.6.0
+CHART := $(CHART_NAME)-$(CHART_VERSION).tgz
 
 $(CHART):
 	$(Q)helm repo add codecentric https://codecentric.github.io/helm-charts $(QEND)
-	$(Q)helm pull codecentric/keycloak --version $(CHART_VERSION)
+	$(Q)helm pull codecentric/$(CHART_NAME) --version $(CHART_VERSION)
 
 # login rpm
 LOGIN_RPM := login.rpm
@@ -17,6 +22,10 @@ PKG_NAME := cube-cos-login
 GITHUB_URL := https://github.com/bigstack-oss/cube-cos-ui
 
 ifneq ($(RC),)
+# NOTE: this RPM and the IMG_BUILD tag below are pinned to a published release, so they
+# still carry a WildFly Keycloak 17 image. They must be moved to a cube-cos-login 18.x
+# release in step with CHART_NAME/CHART_VERSION above -- the keycloakx chart cannot drive
+# a 17.0.1-legacy image.
 $(LOGIN_RPM):
 	$(call RUN_CMD_TIMED, \
 		wget -O login.rpm $(GITHUB_URL)/releases/download/$(PKG_NAME)-v3.1.0-rc3/$(PKG_NAME)-17.2.0-1.9835cfd.x86_64.rpm, \
@@ -141,10 +150,11 @@ endif
 
 test-podman:: .load-img
 	$(Q)podman run -d -p 80:8080 -p 443:8443 --name=keycloak \
-		-e KEYCLOAK_USER=admin \
-		-e KEYCLOAK_PASSWORD=admin \
-		-e KEYCLOAK_DEFAULT_THEME=cube \
-		$(shell cat .load-img)
+		-e KEYCLOAK_ADMIN=admin \
+		-e KEYCLOAK_ADMIN_PASSWORD=admin \
+		-e KC_SPI_THEME_DEFAULT=cos-ui \
+		$(shell cat .load-img) \
+		start-dev
 	$(Q)echo Accessing keycloak on http://$(shell cat /etc/hosts | grep $$(cat /etc/hostname) | awk '{print $$1}')/auth/
 
 testclean::

--- a/core/keycloak/chart-values.yaml
+++ b/core/keycloak/chart-values.yaml
@@ -1,8 +1,28 @@
 image:
   repository: localhost:5080/bigstack/keycloak
-  tag: 17.2.0
+  tag: 18.0.0
 
 replicas: 1
+
+# The Keycloak container entrypoint is kc.sh with no default command, so the start
+# command has to be spelled out. TLS is terminated by the k3s ingress, and the
+# controller is reached by VIP rather than by a registered hostname, so the strict
+# hostname checks Quarkus enables by default have to be turned off.
+command:
+  - /opt/keycloak/bin/kc.sh
+  - start
+  - --http-enabled=true
+  - --http-port=8080
+  - --hostname-strict=false
+  - --hostname-strict-https=false
+
+# Keycloak 18 drops the /auth context that the WildFly distribution served everything
+# under, but keystone's cube_idp remote-id, the ceph dashboard, rancher and the SAML
+# metadata already persisted in /etc/keycloak all still expect it. Pinning it here keeps
+# every existing SAML client valid. This is also baked into the image at build time
+# because Quarkus fixes quarkus.http.root-path at augmentation.
+http:
+  relativePath: /auth
 
 ingress:
   enabled: true
@@ -12,69 +32,102 @@ ingress:
         - path: /auth
           pathType: Prefix
 
-postgresql:
-  enabled: false
+# Credentials stay in the keycloak-db-secret that config_keycloak.cpp creates from
+# /opt/keycloak/db, so only the non-secret coordinates are set here.
+database:
+  vendor: mariadb
+  hostname: cube-controller.default
+  port: 3306
+
+proxy:
+  enabled: true
+  mode: edge
+
+# Emits KC_CACHE=ispn and KC_CACHE_STACK=kubernetes. That stack discovers peers with
+# JGroups DNS_PING, which has no default for jgroups.dns.query -- it is supplied via
+# JAVA_OPTS_APPEND below and must point at the chart's headless service.
+cache:
+  stack: default
+
+# The chart's stock probes GET the relative path root, which is the welcome page. Only a
+# login theme is shipped for cos-ui, so every one of those requests logs a "Failed to find
+# WELCOME theme" error -- once per liveness probe, forever. Point the probes at the health
+# endpoints the image is built with instead; they are cheaper and they say more.
+livenessProbe: |
+  httpGet:
+    path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/live'
+    port: http
+  initialDelaySeconds: 0
+  timeoutSeconds: 5
+
+readinessProbe: |
+  httpGet:
+    path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/ready'
+    port: http
+  initialDelaySeconds: 10
+  timeoutSeconds: 1
+
+# The 17 -> 18 Liquibase migration runs on the first pod to come up, so give the
+# startup probe room to wait it out (120 * 5s = 10m) instead of restarting mid-migration.
+startupProbe: |
+  httpGet:
+    path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/live'
+    port: http
+  initialDelaySeconds: 15
+  timeoutSeconds: 1
+  failureThreshold: 120
+  periodSeconds: 5
 
 extraEnv: |
-  - name: DB_VENDOR
-    value: mariadb
-  - name: DB_ADDR
-    value: cube-controller.default
-  - name: DB_PORT
-    value: "3306"
-  - name: DB_DATABASE
+  # Keycloak is reached on K3S_INGRESS_HTTPS_PORT (10443), but the proxies in front of it
+  # terminate TLS on the default HTTPS port, so with proxy=edge Keycloak resolves the
+  # frontend port to 443 and leaves it out of the URLs it advertises -- setting a Host
+  # header carrying the port does not bring it back. The WildFly distribution derived the
+  # port from that header and kept it. Without this, the SAML entityID and the OIDC issuer
+  # become https://<vip>/auth/realms/master, which matches neither keystone's cube_idp
+  # remote-id nor any redirect URI already registered against the SAML clients.
+  - name: KC_HOSTNAME_PORT
+    value: "10443"
+  {{- if .Values.cubeController }}
+  # hostname-port only covers the frontend URL. Keycloak resolves the admin console URL
+  # separately, and with hostname-strict=false it takes that one from the request, so it
+  # comes back as https://<vip>/auth -- port 443, which is the CubeCOS web UI rather than
+  # Keycloak, and every visit to /auth/admin is redirected onto the wrong service.
+  # hostname-admin is the only lever for it in Keycloak 18 (hostname-admin-url arrived
+  # later) and it does accept host:port. cubeController is passed in by
+  # config_keycloak.cpp with --set, the same way replicas is.
+  - name: KC_HOSTNAME_ADMIN
+    value: {{ .Values.cubeController }}:10443
+  {{- end }}
+  - name: KC_DB_URL_DATABASE
     valueFrom:
       secretKeyRef:
         name: keycloak-db-secret
         key: db-database
-  - name: DB_USER
+  - name: KC_DB_USERNAME
     valueFrom:
       secretKeyRef:
         name: keycloak-db-secret
         key: db-user
-  - name: DB_PASSWORD
+  - name: KC_DB_PASSWORD
     valueFrom:
       secretKeyRef:
         name: keycloak-db-secret
         key: db-password
-  - name: KEYCLOAK_USER
+  - name: KEYCLOAK_ADMIN
     valueFrom:
       secretKeyRef:
         name: keycloak-db-secret
         key: keycloak-user
-  - name: KEYCLOAK_PASSWORD
+  - name: KEYCLOAK_ADMIN_PASSWORD
     valueFrom:
       secretKeyRef:
         name: keycloak-db-secret
         key: keycloak-password
-  - name: KEYCLOAK_DEFAULT_THEME
-    value: cos-ui
-  - name: PROXY_ADDRESS_FORWARDING
-    value: "true"
-  - name: JGROUPS_DISCOVERY_PROTOCOL
-    value: kubernetes.KUBE_PING
-  - name: KUBERNETES_NAMESPACE
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.namespace
-  - name: CACHE_OWNERS_COUNT
-    value: "3"
-  - name: CACHE_OWNERS_AUTH_SESSIONS_COUNT
-    value: "3"
+  - name: JAVA_OPTS_APPEND
+    value: -Djgroups.dns.query=keycloak-keycloakx-headless.keycloak.svc.cluster.local
   - name: LOGIN_GREETING
     value:
-
-rbac:
-  create: true
-  rules:
-    - apiGroups:
-        - ""
-      resources:
-        - pods
-      verbs:
-        - get
-        - list
 
 tolerations:
   - key: CriticalAddonsOnly

--- a/core/keycloak/keycloak.mk
+++ b/core/keycloak/keycloak.mk
@@ -8,7 +8,7 @@ KEYCLOAK_CONF_DIR := /etc/keycloak
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KEYCLOAK_DIR)
 	$(Q)cp -f $(COREDIR)/keycloak/chart-values.yaml $(ROOTDIR)/$(KEYCLOAK_DIR)/
-	$(Q)cp -f $(TOP_BLDDIR)/core/keycloak/keycloak-*.tgz $(ROOTDIR)/$(KEYCLOAK_DIR)/
+	$(Q)cp -f $(TOP_BLDDIR)/core/keycloak/keycloakx-*.tgz $(ROOTDIR)/$(KEYCLOAK_DIR)/
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KEYCLOAK_DIR)/db
 	$(Q)cp -f $(COREDIR)/keycloak/db/* $(ROOTDIR)/$(KEYCLOAK_DIR)/db/
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KEYCLOAK_CONF_DIR)

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -3,6 +3,11 @@
 #include "config_keycloak.hpp"
 
 static const std::string APP = "statefulset.apps/keycloak-keycloakx";
+/**
+ * The statefulset the WildFly-based chart used to create. CubeCOS v3.1.0 and older
+ * deploy this one, and it stays up until a rolling upgrade reaches its last control node.
+ */
+static const std::string LEGACY_APP = "statefulset.apps/keycloak";
 static const std::string APP_NAMESPACE = "keycloak";
 static const std::string CHART_RELEASE_NAME = "keycloak";
 static const char KEYCLOAK_CHARTS[] = "/opt/keycloak/keycloakx-*.tgz";
@@ -201,18 +206,15 @@ createKeycloakDbSecrets()
 }
 
 /**
- * Check if Keycloak is deployed or not.
+ * Check if a given Keycloak statefulset is rolled out on every node.
  */
 static bool
-checkKeycloak()
+checkKeycloakApp(const std::string& app)
 {
-    HexLogInfo("check keycloak");
-
-    if (!K3sWatchRollOut(APP, APP_NAMESPACE, "1s")) {
-        HexLogError("failed to see all pods rolled out");
+    if (!K3sWatchRollOut(app, APP_NAMESPACE, "1s")) {
+        HexLogInfo("%s has not rolled out all its pods", app.c_str());
         return false;
     }
-    HexLogInfo("all keycloak pods are rolled out");
 
     int nodeCount = K3sGetNodeCounts();
     if (nodeCount < 0) {
@@ -220,23 +222,50 @@ checkKeycloak()
         return false;
     }
 
-    int replicaCount = K3sGetReadyReplicas(APP, APP_NAMESPACE);
+    int replicaCount = K3sGetReadyReplicas(app, APP_NAMESPACE);
     if (replicaCount < 0) {
         HexLogError("failed to get the ready replica count");
         return false;
     }
 
     if (nodeCount != replicaCount) {
-        HexLogError(
-            "control node count: %d doesn't match replica count: %d",
+        HexLogInfo(
+            "control node count: %d doesn't match replica count: %d of %s",
             nodeCount,
-            replicaCount);
+            replicaCount,
+            app.c_str());
         return false;
     }
-    HexLogInfo("keycloak replica count matched the node count");
 
-    HexLogInfo("checked keycloak");
     return true;
+}
+
+/**
+ * Check if Keycloak is deployed or not.
+ */
+static bool
+checkKeycloak()
+{
+    HexLogInfo("check keycloak");
+
+    if (checkKeycloakApp(APP)) {
+        HexLogInfo("checked keycloak");
+        return true;
+    }
+
+    /**
+     * A rolling upgrade only hands the helm release over to the Quarkus chart on the
+     * last control node, so a node that has already been upgraded still has the
+     * WildFly statefulset from CubeCOS v3.1.0 serving logins. That is healthy, not a
+     * failure, so do not report keycloak down for the whole length of the upgrade.
+     */
+    if (checkKeycloakApp(LEGACY_APP)) {
+        HexLogInfo("checked keycloak, still served by the pre-quarkus statefulset");
+        return true;
+    }
+
+    HexLogError("neither %s nor %s is rolled out", APP.c_str(), LEGACY_APP.c_str());
+    return false;
 }
 
 /**
@@ -262,12 +291,52 @@ isUpdateKeycloakPossible(
 }
 
 /**
+ * Retire the statefulset the WildFly-based chart created.
+ *
+ * Keycloak 18 runs its schema migration the first time a pod starts, and the WildFly 17
+ * pods cannot run against the migrated schema. Helm would delete the old statefulset on
+ * its own, but only after it has already created the new one, which leaves both versions
+ * pointed at the same database for a while. Take the old one down first so they never
+ * overlap.
+ */
+static void
+retireLegacyKeycloak()
+{
+    const ExecSyncResult found = ExecBashSync(
+        0,
+        false,
+        false,
+        {},
+        "/usr/local/bin/k3s kubectl get " + LEGACY_APP + " -n " + APP_NAMESPACE);
+    if (found.exitCode != 0) {
+        // nothing to retire, this cluster is already on the quarkus chart
+        return;
+    }
+
+    HexLogInfo("retire the pre-quarkus keycloak statefulset");
+    const ExecSyncResult deleted = ExecBashSync(
+        0,
+        false,
+        false,
+        {},
+        "/usr/local/bin/k3s kubectl delete " + LEGACY_APP + " -n " + APP_NAMESPACE
+            + " --wait=true --timeout=3m");
+    if (deleted.exitCode != 0) {
+        HexLogError("failed to retire the pre-quarkus keycloak statefulset");
+        return;
+    }
+    HexLogInfo("retired the pre-quarkus keycloak statefulset");
+}
+
+/**
  * Deploy Keycloak using Helm.
  */
 static bool
 updateKeycloak()
 {
     HexLogInfo("update keycloak helm chart and roll out pods");
+
+    retireLegacyKeycloak();
 
     int nodeCount = K3sGetNodeCounts();
     if (nodeCount < 0) {
@@ -758,6 +827,16 @@ repairKeycloak()
 {
     if (!IsControl(s_eCubeRole)) {
         HexLogNotice("keycloak should not be repaired from a non-control node");
+        return true;
+    }
+
+    /**
+     * Repairing redeploys the helm release, which on a cluster still running the WildFly
+     * chart hands it over to Keycloak 18 and migrates the shared schema. Mid rolling
+     * upgrade that would strand the control nodes still on CubeCOS v3.1.0, whose WildFly
+     * pods cannot read the migrated schema, so leave the handover to the last node.
+     */
+    if (!isUpdateKeycloakPossible(s_ha, s_hostname, s_ctrlHosts)) {
         return true;
     }
 

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -283,6 +283,12 @@ updateKeycloak()
         nodeCount = 1;
     }
 
+    /**
+     * chart-values.yaml needs the address Keycloak is reached on so it can pin the admin
+     * console URL, which Keycloak resolves separately from the frontend one.
+     */
+    const std::string sharedId = G(SHARED_ID);
+
     const ExecSyncResult r = ExecBashSync(
         0,
         false,
@@ -294,7 +300,8 @@ updateKeycloak()
             + "-f " + KEYCLOAK_CHART_VALUES + " "
             + "-n " + APP_NAMESPACE + " "
             + "--create-namespace "
-            + "--set replicas=" + std::to_string(nodeCount));
+            + "--set replicas=" + std::to_string(nodeCount) + " "
+            + "--set cubeController=" + sharedId);
     return (r.exitCode == 0);
 }
 

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -17,6 +17,8 @@ static const char KEYCLOAK_SAML_METADATA_FILE[] = "/etc/keycloak/saml-metadata.x
 static const std::string KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET = "admin-password";
 static const std::string KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE
     = "/etc/cube/cos/terraform/values/keycloak-admin-password.tfvars";
+// the login theme cube-cos-ui ships, see setMasterRealmLoginTheme()
+static const std::string KEYCLOAK_LOGIN_THEME = "cos-ui";
 
 // external global variables
 CONFIG_GLOBAL_STR_REF(MGMT_ADDR);
@@ -501,6 +503,191 @@ downloadKeycloakSamlMetadata(const std::string& endpointIp)
     return isDownloadSuccessful && isCopySuccessful;
 }
 
+/**
+ * Check if the admin password is stored in K8S secret on K3S.
+ */
+static bool
+isKeycloakUserPasswordInK8sSecret()
+{
+    bool ret = HexUtilSystemF(
+                   0,
+                   0,
+                   "/usr/local/bin/k3s kubectl get secret %s -n %s",
+                   KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET.c_str(),
+                   APP_NAMESPACE.c_str())
+        == 0;
+
+    if (ret) {
+        HexLogInfo("found the existing keycloak admin password");
+    }
+
+    return ret;
+}
+
+/**
+ * Get the admin password from the K8S secret.
+ */
+static std::string
+getKeycloakAdminPasswordFromK8sSecret()
+{
+    if (!isKeycloakUserPasswordInK8sSecret()) {
+        return "";
+    }
+
+    TempFile base64encodedAdminPass = CreateTempFile();
+    if (!base64encodedAdminPass.isValid) {
+        HexLogError("failed to create a temporary file");
+        return "";
+    }
+    if (HexUtilSystemF(
+            0,
+            0,
+            "/usr/local/bin/k3s kubectl get secret %s -n %s -o jsonpath='{.data.password}' > %s",
+            KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET.c_str(),
+            APP_NAMESPACE.c_str(),
+            base64encodedAdminPass.fileName.c_str())
+        != 0) {
+        HexLogError("failed to read the existing keycloak admin password k8s secret");
+        return "";
+    }
+    HexLogInfo("extracted the existing keycloak admin password");
+
+    const std::string base64encodedAdminPassString = HexUtilPOpen(
+        "base64 --decode %s",
+        base64encodedAdminPass.fileName.c_str());
+    DeleteTempFile(base64encodedAdminPass);
+
+    return base64encodedAdminPassString;
+}
+
+static std::string
+getKeycloakAdminAccessToken(
+    const std::string& endpointIp,
+    const std::string& adminPass)
+{
+    HexLogInfo("get keycloak admin access token");
+
+    std::string host = endpointIp;
+    host += (":" + std::to_string(K3S_INGRESS_HTTPS_PORT));
+    Url url = Url(host, "/auth/realms/master/protocol/openid-connect/token");
+    url.scheme = "https";
+
+    const std::vector<std::string> formBody = {
+        "grant_type=password",
+        "client_id=admin-cli",
+        "username=admin",
+        "password=" + adminPass,
+    };
+
+    const HttpResponse r = PostFormHttp(url, formBody);
+
+    if (!r.error.empty()) {
+        HexLogError("failed to send the http request");
+
+        CleanupHttpResponse(r);
+        return "";
+    }
+    if (!isHttpResponseSuccessful(r)) {
+        HexLogError("failed to get the response");
+
+        CleanupHttpResponse(r);
+        return "";
+    }
+
+    std::string fsError;
+    const std::string responseString = ReadFile(fsError, r.outputFileName);
+    CleanupHttpResponse(r);
+
+    if (!fsError.empty()) {
+        HexLogError("failed to read out the response");
+        return "";
+    }
+
+    std::string jsonError;
+    const json11::Json responseJson = json11::Json::parse(responseString.c_str(), jsonError);
+    if (!jsonError.empty()) {
+        HexLogError("failed to parse the response");
+        return "";
+    }
+
+    std::string token;
+    if (responseJson["access_token"].is_string()) {
+        token = responseJson["access_token"].string_value();
+    }
+
+    HexLogInfo("got keycloak admin access token");
+    return token;
+}
+
+/**
+ * Point the master realm's login theme at the theme cube-cos-ui ships.
+ *
+ * The WildFly image took this from KEYCLOAK_DEFAULT_THEME, which set a server-wide default
+ * for every theme type. cos-ui only carries a login theme, so that left the account,
+ * admin, email and welcome pages failing over to the built-in theme and logging an error
+ * every time one was rendered (bigstack-oss/cubecos#187). Setting it per realm scopes the
+ * theme to the only page it actually provides.
+ */
+static bool
+setMasterRealmLoginTheme(const std::string& endpointIp)
+{
+    std::string adminPass = "admin";
+    if (isKeycloakUserPasswordInK8sSecret()) {
+        const std::string adminPassInK8sSecret = getKeycloakAdminPasswordFromK8sSecret();
+        if (adminPassInK8sSecret.empty()) {
+            HexLogError("failed to get the admin password from the k8s secret");
+            return false;
+        }
+
+        adminPass = adminPassInK8sSecret;
+    }
+
+    const std::string token = getKeycloakAdminAccessToken(endpointIp, adminPass);
+    if (token.empty()) {
+        HexLogError("failed to get the keycloak admin access token");
+        return false;
+    }
+
+    HexLogInfo("set the login theme of the master realm to %s", KEYCLOAK_LOGIN_THEME.c_str());
+
+    std::string host = endpointIp;
+    host += (":" + std::to_string(K3S_INGRESS_HTTPS_PORT));
+    Url url = Url(host, "/auth/admin/realms/master");
+    url.scheme = "https";
+
+    /**
+     * Keycloak only applies the fields a realm update actually carries, so naming just the
+     * realm and the login theme leaves every other realm setting alone.
+     */
+    const HttpRequest req = {
+        .method = "PUT",
+        .url = url,
+        .header = {
+            { "Authorization", "Bearer " + token },
+            { "Content-Type", "application/json" },
+        },
+        .body = R"({"realm":"master","loginTheme":")" + KEYCLOAK_LOGIN_THEME + R"("})",
+    };
+    const HttpResponse res = DoHttp(req);
+
+    if (!res.error.empty()) {
+        HexLogError("failed to send the http request");
+
+        CleanupHttpResponse(res);
+        return false;
+    }
+    if (!isHttpResponseSuccessful(res)) {
+        HexLogError("failed to set the login theme of the master realm");
+
+        CleanupHttpResponse(res);
+        return false;
+    }
+    CleanupHttpResponse(res);
+
+    HexLogInfo("set the login theme of the master realm");
+    return true;
+}
+
 static bool
 Commit(bool modified, int dryLevel)
 {
@@ -582,6 +769,11 @@ Commit(bool modified, int dryLevel)
 
             // let other modules to commit
             return true;
+        }
+
+        // serve the cube-cos-ui login page
+        if (!setMasterRealmLoginTheme(sharedId)) {
+            HexLogError("failed to set the login theme of the master realm");
         }
 
         // create default cube groups
@@ -907,63 +1099,6 @@ RemoveKeycloakSamlMetadataMain(int argc, char** argv)
 CONFIG_COMMAND_WITH_SETTINGS(remove_keycloak_saml_metadata, RemoveKeycloakSamlMetadataMain, RemoveKeycloakSamlMetadataUsage);
 
 /**
- * Check if the admin password is stored in K8S secret on K3S.
- */
-static bool
-isKeycloakUserPasswordInK8sSecret()
-{
-    bool ret = HexUtilSystemF(
-                   0,
-                   0,
-                   "/usr/local/bin/k3s kubectl get secret %s -n %s",
-                   KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET.c_str(),
-                   APP_NAMESPACE.c_str())
-        == 0;
-
-    if (ret) {
-        HexLogInfo("found the existing keycloak admin password");
-    }
-
-    return ret;
-}
-
-/**
- * Get the admin password from the K8S secret.
- */
-static std::string
-getKeycloakAdminPasswordFromK8sSecret()
-{
-    if (!isKeycloakUserPasswordInK8sSecret()) {
-        return "";
-    }
-
-    TempFile base64encodedAdminPass = CreateTempFile();
-    if (!base64encodedAdminPass.isValid) {
-        HexLogError("failed to create a temporary file");
-        return "";
-    }
-    if (HexUtilSystemF(
-            0,
-            0,
-            "/usr/local/bin/k3s kubectl get secret %s -n %s -o jsonpath='{.data.password}' > %s",
-            KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET.c_str(),
-            APP_NAMESPACE.c_str(),
-            base64encodedAdminPass.fileName.c_str())
-        != 0) {
-        HexLogError("failed to read the existing keycloak admin password k8s secret");
-        return "";
-    }
-    HexLogInfo("extracted the existing keycloak admin password");
-
-    const std::string base64encodedAdminPassString = HexUtilPOpen(
-        "base64 --decode %s",
-        base64encodedAdminPass.fileName.c_str());
-    DeleteTempFile(base64encodedAdminPass);
-
-    return base64encodedAdminPassString;
-}
-
-/**
  * Save the new admin password to the K8S secret.
  */
 static bool
@@ -1024,65 +1159,6 @@ static void
 UpdateKeycloakAdminPasswordUsage()
 {
     fprintf(stderr, "Usage: %s update_keycloak_admin_password <password>\n", HexLogProgramName());
-}
-
-static std::string
-getKeycloakAdminAccessToken(
-    const std::string& endpointIp,
-    const std::string& adminPass)
-{
-    HexLogInfo("get keycloak admin access token");
-
-    std::string host = endpointIp;
-    host += (":" + std::to_string(K3S_INGRESS_HTTPS_PORT));
-    Url url = Url(host, "/auth/realms/master/protocol/openid-connect/token");
-    url.scheme = "https";
-
-    const std::vector<std::string> formBody = {
-        "grant_type=password",
-        "client_id=admin-cli",
-        "username=admin",
-        "password=" + adminPass,
-    };
-
-    const HttpResponse r = PostFormHttp(url, formBody);
-
-    if (!r.error.empty()) {
-        HexLogError("failed to send the http request");
-
-        CleanupHttpResponse(r);
-        return "";
-    }
-    if (!isHttpResponseSuccessful(r)) {
-        HexLogError("failed to get the response");
-
-        CleanupHttpResponse(r);
-        return "";
-    }
-
-    std::string fsError;
-    const std::string responseString = ReadFile(fsError, r.outputFileName);
-    CleanupHttpResponse(r);
-
-    if (!fsError.empty()) {
-        HexLogError("failed to read out the response");
-        return "";
-    }
-
-    std::string jsonError;
-    const json11::Json responseJson = json11::Json::parse(responseString.c_str(), jsonError);
-    if (!jsonError.empty()) {
-        HexLogError("failed to parse the response");
-        return "";
-    }
-
-    std::string token;
-    if (responseJson["access_token"].is_string()) {
-        token = responseJson["access_token"].string_value();
-    }
-
-    HexLogInfo("got keycloak admin access token");
-    return token;
 }
 
 static std::string

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -2,10 +2,10 @@
 
 #include "config_keycloak.hpp"
 
-static const std::string APP = "statefulset.apps/keycloak";
+static const std::string APP = "statefulset.apps/keycloak-keycloakx";
 static const std::string APP_NAMESPACE = "keycloak";
 static const std::string CHART_RELEASE_NAME = "keycloak";
-static const char KEYCLOAK_CHARTS[] = "/opt/keycloak/keycloak-*.tgz";
+static const char KEYCLOAK_CHARTS[] = "/opt/keycloak/keycloakx-*.tgz";
 static const char KEYCLOAK_CHART_VALUES[] = "/opt/keycloak/chart-values.yaml";
 static const std::string DB_NAME = "keycloak";
 static const char KEYCLOAK_SAML_METADATA_FILE[] = "/etc/keycloak/saml-metadata.xml";

--- a/core/terraform/Makefile
+++ b/core/terraform/Makefile
@@ -8,7 +8,12 @@ RANCHER_PROV_VER      := v7.0.0
 RANCHER_PROV_DIR      := terraform-provider-rancher2
 RANCHER_UPSTREAM_BIN  := $(RANCHER_PROV_DIR)/bin/terraform-provider-rancher2
 KEYCLOAK_PROV_REPO    := https://github.com/mrparkers/terraform-provider-keycloak.git
-KEYCLOAK_PROV_VER     := v3.10.0
+# 4.x is the first line that understands the Quarkus distribution. Its releases up to
+# 4.2.0 are validated against Keycloak 19, the closest supported neighbour of the 18.x we
+# deploy; 4.3.0 onwards moved to Keycloak 21. Keep the required_providers pins in
+# src/keycloak/**/main.tf in step with this.
+KEYCLOAK_PROV_VER     := v4.2.0
+KEYCLOAK_PROV_SEMVER  := $(patsubst v%,%,$(KEYCLOAK_PROV_VER))
 KEYCLOAK_PROV_DIR     := terraform-provider-keycloak
 KEYCLOAK_UPSTREAM_BIN := $(KEYCLOAK_PROV_DIR)/terraform-provider-keycloak
 TF_CORE_REPO          := https://github.com/hashicorp/terraform.git
@@ -80,7 +85,7 @@ terraform: $(TF_CORE_BIN) $(RANCHER_UPSTREAM_BIN) $(KEYCLOAK_UPSTREAM_BIN)
 	$(Q)cp -f $(RANCHER_UPSTREAM_BIN) \
         ./$@/.terraform/providers/registry.terraform.io/rancher/rancher2/7.0.0/linux_amd64/terraform-provider-rancher2_v7.0.0
 	$(Q)cp -f $(KEYCLOAK_UPSTREAM_BIN) \
-		./$@/.terraform/providers/registry.terraform.io/mrparkers/keycloak/3.10.0/linux_amd64/terraform-provider-keycloak_v3.10.0
+		./$@/.terraform/providers/registry.terraform.io/mrparkers/keycloak/$(KEYCLOAK_PROV_SEMVER)/linux_amd64/terraform-provider-keycloak_$(KEYCLOAK_PROV_VER)
 	$(Q)make clean-etcd
 
 install: terraform

--- a/core/terraform/src/keycloak/api_client/main.tf
+++ b/core/terraform/src/keycloak/api_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 3.10.0"
+      version = "= 4.2.0"
     }
   }
 }
@@ -14,6 +14,8 @@ provider "keycloak" {
   username                 = "admin"
   password                 = var.keycloak_admin_password
   url                      = "https://${var.cube_controller}:10443"
+  # Keycloak still serves under /auth; provider 4.x defaults base_path to "".
+  base_path                = "/auth"
   tls_insecure_skip_verify = true
 }
 

--- a/core/terraform/src/keycloak/ceph_dashboard_client/main.tf
+++ b/core/terraform/src/keycloak/ceph_dashboard_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 3.10.0"
+      version = "= 4.2.0"
     }
   }
 }
@@ -14,6 +14,8 @@ provider "keycloak" {
   username                 = "admin"
   password                 = var.keycloak_admin_password
   url                      = "https://${var.cube_controller}:10443"
+  # Keycloak still serves under /auth; provider 4.x defaults base_path to "".
+  base_path                = "/auth"
   tls_insecure_skip_verify = true
 }
 

--- a/core/terraform/src/keycloak/keystone_client/main.tf
+++ b/core/terraform/src/keycloak/keystone_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 3.10.0"
+      version = "= 4.2.0"
     }
   }
 }
@@ -14,6 +14,8 @@ provider "keycloak" {
   username                 = "admin"
   password                 = var.keycloak_admin_password
   url                      = "https://${var.cube_controller}:10443"
+  # Keycloak still serves under /auth; provider 4.x defaults base_path to "".
+  base_path                = "/auth"
   tls_insecure_skip_verify = true
 }
 

--- a/core/terraform/src/keycloak/lmi_client/main.tf
+++ b/core/terraform/src/keycloak/lmi_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 3.10.0"
+      version = "= 4.2.0"
     }
   }
 }
@@ -14,6 +14,8 @@ provider "keycloak" {
   username                 = "admin"
   password                 = var.keycloak_admin_password
   url                      = "https://${var.cube_controller}:10443"
+  # Keycloak still serves under /auth; provider 4.x defaults base_path to "".
+  base_path                = "/auth"
   tls_insecure_skip_verify = true
 }
 

--- a/core/terraform/src/keycloak/main.tf
+++ b/core/terraform/src/keycloak/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 3.10.0"
+      version = "= 4.2.0"
     }
   }
 }
@@ -14,6 +14,8 @@ provider "keycloak" {
   username                 = "admin"
   password                 = var.keycloak_admin_password
   url                      = "https://${var.cube_controller}:10443"
+  # Keycloak still serves under /auth; provider 4.x defaults base_path to "".
+  base_path                = "/auth"
   tls_insecure_skip_verify = true
 }
 

--- a/core/terraform/src/keycloak/rancher_client/main.tf
+++ b/core/terraform/src/keycloak/rancher_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 3.10.0"
+      version = "= 4.2.0"
     }
   }
 }
@@ -14,6 +14,8 @@ provider "keycloak" {
   username                 = "admin"
   password                 = var.keycloak_admin_password
   url                      = "https://${var.cube_controller}:10443"
+  # Keycloak still serves under /auth; provider 4.x defaults base_path to "".
+  base_path                = "/auth"
   tls_insecure_skip_verify = true
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Deploys Keycloak 18.0.2 on Quarkus in place of 17.0.1-legacy on WildFly. We have been running
a 2022 Keycloak, which is not defensible in an audit.

**Requires bigstack-oss/cube-cos-ui#847**, which produces the `cube-cos-login` 18.0.0 image
this expects. Merging this alone leaves the chart pointed at an image tag that does not exist.

**The chart changes line, not just version.** `codecentric/keycloak` is the WildFly chart —
its `18.x` numbers are chart versions and every one of them still ships appVersion
`17.0.1-legacy`, so the `CHART_VERSION := 18.1.1` we had was never Keycloak 18. Quarkus needs
`codecentric/keycloakx`; `1.6.0` is the newest chart whose appVersion is `18.x`. That renames
the objects it creates, so `APP` becomes `statefulset.apps/keycloak-keycloakx` and the chart
glob becomes `keycloakx-*.tgz` — the glob has to change rather than widen, since
`keycloak-*.tgz` does not match `keycloakx-1.6.0.tgz`.

**`/auth` is kept.** Keycloak 18 drops that context by default, but it is load-bearing in
eight places: `config_keystone.cpp` (the `cube_idp` remote-id), `sdk_ceph.sh`, the mellon
conf, and every SAML metadata URL. Pinning `http-relative-path=/auth` keeps every registered
SAML client and the persisted `/etc/keycloak/saml-metadata.xml` valid, instead of rewriting
those consumers.

**Every WildFly env var is translated**: `DB_VENDOR`/`DB_ADDR`/`DB_PORT` → the chart's
`database` block plus `KC_DB_*`, `KEYCLOAK_USER`/`KEYCLOAK_PASSWORD` →
`KEYCLOAK_ADMIN`/`KEYCLOAK_ADMIN_PASSWORD`, `PROXY_ADDRESS_FORWARDING` → `proxy.mode=edge`.
Credentials still come from the `keycloak-db-secret` this module already creates, so
`/opt/keycloak/db` and `createKeycloakDbSecrets()` are untouched.
`JGROUPS_DISCOVERY_PROTOCOL=kubernetes.KUBE_PING` → `KC_CACHE_STACK=kubernetes`, which uses
JGroups DNS_PING; `jgroups.dns.query` has **no default at all**, so `JAVA_OPTS_APPEND` must
point it at the chart's headless service or clustering cannot start. The `rbac` rules KUBE_PING
needed go away with it.

**Terraform provider `mrparkers/keycloak` 3.10.0 → 4.2.0.** 4.x is the first line that
understands the Quarkus distribution, and 4.2.0 is the newest release still validated against
Keycloak 19 — the closest supported neighbour of the 18.x we deploy, since 4.3.0 moved to
Keycloak 21. 4.0.0 changed the default of `base_path` from `/auth` to `""`, so each of the six
provider blocks now names it explicitly or the admin API calls land a path segment short.

#### Which issue(s) this PR fixes

Fixes #621
Fixes #187

#187 falls out of how the theme is applied. The WildFly image took
`KEYCLOAK_DEFAULT_THEME`, a server-wide default covering **every** theme type, while
`cube-cos-ui` only ships a `login` theme — so the account, admin, email and welcome pages each
failed over to the built-in theme and logged an error. Quarkus has the same behaviour behind
`KC_SPI_THEME_DEFAULT`, and the theme SPI can only override the `welcome` type individually,
so carrying that variable across would have carried the bug with it. This sets the theme as
the **master realm's login theme** instead, via the admin API, so it applies to the one page
`cos-ui` actually provides.

#### Special notes for your reviewer

> **Three defects here were found by diffing against the running WildFly deployment, not by
> reading docs.** Each would have shipped as a working-looking Keycloak with broken SSO:
>
> 1. **`:10443` disappeared from every advertised URL.** The proxies in front terminate TLS on
>    the default HTTPS port, so with `proxy=edge` Keycloak resolves the frontend port to 443
>    and omits it — and sending a `Host` header carrying the port does *not* bring it back.
>    WildFly derived it from that header. The SAML `entityID` and OIDC issuer became
>    `https://<vip>/auth/realms/master`, matching neither keystone's `cube_idp` remote-id nor
>    any registered redirect URI. Fixed with `KC_HOSTNAME_PORT`.
> 2. **The admin console URL is resolved separately, and `hostname-port` does not cover it.**
>    So `/auth/admin` redirected to port 443 — the CubeCOS web UI, not Keycloak. Of the
>    candidates, only `hostname-admin=<vip>:10443` works on 18.0.2: `hostname-admin=<vip>`
>    alone does not, and neither does `hostname=<vip>` with `hostname-strict=true`.
>    `hostname-admin-url` (the option you would reach for) only arrived after 18. Because it
>    needs the VIP, `updateKeycloak()` passes `--set cubeController=<SHARED_ID>` alongside the
>    existing `--set replicas=`, and the values emit `KC_HOSTNAME_ADMIN` only when that is
>    present — verified it renders with the VIP and is omitted entirely without it, so a
>    bootstrap with an empty `SHARED_ID` cannot produce a malformed hostname.
> 3. **The chart's stock probes GET the relative-path root**, which is the welcome page. With
>    no `welcome` theme in `cos-ui`, every liveness probe logged a theme fallback error —
>    once every ten seconds, forever, into the log pipeline. The probes now use the health
>    endpoints the image is built with.

> **Rolling upgrade.** A 3cc reboots one control node at a time, so the cluster runs this
> beside nodes still on v3.1.0, both against the same `keycloak` database. Keycloak 18
> migrates that schema on first start and the WildFly 17 pods cannot read the result, so the
> handover must happen once and only when no 17 pod is left. `isUpdateKeycloakPossible()`
> already defers to the last control node; three gaps around it are closed:
> `retireLegacyKeycloak()` takes the old statefulset down *before* the new one starts (Helm
> would delete it only afterwards, overlapping both versions on the database);
> `checkKeycloak()` falls back to the WildFly statefulset so an upgraded node whose release
> still belongs to the last node is not reported down for the whole upgrade; and
> `repair_keycloak` now honours the same guard, since running it from a non-last node would
> migrate the schema early.

> **What is NOT verified: the 3cc ordering itself.** `jim-1cc` is a single
> `control-converged` node with `cubesys.ha=false`. The handover mechanics were observed on
> one node — legacy statefulset retired before the Quarkus pod starts, liquibase advances to
> `18.0.0-10625`, no overlap — but the multi-node sequencing is reasoned from the guard, not
> seen. Likewise the single-node jgroups path was exercised (DNS_PING formed a one-member
> cluster) but peer discovery across three pods was not. **A 3cc run before release is worth
> it**, and it is the highest remaining risk in this change.

> **`keycloak_generic_client_protocol_mapper` is deliberately left on the deprecated name.**
> 4.x renamed it to `keycloak_generic_protocol_mapper` but keeps the old one working until the
> next major; migrating means `terraform state rm` plus `terraform import` against live
> clusters. It logs a deprecation warning until we move to 5.x.

> **No extra terraform init step is needed on upgraded clusters.** `terraform-action.sh`
> already runs `init -upgrade` before every command, `rootfs_install` ships without a lock
> file, and only `terraform.tfstate*` survives an upgrade, so an upgraded node's mirror holds
> just the newly built provider. Confirmed the worst case anyway: a stale lock pinning 3.10.0
> with 3.10.0 still in the mirror as a decoy still re-resolved to 4.2.0, applied cleanly and
> rewrote the lock.

> **Pre-existing inconsistency left alone:** the `RC` branch of `core/keycloak/Makefile` is
> still pinned to the published `cube-cos-login-17.2.0` RPM and a `keycloak:17.1.0` tag, which
> the keycloakx chart cannot drive. I added a comment rather than silently editing release
> pins — they need to move to an 18.x release when the next RC is cut.

**Verified on jim-1cc** (real 17 → 18 migration on a live cluster, not a fresh install):

- Pod ready in ~25s, Keycloak 18.0.2, **no re-augmentation and no build-time property
  warnings** — the image's baked options match the runtime env.
- Liquibase advanced to `18.0.0-10625`; realm data intact (2 users, 11 clients, 3 groups, all
  4 SAML clients).
- SAML descriptor `entityID` and `Location`s **byte-identical** to the WildFly 17 baseline,
  realm signing certificate unchanged, OIDC issuer/authorization/token endpoints unchanged.
- `login_theme=cos-ui` with `admin_theme` and `account_theme` left NULL; login page renders
  through `cos-ui` with css/js/favicon/fonts at 200; welcome, admin and account pages return
  200 with **zero** `Failed to find` errors.
- Admin console completes a full PKCE authorization-code login (authorize → credentials →
  code → token, issuer `https://10.1.0.1:10443/auth/realms/master`) and calls
  `GET /auth/admin/realms/master` successfully.
- keystone `cube_idp` remote-id and the ceph dashboard SAML IdP entityId both still resolve to
  `https://10.1.0.1:10443/auth/realms/master`.
- `hex_config check_keycloak` OK and `health_keycloak_check` reports
  `{"SERVICE":"keycloak","ERROR_CODE":"0","DESCRIPTION":"ok"}` against the renamed statefulset.
- All five terraform keycloak modules apply `0 added, 0 changed, 0 destroyed` under provider
  4.2.0 — the provider refreshes existing state without drift or recreation.
- Only remaining log ERROR is `KC-SERVICES0010: Failed to add user 'admin' ... user with
  username exists`, which WildFly logged too.

#### Additional documentation

```docs

```
