### PR TITLE
feat(mariadb): bump mariadb from 10.6.x to 10.11.x for openstack caracal

### DIFF
--- a/core/modules/config_mysql.cpp
+++ b/core/modules/config_mysql.cpp
@@ -129,8 +129,20 @@ UpdateCheck()
     if (access(BACKDIR, F_OK) != 0)
         return true;
 
-    // defer mysql_upgrade until every control node runs the same MariaDB
-    // version -- its system-table DDL replicates to peers
+    // Defer mysql_upgrade until every control node runs the same MariaDB version.
+    //
+    // The gate stays, but not for the reason recorded here before: --skip-write-binlog
+    // sets sql_log_bin=0, and galera carries TOI DDL over that same binlog path, so the
+    // system-table DDL does NOT reach the peers. Measured on the 3cc accept cluster
+    // across the 10.6.27 -> 10.11.18 roll: after this ran on cc1, cc1's
+    // mysql.column_stats had the new definition while cc2 and cc3 still had the old one.
+    //
+    // Two consequences. Every control node has to run this itself -- which is what
+    // happens, since UpdateCheck() is per-node and each node's migrate hook leaves its
+    // own BACKDIR. And the deferral is still the right order: MariaDB's own galera
+    // guidance is to get every node onto the new server before upgrading system tables,
+    // and it keeps a just-upgraded node from becoming an SST donor with new-format
+    // system tables while an old-version joiner is still asking for them.
     if (HexSystemF(0, HEX_SDK " os_mariadb_version_uniform") != 0)
         return true;
 

--- a/core/mysql/mysql.mk
+++ b/core/mysql/mysql.mk
@@ -1,14 +1,28 @@
 # Cube SDK
 # mysql installation
 
-# Unknown system variable 'innodb_version' since MariaDB 10.10
+# MariaDB comes from MariaDB.org's own repo rather than appstream's mariadb module,
+# which core/heavyfs/Makefile disables. The commented ROOTFS_DNF line below is what that
+# used to be; the warning that sat beside it -- "Unknown system variable 'innodb_version'
+# since MariaDB 10.10" -- is obsolete and has been dropped. Nothing in this tree or in
+# the telegraf fork reads innodb_version, and 10.11.18 starts clean on the config
+# core/modules/config_mysql.cpp generates (verified on cc1).
 # ROOTFS_DNF += mariadb-server mariadb-server-galera rsync
 # rpmfind.net is often not responsive
 # MARIADB_URL := https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages
 
-MARIADB_VER := 10.6.27-1.el9
+# 10.11 is the series OpenStack Caracal targets (cubecos#651). galera-4 is published at
+# the same 26.4.27 under the 10.11 tree, so only the series directory moves.
+#
+# MariaDB-server 10.11 adds a hard, rich dependency that 10.6 did not have:
+#   (mysql-selinux >= 1.0.14 if selinux-policy-targeted)
+# selinux-policy-targeted is in the rootfs, so mysql-selinux is pulled in for real. It
+# lives in appstream and is NOT part of the mariadb module, so the module being disabled
+# does not hide it and it needs no entry here. lsof/pv/socat are new *weak* deps and are
+# allowed to be skipped.
+MARIADB_VER := 10.11.18-1.el9
 GALERA_VER := 26.4.27-1.el9
-MARIADB_URL := https://archive.mariadb.org/yum/10.6/rocky9-amd64/rpms
+MARIADB_URL := https://archive.mariadb.org/yum/10.11/rocky9-amd64/rpms
 
 # Official MariaDB package list
 # Note: we dropped errmsg and server-utils as they are now bundled


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Bumps MariaDB from 10.6.x to 10.11.x so the database is on the series OpenStack Caracal targets. Same shape as #890 did for Antelope (10.5 -> 10.6): the pin moves, nothing else.

`galera-4` is published at the same `26.4.27` under the 10.11 tree, so only `MARIADB_VER` and the series directory in `MARIADB_URL` change. All eight pinned rpm URLs were confirmed to return 200 through the squid proxy.

```
MARIADB_VER := 10.11.18-1.el9      # was 10.6.27-1.el9
GALERA_VER  := 26.4.27-1.el9       # unchanged
MARIADB_URL := https://archive.mariadb.org/yum/10.11/rocky9-amd64/rpms
```

Two things came out of the build-dependency check and are recorded in the makefile:

- `MariaDB-server` 10.11 adds a **hard** rich dependency 10.6 did not have: `(mysql-selinux >= 1.0.14 if selinux-policy-targeted)`. `selinux-policy-targeted` is in the rootfs, so it resolves for real. `mysql-selinux` is non-modular and lives in appstream, so `core/heavyfs/Makefile` disabling the `mariadb` module does not hide it and it needs no entry of its own.
- `lsof`, `pv` and `socat` are new *weak* deps (`pv` only exists in EPEL) and are allowed to be skipped.

The second commit corrects a factually wrong comment in `config_mysql.cpp` — no behaviour change, details under Special notes.

The stale `Unknown system variable 'innodb_version' since MariaDB 10.10` warning is dropped: nothing in this tree or in the telegraf fork reads `innodb_version`, and 10.11.18 starts clean on the config `config_mysql.cpp` generates.

**Verified on jim-1cc (single node)**

- Installs, starts, serves; `mariadb-upgrade` returns 0 across 1021 tables.
- **No unknown-variable errors** — every option `config_mysql.cpp` writes is still accepted at 10.11, including the deprecated `wsrep_slave_threads` / `wsrep_slave_FK_checks` aliases.
- `/usr/bin/mysql_upgrade` still exists as a symlink to `mariadb-upgrade` (the code hardcodes that path).
- Keystone / nova / neutron / glance / cinder reads plus a `nova_api` write all pass; horizon's `mysqlclient` still links (client lib 3.3.19).
- The **Caracal venv** (SQLAlchemy 1.4.51 + PyMySQL 1.1.0) connects and reads server version and `sql_mode`.

**Verified on accept-3cc (rolling / mixed-version DoD from #651)**

Rolled cc3 -> cc2 -> cc1, then finalized.

| DoD item | Result |
| --- | --- |
| Quorum preserved | Held 2/3 Primary at every step; never below quorum |
| Mixed-version cluster operates | 12 min mixed (17:52 -> 18:04), all `Synced` at `wsrep_cluster_size` 3, replication confirmed **both** directions |
| Cross-version rejoin | 10.11.18 joiner rejoined from a **10.6.27 donor**; `wsrep_sst_rsync` took its IST branch (763 writesets), no full datadir copy |
| `mariadb-upgrade` deferred to finalization | Ran only after all three were new; `os_mariadb_version_uniform` returned 0 first |
| Live migration while mixed | cc1 -> cc2 completed in ~20s |
| Health-gated advance | **Not met — see Special notes** |

Both environments are left healthy on 10.11.18, cluster `Synced` 3/3, `health_mysql_check` rc=0.

#### Which issue(s) this PR fixes

Fixes #651

#### Special notes for your reviewer

> Note
>
> **Merge order: this must land after #1295.** Per repo semantics the version switch comes first — #1295 moves `RELEASE_VERSION` to 3.1.20 and returns the component branches to their default branch now that `release_3.1.10` is cut. MariaDB 10.11 is Caracal groundwork and belongs on the 3.1.20 line, so please merge #1295 before this one.

> Note
>
> **One DoD item on #651 is not met by this PR, and is not a line change.** "Health-gated advance — the node roll advances only when the just-upgraded node reports Synced + cluster_size restored" is unimplemented today. `grep -n "health_mysql\|wsrep\|mariadb" core/sdk_sh/modules/sdk_power.sh` returns nothing: `power_roll_advance` kicks the next node purely on the booted node reaching its boot path plus `.status=="pending"`, with no Galera check. The related "roll halts safely rather than dropping to 1/3 if a node cannot rejoin" follows from the same gap. This sits next to the already-deferred roll-relay advance race, so it wants its own issue rather than being bolted on here — **please say whether you want #651 split before this merges and closes it.**

> Note
>
> **Why the second commit exists.** `config_mysql.cpp` said `mysql_upgrade` is deferred because "its system-table DDL replicates to peers". It does not — `--skip-write-binlog` sets `sql_log_bin=0`, and galera carries TOI DDL over that same binlog path, so the upgrade stays local. Measured on 3cc across the roll: after it ran on cc1, cc1's `mysql.column_stats` had the new definition (`JSON_HB`, `longblob`) while cc2 and cc3 still had the old one; both peers needed their own run before their upgrade markers moved to 10.11.18. `UpdateCheck()` is already per-node so behaviour is correct — but the recorded reasoning would justify collapsing it to a single cluster-wide run, which would silently leave two of three nodes on 10.6-format system tables.

> Note
>
> **In-place cross-family upgrade is refused by MariaDB.org's own `%prein`.** A 10.6 -> 10.11 `dnf upgrade` aborts the whole transaction ("A manual upgrade is required"), because the scriptlet rejects any change of version family. Fresh rootfs builds are unaffected — no server package is installed, so the check is skipped, which is why this PR needs no build-side workaround. It matters for the bridge #651 floats delivering "as a no-reboot fixpack": such a fixpack must remove-then-install, not `dnf upgrade`. Worth settling before anyone commits to that delivery mechanism.

> Note
>
> **Pre-existing bug found while verifying, deliberately not touched here.** `config_mysql.cpp` writes the `[mysqld_safe]` header and then keeps emitting *mysqld* options under it, so mariadbd ignores them. Confirmed live on the HA node: `innodb_autoinc_lock_mode` reads **1**, not the 2 `cube.cnf` asks for — and **galera requires 2**; `innodb_flush_log_at_trx_commit` reads 1 not 0; `innodb_buffer_pool_size` is the 128M default not 122M. It predates this bump and is unrelated to it, and fixing it would newly activate a durability change on every node, so it belongs in its own reviewed commit.

#### Additional documentation

```docs

```
