### PR TITLE
Mention the scenario sidecar in the handbook DoD checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -75,3 +75,5 @@ Insert content here.
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -91,3 +91,5 @@ Insert content here.
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -43,3 +43,5 @@ Insert content here.
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -64,3 +64,5 @@ None
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -34,3 +34,5 @@ TBD
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -32,3 +32,5 @@ Insert content here.
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -53,3 +53,5 @@ As a **[type of user]**, I want **[some goal]** so that **[some reason]**.
 - [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
       work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
       `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).
+      Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`)
+      beside the note.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

Appends one sentence to the **Handbook knowledge update** DoD checkbox in the 7 issue templates that carry it (bug, bug_report, epic, feature, spike, task, user-story): *"Diagnosed or fixed a failure? Ship the scenario sidecar (`<note>.scenario.yaml`) beside the note."* The handbook note-generation loop captures reproducible fault scenarios beside diagnostic notes (bigstack-oss/bigstack-handbook#293, per cube-ai-advisor ADR 0008); this makes the capture step visible exactly where devs read their DoD.

#### Which issue(s) this PR fixes

Fixes #1290

#### Special notes for your reviewer

> Template-text only — no code paths. Wording approved by Travis; `handbook doctor` gates the sidecar schema on the handbook side (bigstack-oss/bigstack-handbook#295).

#### Additional documentation

```docs
bigstack-handbook: kb/bigstack/workflows/claude-code-development-flow.md (consumer #6),
kb/_meta/templates/scenario.yaml, kb/cube-ai-advisor/adrs/0008-trajectory-capture-training-deferred.md
```