### PR TITLE
fix(grafana): keep a VM's vGPU history in one series across host reboots

### DIFF
--- a/core/grafana/provisioning/dashboards/instance.json
+++ b/core/grafana/provisioning/dashboards/instance.json
@@ -1597,19 +1597,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "[[tag_name]] {[[tag_gid]]}",
+              "alias": "[[tag_name]]",
               "groupBy": [
                 {
                   "params": [
                     "$__interval"
                   ],
                   "type": "time"
-                },
-                {
-                  "params": [
-                    "gid"
-                  ],
-                  "type": "tag"
                 },
                 {
                   "params": [
@@ -1742,19 +1736,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "[[tag_name]] {[[tag_gid]]}: Total",
+              "alias": "[[tag_name]]: Total",
               "groupBy": [
                 {
                   "params": [
                     "$__interval"
                   ],
                   "type": "time"
-                },
-                {
-                  "params": [
-                    "gid"
-                  ],
-                  "type": "tag"
                 },
                 {
                   "params": [
@@ -1798,19 +1786,13 @@
               ]
             },
             {
-              "alias": "[[tag_name]] {[[tag_gid]]}: Used",
+              "alias": "[[tag_name]]: Used",
               "groupBy": [
                 {
                   "params": [
                     "$__interval"
                   ],
                   "type": "time"
-                },
-                {
-                  "params": [
-                    "gid"
-                  ],
-                  "type": "tag"
                 },
                 {
                   "params": [
@@ -1945,19 +1927,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "[[tag_name]] {[[tag_gid]]}",
+              "alias": "[[tag_name]]",
               "groupBy": [
                 {
                   "params": [
                     "$__interval"
                   ],
                   "type": "time"
-                },
-                {
-                  "params": [
-                    "gid"
-                  ],
-                  "type": "tag"
                 },
                 {
                   "params": [
@@ -2090,19 +2066,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "[[tag_name]] {[[tag_gid]]}",
+              "alias": "[[tag_name]]",
               "groupBy": [
                 {
                   "params": [
                     "$__interval"
                   ],
                   "type": "time"
-                },
-                {
-                  "params": [
-                    "gid"
-                  ],
-                  "type": "tag"
                 },
                 {
                   "params": [


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The instance dashboard's vGPU panels grouped by `gid`, the vGPU ID that the vGPU
manager assigns per instantiation. It changes whenever the host reboots, so a VM
that was never touched still gets a new one: measured on cn13, a VM created on
08-12 and never rebooted (`created`/`updated`/`launched_at` all identical,
`power_state: 1`) switched from `3251669307` to `3251634296` after the node came
back up on 08-14 17:41. Grouping by it breaks the line at every reboot and
duplicates the legend, for a VM whose identity never changed.

Group by the vGPU name instead — the profile in effect. Verified in InfluxDB: with
`GROUP BY "name"` the two segments collapse into one series (1454 points over 7
days) against 569 + 818 in two series when grouped by gid; and visually, the
Total line now runs unbroken across the 08-14 reboot with a single legend entry
per metric.

#### Which issue(s) this PR fixes

Part of #826.

#### Special notes for your reviewer

> This assumes **one vGPU per VM**, which is what the product supports today. Two
> vGPUs of the same profile on one VM would land in the same series and be averaged
> by `mean()`. Distinguishing them again would need a per-vGPU identity that
> survives a reboot, and nvidia-smi does not currently offer one (`vGPU UUID` and
> `Placement ID` are both re-generated per instantiation).

> Panel ids **36/37** in this row are now pinned by cube-cos-api's deep links
> (bigstack-oss/cube-cos-api#635), same cross-team contract as the device
> dashboard's 50/51 — please do not renumber or reorder that row.

> Verified by hot-patching `/etc/grafana/provisioning/dashboards/instance.json` on
> cn13 plus a grafana restart; no ISO build was needed for the behaviour. If
> "shipped in the image" evidence is wanted, note that this file is copied by a
> `rootfs_install::` recipe (`core/grafana/grafana.mk:7,13`), so make will not
> rebuild the rootfs just because a copied file changed — that run has to be
> `distclean iso`, and the result verified by content rather than by a green build.

> One pre-existing wart noticed while verifying, out of scope here: the Used
> series uses `fill(0)`, so a telegraf/Kafka outage renders as "0 MB used" instead
> of a gap.

#### Additional documentation

```docs

```
