### PR TITLE
feat(advisor): verify the agent artifact, and the operator commands that use it

### DIFF
--- a/core/advisor/README.md
+++ b/core/advisor/README.md
@@ -1,0 +1,75 @@
+# Advisor release public key
+
+The trust anchor for the Cube AI Advisor agent is compiled into `hex_config`
+at build time (see `advisor_key.h` in `core/modules/Makefile`) and used to
+verify the signature over an agent release manifest before anything from that
+release is installed or executed.
+
+## Where the key comes from
+
+The build environment provides it at `/etc/ssl/advisor-release.pub.pem`
+(override with `ADVISOR_PUB_PEM=`) — the same provisioning model as the
+licence key at `/etc/ssl/public.pem` (`hex/src/hex_sdk_library/license/`):
+
+- **Production** injects the real public key at that path before the build.
+  The private half lives in the `cube-ai-advisor` release CI (ADR 0003) and
+  never appears on a build machine.
+- **A build without an injected key** — any dev build — mints a throwaway
+  keypair on the spot, leaving the private half beside the public one. That
+  makes the whole signing chain testable end to end: sign a manifest with the
+  private half, watch `advisor_verify_release` accept it, and watch it refuse
+  everyone else's.
+
+A dev image therefore trusts only its own throwaway key. That is a feature,
+not a gap: an image built outside the production pipeline cannot verify — and
+so will not install — anything the real release pipeline signs, and vice
+versa. Which key any given image trusts is auditable on the image itself:
+
+```sh
+hex_config advisor_pubkey
+```
+
+## Why it is not read from disk at runtime
+
+A key file on a node can be replaced by any root process, which would defeat
+verification silently — the check would still report success, against the
+attacker's key. Compiled in, an attacker must replace `hex_config` itself.
+
+## Why the check is compiled in too
+
+`hex_config advisor_verify_release` does the whole check — signature, then
+digests — rather than handing the key to a shell script. Key and check belong
+together: `/usr/lib/hex_sdk/modules/sdk_advisor.sh` is an ordinary file that
+root can edit, so a shell verifier could have its check deleted while this key
+stayed perfectly safe. That protects the wrong half. It is the same reasoning,
+and the same mechanism, as licence verification in
+`hex/src/hex_sdk_library/license/`.
+
+Verifying our releases without trusting our binary stays possible, because the
+manifest is in `sha256sum`'s own format and `advisor_pubkey` will print the
+anchor:
+
+```sh
+hex_config advisor_pubkey > release.pub
+openssl dgst -sha256 -verify release.pub -signature manifest.txt.sig manifest.txt
+sha256sum -c manifest.txt
+```
+
+That independent path is a property of the published format, not of what our
+verifier happens to be written in.
+
+## Why it is not the licence key
+
+The licence keypair (`hex/make/devtools_definitions.mk`) belongs to whoever
+issues licences; this one belongs to the release pipeline that signs agent
+artifacts. Sharing them would mean a compromise of either could mint the other:
+a licence-signing key that can also sign binaries a node will execute, or the
+reverse. Same provisioning model, separate keys.
+
+## Rotation
+
+Rotating means injecting the new public key into the production build and
+rebuilding the image; nodes running an older image continue to trust the older
+key, so the release pipeline must keep signing with both until those nodes are
+updated. Image-baked keys make rotation a release, so treat the key as
+long-lived and protect the private half accordingly.

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -223,6 +223,7 @@ hex_cli_MODULES += cli_autoscaler.o
 hex_cli_MODULES += cli_app.o
 hex_cli_MODULES += cli_k3s.o
 hex_cli_MODULES += cli_agent.o
+hex_cli_MODULES += cli_advisor.o
 
 hex_cli_LIBS += $(PROJ_LIBDIR)/libcube_sdk.a
 

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -180,6 +180,7 @@ hex_config_MODULES += config_kafka.o
 hex_config_MODULES += config_prometheus.o
 hex_config_MODULES += config_gpu.o
 hex_config_MODULES += config_lachesis.o
+hex_config_MODULES += config_advisor.o
 
 PROGRAMS += hex_config
 

--- a/core/modules/Makefile
+++ b/core/modules/Makefile
@@ -9,6 +9,36 @@ LIB_SRCS := $(filter-out $(EXCLUDE_SRCS), $(shell cd $(SRCDIR) && ls *.c *.cpp 2
 
 SUBDIRS := tests
 
+# The Advisor release public key is compiled in rather than read from disk: a
+# key file on a node can be replaced by any root process, which would defeat
+# verification silently. Same mechanism as hex's license_key.h.
+#
+# Provisioned like the licence key too: the production build injects the real
+# public key at this path (the private half never leaves the release CI); a
+# build without one mints a throwaway dev keypair so the signing chain can be
+# exercised end to end.
+ADVISOR_PUB_PEM ?= /etc/ssl/advisor-release.pub.pem
+ADVISOR_PRIV_PEM ?= /etc/ssl/advisor-release.priv.pem
+
+# Fires only when no key was injected. Must not depend on the private half:
+# a production build carries only the public key, and a rule keyed on the
+# private file would mint a fresh pair over the real anchor.
+$(ADVISOR_PUB_PEM):
+	$(Q)openssl ecparam -name prime256v1 -genkey -noout -out $(ADVISOR_PRIV_PEM)
+	$(Q)chmod 600 $(ADVISOR_PRIV_PEM)
+	$(Q)openssl ec -in $(ADVISOR_PRIV_PEM) -pubout -out $@ 2>/dev/null
+
+advisor_key.h: $(ADVISOR_PUB_PEM)
+	$(Q)echo "#define ADVISOR_RELEASE_PUBLIC_KEY \"$(shell cat $< | awk '{printf "%s\\n", $$0}')\"" > $@
+
+BUILD += advisor_key.h
+
+# BUILD names the header and the objects side by side, which under -j leaves
+# their order to chance. config_advisor.cpp includes the header, so say so.
+config_advisor.o: advisor_key.h
+
+CLEAN += advisor_key.h
+
 # needed for mysql operations
 CPPFLAGS += \
 	-I$(TOP_SRCDIR)/hex/src/modules/ \

--- a/core/modules/cli_advisor.cpp
+++ b/core/modules/cli_advisor.cpp
@@ -1,0 +1,138 @@
+// CUBE SDK
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <hex/process.h>
+#include <hex/log.h>
+#include <hex/strict.h>
+
+#include <hex/cli_module.h>
+#include <hex/cli_util.h>
+
+// Operator commands for the Cube AI Advisor agent.
+//
+// A separate mode from "agent", which belongs to the zero-touch install agent
+// (phone-home-agent). Two different agents with two different lifetimes: one
+// runs during installation, this one is a day-2 daemon a customer enrols
+// deliberately.
+//
+// The work lives in hex_sdk (advisor_enroll, advisor_verify_release); this is
+// the thin operator-facing layer, as elsewhere in the CLI.
+
+static const char* ADVISOR_AGENT = "/usr/local/bin/cube-advisor-agent";
+
+// Writes the pairing token to a file only its owner can read, and returns the
+// path.
+//
+// The token is deliberately never an argv element. A token passed as an
+// argument appears in `ps` for every user on the box and in the CLI's own
+// history, and enrolment is precisely when a working credential exists to leak.
+// It lives on tmpfs and is removed as soon as enrolment returns.
+static bool
+WriteTokenFile(const std::string& token, std::string* path)
+{
+    char tmpl[] = "/run/advisor-token.XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd < 0) {
+        CliPrintf("Could not create a temporary file for the pairing token.");
+        return false;
+    }
+    if (fchmod(fd, 0600) != 0) {
+        close(fd);
+        unlink(tmpl);
+        return false;
+    }
+    ssize_t n = write(fd, token.c_str(), token.size());
+    close(fd);
+    if (n != (ssize_t)token.size()) {
+        unlink(tmpl);
+        return false;
+    }
+    *path = tmpl;
+    return true;
+}
+
+static int
+EnrollMain(int argc, const char** argv)
+{
+    if (argc > 3 /* [0]="enroll" [1]=server [2]=version */)
+        return CLI_INVALID_ARGS;
+
+    std::string server, version, token;
+
+    if (!CliReadInputStr(argc, argv, 1, "Advisor service URL: ", &server) || server.length() <= 0)
+        return CLI_INVALID_ARGS;
+    if (!CliReadInputStr(argc, argv, 2, "Agent version to install: ", &version) || version.length() <= 0)
+        return CLI_INVALID_ARGS;
+
+    // Prompted, never taken from argv -- see WriteTokenFile.
+    if (!CliReadLine("Pairing token: ", token) || token.length() <= 0) {
+        CliPrintf("A pairing token is required. Ask your Advisor administrator to issue one.");
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string tokenPath;
+    if (!WriteTokenFile(token, &tokenPath))
+        return CLI_UNEXPECTED_ERROR;
+
+    int rc = HexSpawn(0, HEX_SDK, "advisor_enroll",
+                      server.c_str(), tokenPath.c_str(), version.c_str(), NULL);
+
+    // Removed whatever happened. A pairing token left on disk after a failed
+    // enrolment is a credential nobody is watching.
+    unlink(tokenPath.c_str());
+
+    if (rc != 0) {
+        CliPrintf("Enrolment did not complete. Nothing was changed on this node.");
+        return CLI_FAILURE;
+    }
+    return CLI_SUCCESS;
+}
+
+static int
+StatusMain(int argc, const char** argv)
+{
+    if (argc > 1)
+        return CLI_INVALID_ARGS;
+
+    if (access(ADVISOR_AGENT, X_OK) != 0) {
+        CliPrintf("The Advisor agent is not installed on this node.");
+        return CLI_SUCCESS;
+    }
+    HexSpawn(0, (char*)ADVISOR_AGENT, "status", NULL);
+    return CLI_SUCCESS;
+}
+
+// Verifying a downloaded release without installing it. Useful for the offline
+// path, where an operator brings a release in on media and wants to know it is
+// genuine before doing anything with it.
+static int
+VerifyMain(int argc, const char** argv)
+{
+    if (argc != 2 /* [0]="verify" [1]=directory */)
+        return CLI_INVALID_ARGS;
+
+    if (HexSpawn(0, HEX_SDK, "advisor_verify_release", argv[1], NULL) != 0) {
+        CliPrintf("The release in %s did not verify. Do not install it.", argv[1]);
+        return CLI_FAILURE;
+    }
+    CliPrintf("The release in %s is signed by Bigstack and its artifacts match.", argv[1]);
+    return CLI_SUCCESS;
+}
+
+CLI_MODE(CLI_TOP_MODE, "advisor",
+         "Work with the Cube AI Advisor agent.",
+         !HexStrictIsErrorState());
+
+CLI_MODE_COMMAND("advisor", "enroll", EnrollMain, NULL,
+    "Install and enrol the Advisor agent on this node.",
+    "enroll [<service-url> [<version>]]");
+
+CLI_MODE_COMMAND("advisor", "status", StatusMain, NULL,
+    "Show whether this node is enrolled with the Advisor, and as which cluster.",
+    "status");
+
+CLI_MODE_COMMAND("advisor", "verify", VerifyMain, NULL,
+    "Verify a downloaded Advisor release without installing it.",
+    "verify <directory>");

--- a/core/modules/config_advisor.cpp
+++ b/core/modules/config_advisor.cpp
@@ -1,0 +1,431 @@
+// CUBE SDK
+
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/bio.h>
+#include <openssl/sha.h>
+
+#include <hex/log.h>
+#include <hex/config_module.h>
+
+#include "advisor_key.h"
+
+// Verification of Cube AI Advisor agent releases.
+//
+// The agent is released by Bigstack as signed per-arch artifacts and must be
+// verified before a node executes one. Two decisions from ADR 0003 shape what
+// is here:
+//
+//   * This lives in cubecos, not in the agent's own repository. A verifier must
+//     not share a build pipeline with the artifact it verifies, or one
+//     compromised pipeline produces both.
+//   * The trust anchor belongs to the OS, and is compiled in rather than read
+//     from a file -- the same mechanism hex uses for the licence key. A key
+//     file on a node can be replaced by any root process, and the failure would
+//     be silent: verification would still report success, against the
+//     attacker's key. Compiled in, an attacker has to replace hex_config, which
+//     is part of the signed OS image.
+//
+// Verification is here rather than in shell for the same reason it is done this
+// way for licences: key and check belong in one place. A shell verifier reads a
+// key the image protects, but lives in a file under /usr/lib/hex_sdk that root
+// can edit -- so the check could be removed while the key stayed safe.
+//
+// advisor_pubkey still prints the key, deliberately. The manifest format is
+// sha256sum's own, so a customer who does not want to trust this binary can
+// extract the key and run the two standard commands themselves:
+//
+//     hex_config advisor_pubkey > release.pub
+//     openssl dgst -sha256 -verify release.pub -signature manifest.txt.sig manifest.txt
+//     sha256sum -c manifest.txt
+//
+// That independent path is a property of the published format, not of what this
+// verifier is written in, and it is worth keeping either way.
+
+static const char MANIFEST_NAME[]  = "manifest.txt";
+static const char SIGNATURE_NAME[] = "manifest.txt.sig";
+
+// Bounds, so a hostile file cannot be read into memory unbounded. Both are far
+// above any real release: a manifest is a few lines per architecture.
+static const size_t MAX_MANIFEST_SIZE  = 1024 * 1024;
+static const size_t MAX_SIGNATURE_SIZE = 16 * 1024;
+
+// Opens name inside dirFd for reading.
+//
+// openat rather than building a path, and O_NOFOLLOW rather than trusting the
+// name: a release directory entry that is a symlink would otherwise be read
+// through, and every check below would then describe a file somewhere else
+// entirely. The name is already constrained to a bare file name; this makes
+// escaping it impossible rather than merely rejected.
+static FILE *
+OpenAt(int dirFd, const std::string& name)
+{
+    int fd = openat(dirFd, name.c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0)
+        return NULL;
+    FILE *fp = fdopen(fd, "rb");
+    if (!fp)
+        close(fd);
+    return fp;
+}
+
+// Reads name (relative to dirFd) into out, refusing anything larger than maxSize.
+static bool
+ReadFileAt(int dirFd, const std::string& name, size_t maxSize, std::string *out)
+{
+    FILE *fp = OpenAt(dirFd, name);
+    if (!fp) {
+        fprintf(stderr, "Error: cannot read %s\n", name.c_str());
+        return false;
+    }
+
+    // fstat on the descriptor we are about to read, not stat on a name that
+    // could refer to something else by the time we open it.
+    struct stat st;
+    if (fstat(fileno(fp), &st) != 0 || !S_ISREG(st.st_mode)) {
+        fclose(fp);
+        fprintf(stderr, "Error: %s is not a regular file\n", name.c_str());
+        return false;
+    }
+
+    out->clear();
+    char buf[65536];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), fp)) > 0) {
+        if (out->size() + n > maxSize) {
+            fclose(fp);
+            fprintf(stderr, "Error: %s is larger than the %zu byte limit\n",
+                    name.c_str(), maxSize);
+            return false;
+        }
+        out->append(buf, n);
+    }
+    bool ok = (ferror(fp) == 0);
+    fclose(fp);
+    if (!ok)
+        fprintf(stderr, "Error: read failed on %s\n", name.c_str());
+    return ok;
+}
+
+// Verifies sig over data using the compiled-in release public key.
+//
+// The key is parsed from the embedded PEM on every call rather than cached: it
+// is a handful of microseconds, and a cached EVP_PKEY is one more piece of
+// mutable process state for something whose whole job is to be immutable.
+static bool
+VerifySignature(const std::string& data, const std::string& sig)
+{
+    BIO *bio = BIO_new_mem_buf((void *)ADVISOR_RELEASE_PUBLIC_KEY, -1);
+    if (!bio) {
+        HexLogError("advisor: cannot allocate key BIO");
+        return false;
+    }
+    EVP_PKEY *pkey = PEM_read_bio_PUBKEY(bio, NULL, NULL, NULL);
+    BIO_free(bio);
+    if (!pkey) {
+        // A build problem, not an input problem: the embedded key is a constant.
+        HexLogError("advisor: embedded release public key is unusable");
+        fprintf(stderr, "Error: embedded release public key is unusable\n");
+        return false;
+    }
+
+    bool ok = false;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (ctx) {
+        if (EVP_DigestVerifyInit(ctx, NULL, EVP_sha256(), NULL, pkey) == 1 &&
+            EVP_DigestVerifyUpdate(ctx, data.data(), data.size()) == 1 &&
+            EVP_DigestVerifyFinal(ctx, (const unsigned char *)sig.data(), sig.size()) == 1) {
+            ok = true;
+        }
+        EVP_MD_CTX_free(ctx);
+    }
+    EVP_PKEY_free(pkey);
+    return ok;
+}
+
+// Hex-encoded SHA-256 of a file, streamed so artifact size does not bound memory.
+static bool
+FileDigestAt(int dirFd, const std::string& name, std::string *hexOut)
+{
+    // Whether an absent file is an error depends on what the caller asked, so
+    // the caller reports it -- an install fetches one architecture and leaves
+    // its siblings legitimately missing.
+    FILE *fp = OpenAt(dirFd, name);
+    if (!fp)
+        return false;
+
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        fclose(fp);
+        return false;
+    }
+
+    bool ok = (EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) == 1);
+    unsigned char buf[65536];
+    size_t n;
+    while (ok && (n = fread(buf, 1, sizeof(buf), fp)) > 0)
+        ok = (EVP_DigestUpdate(ctx, buf, n) == 1);
+    if (ferror(fp))
+        ok = false;
+    fclose(fp);
+
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int mdLen = 0;
+    if (ok)
+        ok = (EVP_DigestFinal_ex(ctx, md, &mdLen) == 1);
+    EVP_MD_CTX_free(ctx);
+    if (!ok)
+        return false;
+
+    static const char HEXDIGITS[] = "0123456789abcdef";
+    hexOut->clear();
+    for (unsigned int i = 0; i < mdLen; ++i) {
+        hexOut->push_back(HEXDIGITS[md[i] >> 4]);
+        hexOut->push_back(HEXDIGITS[md[i] & 0x0f]);
+    }
+    return true;
+}
+
+static bool
+IsLowerHex(const std::string& s)
+{
+    for (size_t i = 0; i < s.size(); ++i) {
+        char c = s[i];
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+            return false;
+    }
+    return true;
+}
+
+// An artifact name is a bare file name in the release directory and nothing
+// else. Rejecting separators and dot entries here is what stops a signed
+// manifest -- or a manifest an attacker hopes we check before the signature --
+// from naming a path outside the directory being verified.
+static bool
+IsSafeArtifactName(const std::string& name)
+{
+    if (name.empty() || name == "." || name == "..")
+        return false;
+    if (name.find('/') != std::string::npos || name.find('\\') != std::string::npos)
+        return false;
+    if (name[0] == '-')
+        return false;
+    for (size_t i = 0; i < name.size(); ++i) {
+        unsigned char c = (unsigned char)name[i];
+        if (c < 0x21 || c > 0x7e)
+            return false;
+    }
+    return true;
+}
+
+struct Entry {
+    std::string digest;
+    std::string name;
+};
+
+// Parses the manifest.
+//
+// The format is fixed by pkg/release.Render in the agent repository: comment
+// lines carrying metadata, then "<64 lowercase hex>  <name>" per artifact. It is
+// parsed strictly. Our own tooling is the only thing that produces a manifest,
+// so anything that does not match exactly is not a manifest we should act on.
+static bool
+ParseManifest(const std::string& text, std::vector<Entry> *out)
+{
+    size_t pos = 0;
+    while (pos <= text.size()) {
+        size_t eol = text.find('\n', pos);
+        std::string line = (eol == std::string::npos)
+            ? text.substr(pos) : text.substr(pos, eol - pos);
+        pos = (eol == std::string::npos) ? text.size() + 1 : eol + 1;
+
+        if (!line.empty() && line[line.size() - 1] == '\r')
+            line.erase(line.size() - 1);
+        if (line.empty() || line[0] == '#')
+            continue;
+
+        if (line.size() < 67 || line.compare(64, 2, "  ") != 0) {
+            fprintf(stderr, "Error: unparseable manifest line: %s\n", line.c_str());
+            return false;
+        }
+        Entry e;
+        e.digest = line.substr(0, 64);
+        e.name = line.substr(66);
+        if (!IsLowerHex(e.digest)) {
+            fprintf(stderr, "Error: manifest line does not begin with a sha256 digest: %s\n",
+                    line.c_str());
+            return false;
+        }
+        if (!IsSafeArtifactName(e.name)) {
+            fprintf(stderr, "Error: manifest names an unacceptable artifact: %s\n", e.name.c_str());
+            return false;
+        }
+        out->push_back(e);
+    }
+
+    if (out->empty()) {
+        fprintf(stderr, "Error: manifest lists no artifacts\n");
+        return false;
+    }
+    return true;
+}
+
+// VerifyRelease checks the release in dir, and -- when requiredArtifact is not
+// empty -- that the manifest lists that artifact.
+//
+// Order is load-bearing. The signature is checked FIRST, because the digest
+// list is only worth applying once we know Bigstack wrote it. Checking digests
+// first would mean deciding a file is "the right file" according to a list an
+// attacker may have supplied; the list is the thing being attacked.
+static bool
+VerifyRelease(const std::string& dir, const std::string& requiredArtifact)
+{
+    // Caller-supplied, and hex_config opens it as root (config_main.cpp
+    // setuid(0)): require an absolute path with no "..".
+    if (dir.empty() || dir[0] != '/' || dir.size() >= PATH_MAX ||
+        strstr(dir.c_str(), "..") != NULL) {
+        fprintf(stderr, "Error: release directory must be an absolute path "
+                        "without \"..\"\n");
+        return false;
+    }
+
+    // Everything below is read relative to this descriptor, so no artifact name
+    // is ever concatenated into a path.
+    int dirFd = open(dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (dirFd < 0) {
+        fprintf(stderr, "Error: cannot open release directory %s\n", dir.c_str());
+        return false;
+    }
+
+    std::string manifest, signature;
+    if (!ReadFileAt(dirFd, MANIFEST_NAME, MAX_MANIFEST_SIZE, &manifest) ||
+        !ReadFileAt(dirFd, SIGNATURE_NAME, MAX_SIGNATURE_SIZE, &signature)) {
+        close(dirFd);
+        return false;
+    }
+
+    // 1. Is this manifest Bigstack's?
+    if (!VerifySignature(manifest, signature)) {
+        HexLogError("advisor: release manifest signature does not verify in %s", dir.c_str());
+        fprintf(stderr, "Error: release manifest signature does not verify against the "
+                        "release key in this image\n");
+        close(dirFd);
+        return false;
+    }
+
+    std::vector<Entry> entries;
+    if (!ParseManifest(manifest, &entries)) {
+        HexLogError("advisor: signed manifest in %s did not parse", dir.c_str());
+        close(dirFd);
+        return false;
+    }
+
+    // 2. Are the artifacts the ones it describes?
+    //
+    // A release is signed for every architecture at once, but an install fetches
+    // only the one this node runs, so naming an artifact means "is this one
+    // genuine" and the siblings are legitimately absent. Naming none means "is
+    // this whole release intact" -- offline media, an audit -- and then every
+    // entry must be there. The required artifact is tracked rather than merely
+    // looked up: it is the file about to be executed, so being listed is not
+    // enough, it has to have been digested here.
+    bool requiredDigested = false;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        std::string actual;
+        if (!FileDigestAt(dirFd, entries[i].name, &actual)) {
+            if (!requiredArtifact.empty() && entries[i].name != requiredArtifact) {
+                continue;
+            }
+            HexLogError("advisor: cannot digest %s listed in the signed manifest",
+                        entries[i].name.c_str());
+            fprintf(stderr, "Error: cannot read %s, which the signed manifest lists\n",
+                    entries[i].name.c_str());
+            close(dirFd);
+            return false;
+        }
+        if (actual != entries[i].digest) {
+            HexLogError("advisor: %s does not match the signed manifest in %s",
+                        entries[i].name.c_str(), dir.c_str());
+            fprintf(stderr, "Error: %s does not match the signed manifest\n",
+                    entries[i].name.c_str());
+            close(dirFd);
+            return false;
+        }
+        if (entries[i].name == requiredArtifact) {
+            requiredDigested = true;
+        }
+    }
+
+    // 3. Is the artifact we were asked about one the manifest covers, and did we
+    //    just check it? A file that happens to sit in a verified directory is
+    //    not itself verified.
+    if (!requiredArtifact.empty() && !requiredDigested) {
+        fprintf(stderr, "Error: %s is not listed in the signed manifest\n",
+                requiredArtifact.c_str());
+        close(dirFd);
+        return false;
+    }
+
+    close(dirFd);
+    return true;
+}
+
+static void
+PubkeyUsage(void)
+{
+    fprintf(stderr, "Usage: %s advisor_pubkey\n", HexLogProgramName());
+}
+
+static int
+PubkeyMain(int argc, char **argv)
+{
+    if (argc != 1) {
+        PubkeyUsage();
+        return EXIT_FAILURE;
+    }
+
+    // stdout, so a caller can consume it through a pipe; nothing here writes a file.
+    fputs(ADVISOR_RELEASE_PUBLIC_KEY, stdout);
+    return EXIT_SUCCESS;
+}
+
+static void
+VerifyReleaseUsage(void)
+{
+    fprintf(stderr, "Usage: %s advisor_verify_release <dir> [artifact]\n", HexLogProgramName());
+}
+
+static int
+VerifyReleaseMain(int argc, char **argv)
+{
+    if (argc != 2 && argc != 3) {
+        VerifyReleaseUsage();
+        return EXIT_FAILURE;
+    }
+
+    const std::string dir = argv[1];
+    const std::string artifact = (argc == 3) ? argv[2] : "";
+
+    if (!artifact.empty() && !IsSafeArtifactName(artifact)) {
+        fprintf(stderr, "Error: %s is not an acceptable artifact name\n", artifact.c_str());
+        return EXIT_FAILURE;
+    }
+
+    return VerifyRelease(dir, artifact) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+CONFIG_MODULE(advisor, 0, 0, 0, 0, 0);
+
+CONFIG_COMMAND(advisor_pubkey, PubkeyMain, PubkeyUsage);
+CONFIG_COMMAND(advisor_verify_release, VerifyReleaseMain, VerifyReleaseUsage);

--- a/core/modules/tests/config_advisor/Makefile
+++ b/core/modules/tests/config_advisor/Makefile
@@ -1,0 +1,13 @@
+# HEX SDK
+
+include ../../../../build.mk
+
+hex_config_LIBS = $(PROJ_LIBDIR)/libcube_sdk.a
+
+TESTS_EXTRA_PROGRAMS = hex_config
+
+hex_config_MODULES = config_advisor.o
+
+CPPFLAGS += -I$(COREDIR)/modules -I$(TOP_SRCDIR)/hex/src/modules/include -I$(COREDIR)/cube_sdk_library/include
+
+include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/core/modules/tests/config_advisor/stub/driver.cpp
+++ b/core/modules/tests/config_advisor/stub/driver.cpp
@@ -1,0 +1,20 @@
+// Dispatches to the commands config_advisor.cpp registers, so the logic test
+// can drive them the same way an operator drives hex_config.
+#include <string.h>
+
+const char *HexLogProgramName() { return "hex_config"; }
+
+extern int (*g_advisor_pubkey)(int, char **);
+extern int (*g_advisor_verify_release)(int, char **);
+
+int
+main(int argc, char **argv)
+{
+    if (argc < 2)
+        return 2;
+    if (strcmp(argv[1], "advisor_pubkey") == 0)
+        return g_advisor_pubkey(argc - 1, argv + 1);
+    if (strcmp(argv[1], "advisor_verify_release") == 0)
+        return g_advisor_verify_release(argc - 1, argv + 1);
+    return 2;
+}

--- a/core/modules/tests/config_advisor/stub/hex/config_module.h
+++ b/core/modules/tests/config_advisor/stub/hex/config_module.h
@@ -1,0 +1,7 @@
+// Minimal stand-in for hex/config_module.h. The registration macros become
+// plain function pointers the driver can call, which is all the logic test
+// needs; the real registration path is covered by test_config_advisor_01.sh
+// against a properly linked hex_config.
+#pragma once
+#define CONFIG_MODULE(a, b, c, d, e, f)
+#define CONFIG_COMMAND(name, mainf, usagef) int (*g_##name)(int, char **) = mainf;

--- a/core/modules/tests/config_advisor/stub/hex/log.h
+++ b/core/modules/tests/config_advisor/stub/hex/log.h
@@ -1,0 +1,7 @@
+// Minimal stand-in for hex/log.h, so config_advisor.cpp can be compiled in
+// isolation by test_config_advisor_02.sh. See that script for why.
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+const char *HexLogProgramName();
+#define HexLogError(fmt, ...) do { fprintf(stderr, "syslog: Error: " fmt "\n", ## __VA_ARGS__); } while (0)

--- a/core/modules/tests/config_advisor/test_config_advisor_01.sh
+++ b/core/modules/tests/config_advisor/test_config_advisor_01.sh
@@ -1,0 +1,116 @@
+#
+# TEST - advisor_verify_release refuses everything it should, and advisor_pubkey
+#        emits the key this image was built with.
+#
+# This binary links the module object built for the product, so it embeds the
+# key this build was provisioned with: the real release public key on a
+# production build (whose private half never leaves the release CI), or the
+# throwaway dev keypair the build minted when none was injected.
+#
+# The refusals below hold either way. The accept path is only reachable when
+# the dev private half is on disk (section 6); on a production build that
+# section skips and test_config_advisor_02.sh covers acceptance by compiling
+# the same source against a key it can sign with.
+#
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not available"; exit 0; }
+
+# ---- 1. the embedded key is real and is what the image ships ----
+./hex_config advisor_pubkey > "$WORK/embedded.pub" \
+    || fail "advisor_pubkey exited non-zero"
+openssl pkey -pubin -in "$WORK/embedded.pub" -noout 2>/dev/null \
+    || fail "the embedded public key is not a key openssl can read"
+
+# The trust anchor is compiled in, so it must match the PEM the build was
+# provisioned with -- injected in production, minted for dev. If these
+# diverge, the image is verifying against something nobody provided.
+PUBPEM="${ADVISOR_PUB_PEM:-/etc/ssl/advisor-release.pub.pem}"
+if [ -f "$PUBPEM" ]; then
+    diff -q <(openssl pkey -pubin -in "$WORK/embedded.pub" -outform PEM) \
+            <(openssl pkey -pubin -in "$PUBPEM" -outform PEM) >/dev/null \
+        || fail "the compiled-in key is not $PUBPEM"
+fi
+
+# ---- 2. a release signed by anyone else is refused ----
+mkrelease() {
+    local d=$1 key=$2
+    rm -rf "$d" ; mkdir -p "$d"
+    printf 'agent\n' > "$d/cube-advisor-agent_linux_amd64"
+    {
+        echo "# cube-advisor-agent release manifest"
+        echo "# version: 0.0.0-test"
+        ( cd "$d" && sha256sum cube-advisor-agent_linux_amd64 )
+    } > "$d/manifest.txt"
+    openssl dgst -sha256 -sign "$key" -out "$d/manifest.txt.sig" "$d/manifest.txt"
+}
+
+openssl ecparam -name prime256v1 -genkey -noout -out "$WORK/attacker.key" 2>/dev/null
+mkrelease "$WORK/rel" "$WORK/attacker.key"
+./hex_config advisor_verify_release "$WORK/rel" >/dev/null 2>&1 \
+    && fail "accepted a release signed by a key that is not the image's"
+
+# ---- 3. missing pieces are refusals, not warnings ----
+rm -f "$WORK/rel/manifest.txt.sig"
+./hex_config advisor_verify_release "$WORK/rel" >/dev/null 2>&1 \
+    && fail "accepted a release with no signature"
+
+mkrelease "$WORK/rel" "$WORK/attacker.key"
+rm -f "$WORK/rel/manifest.txt"
+./hex_config advisor_verify_release "$WORK/rel" >/dev/null 2>&1 \
+    && fail "accepted a release with no manifest"
+
+./hex_config advisor_verify_release "$WORK/nonexistent" >/dev/null 2>&1 \
+    && fail "accepted a directory that does not exist"
+
+# ---- 4. usage ----
+./hex_config advisor_verify_release >/dev/null 2>&1 \
+    && fail "accepted a call with no release directory"
+./hex_config advisor_verify_release a b c >/dev/null 2>&1 \
+    && fail "accepted a call with too many arguments"
+./hex_config advisor_pubkey extra >/dev/null 2>&1 \
+    && fail "advisor_pubkey accepted an argument"
+
+# ---- 5. an artifact name that escapes the release directory ----
+mkrelease "$WORK/rel" "$WORK/attacker.key"
+./hex_config advisor_verify_release "$WORK/rel" ../../etc/passwd >/dev/null 2>&1 \
+    && fail "accepted an artifact name containing a path"
+./hex_config advisor_verify_release "$WORK/rel" /etc/passwd >/dev/null 2>&1 \
+    && fail "accepted an absolute artifact name"
+
+# ---- 5b. the release directory itself ----
+# It comes from the caller and hex_config opens it as root, so a relative path
+# (resolved against the caller's cwd) and traversal are refused BEFORE the open.
+# The refusal reason is asserted, not just the exit status: every release in this
+# test is refused anyway for its signature, so an exit code alone would pass
+# whether the check exists or not.
+HERE=$(pwd)
+out=$( (cd "$WORK" && "$HERE/hex_config" advisor_verify_release rel) 2>&1 ) || true
+case $out in
+    *"absolute path"*) ;;
+    *) fail "a relative release directory was not refused as a path: $out" ;;
+esac
+out=$(./hex_config advisor_verify_release "$WORK/../$(basename "$WORK")/rel" 2>&1) || true
+case $out in
+    *"absolute path"*) ;;
+    *) fail "a release directory containing .. was not refused as a path: $out" ;;
+esac
+
+# ---- 6. a dev build proves the accept path against the shipped binary ----
+# Only when the build minted a dev keypair: its private half is on disk and
+# matches the embedded key, so a signature it makes must verify. A production
+# build has no private half here and skips this.
+PRIVPEM="${ADVISOR_PRIV_PEM:-/etc/ssl/advisor-release.priv.pem}"
+if [ -f "$PRIVPEM" ] \
+   && diff -q <(openssl pkey -pubin -in "$WORK/embedded.pub" -outform PEM) \
+              <(openssl pkey -in "$PRIVPEM" -pubout 2>/dev/null) >/dev/null 2>&1; then
+    mkrelease "$WORK/goodrel" "$PRIVPEM"
+    ./hex_config advisor_verify_release "$WORK/goodrel" >/dev/null 2>&1 \
+        || fail "refused a release signed with this image's own key"
+fi
+
+exit 0

--- a/core/modules/tests/config_advisor/test_config_advisor_02.sh
+++ b/core/modules/tests/config_advisor/test_config_advisor_02.sh
@@ -1,0 +1,206 @@
+#
+# TEST - the verification logic itself: what advisor_verify_release accepts as
+#        well as what it refuses.
+#
+# The hex_config binary in this directory embeds the product's release public
+# key, and the matching private key is not in this repository -- so that binary
+# can never be handed a signature it accepts, and test_config_advisor_01.sh can
+# only assert refusals. A verifier that refused everything would pass it.
+#
+# So this compiles the same source against a throwaway keypair generated here,
+# which makes the accept path reachable. The stubs under stub/ replace hex/log.h
+# and hex/config_module.h only; the code under test is byte-for-byte the code
+# that ships.
+#
+# openssl and sha256sum are used to build the fixtures rather than to do the
+# checking -- the point is that an independently produced signature is one this
+# verifier agrees with, which is also what a customer checking our work does.
+#
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl not available"; exit 0; }
+command -v g++     >/dev/null 2>&1 || { echo "SKIP: g++ not available";     exit 0; }
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+SRC="$DIR/../../config_advisor.cpp"
+[ -f "$SRC" ] || fail "cannot find config_advisor.cpp at $SRC"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# A throwaway release keypair, generated per run so no key is committed, and a
+# second one standing in for an attacker.
+openssl ecparam -name prime256v1 -genkey -noout -out "$WORK/release.key" 2>/dev/null
+openssl ec -in "$WORK/release.key" -pubout -out "$WORK/release.pub" 2>/dev/null
+openssl ecparam -name prime256v1 -genkey -noout -out "$WORK/attacker.key" 2>/dev/null
+
+# Embed it exactly the way core/modules/Makefile embeds the real one.
+{ printf '#define ADVISOR_RELEASE_PUBLIC_KEY "'
+  awk '{printf "%s\\n", $0}' "$WORK/release.pub"
+  printf '"\n'
+} > "$WORK/advisor_key.h"
+
+g++ -Wall -Werror -Wno-unused-result -I"$WORK" -I"$DIR/stub" \
+    -o "$WORK/advisorctl" "$SRC" "$DIR/stub/driver.cpp" -lcrypto \
+    || fail "config_advisor.cpp did not compile against a test key"
+
+V="$WORK/advisorctl"
+
+# make_release <dir> [signing key]
+make_release() {
+    local dir=$1 key=${2:-$WORK/release.key}
+    rm -rf "$dir" ; mkdir -p "$dir"
+    printf 'amd64 agent\n' > "$dir/cube-advisor-agent_linux_amd64"
+    printf 'arm64 agent\n' > "$dir/cube-advisor-agent_linux_arm64"
+    {
+        echo "# cube-advisor-agent release manifest"
+        echo "# version: 0.2.0"
+        echo "# commit: abc1234"
+        echo "# protocol: 1"
+        ( cd "$dir" && sha256sum cube-advisor-agent_linux_amd64 cube-advisor-agent_linux_arm64 )
+    } > "$dir/manifest.txt"
+    openssl dgst -sha256 -sign "$key" -out "$dir/manifest.txt.sig" "$dir/manifest.txt"
+}
+
+# resign <dir> -- re-sign whatever the manifest now says, with the real release
+# key. Used to test the parser on input that has already passed the signature
+# check, which is the only way those paths are reachable.
+resign() {
+    openssl dgst -sha256 -sign "$WORK/release.key" -out "$1/manifest.txt.sig" "$1/manifest.txt"
+}
+
+REL="$WORK/rel"
+
+# ---- accept ----
+make_release "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    || fail "refused a genuine release"
+$V advisor_verify_release "$REL" cube-advisor-agent_linux_amd64 >/dev/null 2>&1 \
+    || fail "refused an artifact the signed manifest lists"
+
+# The published two-command check has to agree with us, or the format's promise
+# that a customer can verify our releases without our binary is not true.
+$V advisor_pubkey > "$WORK/extracted.pub" 2>/dev/null \
+    || fail "advisor_pubkey exited non-zero"
+openssl dgst -sha256 -verify "$WORK/extracted.pub" \
+    -signature "$REL/manifest.txt.sig" "$REL/manifest.txt" >/dev/null 2>&1 \
+    || fail "openssl rejects a manifest this verifier accepts"
+( cd "$REL" && sha256sum -c manifest.txt >/dev/null 2>&1 ) \
+    || fail "sha256sum -c rejects a manifest this verifier accepts"
+
+# A file that is merely present is not verified.
+printf 'squatter\n' > "$REL/extra-binary"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    || fail "an unlisted extra file broke verification of the listed ones"
+$V advisor_verify_release "$REL" extra-binary >/dev/null 2>&1 \
+    && fail "approved a binary the signed manifest does not list"
+
+# ---- refuse: tampering ----
+make_release "$REL" ; printf 'evil\n' > "$REL/cube-advisor-agent_linux_amd64"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted a swapped artifact"
+
+make_release "$REL" ; sed -i 's/^# version: 0.2.0/# version: 9.9.9/' "$REL/manifest.txt"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted a manifest edited after signing"
+
+# The case signature-first exists for: the attacker rewrites the binary AND the
+# digest list, and only the signature is stale. Checking digests first would
+# call this consistent.
+make_release "$REL" ; printf 'evil\n' > "$REL/cube-advisor-agent_linux_amd64"
+{ echo "# v" ; ( cd "$REL" && sha256sum cube-advisor-agent_linux_amd64 ) ; } > "$REL/manifest.txt"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted an attacker-authored manifest carrying a stale signature"
+
+make_release "$REL" "$WORK/attacker.key"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted a manifest signed by another key"
+
+make_release "$REL" ; head -c 100 /dev/urandom > "$REL/manifest.txt.sig"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted a random signature"
+
+make_release "$REL" ; : > "$REL/manifest.txt.sig"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted an empty signature"
+
+# ---- refuse: missing ----
+make_release "$REL" ; rm -f "$REL/manifest.txt.sig"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 && fail "accepted a missing signature"
+make_release "$REL" ; rm -f "$REL/manifest.txt"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 && fail "accepted a missing manifest"
+make_release "$REL" ; rm -f "$REL/cube-advisor-agent_linux_arm64"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "accepted a manifest listing an artifact that is not there"
+
+# ---- targeted install: only the artifact being installed need be present ----
+# advisor_enroll fetches the manifest, the signature and ONLY this node's arch,
+# so a release signed for several architectures leaves the others absent.
+# Naming an artifact asks "is this one genuine"; naming none asks "is this whole
+# release intact", which stays strict -- the case just above.
+make_release "$REL" ; rm -f "$REL/cube-advisor-agent_linux_arm64"
+$V advisor_verify_release "$REL" cube-advisor-agent_linux_amd64 >/dev/null 2>&1 \
+    || fail "refused the arch it was asked about because another arch was not fetched"
+
+# Either direction -- there is nothing special about amd64.
+make_release "$REL" ; rm -f "$REL/cube-advisor-agent_linux_amd64"
+$V advisor_verify_release "$REL" cube-advisor-agent_linux_arm64 >/dev/null 2>&1 \
+    || fail "refused the arch that is present"
+
+# Skipping the absent entries must not skip the one that matters: listed is not
+# verified, and this is the artifact about to be installed and executed.
+make_release "$REL" ; rm -f "$REL/cube-advisor-agent_linux_amd64"
+$V advisor_verify_release "$REL" cube-advisor-agent_linux_amd64 >/dev/null 2>&1 \
+    && fail "accepted an artifact that the manifest lists but nobody fetched"
+
+# Nor may a partially fetched release become a way to smuggle a swapped binary.
+make_release "$REL" ; rm -f "$REL/cube-advisor-agent_linux_arm64"
+printf 'evil\n' > "$REL/cube-advisor-agent_linux_amd64"
+$V advisor_verify_release "$REL" cube-advisor-agent_linux_amd64 >/dev/null 2>&1 \
+    && fail "accepted a swapped artifact in a partially fetched release"
+
+# ---- refuse: the parser, on input that already passed the signature check ----
+make_release "$REL" ; printf '# only comments\n' > "$REL/manifest.txt" ; resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 && fail "accepted a manifest listing nothing"
+
+make_release "$REL" ; printf '# v\nZZZZ  x\n' > "$REL/manifest.txt" ; resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 && fail "accepted a line that is not a digest"
+
+make_release "$REL" ; sed -i 's/^\([0-9a-f]\{64\}\)  /\1 /' "$REL/manifest.txt" ; resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 && fail "accepted a single-space separator"
+
+make_release "$REL" ; sed -i 's/^\([0-9a-f]\{64\}\)/\U\1/' "$REL/manifest.txt" ; resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 && fail "accepted uppercase digests"
+
+# A name that escapes the release directory, in a manifest we ourselves signed.
+# Signing is not supposed to be the only thing standing between a manifest and
+# an arbitrary path, so the target here EXISTS -- otherwise the refusal would
+# come from the open failing and would prove nothing.
+printf 'SECRET\n' > "$WORK/secret.txt"
+make_release "$REL"
+printf '# v\n%s  ../secret.txt\n' "$(sha256sum "$WORK/secret.txt" | cut -d' ' -f1)" > "$REL/manifest.txt"
+resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "verified a file outside the release directory"
+
+make_release "$REL"
+printf '# v\n%s  /etc/passwd\n' "$(sha256sum /etc/passwd | cut -d' ' -f1)" > "$REL/manifest.txt"
+resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "verified an absolute path named by a signed manifest"
+
+# A bare name is a legal artifact name, so rejecting names is not enough on its
+# own: the entry itself can be a symlink out of the directory. Reading through
+# it would mean every check below describes a file somewhere else.
+make_release "$REL"
+ln -sf "$WORK/secret.txt" "$REL/cube-advisor-agent_linux_amd64"
+{
+    echo "# v"
+    printf '%s  cube-advisor-agent_linux_amd64\n' "$(sha256sum "$WORK/secret.txt" | cut -d' ' -f1)"
+} > "$REL/manifest.txt"
+resign "$REL"
+$V advisor_verify_release "$REL" >/dev/null 2>&1 \
+    && fail "followed a symlink out of the release directory"
+
+exit 0

--- a/core/sdk_sh/modules/sdk_advisor.sh
+++ b/core/sdk_sh/modules/sdk_advisor.sh
@@ -1,0 +1,175 @@
+# CUBE SDK
+
+# PROG must be set before sourcing this file
+if [ -z "$PROG" ] ; then
+    echo "Error: PROG not set" >&2
+    exit 1
+fi
+
+# Node-side helpers for the Cube AI Advisor agent.
+#
+# The agent is released by Bigstack as signed per-arch artifacts and must be
+# verified before a node executes one. Two decisions from ADR 0003 shape what is
+# here:
+#
+#   * Verification lives in cubecos, not in the agent's own repository. A
+#     verifier must not share a build pipeline with the artifact it verifies, or
+#     one compromised pipeline produces both.
+#   * The trust anchor belongs to the OS, and is compiled into hex_config the
+#     same way hex compiles in the licence key -- so it is deliberately NOT
+#     configurable from here. A verifier whose trust anchor is chosen by its
+#     caller verifies nothing.
+#
+# The check itself is in hex_config rather than in this file. Key and check
+# belong in one place: this file lives under /usr/lib/hex_sdk where root can
+# edit it, so a shell verifier could have its check removed while the compiled-in
+# key stayed perfectly safe -- which protects the wrong half.
+#
+# A customer who would rather not trust our binary can still do the whole check
+# with standard tools, because the manifest is in sha256sum's own format:
+#
+#     hex_config advisor_pubkey > release.pub
+#     openssl dgst -sha256 -verify release.pub -signature manifest.txt.sig manifest.txt
+#     sha256sum -c manifest.txt
+
+ADVISOR_MANIFEST_NAME=manifest.txt
+ADVISOR_SIGNATURE_NAME=manifest.txt.sig
+
+# advisor_verify_release <dir> [artifact]
+#
+# Verifies the release in <dir>: the manifest's signature against the key
+# compiled into this image, then every artifact digest the manifest lists. When
+# <artifact> is given, it must additionally be one the manifest names.
+#
+# Returns 0 only when every check passes. Every other outcome is a refusal.
+advisor_verify_release()
+{
+    # artifact is optional; default it so a one-argument call is not an
+    # unbound-variable error under set -u.
+    local dir=$1 artifact=${2:-}
+
+    if [ -z "$dir" ] ; then
+        echo "Error: advisor_verify_release: no release directory given" >&2
+        return 1
+    fi
+
+    # Branch rather than leaving $artifact unquoted: an empty positional would
+    # be a second argument, and an unquoted one would word-split.
+    if [ -n "$artifact" ] ; then
+        $HEX_CFG advisor_verify_release "$dir" "$artifact"
+    else
+        $HEX_CFG advisor_verify_release "$dir"
+    fi
+}
+
+# advisor_release_version <dir>
+#
+# Prints the version recorded in a release manifest. Reads a comment line, so it
+# must only ever be called on a manifest that advisor_verify_release has already
+# accepted — otherwise it is reporting whatever an attacker wrote.
+advisor_release_version()
+{
+    local dir=$1
+    awk -F': *' '/^# version:/ { print $2 ; exit }' "$dir/$ADVISOR_MANIFEST_NAME" 2>/dev/null
+}
+
+# advisor_install_release <dir> <artifact> <dest>
+#
+# Verifies then installs. The two are one function on purpose: an install path
+# that can be called without verifying is an install path that eventually is.
+advisor_install_release()
+{
+    local dir=$1 artifact=$2 dest=$3
+
+    if [ -z "$artifact" ] || [ -z "$dest" ] ; then
+        echo "Error: advisor_install_release: usage <dir> <artifact> <dest>" >&2
+        return 1
+    fi
+    # Passing the artifact makes "is this file covered by the signature?" part of
+    # the same verification, rather than a second check that could be skipped. A
+    # file that happens to sit in a verified directory is not itself verified.
+    advisor_verify_release "$dir" "$artifact" || return 1
+
+    install -m 0755 -o root -g root "$dir/$artifact" "$dest" || return 1
+    echo "Installed $artifact $(advisor_release_version "$dir") to $dest"
+    return 0
+}
+
+# advisor_agent_arch
+#
+# Maps this machine to the artifact naming the release manifest uses. Unknown
+# architectures are a refusal rather than a guess: installing the wrong binary
+# fails later and less clearly than not installing one.
+advisor_agent_arch()
+{
+    local m
+    m=$(uname -m)
+    case "$m" in
+        x86_64)  echo amd64 ;;
+        aarch64) echo arm64 ;;
+        *)       echo "Error: no Advisor agent build for $m" >&2 ; return 1 ;;
+    esac
+}
+
+# advisor_enroll <server> <token-file> <version>
+#
+# The whole node-side install path: fetch the release, verify it against the
+# image's public key, install the agent, then enrol this cluster.
+#
+# The token is read from a file rather than an argument. A pairing token on a
+# command line is visible in ps to every user on the box for as long as the
+# process runs, and this function is exactly the place that would otherwise
+# leak it.
+#
+# Every step fails closed. A partial install -- a verified binary with no
+# identity, or an identity with no binary -- is worse than a clean failure the
+# operator can retry.
+advisor_enroll()
+{
+    local server=$1 token_file=$2 version=$3
+    local arch artifact tmp rc
+
+    if [ -z "$server" ] || [ -z "$token_file" ] || [ -z "$version" ] ; then
+        echo "Error: advisor_enroll: usage <server> <token-file> <version>" >&2
+        return 1
+    fi
+    if [ ! -r "$token_file" ] ; then
+        echo "Error: cannot read the pairing token file: $token_file" >&2
+        return 1
+    fi
+    arch=$(advisor_agent_arch) || return 1
+    artifact="cube-advisor-agent_linux_$arch"
+
+    tmp=$(mktemp -d /run/advisor-release.XXXXXX) || return 1
+    # The download directory holds no secrets, but it does hold a binary that is
+    # about to be trusted; do not leave it lying around either way.
+    trap 'rm -rf "$tmp"' RETURN
+
+    local url="$server/api/v1/releases/$version"
+    local f
+    for f in "$ADVISOR_MANIFEST_NAME" "$ADVISOR_SIGNATURE_NAME" "$artifact" ; do
+        if ! curl -fsS --max-time 120 \
+                -H "Authorization: Bearer $(cat "$token_file")" \
+                -o "$tmp/$f" "$url/$f" ; then
+            echo "Error: cannot fetch $f from $url" >&2
+            return 1
+        fi
+    done
+
+    # Verification happens before anything is installed or executed, which is
+    # the entire point of the chain: the artifact is untrusted until the image's
+    # own public key says otherwise.
+    advisor_install_release "$tmp" "$artifact" /usr/local/bin/cube-advisor-agent || return 1
+
+    /usr/local/bin/cube-advisor-agent enroll \
+        -server "$server" -token-file "$token_file"
+    rc=$?
+    case $rc in
+        0) ;;
+        3) echo "This node is already enrolled; nothing was changed." >&2 ;;
+        4) echo "The pairing token was refused -- ask for a fresh one." >&2 ;;
+        5) echo "The Advisor service was unreachable from this node." >&2 ;;
+        *) echo "Error: enrolment failed (exit $rc)" >&2 ;;
+    esac
+    return $rc
+}

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2407,13 +2407,14 @@ _health_neutron_auto_repair()
             # (a db_sync can't help here: ovn_db_sync never touches port status)
             Quiet -n cmd -c -- $HEX_SDK os_neutron_ovn_port_status_resync $OVN_STALE_PORTS
             sleep 10
-            # only if that didn't take, fall back to bouncing neutron-server one
-            # node at a time: its IDL reconnect re-dumps and re-derives every port
-            if [ -n "$($HEX_SDK os_neutron_ovn_port_status_stale)" ] ; then
+            # didn't take: bounce neutron-server one node at a time (its IDL
+            # reconnect re-derives every port). No grace period on the re-check --
+            # the toggle above refreshed updated_at.
+            if [ -n "$(OVN_PORT_STALE_MIN_AGE=0 $HEX_SDK os_neutron_ovn_port_status_stale $OVN_STALE_PORTS)" ] ; then
                 for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
                     remote_systemd_restart $node neutron-server
                     sleep 20
-                    [ -n "$($HEX_SDK os_neutron_ovn_port_status_stale)" ] || break
+                    [ -n "$(OVN_PORT_STALE_MIN_AGE=0 $HEX_SDK os_neutron_ovn_port_status_stale $OVN_STALE_PORTS)" ] || break
                 done
             fi
         else
@@ -2459,6 +2460,20 @@ health_neutron_repair()
             $OPENSTACK network agent delete $i
         fi
     done
+
+    # Port status stale vs OVN (ERR_CODE 7): bounce neutron-server one node at a
+    # time. Nothing above touches port status, and check_repair has already
+    # accepted disruption, so skip the toggle the auto path tries first.
+    local stale_ports="$($HEX_SDK os_neutron_ovn_port_status_stale)"
+    if [ -n "$stale_ports" ] ; then
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            remote_systemd_restart $node neutron-server
+            sleep 20
+            # named ports, no grace period: a port that plugged since must
+            # not keep the loop going
+            [ -n "$(OVN_PORT_STALE_MIN_AGE=0 $HEX_SDK os_neutron_ovn_port_status_stale $stale_ports)" ] || break
+        done
+    fi
 }
 
 health_glance_report()

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1875,19 +1875,32 @@ os_octavia_sgid_get()
 # status is event-driven with no reconciliation, so a neutron-server whose IDL
 # stops delivering Logical_Switch_Port events leaves them DOWN forever and every
 # nova build routed to it dies on vif_plugging_timeout. Prints the port ids.
+# os_neutron_ovn_port_status_stale [port ...]  -- named ports, or every compute
+# port. OVN_PORT_STALE_MIN_AGE (default 90) is how long a port must have been
+# DOWN-while-OVN-says-up to count; 0 skips the grace period, which a post-repair
+# re-check needs because a repair refreshes the port's updated_at.
 os_neutron_ovn_port_status_stale()
 {
     local now=$(date -u +%s) p up ts age rc=1
-    # port list has no --status filter; take the json and pick the DOWN ones
-    for p in $($OPENSTACK port list --device-owner compute:nova -f json 2>/dev/null | \
-               python3 -c 'import sys,json;[print(x["ID"]) for x in json.load(sys.stdin) if x.get("Status")=="DOWN"]' 2>/dev/null) ; do
+    local min_age=${OVN_PORT_STALE_MIN_AGE:-90}
+    local ports="$@"
+    if [ -z "$ports" ] ; then
+        # port list has no --status filter; take the json and pick the DOWN ones
+        ports="$($OPENSTACK port list --device-owner compute:nova -f json 2>/dev/null | \
+                 python3 -c 'import sys,json;[print(x["ID"]) for x in json.load(sys.stdin) if x.get("Status")=="DOWN"]' 2>/dev/null)"
+    else
+        ports="$(for p in $ports ; do
+                     [ "x$($OPENSTACK port show $p -f value -c status 2>/dev/null)" = "xDOWN" ] && echo $p
+                 done)"
+    fi
+    for p in $ports ; do
         up=$(ovn-nbctl --timeout=5 get logical_switch_port $p up 2>/dev/null | tr -d '"')
         [ "x$up" = "xtrue" ] || continue
         # skip ports still inside the normal plug window -- a healthy transition
         # is sub-second, so only a stale one is still inconsistent this late
         ts=$($OPENSTACK port show $p -f value -c updated_at 2>/dev/null)
         age=$(( now - $(date -u -d "$ts" +%s 2>/dev/null || echo $now) ))
-        [ $age -ge 90 ] || continue
+        [ $age -ge $min_age ] || continue
         echo $p
         rc=0
     done

--- a/core/sdk_sh/tests/test_neutron_port_status_repair.sh
+++ b/core/sdk_sh/tests/test_neutron_port_status_repair.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+#
+# Unit test for the neutron ERR_CODE 7 (port status stale vs OVN) repair paths:
+#   os_neutron_ovn_port_status_stale  -- ../modules/sdk_os.sh
+#   _health_neutron_auto_repair       -- ../modules/sdk_health.sh (auto path)
+#   health_neutron_repair             -- ../modules/sdk_health.sh (operator path)
+#
+# The regression that matters: the repair's first action toggles admin_state_up,
+# which refreshes the port's updated_at -- so a re-check that keeps the detector's
+# 90s grace period reports a still-stale port as healthy and the neutron-server
+# restart never escalates. Observed on QA 10.32.36.10: toggle ran, no restart
+# followed, ports stayed DOWN until neutron-server was bounced by hand.
+#
+# Self-contained: extracts only the functions under test and stubs openstack,
+# ovn-nbctl, hex_sdk, remote_systemd_restart and sleep, so it needs no cluster.
+#   Run: bash test_neutron_port_status_repair.sh   (exit 0 = pass)
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OS_SRC="$DIR/../modules/sdk_os.sh"
+HEALTH_SRC="$DIR/../modules/sdk_health.sh"
+
+extract() {
+    local name=$1 src=$2 fn
+    fn="$(awk -v n="^$name\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$src")"
+    [ -n "$fn" ] || { echo "FAIL: $name not found in $src"; exit 1; }
+    eval "$fn"
+}
+
+extract os_neutron_ovn_port_status_stale "$OS_SRC"
+extract _health_neutron_auto_repair "$HEALTH_SRC"
+extract health_neutron_repair "$HEALTH_SRC"
+
+pass=0 fail=0
+ok()  { pass=$((pass+1)); }
+bad() { fail=$((fail+1)); echo "FAIL: $1"; }
+check() { if [ "$2" = "$3" ]; then ok; else bad "$1: got '$2', want '$3'"; fi; }
+
+# ---- fixture -------------------------------------------------------------
+# PORT_STATUS[p]=DOWN|ACTIVE   PORT_UP[p]=true|false   PORT_AGE[p]=seconds
+declare -A PORT_STATUS PORT_UP PORT_AGE
+RESTARTS=""      # "<node>:<service>" per remote_systemd_restart
+TOGGLED=""       # ports passed to the resync helper
+CALLS=""         # other hex_sdk calls
+
+reset_fixture() {
+    PORT_STATUS=([p1]=DOWN [p2]=DOWN [p3]=ACTIVE)
+    PORT_UP=([p1]=true [p2]=true [p3]=true)
+    PORT_AGE=([p1]=300 [p2]=300 [p3]=300)
+    RESTARTS=""; TOGGLED=""; CALLS=""
+    unset OVN_PORT_STALE_MIN_AGE || true
+}
+
+# openstack stub: only the three forms the code under test uses
+openstack_stub() {
+    case "$*" in
+        "port list --device-owner compute:nova -f json")
+            local p first=1
+            echo -n "["
+            for p in "${!PORT_STATUS[@]}"; do
+                [ $first -eq 1 ] || echo -n ","
+                first=0
+                echo -n "{\"ID\": \"$p\", \"Status\": \"${PORT_STATUS[$p]}\"}"
+            done
+            echo "]" ;;
+        "port show "*" -f value -c status")
+            local p=$(echo "$*" | awk '{print $3}')
+            echo "${PORT_STATUS[$p]:-}" ;;
+        "port show "*" -f value -c updated_at")
+            local p=$(echo "$*" | awk '{print $3}')
+            # updated_at rendered from the fixture age
+            date -u -d "@$(( $(date -u +%s) - ${PORT_AGE[$p]:-0} ))" +%Y-%m-%dT%H:%M:%SZ ;;
+        "network agent list -f value -c Alive") echo "True" ;;
+        "network agent list -f json -c ID -c Alive") echo "[]" ;;
+        "subnet list") : ;;
+        *) : ;;
+    esac
+}
+OPENSTACK=openstack_stub
+
+ovn-nbctl() {  # --timeout=5 get logical_switch_port <p> up
+    local p=$4
+    echo "${PORT_UP[$p]:-false}"
+}
+
+# hex_sdk stub: dispatch to the real detector, record everything else
+hex_sdk_stub() {
+    case "$1" in
+        os_neutron_ovn_port_status_stale)
+            shift; os_neutron_ovn_port_status_stale "$@" ;;
+        os_neutron_ovn_port_status_resync)
+            shift; TOGGLED="$*"
+            # the toggle writes to the port -- updated_at is refreshed. This is
+            # the whole point of the regression: it does NOT fix a real desync.
+            local p; for p in "$@"; do PORT_AGE[$p]=0; done ;;
+        *) CALLS+="$* " ;;
+    esac
+}
+HEX_SDK=hex_sdk_stub
+HEX_CFG=:
+
+remote_systemd_restart() {
+    RESTARTS+="$1:$2 "
+    # a neutron-server bounce re-derives status: model it as the fix
+    if [ "$2" = "neutron-server" ]; then
+        local p; for p in "${!PORT_STATUS[@]}"; do PORT_STATUS[$p]=ACTIVE; done
+    fi
+}
+
+sleep() { :; }
+
+# Quiet/cmd are wrappers, not sinks: strip their flags and run what they wrap,
+# or the repair's own actions never happen and every assertion below is vacuous.
+Quiet() {
+    while [ $# -gt 0 ] && case "$1" in -*|--) true ;; *) false ;; esac; do shift; done
+    [ $# -gt 0 ] || return 0
+    "$@"
+}
+cmd() {
+    while [ $# -gt 0 ] && case "$1" in -*|--) true ;; *) false ;; esac; do shift; done
+    [ $# -gt 0 ] || return 0
+    # only shell functions (our stubs) are safe to run in a unit test
+    if declare -F "$1" >/dev/null 2>&1; then "$@"; else CALLS+="$* "; fi
+}
+jq() { echo ""; }
+log_info() { :; }
+_ovn_metadata_wait_caught_up() { :; }
+CUBE_NODE_CONTROL_HOSTNAMES=(c1 c2 c3)
+OVN_META_STUCK=""
+CEPH=:
+
+# ---- the detector --------------------------------------------------------
+reset_fixture
+check "stale ports, default grace" "$(os_neutron_ovn_port_status_stale | sort | tr '\n' ' ')" "p1 p2 "
+
+reset_fixture
+PORT_AGE=([p1]=10 [p2]=10 [p3]=300)
+check "inside the plug window: not stale" "$(os_neutron_ovn_port_status_stale)" ""
+check "same ports with no grace period" \
+    "$(OVN_PORT_STALE_MIN_AGE=0 os_neutron_ovn_port_status_stale | sort | tr '\n' ' ')" "p1 p2 "
+
+reset_fixture
+check "named port restricts the scan" "$(os_neutron_ovn_port_status_stale p2)" "p2"
+check "an ACTIVE named port is not stale" "$(os_neutron_ovn_port_status_stale p3)" ""
+
+reset_fixture
+PORT_UP=([p1]=false [p2]=false [p3]=true)
+check "DOWN in both neutron and OVN is not a desync" "$(os_neutron_ovn_port_status_stale)" ""
+
+reset_fixture
+os_neutron_ovn_port_status_stale >/dev/null; check "rc 0 when stale" "$?" "0"
+PORT_STATUS=([p1]=ACTIVE [p2]=ACTIVE [p3]=ACTIVE)
+os_neutron_ovn_port_status_stale >/dev/null; check "rc 1 when clean" "$?" "1"
+
+# ---- auto path (ERR_CODE 7) ---------------------------------------------
+# The toggle runs first; because it refreshes updated_at, the fallback must
+# re-check without the grace period or it never escalates (the QA symptom).
+reset_fixture
+ERR_CODE=7 ERR_MSG="" OVN_STALE_PORTS="p1 p2"
+_health_neutron_auto_repair
+check "auto path toggles the stale ports" "$TOGGLED" "p1 p2"
+check "auto path escalates to a neutron-server bounce" "$RESTARTS" "c1:neutron-server "
+
+# toggle actually works (ports come back ACTIVE): no restart at all
+reset_fixture
+hex_sdk_stub() {
+    case "$1" in
+        os_neutron_ovn_port_status_stale) shift; os_neutron_ovn_port_status_stale "$@" ;;
+        os_neutron_ovn_port_status_resync)
+            shift; TOGGLED="$*"
+            local p; for p in "$@"; do PORT_STATUS[$p]=ACTIVE; PORT_AGE[$p]=0; done ;;
+        *) CALLS+="$* " ;;
+    esac
+}
+ERR_CODE=7 ERR_MSG="" OVN_STALE_PORTS="p1 p2"
+_health_neutron_auto_repair
+check "toggle sufficed: no restart" "$RESTARTS" ""
+
+# restore the realistic stub
+hex_sdk_stub() {
+    case "$1" in
+        os_neutron_ovn_port_status_stale) shift; os_neutron_ovn_port_status_stale "$@" ;;
+        os_neutron_ovn_port_status_resync)
+            shift; TOGGLED="$*"
+            local p; for p in "$@"; do PORT_AGE[$p]=0; done ;;
+        *) CALLS+="$* " ;;
+    esac
+}
+
+# ---- operator path (check_repair) ---------------------------------------
+reset_fixture
+health_neutron_repair
+check "operator path bounces neutron-server" "$RESTARTS" "c1:neutron-server "
+check "operator path does not toggle first" "$TOGGLED" ""
+
+reset_fixture
+PORT_STATUS=([p1]=ACTIVE [p2]=ACTIVE [p3]=ACTIVE)
+health_neutron_repair
+check "no stale ports: no restart" "$RESTARTS" ""
+
+# a node whose restart does not clear it moves on to the next node
+reset_fixture
+remote_systemd_restart() { RESTARTS+="$1:$2 "; }   # never clears
+health_neutron_repair
+check "escalates across every control node" "$RESTARTS" \
+    "c1:neutron-server c2:neutron-server c3:neutron-server "
+
+echo "----"
+echo "pass=$pass fail=$fail"
+[ $fail -eq 0 ] || exit 1
+exit 0

--- a/core/sdk_sh/tests/test_sdk_advisor_verify.sh
+++ b/core/sdk_sh/tests/test_sdk_advisor_verify.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+#
+# Unit test for the Advisor helpers in ../modules/sdk_advisor.sh.
+#
+# Verification itself is NOT here any more -- it moved into hex_config, for the
+# same reason licence verification lives there: the key and the check belong in
+# one place, and this file lives under /usr/lib/hex_sdk where root can edit it.
+# The crypto is covered by core/modules/tests/config_advisor/.
+#
+# What is left in shell is a contract, and that is what this tests: which
+# arguments reach hex_config, that nothing is installed unless it said yes, and
+# that the surrounding helpers refuse rather than guess. hex_config is stubbed
+# so a refusal can be simulated without needing the release private key.
+#
+# Self-contained: extracts only the functions under test, so it needs none of
+# sdk_advisor.sh's runtime prerequisites (PROG / SDK_DIR / errcodes).
+# Run:  bash test_sdk_advisor_verify.sh   (exit 0 = pass)
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_advisor.sh"
+
+for f in advisor_verify_release advisor_release_version advisor_install_release advisor_agent_arch advisor_enroll ; do
+    fn="$(awk -v want="^$f\\\\(\\\\)" '$0 ~ want {f=1} f{print} f&&/^}/{exit}' "$SRC")"
+    [ -n "$fn" ] || { echo "FAIL: $f not found in $SRC"; exit 1; }
+    eval "$fn"
+done
+
+ADVISOR_MANIFEST_NAME=manifest.txt
+ADVISOR_SIGNATURE_NAME=manifest.txt.sig
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A stand-in hex_config: records the arguments it was called with and exits with
+# whatever STUB_RC says. Recording the arguments is the point -- a wrapper that
+# quietly dropped the artifact name would still "work", and would stop checking
+# that the file being installed is one the signature covers.
+cat > "$WORK/hex_config" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "$STUB_LOG"
+exit "${STUB_RC:-0}"
+STUB
+chmod +x "$WORK/hex_config"
+HEX_CFG="$WORK/hex_config"
+export STUB_LOG="$WORK/calls"
+export STUB_RC=0
+
+pass=0 fail=0
+ok()   { pass=$((pass+1)); }
+bad()  { fail=$((fail+1)); echo "FAIL: $1"; }
+check() { if [ "$2" = "$3" ] ; then ok ; else bad "$1: got '$2', want '$3'" ; fi ; }
+
+reset() { : > "$STUB_LOG" ; STUB_RC=0 ; }
+lastcall() { tail -1 "$STUB_LOG" 2>/dev/null ; }
+
+REL="$WORK/rel"
+mkdir -p "$REL"
+printf 'amd64 agent\n' > "$REL/cube-advisor-agent_linux_amd64"
+{
+    echo "# cube-advisor-agent release manifest"
+    echo "# version: 0.2.0"
+    echo "# commit: abc1234"
+    echo "# protocol: 1"
+    ( cd "$REL" && sha256sum cube-advisor-agent_linux_amd64 )
+} > "$REL/$ADVISOR_MANIFEST_NAME"
+: > "$REL/$ADVISOR_SIGNATURE_NAME"
+
+# --- what reaches hex_config -----------------------------------------------
+reset
+advisor_verify_release "$REL" >/dev/null 2>&1
+check "verify delegates the directory" "$(lastcall)" "advisor_verify_release $REL"
+
+reset
+advisor_verify_release "$REL" cube-advisor-agent_linux_amd64 >/dev/null 2>&1
+check "verify passes the artifact through" "$(lastcall)" \
+      "advisor_verify_release $REL cube-advisor-agent_linux_amd64"
+
+# An empty artifact must not become an empty second argument.
+reset
+advisor_verify_release "$REL" "" >/dev/null 2>&1
+check "an empty artifact is not passed as an argument" "$(lastcall)" \
+      "advisor_verify_release $REL"
+
+# --- refusals do not reach hex_config at all --------------------------------
+reset
+if advisor_verify_release "" >/dev/null 2>&1 ; then
+    bad "verify accepted an empty release directory"
+else
+    ok
+fi
+[ -s "$STUB_LOG" ] && bad "verify called hex_config with no directory to check"
+
+# --- the verifier's verdict is the install gate ------------------------------
+reset ; STUB_RC=1
+if advisor_install_release "$REL" cube-advisor-agent_linux_amd64 "$WORK/installed" >/dev/null 2>&1 ; then
+    bad "installed although verification refused"
+else
+    ok
+fi
+[ -e "$WORK/installed" ] && bad "a refused install still wrote its destination"
+
+# The install path must ask about the artifact, not just the directory: a file
+# that happens to sit in a verified directory is not itself verified.
+check "install asks about the specific artifact" "$(lastcall)" \
+      "advisor_verify_release $REL cube-advisor-agent_linux_amd64"
+
+reset ; STUB_RC=0
+if advisor_install_release "$REL" cube-advisor-agent_linux_amd64 "$WORK/installed" >/dev/null 2>&1 \
+   && [ -x "$WORK/installed" ] ; then
+    ok
+else
+    bad "a verified artifact did not install"
+fi
+
+reset
+if advisor_install_release "$REL" "" "$WORK/nowhere" >/dev/null 2>&1 ; then
+    bad "install ran with no artifact named"
+else
+    ok
+fi
+
+# --- version comes off the manifest ------------------------------------------
+check "version is read from the manifest" "$(advisor_release_version "$REL")" "0.2.0"
+
+# --- arch mapping refuses to guess -------------------------------------------
+# Installing the wrong binary fails later and less clearly than not installing
+# one, so an unknown machine is a refusal.
+uname() { echo "$FAKE_UNAME"; }
+FAKE_UNAME=x86_64  ; check "x86_64 maps to amd64"  "$(advisor_agent_arch)" "amd64"
+FAKE_UNAME=aarch64 ; check "aarch64 maps to arm64" "$(advisor_agent_arch)" "arm64"
+FAKE_UNAME=riscv64
+if advisor_agent_arch >/dev/null 2>&1 ; then
+    bad "an unknown architecture was mapped instead of refused"
+else
+    ok
+fi
+unset -f uname
+
+# --- enroll validates its inputs before touching the network -----------------
+if advisor_enroll "" "" "" >/dev/null 2>&1 ; then
+    bad "advisor_enroll ran with no arguments"
+else
+    ok
+fi
+if advisor_enroll https://example "$WORK/no-such-token" 0.2.0 >/dev/null 2>&1 ; then
+    bad "advisor_enroll ran with an unreadable token file"
+else
+    ok
+fi
+
+echo "----"
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind bug

#### What this PR does / why we need it

Three concerns on disjoint files, reviewable commit by commit:

1. **Advisor signed-artifact verification** (the original scope). A node must not execute an agent binary before checking it is the one Bigstack released. `hex_config advisor_verify_release` does the whole check with the release public key compiled in via `advisor_key.h` — same mechanism as `license_key.h`. Per [ADR 0003](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/cube-ai-advisor/adrs/0003-signed-agent-artifact-enrolled-by-the-os.md), it lives in cubecos (a verifier sharing a pipeline with its artifact verifies nothing) and the anchor is not an argument. Plus `hex_cli advisor enroll|status|verify`.
2. **hex bump** `2a9d9ee` → `eb1468d` — hex #155 stages `/var/support/preflight-report.json`; its readers are cube-cos-driver #71 (merged) and #1278.
3. **neutron ERR_CODE 7 repair** — the detection #1302 shipped is sound; the repair never worked. Now included (rebased onto #1342, which brought the detector to develop).

#### Which issue(s) this PR fixes

Fixes #1288, fixes #1343.

#### Special notes for your reviewer

- **Order is load-bearing.** Signature first, then digests: a digest list is only worth applying once we know Bigstack wrote it. Covered directly — a substituted binary with a re-written manifest whose digests match it perfectly is refused by the signature, not the digests.
- **Where the key comes from.** Production builds inject the real public key (private half never leaves the release CI); any build without one mints a throwaway pair, so a dev image can never install what production signs, or vice versa. `hex_config advisor_pubkey` audits which key an image trusts.
- **Three fixes after cross-repo review.** The verified enrol path could never succeed (a release is signed for every arch, `advisor_enroll` fetches one, and the verifier demanded all); neither advisor object was linked into the shipped binaries (`core/main/cube.mk` enumerates them, and the test harness names its own — so unit tests passed against code the product did not contain); `cli_advisor.cpp` used `fchmod` without `<sys/stat.h>` and stopped compiling on current develop.
- **The neutron half, briefly.** `health_neutron_repair()` had no ERR_CODE 7 branch, so `check_repair` reported `FAIL [neutron(7)]` and fixed nothing — it now bounces `neutron-server` one control node at a time. And the auto path's fallback could never fire: the `admin_state_up` toggle refreshes the port's `updated_at`, the detector ignores ports younger than 90s, so the re-check 10s later always saw nothing (matches QA `10.32.36.10` — toggle logged, no restart). The detector now takes a port list plus `OVN_PORT_STALE_MIN_AGE`. **Not fixed, not claimed:** whether the toggle deserves to stay the auto path's first action — unproven against a real desync.
- **CodeQL.** `open(dir)` is now guarded (absolute path, no `".."`, under `PATH_MAX`) with a test that asserts the refusal *reason*, since every release in that suite is refused for its signature anyway. CodeQL still reports the residual `argv`→`open` flow — it accepts no inline sanitizer. That flow is a property of `hex_config` itself (`config_main.cpp` calls `setuid(0)`, binary is `4755`, so `apply <dir>` and `commit <file>` are identical in shape), cannot be fixed by dropping privilege here, and a fixed path prefix would break verifying a release from removable media. **Wants dismissing as won't-fix**; `hex_config`'s privilege model deserves its own issue.
- **Tests.** `config_advisor_01/02` (refusals against the binary as built; full accept/refuse matrix incl. partially fetched multi-arch releases), `test_sdk_advisor_verify.sh` 14/14 (wrapper contract with `hex_config` stubbed), `test_neutron_port_status_repair.sh` 15 assertions. Mutation-tested — 7 verifier mutations, 4 wrapper, 2 neutron — each caught.
- Rebased after #1265 merged; in the jail: `core/modules` builds, `hex_config` + `hex_cli` link, every suite green.

#### Additional documentation

```docs
kb/cube-ai-advisor/adrs/0003-signed-agent-artifact-enrolled-by-the-os.md
```
