### PR TITLE
fix(gpu): stop creating example flavors that can never boot

### DIFF
--- a/core/sdk_sh/modules/sdk_hwdetect.sh
+++ b/core/sdk_sh/modules/sdk_hwdetect.sh
@@ -26,11 +26,11 @@ hwdetect_cluster_ready()
         Quiet -n $OPENSTACK flavor create --vcpus 4 --ram 16384 --disk 160 --property hw:cpu_sockets=1 --property hw:cpu_cores=2 --property hw:cpu_threads=2 --public t2.xlarge
         Quiet -n $OPENSTACK flavor create --vcpus 8 --ram 32768 --disk 160 --property hw:cpu_sockets=2 --property hw:cpu_cores=2 --property hw:cpu_threads=2 --public t2.2xlarge
 
-        Quiet -n $OPENSTACK flavor create --vcpus 2 --ram 4096 --disk 40 --public vgpu.example
-        Quiet -n $OPENSTACK flavor set vgpu.example --property "resources:VGPU=1"
-
-        Quiet -n $OPENSTACK flavor create --vcpus 2 --ram 4096 --disk 40 --public pgpu.example
-        Quiet -n $OPENSTACK flavor set pgpu.example --property 'accel:device_profile=<profile_name>'
+        # No GPU example flavors here. Neither property can hold a valid value at
+        # set_ready time: a PCI alias name is minted by gpu_resource_set when a card is
+        # carved (and encodes the chosen profile), and a cyborg device profile is created
+        # by the operator afterwards. Anything written here is wrong or an unfillable
+        # placeholder - see the carving procedure for the working flavor forms.
     fi
 
     if [ -n "$iprange" ] ; then


### PR DESCRIPTION
Split out of #1280, which was deferred until after #1266. This change has no cyborg
or OpenStack-release dependency, so it does not need to wait.

`hwdetect_cluster_ready` created two example flavors alongside the `t2.*` set:

```bash
flavor set vgpu.example --property "resources:VGPU=1"
flavor set pgpu.example --property 'accel:device_profile=<profile_name>'
```

Neither can boot a VM. `resources:VGPU` is Nova's mediated-device mechanism; CubeCOS
hands whole SR-IOV VFs to Nova through a PCI alias and never registers `VGPU`
inventory, so nothing on any resource provider can satisfy that request — checked
across every provider on a live cluster. `pgpu.example` carries the literal string
`<profile_name>`, angle brackets included.

An example needing values filled in would be fine. The problem is that `vgpu.example`
demonstrates **the wrong mechanism**: copying it yields `NoValidHost`, which sends the
reader to the scheduler, host aggregates or quota — none of which is where the problem
is.

They also cannot be made correct where they are created. A PCI alias name is minted by
`gpu_resource_set` when a card is carved and encodes the chosen profile
(`nvidia_rtx_pro_6000_blackwell_dc_12q_1528`); a cyborg device profile is created by
the operator afterwards. At `set_ready` neither exists, so any value written there is
either wrong or an unfillable placeholder. A comment now records that, so the examples
do not come back.

The example predates the implementation it appears to describe: `vgpu.example` arrived
in `b48c12fa` (2025-03-15), the commit that created `sdk_hwdetect.sh`, while the GPU
resource-type work first appears in 2026-06.

## Verification

`bash -n` clean locally and on the node; deployed to cn13, where `hex_sdk` still loads
the module, `hwdetect_cluster_ready` still parses, and no `*.example` creation path
remains in the deployed file.

The flavor block only runs at `cluster set_ready` and only when `t2.medium` is absent,
so on an already-provisioned cluster there is **no way to exercise it end to end** —
that is the limit of what was tested here.

## Note

**Existing clusters keep the two flavors.** Removing them was left out deliberately:
deleting flavors is destructive and belongs in an upgrade step, not here.

Fixes #1264
