### PR TITLE
fix(gpu): stop advertising GPU resources that cannot be delivered

### DIFF
--- a/core/cyborg/yoga_patch/accelerator/drivers/gpu/utils.py
+++ b/core/cyborg/yoga_patch/accelerator/drivers/gpu/utils.py
@@ -1,0 +1,274 @@
+# Copyright 2018 Beijing Lenovo Software Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+"""
+Utils for GPU driver.
+"""
+from oslo_concurrency import processutils
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+
+import os
+import re
+
+from cyborg.accelerator.common import utils
+from cyborg.common import constants
+from cyborg.conf import CONF
+from cyborg.objects.driver_objects import driver_attach_handle
+from cyborg.objects.driver_objects import driver_attribute
+from cyborg.objects.driver_objects import driver_controlpath_id
+from cyborg.objects.driver_objects import driver_deployable
+from cyborg.objects.driver_objects import driver_device
+import cyborg.privsep
+
+LOG = logging.getLogger(__name__)
+
+GPU_FLAGS = ["VGA compatible controller", "3D controller"]
+GPU_INFO_PATTERN = re.compile(r"(?P<devices>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:"
+                              r"[0-9a-fA-F]{2}\.[0-9a-fA-F]) "
+                              r"(?P<controller>.*) [\[].*]: (?P<model>.*) .*"
+                              r"[\[](?P<vendor_id>[0-9a-fA-F]"
+                              r"{4}):(?P<product_id>[0-9a-fA-F]{4})].*")
+
+VENDOR_MAPS = {"10de": "nvidia", "102b": "matrox"}
+
+# CubeCOS owns GPU resource-type configuration through hex_config. This file is
+# its source of truth: one entry per physical card, with the type the operator
+# assigned (pgpu / sriovVgpu / migBackedVgpu). A card that is not recorded here
+# as "pgpu" is not available for whole-card passthrough, so cyborg must not
+# advertise it.
+HEX_GPU_CONFIG_FILE = "/etc/cube/cos/gpu/config.json"
+SYS_PCI_DEVICES = "/sys/bus/pci/devices"
+
+
+@cyborg.privsep.sys_admin_pctxt.entrypoint
+def lspci_privileged():
+    cmd = ['lspci', '-nnn', '-D']
+    return processutils.execute(*cmd)
+
+
+@cyborg.privsep.sys_admin_pctxt.entrypoint
+def read_hex_gpu_config_privileged():
+    """Read hex's GPU truth file. It is root-owned 0600; the agent is not."""
+    with open(HEX_GPU_CONFIG_FILE, 'r') as f:
+        return f.read()
+
+
+def _normalize_pci_address(address):
+    """hex writes an 8-digit domain and upper-case bus ("00000001:C8:00.0");
+    lspci -D prints a 4-digit domain in lower case ("0001:c8:00.0"). Compare
+    on the lspci form.
+    """
+    parts = address.strip().lower().split(':')
+    if len(parts) != 3:
+        return address.strip().lower()
+    try:
+        domain = int(parts[0], 16)
+    except ValueError:
+        return address.strip().lower()
+    return "%04x:%s:%s" % (domain, parts[1], parts[2])
+
+
+def get_passthrough_addresses():
+    """Addresses of the cards hex has assigned to whole-card passthrough.
+
+    Returns None when the truth file cannot be read, which the caller treats as
+    "report nothing": under-reporting fails scheduling cleanly, while
+    over-reporting hands out a device another VM already holds.
+    """
+    try:
+        raw = read_hex_gpu_config_privileged()
+    except Exception as e:
+        LOG.error("cannot read %s (%s); reporting no GPUs rather than risking "
+                  "a device already in use", HEX_GPU_CONFIG_FILE, e)
+        return None
+
+    try:
+        entries = jsonutils.loads(raw)
+    except ValueError as e:
+        LOG.error("%s is not valid JSON (%s); reporting no GPUs",
+                  HEX_GPU_CONFIG_FILE, e)
+        return None
+
+    if not isinstance(entries, list):
+        LOG.error("%s is not a JSON array; reporting no GPUs",
+                  HEX_GPU_CONFIG_FILE)
+        return None
+
+    return set(
+        _normalize_pci_address(e["pciAddress"])
+        for e in entries
+        if isinstance(e, dict) and e.get("type") == "pgpu" and e.get("pciAddress")
+    )
+
+
+def is_virtual_function(address):
+    """A VF carries a physfn link back to its physical function. A VF is never
+    a whole-card passthrough target, whatever its lspci class says - SR-IOV
+    vGPU VFs report as "3D controller" exactly like the card itself.
+    """
+    return os.path.exists(os.path.join(SYS_PCI_DEVICES, address, "physfn"))
+
+
+def get_pci_devices(pci_flags, vendor_id=None):
+    device_for_vendor_out = []
+    all_device_out = []
+    lspci_out = lspci_privileged()[0].split('\n')
+    for pci in lspci_out:
+        if any(x in pci for x in pci_flags):
+            all_device_out.append(pci)
+            if vendor_id and vendor_id in pci:
+                device_for_vendor_out.append(pci)
+    return device_for_vendor_out if vendor_id else all_device_out
+
+
+def get_traits(vendor_id, product_id):
+    """Generate traits for GPUs.
+    : param vendor_id: vendor_id of PGPU/VGPU, eg."10de"
+    : param product_id: product_id of PGPU/VGPU, eg."1eb8".
+    Example VGPU traits:
+    {traits:["CUSTOM_GPU_NVIDIA", "CUSTOM_GPU_PRODUCT_ID_1EB8"]}
+    """
+    traits = []
+    traits.append("CUSTOM_GPU_" + VENDOR_MAPS.get(vendor_id, "").upper())
+    traits.append("CUSTOM_GPU_PRODUCT_ID_" + product_id.upper())
+    return {"traits": traits}
+
+
+def discover_vendors():
+    vendors = set()
+    gpus = get_pci_devices(GPU_FLAGS)
+    for gpu in gpus:
+        m = GPU_INFO_PATTERN.match(gpu)
+        if m:
+            vendor_id = m.groupdict().get("vendor_id")
+            vendors.add(vendor_id)
+    return vendors
+
+
+def discover_gpus(vendor_id=None):
+    """Report only the cards CubeCOS has assigned to whole-card passthrough.
+
+    Upstream labels every NVIDIA function lspci reports as a GPU with
+    rc=PGPU. On CubeCOS that is wrong twice over: SR-IOV vGPU VFs report as
+    "3D controller" and would each be advertised as a whole card, and a
+    physical card already carved into vGPU by hex_config would be advertised
+    while it is in fact unavailable. Either one lets the scheduler place a
+    passthrough request onto a device that is already in use, which then fails
+    at libvirt attach time.
+    """
+    gpu_list = []
+    passthrough = get_passthrough_addresses()
+    if not passthrough:
+        return gpu_list
+
+    gpus = get_pci_devices(GPU_FLAGS, vendor_id)
+    for gpu in gpus:
+        m = GPU_INFO_PATTERN.match(gpu)
+        if m:
+            gpu_dict = m.groupdict()
+            address = gpu_dict["devices"].lower()
+
+            if is_virtual_function(address):
+                continue
+
+            if address not in passthrough:
+                LOG.debug("skipping %s: not assigned to passthrough in %s",
+                          address, HEX_GPU_CONFIG_FILE)
+                continue
+
+            # generate hostname for deployable_name usage
+            gpu_dict['hostname'] = CONF.host
+            # generate traits info
+            traits = get_traits(gpu_dict["vendor_id"], gpu_dict["product_id"])
+            gpu_dict["rc"] = constants.RESOURCES["PGPU"]
+            gpu_dict.update(traits)
+            gpu_list.append(_generate_driver_device(gpu_dict))
+    return gpu_list
+
+
+def _generate_driver_device(gpu):
+    driver_device_obj = driver_device.DriverDevice()
+    driver_device_obj.vendor = gpu["vendor_id"]
+    driver_device_obj.model = gpu.get('model', 'miss model info')
+    std_board_info = {'product_id': gpu.get('product_id', None),
+                      'controller': gpu.get('controller', None)}
+    vendor_board_info = {'vendor_info': gpu.get('vendor_info', 'gpu_vb_info')}
+    driver_device_obj.std_board_info = jsonutils.dumps(std_board_info)
+    driver_device_obj.vendor_board_info = jsonutils.dumps(vendor_board_info)
+    driver_device_obj.type = constants.DEVICE_GPU
+    driver_device_obj.stub = gpu.get('stub', False)
+    driver_device_obj.controlpath_id = _generate_controlpath_id(gpu)
+    driver_device_obj.deployable_list = _generate_dep_list(gpu)
+    return driver_device_obj
+
+
+def _generate_controlpath_id(gpu):
+    driver_cpid = driver_controlpath_id.DriverControlPathID()
+    # NOTE: GPUs (either pGPU or vGPU), they all report "PCI" as
+    # their cpid_type, while attach_handle_type of them are different.
+    driver_cpid.cpid_type = "PCI"
+    driver_cpid.cpid_info = utils.pci_str_to_json(gpu["devices"])
+    return driver_cpid
+
+
+def _generate_dep_list(gpu):
+    dep_list = []
+    driver_dep = driver_deployable.DriverDeployable()
+    driver_dep.attribute_list = _generate_attribute_list(gpu)
+    driver_dep.attach_handle_list = []
+    # NOTE(wangzhh): The name of deployable should be unique, its format is
+    # under disscussion, may looks like
+    # <ComputeNodeName>_<NumaNodeName>_<CyborgName>_<NumInHost>
+    # NOTE(yumeng) Now simply named as <Compute_hostname>_<Device_address>
+    # once cyborg needs to support GPU devices discovered from a baremetal
+    # node, we might need to support more formats.
+    driver_dep.name = gpu.get('hostname', '') + '_' + gpu["devices"]
+    driver_dep.driver_name = VENDOR_MAPS.get(gpu["vendor_id"]).upper()
+    # driver_dep.num_accelerators for PGPU is 1, for VGPU should be the
+    # sriov_numvfs of the vGPU device.
+    # TODO(yumeng) support VGPU num report soon
+    driver_dep.num_accelerators = 1
+    driver_dep.attach_handle_list = \
+        [_generate_attach_handle(gpu)]
+    dep_list.append(driver_dep)
+    return dep_list
+
+
+def _generate_attach_handle(gpu):
+    driver_ah = driver_attach_handle.DriverAttachHandle()
+    if gpu["rc"] == "PGPU":
+        driver_ah.attach_type = constants.AH_TYPE_PCI
+    else:
+        driver_ah.attach_type = constants.AH_TYPE_MDEV
+    driver_ah.in_use = False
+    driver_ah.attach_info = utils.pci_str_to_json(gpu["devices"])
+    return driver_ah
+
+
+def _generate_attribute_list(gpu):
+    attr_list = []
+    for k, v in gpu.items():
+        if k == "rc":
+            driver_attr = driver_attribute.DriverAttribute()
+            driver_attr.key, driver_attr.value = k, v
+            attr_list.append(driver_attr)
+        if k == "traits":
+            values = gpu.get(k, [])
+            for index, val in enumerate(values):
+                driver_attr = driver_attribute.DriverAttribute(
+                    key="trait" + str(index), value=val)
+                attr_list.append(driver_attr)
+    return attr_list

--- a/core/cyborg/yoga_patch/accelerator/drivers/gpu/utils.py.orig
+++ b/core/cyborg/yoga_patch/accelerator/drivers/gpu/utils.py.orig
@@ -1,0 +1,179 @@
+# Copyright 2018 Beijing Lenovo Software Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+"""
+Utils for GPU driver.
+"""
+from oslo_concurrency import processutils
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+
+import re
+
+from cyborg.accelerator.common import utils
+from cyborg.common import constants
+from cyborg.conf import CONF
+from cyborg.objects.driver_objects import driver_attach_handle
+from cyborg.objects.driver_objects import driver_attribute
+from cyborg.objects.driver_objects import driver_controlpath_id
+from cyborg.objects.driver_objects import driver_deployable
+from cyborg.objects.driver_objects import driver_device
+import cyborg.privsep
+
+LOG = logging.getLogger(__name__)
+
+GPU_FLAGS = ["VGA compatible controller", "3D controller"]
+GPU_INFO_PATTERN = re.compile(r"(?P<devices>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:"
+                              r"[0-9a-fA-F]{2}\.[0-9a-fA-F]) "
+                              r"(?P<controller>.*) [\[].*]: (?P<model>.*) .*"
+                              r"[\[](?P<vendor_id>[0-9a-fA-F]"
+                              r"{4}):(?P<product_id>[0-9a-fA-F]{4})].*")
+
+VENDOR_MAPS = {"10de": "nvidia", "102b": "matrox"}
+
+
+@cyborg.privsep.sys_admin_pctxt.entrypoint
+def lspci_privileged():
+    cmd = ['lspci', '-nnn', '-D']
+    return processutils.execute(*cmd)
+
+
+def get_pci_devices(pci_flags, vendor_id=None):
+    device_for_vendor_out = []
+    all_device_out = []
+    lspci_out = lspci_privileged()[0].split('\n')
+    for pci in lspci_out:
+        if any(x in pci for x in pci_flags):
+            all_device_out.append(pci)
+            if vendor_id and vendor_id in pci:
+                device_for_vendor_out.append(pci)
+    return device_for_vendor_out if vendor_id else all_device_out
+
+
+def get_traits(vendor_id, product_id):
+    """Generate traits for GPUs.
+    : param vendor_id: vendor_id of PGPU/VGPU, eg."10de"
+    : param product_id: product_id of PGPU/VGPU, eg."1eb8".
+    Example VGPU traits:
+    {traits:["CUSTOM_GPU_NVIDIA", "CUSTOM_GPU_PRODUCT_ID_1EB8"]}
+    """
+    traits = []
+    traits.append("CUSTOM_GPU_" + VENDOR_MAPS.get(vendor_id, "").upper())
+    traits.append("CUSTOM_GPU_PRODUCT_ID_" + product_id.upper())
+    return {"traits": traits}
+
+
+def discover_vendors():
+    vendors = set()
+    gpus = get_pci_devices(GPU_FLAGS)
+    for gpu in gpus:
+        m = GPU_INFO_PATTERN.match(gpu)
+        if m:
+            vendor_id = m.groupdict().get("vendor_id")
+            vendors.add(vendor_id)
+    return vendors
+
+
+def discover_gpus(vendor_id=None):
+    gpu_list = []
+    gpus = get_pci_devices(GPU_FLAGS, vendor_id)
+    for gpu in gpus:
+        m = GPU_INFO_PATTERN.match(gpu)
+        if m:
+            gpu_dict = m.groupdict()
+            # generate hostname for deployable_name usage
+            gpu_dict['hostname'] = CONF.host
+            # generate traits info
+            # TODO(yumeng) support and test VGPU rc generation soon.
+            traits = get_traits(gpu_dict["vendor_id"], gpu_dict["product_id"])
+            gpu_dict["rc"] = constants.RESOURCES["PGPU"]
+            gpu_dict.update(traits)
+            gpu_list.append(_generate_driver_device(gpu_dict))
+    return gpu_list
+
+
+def _generate_driver_device(gpu):
+    driver_device_obj = driver_device.DriverDevice()
+    driver_device_obj.vendor = gpu["vendor_id"]
+    driver_device_obj.model = gpu.get('model', 'miss model info')
+    std_board_info = {'product_id': gpu.get('product_id', None),
+                      'controller': gpu.get('controller', None)}
+    vendor_board_info = {'vendor_info': gpu.get('vendor_info', 'gpu_vb_info')}
+    driver_device_obj.std_board_info = jsonutils.dumps(std_board_info)
+    driver_device_obj.vendor_board_info = jsonutils.dumps(vendor_board_info)
+    driver_device_obj.type = constants.DEVICE_GPU
+    driver_device_obj.stub = gpu.get('stub', False)
+    driver_device_obj.controlpath_id = _generate_controlpath_id(gpu)
+    driver_device_obj.deployable_list = _generate_dep_list(gpu)
+    return driver_device_obj
+
+
+def _generate_controlpath_id(gpu):
+    driver_cpid = driver_controlpath_id.DriverControlPathID()
+    # NOTE: GPUs (either pGPU or vGPU), they all report "PCI" as
+    # their cpid_type, while attach_handle_type of them are different.
+    driver_cpid.cpid_type = "PCI"
+    driver_cpid.cpid_info = utils.pci_str_to_json(gpu["devices"])
+    return driver_cpid
+
+
+def _generate_dep_list(gpu):
+    dep_list = []
+    driver_dep = driver_deployable.DriverDeployable()
+    driver_dep.attribute_list = _generate_attribute_list(gpu)
+    driver_dep.attach_handle_list = []
+    # NOTE(wangzhh): The name of deployable should be unique, its format is
+    # under disscussion, may looks like
+    # <ComputeNodeName>_<NumaNodeName>_<CyborgName>_<NumInHost>
+    # NOTE(yumeng) Now simply named as <Compute_hostname>_<Device_address>
+    # once cyborg needs to support GPU devices discovered from a baremetal
+    # node, we might need to support more formats.
+    driver_dep.name = gpu.get('hostname', '') + '_' + gpu["devices"]
+    driver_dep.driver_name = VENDOR_MAPS.get(gpu["vendor_id"]).upper()
+    # driver_dep.num_accelerators for PGPU is 1, for VGPU should be the
+    # sriov_numvfs of the vGPU device.
+    # TODO(yumeng) support VGPU num report soon
+    driver_dep.num_accelerators = 1
+    driver_dep.attach_handle_list = \
+        [_generate_attach_handle(gpu)]
+    dep_list.append(driver_dep)
+    return dep_list
+
+
+def _generate_attach_handle(gpu):
+    driver_ah = driver_attach_handle.DriverAttachHandle()
+    if gpu["rc"] == "PGPU":
+        driver_ah.attach_type = constants.AH_TYPE_PCI
+    else:
+        driver_ah.attach_type = constants.AH_TYPE_MDEV
+    driver_ah.in_use = False
+    driver_ah.attach_info = utils.pci_str_to_json(gpu["devices"])
+    return driver_ah
+
+
+def _generate_attribute_list(gpu):
+    attr_list = []
+    for k, v in gpu.items():
+        if k == "rc":
+            driver_attr = driver_attribute.DriverAttribute()
+            driver_attr.key, driver_attr.value = k, v
+            attr_list.append(driver_attr)
+        if k == "traits":
+            values = gpu.get(k, [])
+            for index, val in enumerate(values):
+                driver_attr = driver_attribute.DriverAttribute(
+                    key="trait" + str(index), value=val)
+                attr_list.append(driver_attr)
+    return attr_list

--- a/core/sdk_sh/modules/sdk_hwdetect.sh
+++ b/core/sdk_sh/modules/sdk_hwdetect.sh
@@ -26,11 +26,11 @@ hwdetect_cluster_ready()
         Quiet -n $OPENSTACK flavor create --vcpus 4 --ram 16384 --disk 160 --property hw:cpu_sockets=1 --property hw:cpu_cores=2 --property hw:cpu_threads=2 --public t2.xlarge
         Quiet -n $OPENSTACK flavor create --vcpus 8 --ram 32768 --disk 160 --property hw:cpu_sockets=2 --property hw:cpu_cores=2 --property hw:cpu_threads=2 --public t2.2xlarge
 
-        Quiet -n $OPENSTACK flavor create --vcpus 2 --ram 4096 --disk 40 --public vgpu.example
-        Quiet -n $OPENSTACK flavor set vgpu.example --property "resources:VGPU=1"
-
-        Quiet -n $OPENSTACK flavor create --vcpus 2 --ram 4096 --disk 40 --public pgpu.example
-        Quiet -n $OPENSTACK flavor set pgpu.example --property 'accel:device_profile=<profile_name>'
+        # No GPU example flavors here. Neither property can hold a valid value at
+        # set_ready time: a PCI alias name is minted by gpu_resource_set when a card is
+        # carved (and encodes the chosen profile), and a cyborg device profile is created
+        # by the operator afterwards. Anything written here is wrong or an unfillable
+        # placeholder - see the carving procedure for the working flavor forms.
     fi
 
     if [ -n "$iprange" ] ; then


### PR DESCRIPTION
Two independent fixes for the same underlying problem: CubeCOS advertising GPU
resources it cannot actually deliver. Both were found while verifying #828.

## fix(cyborg): report only cards hex assigned to passthrough — #1262

`discover_gpus()` labelled every NVIDIA function `lspci` reports as a GPU with
`rc=PGPU`, unconditionally. SR-IOV vGPU VFs report as `3D controller` exactly
like the card itself, so each of them was advertised as a whole card; and a
card already carved into `sriovVgpu` / `migBackedVgpu` stayed advertised as
available for passthrough. Either one lets the scheduler place a
`resources:PGPU=1` request onto a device another VM already holds — placement
accepts it, libvirt then refuses with
`PCI device <addr> is in use by driver QEMU`.

The filter uses two facts the product already owns, so no new state is
introduced: a VF carries a `physfn` link in sysfs, and
`/etc/cube/cos/gpu/config.json` records the type hex assigned to each card.
That file is root-owned `0600` and the agent runs as `cyborg`, so it is read
through the same privsep entrypoint `lspci` already uses — **no new
privilege**. If it cannot be read, the driver reports nothing rather than
falling back to the old behaviour: under-reporting fails scheduling cleanly,
over-reporting hands out a device that is in use.

## fix(gpu): stop creating example flavors that can never boot — #1264

`vgpu.example` asked for `resources:VGPU=1` — Nova's mediated-device
mechanism. CubeCOS hands whole VFs to Nova through a PCI alias and never
registers `VGPU` inventory, so that flavor could not be scheduled anywhere.
`pgpu.example` carried the literal string `<profile_name>`.

Neither could be made correct where they were created: a PCI alias name is
minted by `gpu_resource_set` when a card is carved, and a cyborg device
profile is created by the operator afterwards — at `set_ready` neither exists.
A comment now records why, so they do not come back.

## Verification

Deployed to **cn13** (all-in-one, 4× RTX PRO 6000 Blackwell — one `pgpu`, one
`sriovVgpu`, two `migBackedVgpu`) and exercised against the live cluster.

`#1262`, before and after restarting `cyborg-agent`:

| | resource providers named `cn13_*` |
|---|---|
| before | **148** offering `PGPU`, one of which could serve it |
| after | **1** |

The three carved cards and every VF were withdrawn, **placement reconciled the
stale providers away on its own**, the surviving provider kept its inventory
(`PGPU total=1`) and its traits, and the two running vGPU VMs kept their VFs
attached (`0x42:00.2`, `0x8c:00.2`). No traceback in `cyborg-agent`; all six
VMs stayed `ACTIVE`.

`#1264` is only reachable at `cluster set_ready`, which has already run on
every existing cluster, so it **cannot be exercised end to end on cn13**. What
was checked: `bash -n` clean on the node, `hex_sdk` still loads the module,
`hwdetect_cluster_ready` still parses, and no `*.example` creation path
remains in the deployed file.

## Notes for the reviewer

- **Existing clusters keep the two example flavors.** Removing them was left
  out deliberately — deleting flavors is destructive and belongs in an upgrade
  step, not here.
- The cyborg change ships as a `yoga_patch` file with its `.orig` alongside,
  matching the existing `api/controllers/v2/arqs.py` convention.
- Upstream carries a `TODO(yumeng) support and test VGPU rc generation soon`
  at the same spot, so this is a gap upstream knows about rather than a
  behaviour anyone depends on.
- The third issue found in the same pass, #1263 (`supportTypes` goes stale
  under vfio-pci), is **not** in this PR — it is #1282, which can be reviewed
  and merged independently of this one; the two touch different files.

Fixes #1264
Refs #1262

**#1262 is deliberately left open.** This PR implements the first half of its
suggested fix — the wrong inventory. The second half, reconciling a stale
`Bound` ARQ after a host reboot (a pgpu VM comes back with no device attached
while cyborg and placement still show it allocated), is untouched and needs
its own change.

