### PR TITLE
feat(cli): add 'agent preflight_report' to show the zero-touch preflight result

### DIFF
--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -221,6 +221,7 @@ hex_cli_MODULES += cli_diagnostics.o
 hex_cli_MODULES += cli_autoscaler.o
 hex_cli_MODULES += cli_app.o
 hex_cli_MODULES += cli_k3s.o
+hex_cli_MODULES += cli_agent.o
 
 hex_cli_LIBS += $(PROJ_LIBDIR)/libcube_sdk.a
 

--- a/core/modules/cli_agent.cpp
+++ b/core/modules/cli_agent.cpp
@@ -1,0 +1,30 @@
+// CUBE SDK
+
+#include <hex/process.h>
+#include <hex/log.h>
+#include <hex/strict.h>
+
+#include <hex/cli_module.h>
+#include <hex/cli_util.h>
+
+// The zero-touch install agent (phone-home-agent) persists its last preflight
+// result to /run during the installer session and, via hex_autoinstall, to
+// /var/support in the booted OS; --report renders it without the driver.
+static int
+PreflightReportMain(int argc, const char** argv)
+{
+    if (argc > 1 /* [0]="preflight_report" */)
+        return CLI_INVALID_ARGS;
+
+    HexSpawn(0, "/usr/sbin/phone-home-agent", "--report", NULL);
+
+    return CLI_SUCCESS;
+}
+
+CLI_MODE(CLI_TOP_MODE, "agent",
+         "Work with the node's zero-touch install agent.",
+         !HexStrictIsErrorState());
+
+CLI_MODE_COMMAND("agent", "preflight_report", PreflightReportMain, NULL,
+    "Show this node's last zero-touch preflight report (network-validation result).",
+    "preflight_report");


### PR DESCRIPTION
## What
New hex_cli command **`hex_cli -c agent -c preflight_report`** (`core/modules/cli_agent.cpp`) renders this node's last zero-touch preflight (network-validation) result via `phone-home-agent --report`.

## Why
When the driver report-back is unavailable after the network check, admin can check the preflight verdict locally on the booted node — no route to the driver needed.

## Test
Jail build: `CXX cli_agent.o` -> `LD hex_cli`, exit 0. End-to-end verify via zero-touch reimage of sky 3cc (combined branch) pending.

## Depends on / pairs with
- **hex** PR `feat(autoinstall): stage the preflight report into the OS rootfs` (submodule bump at merge)
- **cube-cos-driver** PR `feat(agent): fall back to the durable preflight-report copy for --report`

Placement note: kept in `core/modules` (product layer) — `phone-home-agent` is a cubecos/driver binary hex only optionally installs; the installer *staging* lives in hex.

Fixes #1279
