### PR TITLE
fix(fts): zero-touch 3cc install fixes — manila NB-readiness guard, ovn-controller heal, git convergence, keycloak/airgap guards

### DIFF
--- a/core/keycloak/keycloak.mk
+++ b/core/keycloak/keycloak.mk
@@ -5,6 +5,17 @@
 KEYCLOAK_DIR := /opt/keycloak
 KEYCLOAK_CONF_DIR := /etc/keycloak
 
+# the bundled registry (core/docker/registry, copied into the rootfs) must
+# hold the keycloak image tag pinned in chart-values.yaml; a missing or
+# drifted tag means every fresh install ImagePullBackOffs -- fail the build.
+rootfs_install::
+	$(Q)charttag=$$(awk '/^  tag:/ {print $$2; exit}' $(COREDIR)/keycloak/chart-values.yaml); \
+	tagsdir=$(TOP_BLDDIR)/core/docker/registry/docker/registry/v2/repositories/bigstack/keycloak/_manifests/tags; \
+	if [ ! -d "$$tagsdir/$$charttag" ]; then \
+		echo "keycloak: bundled registry lacks bigstack/keycloak:$$charttag (has: $$(ls $$tagsdir 2>/dev/null | tr '\n' ' ')) -- fresh installs would ImagePullBackOff" >&2; \
+		exit 1; \
+	fi
+
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p $(KEYCLOAK_DIR)
 	$(Q)cp -f $(COREDIR)/keycloak/chart-values.yaml $(ROOTDIR)/$(KEYCLOAK_DIR)/

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -864,8 +864,10 @@ ClusterReadyMain(int argc, const char** argv)
     else
         HexSpawn(0, HEX_CFG, "-p", "trigger", "cluster_ready", ZEROCHAR_PTR);
 
-    CliPrintf("[3/6] Starting cluster");
+    CliPrintf("[3/6] Starting and reconciling cluster");
     HexUtilSystemF(0, 0, HEX_SDK " host_local_run hex_sdk cmd " HEX_SDK " cube_cluster_start");
+    // parallel per-node heals (ovn-controller start-limit recovery)
+    HexUtilSystemF(0, 0, "cubectl node exec -pn \"" HEX_CFG " trigger set_ready_reconcile\"");
 
     // the cluster is guaranteed complete here -- never import at boot, where a
     // still-forming ceph wedges the upload (#1139)

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -967,6 +967,25 @@ DisableSflowMain(int argc, char* argv[])
     return EXIT_SUCCESS;
 }
 
+static int
+SetReadyReconcileMain(int argc, char **argv)
+{
+    if (!s_enabled)
+        return EXIT_SUCCESS;
+
+    // ovn-controller (compute-side) can SEGV-crash-loop into its systemd
+    // start limit while the SB DB / VIP are still forming; heal this node.
+    // Fired in parallel on every node from set_ready.
+    if (IsCompute(s_eCubeRole)) {
+        HexUtilSystemF(0, 0,
+                       "systemctl reset-failed ovn-controller 2>/dev/null; "
+                       "systemctl is-active ovn-controller >/dev/null || "
+                       "systemctl restart ovn-controller");
+    }
+
+    return EXIT_SUCCESS;
+}
+
 CONFIG_COMMAND_WITH_SETTINGS(restart_neutron, RestartMain, RestartUsage);
 CONFIG_COMMAND_WITH_SETTINGS(enable_sflow, EnableSflowMain, EnableSflowUsage);
 CONFIG_COMMAND_WITH_SETTINGS(disable_sflow, DisableSflowMain, DisableSflowUsage);
@@ -986,6 +1005,8 @@ CONFIG_OBSERVES(neutron, rabbitmq, ParseRabbitMQ, NotifyMQ);
 CONFIG_OBSERVES(neutron, cubesys, ParseCube, NotifyCube);
 CONFIG_OBSERVES(neutron, nova, ParseNova, NotifyNova);
 CONFIG_OBSERVES(neutron, keystone, ParseKeystone, NotifyKeystone);
+
+CONFIG_TRIGGER_WITH_SETTINGS(neutron, "set_ready_reconcile", SetReadyReconcileMain);
 
 CONFIG_MIGRATE(neutron, "/etc/openvswitch/");
 CONFIG_MIGRATE(neutron, "/var/lib/ovn");

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -135,7 +135,6 @@ eval "ERR_DESC_$SRV[2]='cephfs not all mounted'"
 eval "ERR_DESC_$SRV[3]='nfs-ganesha fail to mount'"
 eval "ERR_DESC_$SRV[4]='nfs-ganesha fail to write'"
 eval "ERR_DESC_$SRV[5]='nfs-ganesha not all up'"
-eval "ERR_DESC_$SRV[6]='git not initialied'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="ceph_osd"

--- a/core/sdk_sh/modules/sdk_git.sh
+++ b/core/sdk_sh/modules/sdk_git.sh
@@ -149,6 +149,25 @@ git_init()
     git_client_init
 }
 
+git_node_init()
+{
+    # Init only THIS node: the master creates the bare repo (and its own /
+    # clone); peers clone from cephfs, failing harmlessly until it exists.
+    source $HEX_TUN $SETTINGS_TXT
+    local master
+    if [ "x$T_cubesys_control_hosts" = "x" ] ; then
+        master=$T_cubesys_controller
+        [ -n "$master" ] || master=$T_net_hostname
+    else
+        master=$(echo $T_cubesys_control_hosts | cut -d"," -f1)
+    fi
+    if [ "x$T_net_hostname" = "x$master" ] ; then
+        $HEX_SDK _git_server_init
+    else
+        $HEX_SDK _git_client_init
+    fi
+}
+
 git_push()
 {
     local msg="${@:-n/a}"

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -1587,8 +1587,6 @@ health_ceph_mds_check()
         ERR_CODE=4
     elif [ $(cmd -cv "systemctl show -p SubState nfs-ganesha" | grep running| wc -l) -lt $num_ctrlnode ] ; then
         ERR_CODE=5
-    elif ! cmd git log ; then
-        ERR_CODE=6
     fi
 
     rm -f $nfs_dir/.alive
@@ -1608,8 +1606,6 @@ _health_ceph_mds_auto_repair()
         cmd $HEX_SDK ceph_mount_cephfs
     elif [ "$ERR_CODE" == "3" -o "$ERR_CODE" == "4" -o "$ERR_CODE" == "5" ] ; then
         cmd -c "systemctl restart nfs-ganesha"
-    elif [ "$ERR_CODE" == "6" ] ; then
-        $HEX_SDK git_init
     fi
 }
 

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -24,26 +24,28 @@ migrate_fixpack()
 
 migrate_git()
 {
-    # Init this node's config-history /.git, detached, and mark migrated only
-    # after git_init actually works (not on a pre-ready no-op). See #1195.
+    # /.git is infra plumbing, not an operator-facing service: converge it in
+    # the background until done and never surface it to health checks. #1195
     [ -f $STATE_DIR/git_migrated ] && return 0
     setsid $HEX_SDK _migrate_git_bg </dev/null >/dev/null 2>&1 &
 }
 
-# Retry (detached, bounded ~10 min) until cube_node_ready and git_init works,
-# then set the marker. Never marks on a no-op.
+# Unbounded self-convergence: this node inits only ITSELF (master hosts the
+# bare repo, peers clone it) -- concurrent full git_init from every node
+# stomped each other's / worktrees. flock keeps one loop per node.
 _migrate_git_bg()
 {
-    local _i
-    for _i in $(seq 1 120) ; do
+    exec 9>/run/migrate_git.lock
+    flock -n 9 || return 0
+    while [ ! -f $STATE_DIR/git_migrated ] ; do
         if $HEX_SDK cube_node_ready ; then
-            $HEX_SDK git_init
+            $HEX_SDK git_node_init
             if git -C / log -1 >/dev/null 2>&1 ; then
                 touch $STATE_DIR/git_migrated
                 return 0
             fi
         fi
-        sleep 5
+        sleep 20
     done
 }
 

--- a/core/sdk_sh/modules/sdk_network.sh
+++ b/core/sdk_sh/modules/sdk_network.sh
@@ -354,6 +354,13 @@ network_ipt_restore()
 airgap_sim_apply()
 {
     touch /etc/appliance/state/airgap_sim
+    # already fully applied? leave the chain untouched so DROP counters keep
+    # accumulating -- re-applying with a flush zeroes them and makes air-gap
+    # violations unauditable (the agent re-applies periodically)
+    if [ "$(iptables -S CUBE_AIRGAP 2>/dev/null | grep -c .)" -eq 8 ] &&
+       iptables -C OUTPUT -j CUBE_AIRGAP 2>/dev/null ; then
+        return 0
+    fi
     iptables -nL CUBE_AIRGAP >/dev/null 2>&1 && iptables -F CUBE_AIRGAP || iptables -N CUBE_AIRGAP
     iptables -A CUBE_AIRGAP -o lo -j RETURN
     local net

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2185,6 +2185,9 @@ os_manila_service_network_dedup()
 os_manila_service_network_ensure()
 {
     is_first_compute_node || return 0
+    # Wait for the OVN NB (pacemaker VIP:6641) before writing to neutron: an
+    # early write's SG lands without a port group. systemd retries on failure.
+    timeout 5 ovsdb-client list-dbs tcp:$(shared_ip):6641 >/dev/null 2>&1 || return 1
     local count i
     # Converge to exactly one: create, then dedup + settle-verify (a create that
     # times out on the client can still land, so don't trust its exit code).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fixes from the master-first zero-touch 3cc install validation (air-gapped, repair opted out, sky lab):

1. **airgap counters**: periodic airgap_sim_apply re-applies flushed the CUBE_AIRGAP chain, zeroing DROP counters and destroying egress-violation evidence — now idempotent.
2. **keycloak air-gap install guard**: build fails when the bundled registry lacks the exact `bigstack/keycloak:<chart tag>` image (the 17.2.0-vs-18.0.x drift that ImagePullBackOff'd every fresh install since Aug 12; also catches the image missing entirely, which an incremental build can produce).
3. **manila service-network ensure gated on OVN NB readiness**: the admin default security group is auto-created by neutron on the manila ensure's first write, which fires the instant the VIP answers — before pacemaker starts the OVN NB listener — so the SG lands without a port group and every later port create 500s (#1273). The ensure now probes `tcp:VIP:6641` and fails its pre-start until the NB is reachable (systemd retries it, off the FTS critical path). This prevents the strand at the source rather than repairing it after.
4. **set_ready_reconcile trigger**: ovn-controller SEGV-crash-loops into its systemd start limit during the pacemaker OVN bring-up window (upstream NULL-deref, unrelated to any cube change; see #1270). set_ready step 3 ("Starting and reconciling cluster") fires a `set_ready_reconcile` hex_config trigger on every node in parallel; config_neutron handles it role-aware and compute nodes heal their own ovn-controller. Idempotent. Validated on sky across 6 zero-touch reimages to 27/27.
5. **git background convergence**: /.git is infra plumbing, not an operator-facing service. The old per-node migrate loops ran the FULL cluster-wide git_init concurrently from every node (stomping each other's / worktrees) inside a 10-min window, and the ceph_mds health check then reported errcode 6 forever. Now each node converges only itself, unbounded, flock-guarded, in the background — and the health check no longer reports git at all.

Validated end-to-end on sky across four zero-touch driver reimages (airgap + repair opt-out), all reaching `cluster check` 27/27 with zero manual intervention. An A/B falsification run (identical branch with/without an ovn-northd handover change) showed the handover was unnecessary — the mid-round northd stop leaves NB/SB up and nothing in the round needs the translation — so it was dropped; the real FTS blockers were the keycloak image drift and the post-FTS inconsistencies the reconcile step heals. The ovn-controller SEGV is a race (13 crashes on one run, 0 on another); the reconcile heal covers both outcomes.

Full narrative + evidence: handbook `kb/cubecos/blueprints/nova-live-resize.md` (fresh-install findings section).

#### Which issue(s) this PR fixes

Fixes #1272, fixes #1273. Related: #1270 (root cause re-attributed to the keycloak drift + reconcile items by an A/B falsification run; see comments). Related: #1271 (build guard here; the keycloak 17/18 version pairing itself is tracked there)

#### Special notes for your reviewer

The ovn-controller SEGV itself (crashes instead of retrying while SB/VIP are forming) deserves its own investigation — coredump preserved on sky141 from the first run. git convergence hot-validated on sky: with /.git wiped on a peer, health stays ok, the loop restores the clone in <1 min, setuid modes survive the re-init.

#### Additional documentation

```docs
bigstack-handbook kb/cubecos/blueprints/nova-live-resize.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkeJmP4qdsDpNzyN6hQs25






