### PR TITLE
fix(cluster): twenty-four roll, boot and upgrade defects found validating 3.1.10-rc1

### DIFF
--- a/core/cubectl/app/config/config_k3s_last.go
+++ b/core/cubectl/app/config/config_k3s_last.go
@@ -311,13 +311,26 @@ func untarLoalCephImageSet() error {
 }
 
 func syncCephImagesToCubeRegistry() error {
+	// Importing these costs ~10 min (821 MiB tarball -> 2.27 GiB of layers,
+	// loaded and pushed), and it ran on every commit even though the registry
+	// already served them. Import only what is missing.
+	missing := []docker.Image{}
+	for _, image := range ceph.CsiImages {
+		if !docker.ExistsInCubeRegistry(image) {
+			missing = append(missing, image)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
 	err := untarLoalCephImageSet()
 	if err != nil {
 		return err
 	}
 
 	defer removeTmpUntarFiles(ceph.CsiLocalStore)
-	err = pushImagesToCuebRegistry(ceph.CsiImages)
+	err = pushImagesToCuebRegistry(missing)
 	if err != nil {
 		return err
 	}

--- a/core/cubectl/app/util/ceph/ceph.go
+++ b/core/cubectl/app/util/ceph/ceph.go
@@ -24,21 +24,17 @@ func GetRadosGatewayUrl() string {
 	return fmt.Sprintf("http://%s:%d/", settings.GetControllerIp(), RadosGatewayPort)
 }
 
+// getRegexMatchedHosts returns every v1 monitor endpoint on a "mon host = " line.
+// It must not filter them against this node's management IP: monitors bind the
+// storage network, so that comparison matched nothing on any cluster with a
+// separate storage VLAN and left ceph-csi without monitors.
 func getRegexMatchedHosts(line string) []string {
 	regex := regexp.MustCompile(`([\d\.]+:6789)`)
 	matches := regex.FindAllStringSubmatch(line, -1)
 	hosts := []string{}
-	hostIP := settings.GetMgmtIfIp()
 
 	for _, match := range matches {
-		if !strings.Contains(match[1], hostIP) {
-			continue
-		}
-
-		for _, m := range matches {
-			hosts = append(hosts, m[1])
-		}
-		break
+		hosts = append(hosts, match[1])
 	}
 
 	return hosts

--- a/core/cubectl/app/util/ceph/ceph_test.go
+++ b/core/cubectl/app/util/ceph/ceph_test.go
@@ -1,0 +1,42 @@
+package ceph
+
+import (
+	"os"
+	"testing"
+)
+
+// Mon endpoints live on the storage network, never on the management network,
+// so the parser must not filter them against a node's mgmt IP.
+func TestParseMonitorHostsOnStorageNetwork(t *testing.T) {
+	conf := `[global]
+mon initial members = sky141,sky143,sky142,
+mon host = [v2:172.18.95.141:3300/0,v1:172.18.95.141:6789/0],[v2:172.18.95.143:3300/0,v1:172.18.95.143:6789/0],[v2:172.18.95.142:3300/0,v1:172.18.95.142:6789/0],
+mon max pg per osd = 4096
+`
+	f, err := os.CreateTemp(t.TempDir(), "ceph.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(conf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	hosts, err := parseMonitorHosts(f)
+	if err != nil {
+		t.Fatalf("parseMonitorHosts: %v", err)
+	}
+
+	want := []string{"172.18.95.141:6789", "172.18.95.143:6789", "172.18.95.142:6789"}
+	if len(hosts) != len(want) {
+		t.Fatalf("got %d hosts %v, want %d %v", len(hosts), hosts, len(want), want)
+	}
+	for i := range want {
+		if hosts[i] != want[i] {
+			t.Errorf("host[%d] = %q, want %q", i, hosts[i], want[i])
+		}
+	}
+}

--- a/core/cubectl/app/util/docker/docker.go
+++ b/core/cubectl/app/util/docker/docker.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"cubectl/util"
 	"fmt"
+	"net/http"
+	"time"
 
 	"cubectl/util/settings"
 
@@ -29,6 +31,32 @@ type Image struct {
 // for example:
 // docker requires google.golang.org/grpc >= 1.27.1, but etcd and other libs require google.golang.org/grpc < 1.27.1
 // at this moment, we don't have much time to resolve the issue becuase it requires a lot of effort to upgrade and test all existing behaviors.
+var manifestTypes = "application/vnd.docker.distribution.manifest.v2+json," +
+	"application/vnd.docker.distribution.manifest.list.v2+json," +
+	"application/vnd.oci.image.manifest.v1+json," +
+	"application/vnd.oci.image.index.v1+json"
+
+// ExistsInCubeRegistry reports whether the node's registry already serves this
+// image:tag, so callers can skip an expensive load+push of what is there.
+func ExistsInCubeRegistry(image Image) bool {
+	url := fmt.Sprintf("http://%s:%s/v2/%s/manifests/%s",
+		settings.GetHostname(), LocalRegistryPort, image.Name, image.Tag)
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Accept", manifestTypes)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK
+}
+
 func PushImageToCubeRegistry(image Image) error {
 	_, outErr, err := util.ExecCmd(Binary, "load", "-i", image.LocalTar)
 	if err != nil {

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -37,6 +37,21 @@ bootstrap_status()
     echo "$1" >> $BOOTSTRAP_CUBE_LOG
     bootstrap_console_write "$space_filler"$'\r'"$1"$'\r'
 }
+# Run a long bootstrap step, logging every line and echoing it to the consoles,
+# without letting a console stall the step. `cmd | tee -a $LOG $KERNEL_CONSOLES`
+# blocks the whole pipeline on a console that stops draining -- that wedged
+# master for 10+ minutes here, in pipe_read, during a full-cluster powercycle.
+# The log is written directly and each console line goes through the bounded
+# writer, so a dead console costs 2s per line instead of the boot.
+bootstrap_run_logged()
+{
+    local line
+    "$@" 2>&1 | while IFS= read -r line ; do
+        echo "$line" >> $BOOTSTRAP_CUBE_LOG
+        bootstrap_console_write "$line"$'\n'
+    done
+    return 0
+}
 BootstrapAndClusterstart()
 {
     if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
@@ -44,7 +59,7 @@ BootstrapAndClusterstart()
         hex_log_event -e BSP00001I "interface=system,host=$HOSTNAME,service=bootstrap,phase=bootstrapping"
         hex_sdk power_bootup_mark bootstrapping   # cluster bootup status: entering the config commit
         [ -e /store/rolling_recover ] && hex_sdk _power_roll_set_phase_ts "$HOSTNAME" bootstrapping   # rolling_restart phase timing
-        bash -c "hex_config -p bootstrap standalone-done | tee -a $BOOTSTRAP_CUBE_LOG $KERNEL_CONSOLES"
+        bootstrap_run_logged hex_config -p bootstrap standalone-done
         if [ ! -e "$BOOTSTRAP_CUBE_MARKER" ] ; then
             bootstrap_status "Bootstrap error: $(journalctl | grep hex | egrep -i 'failed to commit')"
             hex_log_event -e BSP00003W "interface=system,host=$HOSTNAME,service=bootstrap,detail=$(journalctl | grep hex | egrep -i 'failed to commit|took' | tail -2 | tr -d ',\"=|' | tr '\n' ' ')"
@@ -54,7 +69,7 @@ BootstrapAndClusterstart()
             hex_log_event -e BSP00002I "interface=system,host=$HOSTNAME,service=bootstrap,phase=cluster_start"
             hex_sdk power_bootup_mark finalizing   # cluster bootup status: entering cluster_start (+ master check_repair)
             [ -e /store/rolling_recover ] && hex_sdk _power_roll_set_node_status "$HOSTNAME" finalizing   # rolling_restart: status + phase ts (until power_roll_advance -> done)
-            bash -c "hex_sdk -v cube_cluster_start | tee -a $BOOTSTRAP_CUBE_LOG $KERNEL_CONSOLES"
+            bootstrap_run_logged hex_sdk -v cube_cluster_start
             return 0
         fi
     fi

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -18,13 +18,24 @@ export HOSTNAME=$(hostname)
 space_filler=$(printf '%79s' '')
 # console list is fixed at boot -- resolve once
 KERNEL_CONSOLES=$(hex_sdk GetKernelConsoleDevices)
+# Write to each console separately, never one shared tee: a console whose getty
+# was restarted loses CLOCAL and blocks open() until carrier, which would stall
+# the boot path and swallow the healthy consoles too. clocal re-arms the line,
+# timeout bounds the write, and a dead console costs 2s instead of the boot.
+bootstrap_console_write()
+{
+    local c
+    for c in $KERNEL_CONSOLES ; do
+        stty -F "$c" clocal >/dev/null 2>&1
+        printf '%s' "$1" | timeout 2 tee "$c" >/dev/null 2>&1
+    done
+    return 0
+}
 # console: blank, home, print, home (one write); log: plain line per status.
-# tee, not >$(...): a multi-device redirect target is ambiguous and fails.
 bootstrap_status()
 {
-    local msg="$1"
-    echo "$msg" >> $BOOTSTRAP_CUBE_LOG
-    echo -n "$space_filler"$'\r'"$msg"$'\r' | tee $KERNEL_CONSOLES >/dev/null 2>&1
+    echo "$1" >> $BOOTSTRAP_CUBE_LOG
+    bootstrap_console_write "$space_filler"$'\r'"$1"$'\r'
 }
 BootstrapAndClusterstart()
 {
@@ -123,7 +134,7 @@ PostBootRecovery()
 export CLUSTER_SIZE=$(cubectl node list | wc -l)
 
 if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; then
-    echo -n "                                                                    " $'\r' | tee $KERNEL_CONSOLES
+    bootstrap_console_write "$space_filler"$'\r'
     if grep -q manual $BOOTSTRAP_CUBE_MODE ; then
         bootstrap_status "Auto bootstrap is disabled"
         hex_log_event -e BSP00009I "interface=system,host=$HOSTNAME,service=bootstrap"

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -37,12 +37,9 @@ bootstrap_status()
     echo "$1" >> $BOOTSTRAP_CUBE_LOG
     bootstrap_console_write "$space_filler"$'\r'"$1"$'\r'
 }
-# Run a long bootstrap step, logging every line and echoing it to the consoles,
-# without letting a console stall the step. `cmd | tee -a $LOG $KERNEL_CONSOLES`
-# blocks the whole pipeline on a console that stops draining -- that wedged
-# master for 10+ minutes here, in pipe_read, during a full-cluster powercycle.
-# The log is written directly and each console line goes through the bounded
-# writer, so a dead console costs 2s per line instead of the boot.
+# Run a long bootstrap step, logging and echoing each line, without letting a
+# console stall it: one shared `tee` blocks the whole pipeline on a console that
+# stops draining. Each console line goes through the bounded writer instead.
 bootstrap_run_logged()
 {
     local line
@@ -169,10 +166,11 @@ if [ -e /etc/appliance/state/configured -a "x$HOSTNAME" != "xunconfigured" ] ; t
             # cube_cluster_start's tail (skipped on the master). See kb note.
             hex_sdk power_roll_advance "$HOSTNAME"
             hex_sdk power_bootup_mark done
-            # Master waits (bounded) for all nodes committed+synced, then runs one
-            # detached full check_repair -- the single full pass, healing what the
-            # per-node auto_repair/essential passes miss.
-            for _i in $(seq 1 90) ; do hex_sdk cube_cluster_ready && break ; sleep 20 ; done
+            # Master waits (bounded, 1h) for all nodes committed+synced, then runs
+            # one detached full check_repair -- the single full pass, healing what
+            # the per-node auto_repair/essential passes miss. 30min was too strict:
+            # a cold powercycle with slow OSD recovery routinely outran it.
+            for _i in $(seq 1 180) ; do hex_sdk cube_cluster_ready && break ; sleep 20 ; done
             # fire the disruptive full check_repair only when the cluster is
             # ready AND no roll is running (power_roll_advance runs it at roll
             # completion); otherwise skip and tell the operator

--- a/core/main/cube-planned-maintenance.conf
+++ b/core/main/cube-planned-maintenance.conf
@@ -1,0 +1,15 @@
+# Planned-maintenance gate for health monitors that trigger destructive
+# recovery (masakari monitors, octavia health-manager). While the marker is
+# set the unit refuses to start and keeps retrying, so a planned cluster
+# shutdown is never mistaken for a failure. `cluster start` removes the marker
+# and the unit comes up on its next retry.
+#
+# StartLimitIntervalSec=0 is load-bearing: without it systemd rate-limits the
+# retries and parks the unit in failed state permanently.
+[Unit]
+StartLimitIntervalSec=0
+
+[Service]
+ExecStartPre=/usr/bin/test ! -e /etc/appliance/state/cube_planned_maintenance
+Restart=on-failure
+RestartSec=30

--- a/core/main/cube-planned-maintenance.conf
+++ b/core/main/cube-planned-maintenance.conf
@@ -1,11 +1,9 @@
-# Planned-maintenance gate for health monitors that trigger destructive
-# recovery (masakari monitors, octavia health-manager). While the marker is
-# set the unit refuses to start and keeps retrying, so a planned cluster
-# shutdown is never mistaken for a failure. `cluster start` removes the marker
-# and the unit comes up on its next retry.
+# Gate for the health monitors that trigger destructive recovery. While the
+# marker is set the unit refuses to start and keeps retrying, so a planned
+# shutdown is never mistaken for a failure.
 #
 # StartLimitIntervalSec=0 is load-bearing: without it systemd rate-limits the
-# retries and parks the unit in failed state permanently.
+# retries and parks the unit in failed state for good.
 [Unit]
 StartLimitIntervalSec=0
 

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -351,11 +351,8 @@ cube_cluster_start_cluster()
     keys=$keys timeout $SRVSTO $HEX_SDK os_s3_bucket_create admin log >/dev/null 2>&1
     Quiet -n cubectl node rsync /run/ec2.key
 
-    # NB: the planned-maintenance marker is deliberately NOT cleared here. This
-    # half finishes well before the recorded VMs are restored, and arming the
-    # monitors while the amphorae are still SHUTOFF is exactly the false-failure
-    # they are gated against. Released in cluster_check_repair_async, after
-    # power_restore_recorded_vms.
+    # NB: the marker is deliberately NOT cleared here -- this half finishes well
+    # before the VMs are restored. Released by cube_cluster_resume_after_stop.
 }
 
 # Master-only, run-once gate for the cluster-wide half. The master waits until
@@ -1260,6 +1257,30 @@ cube_wait_all_committed()
     return 1
 }
 
+# Finish a planned stop: restore the VMs it recorded and release the gate. The
+# monitors need nothing more -- their drop-in retries until the gate lifts.
+cube_cluster_resume_after_stop()
+{
+    _cube_cluster_start_env
+
+    # Only a planned stop may power a VM back. The recorded list outlives the
+    # restore, so ungated this would restart a VM stopped on purpose. The roll
+    # path records without the marker and restores in PostBootRecovery.
+    $HEX_SDK os_planned_maintenance_active || return 0
+
+    # Wait for the API this needs: cube_cluster_ready only means every node
+    # committed and synced, and the sweep reports FAIL and moves on. Bounded at
+    # 1h -- a cold powercycle with slow OSD recovery can take that long to serve.
+    local i
+    for i in $(seq 1 360) ; do
+        $OPENSTACK compute service list --service nova-compute >/dev/null 2>&1 && break
+        sleep 10
+    done
+
+    $HEX_SDK power_restore_recorded_vms
+    $HEX_SDK os_planned_maintenance_clear
+}
+
 cluster_check_repair_async()
 {
     # Run the final cluster check_repair off the caller's critical path so the
@@ -1268,22 +1289,14 @@ cluster_check_repair_async()
     # it finishes. Detached via setsid so it survives the parent CLI exiting.
     # Held until all nodes have committed so it fires once on a settled cluster.
     # Hidden opt-out: skip the check_repair if the agent dropped the marker (see
-    # #1225) -- but ALWAYS restore the VMs recorded at cluster stop. The opt-out
-    # suppresses health repair so faults stay visible; it must not strand a
-    # customer's running VMs SHUTOFF after a poweroff/power-loss cycle.
+    # #1225) -- it suppresses health repair so faults stay visible. The resume
+    # below runs either way; it is gated on the planned-stop marker, not this.
     setsid bash -c '
         hex_sdk cube_wait_all_committed 1500
         if [ ! -f /etc/appliance/state/cube_repair_optout ] ; then
             out=$(hex_cli -c cluster check_repair 2>&1 | grep -av "Broken pipe")
         fi
-        hex_sdk power_restore_recorded_vms
-        # Bring-up really is done now: the recorded VMs are back, so release the
-        # planned-maintenance gate and arm the monitors directly rather than
-        # waiting out RestartSec. Must follow the restore -- arming while the
-        # amphorae are still SHUTOFF makes octavia rebuild every one of them.
-        hex_sdk os_planned_maintenance_clear
-        hex_sdk os_masakari_monitors start
-        cubectl node exec -r compute -p "systemctl start octavia-health-manager" >/dev/null 2>&1
+        hex_sdk cube_cluster_resume_after_stop
         [ -n "$out" ] || exit 0
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -308,6 +308,10 @@ cube_cluster_start_node()
     cmd "$HEX_SDK network_ipt_serviceint" # customized iptables
     Quiet -n $HEX_SDK ceph_osd_set_bucket_host # assign osds to customized ceph buckets
     Quiet -n $HEX_SDK os_resume_hypervisor     # resume hypervisors disabled due to ins-ha
+    # NB: the instance-HA monitors are deliberately NOT started here. Per-node
+    # start is too early -- the process monitor reports its own not-yet-started
+    # nova-compute as a failure and masakari flags the host on_maintenance.
+    # They are armed once, cluster-wide, in cube_cluster_start_cluster.
     Quiet -n killall /usr/sbin/hex_banner # refresh console banner
     ( $HEX_SDK toggle_health_check | grep ceph_osd | grep -q disabled ) || Quiet -n $HEX_SDK toggle_health_check ceph_osd
     iptables-save > /run/iptables
@@ -346,6 +350,12 @@ cube_cluster_start_cluster()
     fi
     keys=$keys timeout $SRVSTO $HEX_SDK os_s3_bucket_create admin log >/dev/null 2>&1
     Quiet -n cubectl node rsync /run/ec2.key
+
+    # NB: the planned-maintenance marker is deliberately NOT cleared here. This
+    # half finishes well before the recorded VMs are restored, and arming the
+    # monitors while the amphorae are still SHUTOFF is exactly the false-failure
+    # they are gated against. Released in cluster_check_repair_async, after
+    # power_restore_recorded_vms.
 }
 
 # Master-only, run-once gate for the cluster-wide half. The master waits until
@@ -1267,6 +1277,13 @@ cluster_check_repair_async()
             out=$(hex_cli -c cluster check_repair 2>&1 | grep -av "Broken pipe")
         fi
         hex_sdk power_restore_recorded_vms
+        # Bring-up really is done now: the recorded VMs are back, so release the
+        # planned-maintenance gate and arm the monitors directly rather than
+        # waiting out RestartSec. Must follow the restore -- arming while the
+        # amphorae are still SHUTOFF makes octavia rebuild every one of them.
+        hex_sdk os_planned_maintenance_clear
+        hex_sdk os_masakari_monitors start
+        cubectl node exec -r compute -p "systemctl start octavia-health-manager" >/dev/null 2>&1
         [ -n "$out" ] || exit 0
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -1252,18 +1252,22 @@ cube_wait_all_committed()
 
 cluster_check_repair_async()
 {
-    # Hidden opt-out: skip the final check_repair if the agent dropped the marker. See #1225.
-    [ -f /etc/appliance/state/cube_repair_optout ] && return 0
     # Run the final cluster check_repair off the caller's critical path so the
     # operator gets their prompt back immediately and can start using the box.
     # The result is popped onto the console device(s) and broadcast (wall) when
     # it finishes. Detached via setsid so it survives the parent CLI exiting.
     # Held until all nodes have committed so it fires once on a settled cluster.
+    # Hidden opt-out: skip the check_repair if the agent dropped the marker (see
+    # #1225) -- but ALWAYS restore the VMs recorded at cluster stop. The opt-out
+    # suppresses health repair so faults stay visible; it must not strand a
+    # customer's running VMs SHUTOFF after a poweroff/power-loss cycle.
     setsid bash -c '
         hex_sdk cube_wait_all_committed 1500
-        out=$(hex_cli -c cluster check_repair 2>&1 | grep -av "Broken pipe")
-        # Restore VMs recorded at cluster stop, now that services are healed.
+        if [ ! -f /etc/appliance/state/cube_repair_optout ] ; then
+            out=$(hex_cli -c cluster check_repair 2>&1 | grep -av "Broken pipe")
+        fi
         hex_sdk power_restore_recorded_vms
+        [ -n "$out" ] || exit 0
         con=$(hex_sdk GetKernelConsoleDevices)
         { echo "" ; echo "===== cluster check_repair complete =====" ; echo "$out" ; echo "=========================================" ; } | tee $con 2>/dev/null | wall 2>/dev/null
     ' </dev/null >/dev/null 2>&1 &

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -85,6 +85,11 @@ rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/masakari/masakari-instancemonitor.service ./lib/systemd/system
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/masakari/masakari-processmonitor.service ./lib/systemd/system
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/masakari/masakari-hostmonitor.service ./lib/systemd/system
+	$(Q)# gate the monitors on the planned-maintenance marker (see cube-planned-maintenance.conf)
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/systemd/system/masakari-instancemonitor.service.d /etc/systemd/system/masakari-processmonitor.service.d /etc/systemd/system/masakari-hostmonitor.service.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-planned-maintenance.conf ./etc/systemd/system/masakari-instancemonitor.service.d/
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-planned-maintenance.conf ./etc/systemd/system/masakari-processmonitor.service.d/
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-planned-maintenance.conf ./etc/systemd/system/masakari-hostmonitor.service.d/
 
 # masakari command line plugin
 #

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -603,6 +603,11 @@ ClusterCheckRepairMain(int argc, const char** argv)
             CliPrint("A critical service could not be repaired. Stop checking.");
     }
 
+    // Finish a planned stop the operator was told to complete by hand. Gated on
+    // the marker, so a routine sweep touches no workload.
+    if (repair)
+        HexUtilSystemF(0, 0, HEX_SDK " cube_cluster_resume_after_stop");
+
     return CLI_SUCCESS;
 }
 
@@ -636,17 +641,12 @@ ClusterStopMain(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
-// Shared preamble for the planned whole-cluster stops (poweroff and powercycle).
-// Kept in one place because those two paths are near-identical twins and a fix
-// applied to only one of them silently does nothing on the other.
+// Shared by poweroff and powercycle -- near-identical twins, and a fix applied
+// to one of them silently does nothing on the other.
 //
-// Marks the shutdown planned before anything stops: a systemd drop-in gates the
-// monitors that trigger destructive recovery on that marker, so they cannot
-// rearm early on the way back up and read a still-starting service as a failure
-// (masakari flagging the host on_maintenance, octavia rebuilding every amphora
-// on stale heartbeats). Then silences instance-HA before any node goes down --
-// otherwise the nodes stopped first are seen failing by monitors still running
-// on the rest. Cleared by cube_cluster_start_cluster.
+// Marks the stop planned so the gated monitors cannot rearm early on the way
+// back up, then silences instance-HA before any node goes down: otherwise the
+// nodes stopped first are seen failing by monitors still running on the rest.
 static void
 ClusterPlannedStopPrepare()
 {

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -636,6 +636,25 @@ ClusterStopMain(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
+// Shared preamble for the planned whole-cluster stops (poweroff and powercycle).
+// Kept in one place because those two paths are near-identical twins and a fix
+// applied to only one of them silently does nothing on the other.
+//
+// Marks the shutdown planned before anything stops: a systemd drop-in gates the
+// monitors that trigger destructive recovery on that marker, so they cannot
+// rearm early on the way back up and read a still-starting service as a failure
+// (masakari flagging the host on_maintenance, octavia rebuilding every amphora
+// on stale heartbeats). Then silences instance-HA before any node goes down --
+// otherwise the nodes stopped first are seen failing by monitors still running
+// on the rest. Cleared by cube_cluster_start_cluster.
+static void
+ClusterPlannedStopPrepare()
+{
+    HexUtilSystemF(0, 0, HEX_SDK " os_planned_maintenance_set");
+    HexUtilSystemF(0, 0, HEX_SDK " os_masakari_monitors stop");
+    HexUtilSystemF(0, 0, "cubectl node exec -r compute -p 'systemctl stop octavia-health-manager' >/dev/null 2>&1");
+}
+
 static int
 ClusterPoweroffMain(int argc, const char** argv)
 {
@@ -659,6 +678,8 @@ ClusterPoweroffMain(int argc, const char** argv)
     // Record running VMs up front, while the API is healthy -- the per-host stop
     // below can't reliably do it mid-teardown (see power_record_running_vms).
     HexSystemF(0, "ssh root@%s '%s power_record_running_vms'", masterctl.c_str(), HEX_SDK);
+
+    ClusterPlannedStopPrepare();
 
     for (auto& ip : reverse(iplist)) {
         CliPrintf("mark control host %s down", ip.c_str());
@@ -698,6 +719,8 @@ ClusterPowercycleMain(int argc, const char** argv)
     // below can't reliably do it mid-teardown (see power_record_running_vms).
     HexSystemF(0, "ssh root@%s '%s power_record_running_vms'", masterctl.c_str(), HEX_SDK);
 
+    ClusterPlannedStopPrepare();
+
     for (auto& ip : reverse(iplist)) {
         CliPrintf("mark control host %s down", ip.c_str());
         HexSystemF(0, "ssh root@%s '%s cube_cluster_stop' 2>/dev/null", ip.c_str(), HEX_SDK);
@@ -706,7 +729,6 @@ ClusterPowercycleMain(int argc, const char** argv)
 
     HexUtilSystemF(0, 0, HEX_SDK " ceph_osd_compact >/dev/null 2>&1");
     HexUtilSystemF(0, 0, HEX_SDK " ceph_enter_maintenance");
-    HexUtilSystemF(0, 0, HEX_SDK " os_maintain_segment_hosts"); // puts hosts in maintenance if ins-ha is enabled
 
     HexSystemF(0, "ssh root@%s '%s cube_cluster_power cycle' 2>/dev/null", masterctl.c_str(), HEX_SDK);
 

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1060,6 +1060,17 @@ CommitMds(const char* name, const char* hostname)
     if (!IsControl(s_eCubeRole))
         return true;
 
+    // cluster poweroff sets pauserd/pausewr, and nothing lifts them until
+    // cube_cluster_start_node -- which runs a whole phase later, in cluster
+    // start. Every module commit in between, this one included, then waits on
+    // storage that cannot serve: the MDS sits in up:replay with metadata IOs
+    // blocked, and the mgr has no fs metadata to answer with. Measured 4x on
+    // the ceph commit after a cold poweroff (469s vs ~90-125s on a boot with no
+    // flags set). Lift just the client-I/O blocks here, once the mons answer;
+    // noout/norebalance/nobackfill/norecover stay for cube_cluster_start_node's
+    // ceph_leave_maintenance, so a roll's OSD guard is untouched.
+    HexUtilSystemF(0, 0, HEX_SDK " ceph_unpause_client_io");
+
     std::string srv = std::string(name) + "-mds@" + std::string(hostname);
     SystemdCommitService(true, srv.c_str());
     HexUtilSystemF(0, 0, HEX_SDK " ceph_fs_mds_init");

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -1319,8 +1319,27 @@ MountCephfsStore()
         HexUtilSystemF(0, 0, "systemctl start ceph-umountfs");
         // Register this node in the grace DB before ganesha joins (idempotent; also covers a same-hostname rejoin). See #1231.
         // Bounded for the same reason as the remove in RemoveMon(): it is a RADOS
-        // call, and hanging here would wedge the commit that owns it.
-        HexUtilSystemF(0, 0, "timeout 60 ganesha-rados-grace -p %s add %s", GANESHA_RECOV_POOL, s_hostname.c_str());
+        // call, and hanging here would wedge the commit that owns it. The bound can
+        // expire on a node bootstrapping against a still-recovering cluster, so
+        // verify the membership took and retry: ganesha's rados_cluster backend
+        // exits fatally without it, and no restart can recover that.
+        bool joined = false;
+        for (int i = 0; i < 3 && !joined; ++i) {
+            HexUtilSystemF(0, 0, "timeout 60 ganesha-rados-grace -p %s add %s", GANESHA_RECOV_POOL, s_hostname.c_str());
+            const ExecSyncResult gr = ExecBashSync(
+                0,
+                false,
+                false,
+                {},
+                "timeout 30 ganesha-rados-grace -p " + std::string(GANESHA_RECOV_POOL)
+                    + " dump 2>/dev/null | awk '{print $1}' | grep -qx " + s_hostname.c_str());
+            joined = (gr.exitCode == 0);
+            if (!joined)
+                sleep(10);
+        }
+        if (!joined)
+            HexLogError("%s is not in the %s grace DB; nfs-ganesha cannot start until it is",
+                        s_hostname.c_str(), GANESHA_RECOV_POOL);
         HexUtilSystemF(0, 0, "systemctl start nfs-ganesha");
     }
 

--- a/core/modules/config_cubesys.cpp
+++ b/core/modules/config_cubesys.cpp
@@ -463,6 +463,13 @@ CONFIG_MIGRATE(cubesys, MigrateMain);
 //CONFIG_MIGRATE(cubesys, SRV_CRT);
 CONFIG_MIGRATE(cubesys, SSH_CLIENT_CONFIG);
 CONFIG_MIGRATE(cubesys, AUTHORIZED_KEYS);
+// The hidden opt-out markers (cube_repair_optout #1225, cube_git_optout) are a
+// deliberate, persistent operator choice, but they live in the root slot -- so an
+// upgrade, which boots the other slot, silently revoked them and turned auto-repair
+// back on underneath the operator. Only the opt-outs: the *_done markers beside them
+// gate first-time setup and must be re-evaluated by the new firmware, so migrating
+// the whole directory would make it skip init it needs to run.
+CONFIG_MIGRATE(cubesys, "/etc/appliance/state/cube_*_optout");
 
 CONFIG_MODULE(standalone, 0, 0, 0, 0, 0);
 CONFIG_REQUIRES(standalone, time);

--- a/core/modules/config_mysql.cpp
+++ b/core/modules/config_mysql.cpp
@@ -239,16 +239,9 @@ SetupCluster(bool enabled, bool isMaster, bool force, const std::string& ctrlAdd
     }
 
     if (isMaster) {
-        // Never bootstrap over a live cluster. If a peer already holds a galera
-        // PRIMARY, join it instead: bootstrapping here creates a SECOND primary,
-        // and when the two components meet galera aborts one node FATAL with
-        // "conflicting prims: older overrides". Seen 2026-08-23 -- a node
-        // rebooting after a host failure ran SetupCluster and bootstrapped an
-        // empty cluster (initial position 00000000-...:-1) while the two
-        // survivors held quorum; the node was evicted ~48 min later and the VIP
-        // it served had a dead DB until `cluster repair mysql`.
-        // _health_mysql's repair path has always had this guard; the boot path
-        // did not.
+        // Never bootstrap over a live cluster: a second primary meets the first
+        // and galera aborts a node FATAL with "conflicting prims". Join instead.
+        // _health_mysql's repair path has always had this guard; boot did not.
         if (HexSystemF(0, HEX_SDK " os_galera_live_primary >/dev/null 2>&1") == 0) {
             HexLogInfo("galera: a peer already holds a primary, joining instead of bootstrapping");
             // the force path above armed safe_to_bootstrap; disarm it so this node

--- a/core/modules/config_mysql.cpp
+++ b/core/modules/config_mysql.cpp
@@ -239,7 +239,27 @@ SetupCluster(bool enabled, bool isMaster, bool force, const std::string& ctrlAdd
     }
 
     if (isMaster) {
-        HexUtilSystemF(0, 0, "galera_new_cluster");
+        // Never bootstrap over a live cluster. If a peer already holds a galera
+        // PRIMARY, join it instead: bootstrapping here creates a SECOND primary,
+        // and when the two components meet galera aborts one node FATAL with
+        // "conflicting prims: older overrides". Seen 2026-08-23 -- a node
+        // rebooting after a host failure ran SetupCluster and bootstrapped an
+        // empty cluster (initial position 00000000-...:-1) while the two
+        // survivors held quorum; the node was evicted ~48 min later and the VIP
+        // it served had a dead DB until `cluster repair mysql`.
+        // _health_mysql's repair path has always had this guard; the boot path
+        // did not.
+        if (HexSystemF(0, HEX_SDK " os_galera_live_primary >/dev/null 2>&1") == 0) {
+            HexLogInfo("galera: a peer already holds a primary, joining instead of bootstrapping");
+            // the force path above armed safe_to_bootstrap; disarm it so this node
+            // joins the running component instead of forming another one
+            HexSystemF(0, "sed -i 's/^\\(safe_to_bootstrap\\s*:\\s*\\).*$/\\10/' /var/lib/mysql/grastate.dat");
+            // galera_new_cluster would have started mariadb; joining must too
+            SystemdCommitService(enabled, NAME, true);
+        }
+        else {
+            HexUtilSystemF(0, 0, "galera_new_cluster");
+        }
     }
 
     HexSystemF(0, "touch %s", SETUP_MARK);

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -995,6 +995,12 @@ CONFIG_REQUIRES(nova, ceph);
 //CONFIG_REQUIRES(nova, glance);
 
 CONFIG_MIGRATE(nova, "/etc/nova/nova.d");
+// Antelope's nova keys each compute to a local identity file and refuses to
+// start when the DB has nodes for this host but the file is gone (manager.py
+// _ensure_existing_node_identity). It lives in the root slot, so without this
+// an upgrade -- which boots the other slot -- leaves every upgraded node
+// without nova-compute, and the roll stalls with nothing able to migrate.
+CONFIG_MIGRATE(nova, "/var/lib/nova/compute_id");
 CONFIG_MIGRATE_POST(nova, MigratePlacementLogOwner);
 
 // extra tunings

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -630,8 +630,11 @@ Commit(bool modified, int dryLevel)
         MysqlUtilUpdateDbPass(USER, dbPass.c_str());
 
     if (s_bConfigChanged) {
+        // Health-manager endpoints follow CLUSTER ha, not the amphora topology
+        // (s_lbHa): with one endpoint, rebooting that node black-holes every
+        // amphora's heartbeats and octavia marks them ERROR.
         UpdateCfg(s_lbHa, s_cubeDomain, userPass, adminCliPass, cidrIp,
-                  ControllerIpPortList(s_lbHa, s_mgmtCidr.newValue(), cidrIp, s_ctrlAddrs.newValue()),
+                  ControllerIpPortList(s_ha, s_mgmtCidr.newValue(), cidrIp, s_ctrlAddrs.newValue()),
                   s_ha ? s_ctrlAddrs.newValue() : ctrlIp);
         UpdateSharedId(sharedId);
         UpdateMyIp(myip);

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -26,7 +26,6 @@
 #define CERT_DIR    "/etc/octavia/certs/"
 #define DEF_EXT     ".def"
 #define CONF        "/etc/octavia/octavia.conf"
-#define INIT_DONE   "/etc/appliance/state/octavia_init_done"
 
 static const char USER[] = "octavia";
 static const char GROUP[] = "octavia";
@@ -55,7 +54,6 @@ static Configs cfg;
 static Configs oldCfg;
 
 static bool s_bSetup = true;
-static bool s_bInit = true;
 
 static bool s_bCubeModified = false;
 static bool s_bMqModified = false;
@@ -113,18 +111,6 @@ PARSE_TUNING_X_STR(s_mgmtCidr, CUBESYS_MGMT_CIDR, 2);
 PARSE_TUNING_X_BOOL(s_saltkey, CUBESYS_SALTKEY, 2);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 2);
 PARSE_TUNING_X_STR(s_adminCliPass, KEYSTONE_ADMIN_CLI_PASS, 3);
-
-static bool
-InitCheck()
-{
-    if (!IsControl(s_eCubeRole))
-        return true;
-
-    if (access(INIT_DONE, F_OK) != 0)
-        s_bInit = false;
-
-    return true;
-}
 
 // should run after mysql services are running.
 static bool
@@ -418,14 +404,11 @@ UpdateCfg(bool ha, const std::string& domain, const std::string& userPass, const
         cfg["controller_worker"]["amphora_driver"] = "amphora_haproxy_rest_driver";
         cfg["controller_worker"]["loadbalancer_topology"] = ha ? "ACTIVE_STANDBY" : "SINGLE";
 
-        if (s_bInit) {
-            cfg["controller_worker"]["amp_boot_network_list"] = oldCfg["controller_worker"]["amp_boot_network_list"];
-            cfg["controller_worker"]["amp_secgroup_list"] = oldCfg["controller_worker"]["amp_secgroup_list"];
-        }
-        else {
-            cfg["controller_worker"]["amp_boot_network_list"] = "";
-            cfg["controller_worker"]["amp_secgroup_list"] = "";
-        }
+        // Always carry these two forward. They are cluster-wide neutron ids
+        // stamped by ReconfigMain, not settings, so a commit must never author
+        // them: on a genuine first init oldCfg has nothing and they stay empty.
+        cfg["controller_worker"]["amp_boot_network_list"] = oldCfg["controller_worker"]["amp_boot_network_list"];
+        cfg["controller_worker"]["amp_secgroup_list"] = oldCfg["controller_worker"]["amp_secgroup_list"];
 
         cfg["oslo_messaging"]["topic"] = "octavia_prov";
 
@@ -619,7 +602,6 @@ Commit(bool modified, int dryLevel)
     std::string mqPass = GetSaltKey(s_saltkey, s_mqPass, s_seed);
     std::string adminCliPass = GetSaltKey(s_saltkey, s_adminCliPass.newValue(), s_seed.newValue());
 
-    InitCheck();
     SetupCheck();
     if (!s_bSetup) {
         s_bDbPassChanged = true;
@@ -793,10 +775,22 @@ ReconfigMain(int argc, char* argv[])
         curCfg["controller_worker"]["amp_secgroup_list"] = std::string(argv[2]);
     }
     else {
+        // Keep the current ids when the lookup comes back empty (openstack not
+        // answering yet on a booting node). An empty amp_boot_network_list makes
+        // every amphora build on this node's worker fail with nova's misleading
+        // "Multiple possible networks found".
         std::string nid = HexUtilPOpen(HEX_SDK " os_octavia_nid_get");
         std::string sgid = HexUtilPOpen(HEX_SDK " os_octavia_sgid_get");
-        curCfg["controller_worker"]["amp_boot_network_list"] = nid;
-        curCfg["controller_worker"]["amp_secgroup_list"] = sgid;
+        if (!nid.empty())
+            curCfg["controller_worker"]["amp_boot_network_list"] = nid;
+        else
+            HexLogWarning("octavia: lb-mgmt-net lookup empty, keeping amp_boot_network_list=%s",
+                          curCfg["controller_worker"]["amp_boot_network_list"].c_str());
+        if (!sgid.empty())
+            curCfg["controller_worker"]["amp_secgroup_list"] = sgid;
+        else
+            HexLogWarning("octavia: lb-mgmt-sec-grp lookup empty, keeping amp_secgroup_list=%s",
+                          curCfg["controller_worker"]["amp_secgroup_list"].c_str());
     }
 
     WriteConfig(CONF, SB_SEC_WFMT, '=', curCfg);

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -674,7 +674,13 @@ Commit(bool modified, int dryLevel)
         }
         else {
             std::string peer = s_ha ? GetControllerPeers(myip, s_ctrlAddrs)[0] : ctrlIp;
-            HexUtilSystemF(0, 0, "scp -r root@%s:%s %s", peer.c_str(), CERT_DIR, CERT_DIR);
+            // Copy into the PARENT: scp -r <src>/ <dst>/ where dst exists lands
+            // the tree at <dst>/certs/, so ca_01.pem never appears where
+            // octavia.conf points. Any worker flow on such a node then dies with
+            // "Failed to load CA Cert" -- amphora builds and failovers only work
+            // when they happen to land on the master, which is why LB recovery
+            // looked intermittent.
+            HexUtilSystemF(0, 0, "scp -r root@%s:%s /etc/octavia/", peer.c_str(), CERT_DIR);
         }
         HexSystemF(0, "chmod -R 755 %s", CERT_DIR);
     }

--- a/core/octavia/antelope_patch/octavia/compute/drivers/nova_driver.py.orig
+++ b/core/octavia/antelope_patch/octavia/compute/drivers/nova_driver.py.orig
@@ -1,0 +1,420 @@
+# Copyright 2014 Rackspace
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import random
+import string
+
+from novaclient import exceptions as nova_exceptions
+from oslo_config import cfg
+from oslo_log import log as logging
+from stevedore import driver as stevedore_driver
+import tenacity
+
+from octavia.common import clients
+from octavia.common import constants
+from octavia.common import data_models as models
+from octavia.common import exceptions
+from octavia.compute import compute_base
+
+LOG = logging.getLogger(__name__)
+
+CONF = cfg.CONF
+
+
+def _raise_compute_exception(retry_state):
+    LOG.exception("Error retrieving nova virtual machine.")
+    raise exceptions.ComputeGetException()
+
+
+class VirtualMachineManager(compute_base.ComputeBase):
+    '''Compute implementation of virtual machines via nova.'''
+
+    def __init__(self):
+        super().__init__()
+        # Must initialize nova api
+        self._nova_client = clients.NovaAuth.get_nova_client(
+            service_name=CONF.nova.service_name,
+            endpoint=CONF.nova.endpoint,
+            region=CONF.nova.region_name,
+            endpoint_type=CONF.nova.endpoint_type,
+            insecure=CONF.nova.insecure,
+            cacert=CONF.nova.ca_certificates_file)
+        self.manager = self._nova_client.servers
+        self.server_groups = self._nova_client.server_groups
+        self.flavor_manager = self._nova_client.flavors
+        self.availability_zone_manager = self._nova_client.availability_zones
+        self.volume_driver = stevedore_driver.DriverManager(
+            namespace='octavia.volume.drivers',
+            name=CONF.controller_worker.volume_driver,
+            invoke_on_load=True
+        ).driver
+        self.image_driver = stevedore_driver.DriverManager(
+            namespace='octavia.image.drivers',
+            name=CONF.controller_worker.image_driver,
+            invoke_on_load=True
+        ).driver
+
+    def build(self, name="amphora_name", amphora_flavor=None,
+              image_tag=None, image_owner=None, key_name=None, sec_groups=None,
+              network_ids=None, port_ids=None, config_drive_files=None,
+              user_data=None, server_group_id=None, availability_zone=None):
+        '''Create a new virtual machine.
+
+        :param name: optional name for amphora
+        :param amphora_flavor: image flavor for virtual machine
+        :param image_tag: image tag for virtual machine
+        :param key_name: keypair to add to the virtual machine
+        :param sec_groups: Security group IDs for virtual machine
+        :param network_ids: Network IDs to include on virtual machine
+        :param port_ids: Port IDs to include on virtual machine
+        :param config_drive_files:  An optional dict of files to overwrite on
+                                    the server upon boot. Keys are file names
+                                    (i.e. /etc/passwd) and values are the file
+                                    contents (either as a string or as a
+                                    file-like object). A maximum of five
+                                    entries is allowed, and each file must be
+                                    10k or less.
+        :param user_data: Optional user data to pass to be exposed by the
+                          metadata server this can be a file type object as
+                          well or a string
+        :param server_group_id: Optional server group id(uuid) which is used
+                                for anti_affinity feature
+        :param availability_zone: Name of the compute availability zone.
+
+        :raises ComputeBuildException: if nova failed to build virtual machine
+        :returns: UUID of amphora
+
+        '''
+
+        volume_id = None
+        try:
+            network_ids = network_ids or []
+            port_ids = port_ids or []
+            nics = []
+            if network_ids:
+                nics.extend([{"net-id": net_id} for net_id in network_ids])
+            if port_ids:
+                nics.extend([{"port-id": port_id} for port_id in port_ids])
+
+            server_group = None if server_group_id is None else {
+                "group": server_group_id}
+            az_name = availability_zone or CONF.nova.availability_zone
+
+            image_id = self.image_driver.get_image_id_by_tag(
+                image_tag, image_owner)
+
+            if CONF.nova.random_amphora_name_length:
+                r = random.SystemRandom()
+                name = "a{}".format("".join(
+                    [r.choice(string.ascii_uppercase + string.digits)
+                     for i in range(CONF.nova.random_amphora_name_length - 1)]
+                ))
+            block_device_mapping = {}
+            if (CONF.controller_worker.volume_driver !=
+                    constants.VOLUME_NOOP_DRIVER):
+                # creating volume
+                LOG.debug('Creating volume for amphora from image %s',
+                          image_id)
+                volume_id = self.volume_driver.create_volume_from_image(
+                    image_id)
+                LOG.debug('Created boot volume %s for amphora', volume_id)
+                # If use volume based, does not require image ID anymore
+                image_id = None
+                # Boot from volume with parameters: target device name = vda,
+                # device id = volume_id, device type and size unspecified,
+                # delete-on-terminate = true (volume will be deleted by Nova
+                # on instance termination)
+                block_device_mapping = {'vda': '%s:::true' % volume_id}
+            amphora = self.manager.create(
+                name=name, image=image_id, flavor=amphora_flavor,
+                block_device_mapping=block_device_mapping,
+                key_name=key_name, security_groups=sec_groups,
+                nics=nics,
+                files=config_drive_files,
+                userdata=user_data,
+                config_drive=True,
+                scheduler_hints=server_group,
+                availability_zone=az_name
+            )
+
+            return amphora.id
+        except Exception as e:
+            if (CONF.controller_worker.volume_driver !=
+                    constants.VOLUME_NOOP_DRIVER):
+                self.volume_driver.delete_volume(volume_id)
+            LOG.exception("Nova failed to build the instance due to: %s",
+                          str(e))
+            raise exceptions.ComputeBuildException(fault=e)
+
+    def delete(self, compute_id):
+        '''Delete a virtual machine.
+
+        :param compute_id: virtual machine UUID
+        '''
+        try:
+            self.manager.delete(server=compute_id)
+        except nova_exceptions.NotFound:
+            LOG.warning("Nova instance with id: %s not found. "
+                        "Assuming already deleted.", compute_id)
+        except Exception as e:
+            LOG.exception("Error deleting nova virtual machine.")
+            raise exceptions.ComputeDeleteException(compute_msg=str(e))
+
+    def status(self, compute_id):
+        '''Retrieve the status of a virtual machine.
+
+        :param compute_id: virtual machine UUID
+        :returns: constant of amphora status
+        '''
+        try:
+            amphora, fault = self.get_amphora(compute_id)
+            if amphora and amphora.status == 'ACTIVE':
+                return constants.UP
+        except Exception as e:
+            LOG.exception("Error retrieving nova virtual machine status.")
+            raise exceptions.ComputeStatusException() from e
+        return constants.DOWN
+
+    @tenacity.retry(retry=tenacity.retry_if_exception_type(),
+                    stop=tenacity.stop_after_attempt(CONF.compute.max_retries),
+                    retry_error_callback=_raise_compute_exception,
+                    wait=tenacity.wait_fixed(CONF.compute.retry_interval))
+    def get_amphora(self, compute_id, management_network_id=None):
+        '''Retrieve the information in nova of a virtual machine.
+
+        :param compute_id: virtual machine UUID
+        :param management_network_id: ID of the management network
+        :returns: an amphora object
+        :returns: fault message or None
+        '''
+        # utilize nova client ServerManager 'get' method to retrieve info
+        amphora = self.manager.get(compute_id)
+        return self._translate_amphora(amphora, management_network_id)
+
+    def _translate_amphora(self, nova_response, management_network_id=None):
+        '''Convert a nova virtual machine into an amphora object.
+
+        :param nova_response: JSON response from nova
+        :param management_network_id: ID of the management network
+        :returns: an amphora object
+        :returns: fault message or None
+        '''
+        # Extract interfaces of virtual machine to populate desired amphora
+        # fields
+
+        lb_network_ip = None
+        availability_zone = None
+        image_id = None
+
+        if management_network_id:
+            boot_networks = [management_network_id]
+        else:
+            boot_networks = CONF.controller_worker.amp_boot_network_list
+
+        try:
+            inf_list = nova_response.interface_list()
+            for interface in inf_list:
+                net_id = interface.net_id
+                # Pick the first fixed_ip if this is a boot network or if
+                # there are no boot networks configured (use default network)
+                if net_id in boot_networks or not boot_networks:
+                    lb_network_ip = interface.fixed_ips[0]['ip_address']
+                    break
+            try:
+                availability_zone = getattr(
+                    nova_response, 'OS-EXT-AZ:availability_zone')
+            except AttributeError:
+                LOG.info('No availability zone listed for server %s',
+                         nova_response.id)
+        except Exception:
+            LOG.debug('Extracting virtual interfaces through nova '
+                      'os-interfaces extension failed.')
+
+        fault = getattr(nova_response, 'fault', None)
+        if (CONF.controller_worker.volume_driver ==
+                constants.VOLUME_NOOP_DRIVER):
+            image_id = nova_response.image.get("id")
+        else:
+            try:
+                volumes = self._nova_client.volumes.get_server_volumes(
+                    nova_response.id)
+            except Exception:
+                LOG.debug('Extracting volumes through nova '
+                          'os-volumes extension failed.')
+                volumes = []
+            if not volumes:
+                LOG.warning('Boot volume not found for volume backed '
+                            'amphora instance %s ', nova_response.id)
+            else:
+                if len(volumes) > 1:
+                    LOG.warning('Found more than one (%s) volumes '
+                                'for amphora instance %s',
+                                len(volumes), nova_response.id)
+                volume_id = volumes[0].volumeId
+                image_id = self.volume_driver.get_image_from_volume(volume_id)
+
+        response = models.Amphora(
+            compute_id=nova_response.id,
+            status=nova_response.status,
+            lb_network_ip=lb_network_ip,
+            cached_zone=availability_zone,
+            image_id=image_id,
+            compute_flavor=nova_response.flavor.get("id")
+        )
+        return response, fault
+
+    def create_server_group(self, name, policy):
+        """Create a server group object
+
+        :param name: the name of the server group
+        :param policy: the policy of the server group
+        :raises: Generic exception if the server group is not created
+        :returns: the server group object
+        """
+        kwargs = {'name': name,
+                  'policies': [policy]}
+        try:
+            server_group_obj = self.server_groups.create(**kwargs)
+            return server_group_obj
+        except Exception as e:
+            LOG.exception("Error create server group instance.")
+            raise exceptions.ServerGroupObjectCreateException() from e
+
+    def delete_server_group(self, server_group_id):
+        """Delete a server group object
+
+        :raises: Generic exception if the server group is not deleted
+        :param server_group_id: the uuid of a server group
+        """
+        try:
+            self.server_groups.delete(server_group_id)
+
+        except nova_exceptions.NotFound:
+            LOG.warning("Server group instance with id: %s not found. "
+                        "Assuming already deleted.", server_group_id)
+        except Exception as e:
+            LOG.exception("Error delete server group instance.")
+            raise exceptions.ServerGroupObjectDeleteException() from e
+
+    def attach_network_or_port(self, compute_id, network_id=None,
+                               ip_address=None, port_id=None):
+        """Attaching a port or a network to an existing amphora
+
+        :param compute_id: id of an amphora in the compute service
+        :param network_id: id of a network
+        :param ip_address: ip address to attempt to be assigned to interface
+        :param port_id: id of the neutron port
+        :return: nova interface instance
+        :raises ComputePortInUseException: The port is in use somewhere else
+        :raises ComputeUnknownException: Unknown nova error
+        """
+        try:
+            interface = self.manager.interface_attach(
+                server=compute_id, net_id=network_id, fixed_ip=ip_address,
+                port_id=port_id)
+        except nova_exceptions.Conflict as e:
+            # The port is already in use.
+            if port_id:
+                # Check if the port we want is already attached
+                try:
+                    interfaces = self.manager.interface_list(compute_id)
+                    for interface in interfaces:
+                        if interface.id == port_id:
+                            return interface
+                except Exception as e:
+                    raise exceptions.ComputeUnknownException(exc=str(e))
+
+                raise exceptions.ComputePortInUseException(port=port_id)
+
+            # Nova should have created the port, so something is really
+            # wrong in nova if we get here.
+            raise exceptions.ComputeUnknownException(exc=str(e))
+        except nova_exceptions.NotFound as e:
+            if 'Instance' in str(e):
+                raise exceptions.NotFound(resource='Instance', id=compute_id)
+            if 'Network' in str(e):
+                raise exceptions.NotFound(resource='Network', id=network_id)
+            if 'Port' in str(e):
+                raise exceptions.NotFound(resource='Port', id=port_id)
+            raise exceptions.NotFound(resource=str(e), id=compute_id)
+        except Exception as e:
+            LOG.error('Error attaching network %(network_id)s with ip '
+                      '%(ip_address)s and port %(port)s to amphora '
+                      '(compute_id: %(compute_id)s) ',
+                      {
+                          'compute_id': compute_id,
+                          'network_id': network_id,
+                          'ip_address': ip_address,
+                          'port': port_id
+                      })
+            raise exceptions.ComputeUnknownException(exc=str(e))
+        return interface
+
+    def detach_port(self, compute_id, port_id):
+        """Detaches a port from an existing amphora.
+
+        :param compute_id: id of an amphora in the compute service
+        :param port_id: id of the port
+        :return: None
+        """
+        try:
+            self.manager.interface_detach(server=compute_id,
+                                          port_id=port_id)
+        except Exception:
+            LOG.error('Error detaching port %(port_id)s from amphora '
+                      'with compute ID %(compute_id)s. '
+                      'Skipping.',
+                      {
+                          'port_id': port_id,
+                          'compute_id': compute_id
+                      })
+
+    def validate_flavor(self, flavor_id):
+        """Validates that a flavor exists in nova.
+
+        :param flavor_id: ID of the flavor to lookup in nova.
+        :raises: NotFound
+        :returns: None
+        """
+        try:
+            self.flavor_manager.get(flavor_id)
+        except nova_exceptions.NotFound as e:
+            LOG.info('Flavor %s was not found in nova.', flavor_id)
+            raise exceptions.InvalidSubresource(resource='Nova flavor',
+                                                id=flavor_id) from e
+        except Exception as e:
+            LOG.exception('Nova reports a failure getting flavor details for '
+                          'flavor ID %s: %s', flavor_id, str(e))
+            raise
+
+    def validate_availability_zone(self, availability_zone):
+        """Validates that an availability zone exists in nova.
+
+        :param availability_zone: Name of the availability zone to lookup.
+        :raises: NotFound
+        :returns: None
+        """
+        try:
+            compute_zones = [
+                a.zoneName for a in self.availability_zone_manager.list(
+                    detailed=False)]
+            if availability_zone not in compute_zones:
+                LOG.info('Availability zone %s was not found in nova. %s',
+                         availability_zone, compute_zones)
+                raise exceptions.InvalidSubresource(
+                    resource='Nova availability zone', id=availability_zone)
+        except Exception as e:
+            LOG.exception('Nova reports a failure getting listing '
+                          'availability zones: %s', str(e))
+            raise

--- a/core/octavia/antelope_patch/octavia/compute/drivers/nova_driver.py.patch
+++ b/core/octavia/antelope_patch/octavia/compute/drivers/nova_driver.py.patch
@@ -1,0 +1,18 @@
+--- nova_driver.py	2026-08-21 00:17:26.242065455 +0800
++++ nova_driver.py	2026-08-21 00:17:40.751121333 +0800
+@@ -145,7 +145,14 @@
+                 userdata=user_data,
+                 config_drive=True,
+                 scheduler_hints=server_group,
+-                availability_zone=az_name
++                availability_zone=az_name,
++                # Opt amphorae out of masakari evacuation. Amphorae are
++                # octavia-managed and disposable: a nova evacuate rebuilds one
++                # without its injected config, which leaves the load balancer
++                # provisioning_status ERROR and octavia refusing to touch it
++                # again, so the LB stays dead until an operator failovers it.
++                # Octavia's own health-manager rebuild is the right recovery.
++                meta={'HA_Enabled': 'False'}
+             )
+ 
+             return amphora.id

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -80,7 +80,20 @@ rootfs_install::
 # printing any result. Upstream's bug, not this packaging's: RDO's spec carries no
 # patches, so the rpm build fails identically, and master's import list is unchanged.
 rootfs_install::
-	$(Q)[ -d $(OCTAVIA_PATCHDIR) ] && cp -rf $(OCTAVIA_PATCHDIR)/* $(OCTAVIA_SRCDIR)/ || /bin/true
+	$(Q)[ -d $(OCTAVIA_PATCHDIR) ] && rsync -a --exclude='*.py.patch' --exclude='*.py.orig' $(OCTAVIA_PATCHDIR)/ $(OCTAVIA_SRCDIR)/ || /bin/true
+
+# Reviewable unified diffs, same convention as core/masakari: each patch sits at
+# <PATCHDIR>/<rel>.py.patch and targets <SRCDIR>/<rel>.py, with a <rel>.py.orig
+# alongside for review only. Preferred over the whole-file copies above -- a diff
+# shows what we changed, and --forward keeps re-runs idempotent while a failed
+# hunk aborts the build, so upstream drift is caught here rather than shipped.
+rootfs_install::
+	$(Q)set -e; for p in $$(find $(OCTAVIA_PATCHDIR) -name '*.py.patch' 2>/dev/null | sort); do \
+		rel=$${p#$(OCTAVIA_PATCHDIR)/}; tgt=$(OCTAVIA_SRCDIR)/$${rel%.patch}; \
+		echo "  PATCH   $${rel%.patch}"; \
+		patch --forward --no-backup-if-mismatch -r - "$$tgt" < "$$p" \
+			|| { echo "octavia: failed to apply $$p to $$tgt" >&2; exit 1; }; \
+	done
 
 # install the octavia web ui plugin, the openstack-octavia-ui rpm's replacement.
 # Registering its panel and settings snippet is core/horizon's job, where every

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -177,6 +177,10 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/octavia/octavia-worker.service /usr/lib/systemd/system/octavia-worker.service
 	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/octavia/octavia-housekeeping.service /usr/lib/systemd/system/octavia-housekeeping.service
 	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/octavia/octavia-health-manager.service /usr/lib/systemd/system/octavia-health-manager.service
+	$(Q)# gate the health-manager on the planned-maintenance marker: it rebuilds every
+	$(Q)# amphora on stale heartbeats, which a planned shutdown otherwise looks like
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/systemd/system/octavia-health-manager.service.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-planned-maintenance.conf ./etc/systemd/system/octavia-health-manager.service.d/
 
 # adjust file ownerships and permissions
 rootfs_install::

--- a/core/sdk_sh/modules.pre/sdk_01-var-static.sh
+++ b/core/sdk_sh/modules.pre/sdk_01-var-static.sh
@@ -45,7 +45,9 @@ CEPHFS_UPDATE_DIR=/mnt/cephfs/update
 ADMIN_KEYRING=/etc/ceph/ceph.client.admin.keyring
 CEPHFS_CLIENT_AUTHKEY=/etc/ceph/admin.key
 CEPH_OSD_MAP=/var/lib/ceph/osd/dev_osd.map
-CEPH="timeout $SRVSTO /usr/bin/ceph"
+# -k: SIGTERM alone does not free a ceph CLI blocked on an unserving mgr, and
+# plain `timeout` then waits forever -- the cap has to be enforced with a kill.
+CEPH="timeout -k 5 $SRVSTO /usr/bin/ceph"
 GIT="timeout 300 /usr/bin/git"
 MAPFILE=/tmp/monmap.sdk
 CRUSHMAPFILE=/tmp/crushmap.sdk

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -234,6 +234,7 @@ eval "ERR_DESC_$SRV[9]='health-manager down'"
 eval "ERR_DESC_$SRV[10]='lb-mgmt ids unset'"
 eval "ERR_DESC_$SRV[11]='octavia-hm0 port not bound in ovn'"
 eval "ERR_DESC_$SRV[12]='load balancer in ERROR'"
+eval "ERR_DESC_$SRV[13]='planned-maintenance marker stuck, health-manager gated off'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="designate"
@@ -260,6 +261,7 @@ eval "ERR_DESC_$SRV[5]='processmonitor down'"
 eval "ERR_DESC_$SRV[6]='hostmonitor down'"
 eval "ERR_DESC_$SRV[7]='instancemonitor down'"
 eval "ERR_DESC_$SRV[8]='host in maintenance, instance-HA off'"
+eval "ERR_DESC_$SRV[9]='planned-maintenance marker stuck, monitors gated off'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="monasca"

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -188,6 +188,7 @@ eval "ERR_DESC_$SRV[3]='metadata not all up'"
 eval "ERR_DESC_$SRV[4]='vpn not all up'"
 eval "ERR_DESC_$SRV[5]='control not all up'"
 eval "ERR_DESC_$SRV[6]='port create fail'"
+eval "ERR_DESC_$SRV[7]='port status stale vs ovn'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="glance"

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -230,6 +230,7 @@ eval "ERR_DESC_$SRV[6]='octavia-hm0 link missng'"
 eval "ERR_DESC_$SRV[7]='octavia-hm0 route missing'"
 eval "ERR_DESC_$SRV[8]='worker down'"
 eval "ERR_DESC_$SRV[9]='health-manager down'"
+eval "ERR_DESC_$SRV[10]='lb-mgmt ids unset'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="designate"

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -232,6 +232,8 @@ eval "ERR_DESC_$SRV[7]='octavia-hm0 route missing'"
 eval "ERR_DESC_$SRV[8]='worker down'"
 eval "ERR_DESC_$SRV[9]='health-manager down'"
 eval "ERR_DESC_$SRV[10]='lb-mgmt ids unset'"
+eval "ERR_DESC_$SRV[11]='octavia-hm0 port not bound in ovn'"
+eval "ERR_DESC_$SRV[12]='load balancer in ERROR'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="designate"
@@ -257,6 +259,7 @@ eval "ERR_DESC_$SRV[4]='engine down'"
 eval "ERR_DESC_$SRV[5]='processmonitor down'"
 eval "ERR_DESC_$SRV[6]='hostmonitor down'"
 eval "ERR_DESC_$SRV[7]='instancemonitor down'"
+eval "ERR_DESC_$SRV[8]='host in maintenance, instance-HA off'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="monasca"

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -378,6 +378,30 @@ ceph_finish_maintenance()
     Quiet $CEPH osd unset noout
 }
 
+# Lift ONLY the client-I/O blocks (pause, nodown) that cluster poweroff set, as
+# early in the boot as the mons will answer. Deliberately not the full
+# ceph_leave_maintenance: that also schedules ceph_finish_maintenance, which
+# clears noout -- fine at cluster start, wrong mid-roll (see the rolling-op
+# guard note below). Idempotent and cheap: a no-op when the flags are not set.
+#
+# nodown has to go too, not just pause: under nodown the osdmap reads all-up
+# while stale (see ceph_wait_all_osds_up), so clients and the MDS aim I/O at
+# OSDs that have not booted yet and block on them -- that stale map is what
+# stalled ceph_fs_mds_init. Clearing it only makes the map truthful; the costly
+# consequences stay blocked, because noout/nobackfill/norebalance/norecover are
+# untouched here, so nothing is marked out and nothing re-replicates. On a large
+# cluster this marks proportionally more OSDs down while they come up, which is
+# map churn, not data movement -- and it is the same two flags
+# ceph_leave_maintenance already clears on every boot, just earlier.
+ceph_unpause_client_io()
+{
+    $CEPH -s >/dev/null 2>&1 || return 0
+    $CEPH osd dump 2>/dev/null | grep -qE '^flags.*(pauserd|pausewr|nodown)' || return 0
+    log_info "ceph: lifting client-I/O pause left by cluster poweroff"
+    Quiet -n $CEPH osd unset pause
+    Quiet -n $CEPH osd unset nodown
+}
+
 ceph_leave_maintenance()
 {
     # unblock client I/O immediately so the cluster is usable on boot

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3442,3 +3442,43 @@ ceph_osd_list()
     fi
     rm -rf $logpth
 }
+
+ceph_mgr_dashboard_ensure()
+{
+    # Usage: ceph_mgr_dashboard_ensure [<evict-host>]
+    # With <evict-host>: fail the active mgr off that host first (no-op if it
+    # is not the active). Then make sure the dashboard answers on the active
+    # mgr -- it wedges on failover (listener up, TLS never completes), so
+    # bounce the module when the probe fails.
+    local evict=$1
+    local active=$($CEPH mgr stat -f json 2>/dev/null | jq -r .active_name)
+    if [ -n "$evict" ] ; then
+        [ "$active" = "$evict" ] || return 0
+        $CEPH mgr fail
+        for i in $(seq 30) ; do
+            sleep 2
+            active=$($CEPH mgr stat -f json 2>/dev/null | jq -r .active_name)
+            [ -n "$active" -a "$active" != "$evict" ] && break
+        done
+        if [ -z "$active" -o "$active" = "$evict" ] ; then
+            echo "ceph-mgr did not fail over off $evict" >&2
+            return 1
+        fi
+    fi
+    [ -n "$active" ] || return 1
+    local port=7442
+    grep -q "ha = false" $SETTINGS_TXT 2>/dev/null && port=7443
+    local probe="timeout 5 curl -sIk https://$active:$port/ceph/"
+    for i in $(seq 3) ; do
+        $probe 2>/dev/null | grep -q "200 OK" && return 0
+        sleep 5
+    done
+    $CEPH mgr module disable dashboard
+    $CEPH mgr module enable dashboard
+    for i in $(seq 12) ; do
+        sleep 5
+        $probe 2>/dev/null | grep -q "200 OK" && return 0
+    done
+    echo "ceph-mgr dashboard on $active not serving after module bounce" >&2
+    return 1
+}

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3095,11 +3095,9 @@ ceph_osd_compact()
     if $CEPH -s >/dev/null ; then
         hn=$(hostname)
         [ "$VERBOSE" != "1" ] || $CEPH osd df tree $hn 2>/dev/null || true
-        # Bound each compact. A non-master control node runs `cluster stop` from
-        # its own bootstrap before waiting for master, and that lands here; during
-        # a full-cluster powercycle the local OSDs are not up yet while the mon
-        # still lists them, so an unbounded `ceph tell` blocks forever on the
-        # first one and the node never reaches the wait-for-master stage.
+        # Bound each compact: during a full-cluster powercycle the local OSDs are
+        # not up while the mon still lists them, and an unbounded `ceph tell`
+        # blocks forever, wedging this node's bootstrap.
         $CEPH osd tree-from $hn -f json 2>/dev/null | jq .nodes[0].children[] | sort -n \
             | xargs -i timeout -k 5 60 ceph tell osd.{} compact
         [ "$VERBOSE" != "1" ] || $CEPH osd df tree $hn 2>/dev/null || true

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3212,8 +3212,31 @@ ceph_fs_mds_init()
         Quiet -n $CEPH fs set cephfs allow_standby_replay true
         Quiet -n $CEPH fs set cephfs session_timeout 30
         Quiet -n $CEPH fs set cephfs session_autoclose 30
-        Quiet -n ceph_fs_mds_reorder
+        # Every probe in the reorder goes through the mgr, which on a cold boot
+        # is often not serving yet -- waiting for it inline cost 389s of one
+        # boot with every commit worker idle behind it. Run it detached so the
+        # commit is not blocked and the placement still happens: skipping it and
+        # leaving it to the boot-end repair pass would never run on a
+        # repair-opted-out cluster, where that pass is skipped entirely.
+        setsid $HEX_SDK ceph_fs_mds_reorder_when_ready </dev/null >/dev/null 2>&1 &
     fi
+}
+
+# Wait (bounded) for a serving mgr, then reorder MDS placement. Detached from
+# the ceph commit by ceph_fs_mds_init -- never call this inline.
+ceph_fs_mds_reorder_when_ready()
+{
+    local deadline=$(( SECONDS + ${CEPH_MGR_READY_TIMEOUT:-900} ))
+    while [ $SECONDS -lt $deadline ] ; do
+        if [ "x$($CEPH mgr dump -f json 2>/dev/null | jq -r .available)" = "xtrue" ] ; then
+            Quiet -n ceph_fs_mds_reorder
+            return 0
+        fi
+        sleep 10
+    done
+
+    log_error "ceph_fs_mds_reorder_when_ready: mgr never became available on $(hostname); MDS placement left as-is"
+    return 1
 }
 
 ceph_fs_mds_reorder()

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3095,7 +3095,13 @@ ceph_osd_compact()
     if $CEPH -s >/dev/null ; then
         hn=$(hostname)
         [ "$VERBOSE" != "1" ] || $CEPH osd df tree $hn 2>/dev/null || true
-        $CEPH osd tree-from $hn -f json 2>/dev/null | jq .nodes[0].children[] | sort -n | xargs -i ceph tell osd.{} compact
+        # Bound each compact. A non-master control node runs `cluster stop` from
+        # its own bootstrap before waiting for master, and that lands here; during
+        # a full-cluster powercycle the local OSDs are not up yet while the mon
+        # still lists them, so an unbounded `ceph tell` blocks forever on the
+        # first one and the node never reaches the wait-for-master stage.
+        $CEPH osd tree-from $hn -f json 2>/dev/null | jq .nodes[0].children[] | sort -n \
+            | xargs -i timeout -k 5 60 ceph tell osd.{} compact
         [ "$VERBOSE" != "1" ] || $CEPH osd df tree $hn 2>/dev/null || true
     fi
 }

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3283,6 +3283,22 @@ ceph_fs_mds_reorder()
     fi
 }
 
+GANESHA_CONF=${GANESHA_CONF:-/etc/ganesha/ganesha.conf}
+
+# Make this node a member of the ganesha grace DB, idempotently. ganesha's
+# rados_cluster backend exits fatally when its nodeid is not a member, so
+# restarting the daemon cannot recover that state -- the membership must come
+# back first. Registration at commit time is bounded and can expire silently on
+# a node booting into a still-recovering cluster; this restores it.
+ceph_ganesha_grace_join()
+{
+    local pool=$(awk -F'"' '/^[[:space:]]*pool[[:space:]]*=/{print $2; exit}' $GANESHA_CONF 2>/dev/null)
+    pool=${pool:-cephfs_data}
+    timeout 30 ganesha-rados-grace -p $pool dump 2>/dev/null | awk '{print $1}' | grep -qx "$HOSTNAME" && return 0
+    Quiet -n timeout 60 ganesha-rados-grace -p $pool add $HOSTNAME
+    timeout 30 ganesha-rados-grace -p $pool dump 2>/dev/null | awk '{print $1}' | grep -qx "$HOSTNAME"
+}
+
 ceph_nfs_ganesha()
 {
     case $1 in

--- a/core/sdk_sh/modules/sdk_git.sh
+++ b/core/sdk_sh/modules/sdk_git.sh
@@ -6,9 +6,15 @@ if [ -z "$PROG" ] ; then
     exit 1
 fi
 
+# Paths named, not inlined: the tests point them somewhere writable.
+CUBE_GITIGNORE=${CUBE_GITIGNORE:-/.gitignore}
+# Hidden opt-out, like cube_repair_optout: keep this node's uncommitted changes
+# instead of stashing them away, and never publish them to the shared repo.
+CUBE_GIT_OPTOUT=${CUBE_GIT_OPTOUT:-/etc/appliance/state/cube_git_optout}
+
 git_ignore_file()
 {
-    cat >/.gitignore <<EOF
+    cat >$CUBE_GITIGNORE <<EOF
 *.pyc
 *.po
 *.mo
@@ -57,7 +63,7 @@ _git_server_init()
         Quiet -n git init -b $branch
         # local cephfs path, not ssh://VIP (stalls during set_ready reconfig). #1195
         Quiet -n $GIT remote add $project ${cube_git_dir}
-        if [ -e "/.gitignore" ] ; then
+        if [ -e "$CUBE_GITIGNORE" ] ; then
             if ! git log -1 >/dev/null 2>&1 ; then
                 Quiet -n git add -A
                 Quiet -n git commit -m "$(hex_cli -c firmware list | grep ACTIVE | awk '{print $2}')" -a
@@ -65,7 +71,7 @@ _git_server_init()
             Quiet -n git push --set-upstream $project $branch
             git -P branch -r | grep -q "${project}/${branch}"
         else
-            Error "failed to generate /.gitignore"
+            Error "failed to generate $CUBE_GITIGNORE"
         fi
         Quiet -n popd
         $GIT -P log || Error "failed to initialize GIT server"
@@ -120,19 +126,25 @@ _git_client_init()
     Quiet -n $GIT init -b $branch
     # local cephfs path, not ssh://VIP (stalls during set_ready reconfig). #1195
     Quiet -n $GIT remote add $project ${cube_git_dir}
-    if [ -e "/.gitignore" ] ; then
+    if [ -e "$CUBE_GITIGNORE" ] ; then
         if $GIT fetch ; then
             _git_suid_save
             Quiet -n $GIT branch --track $branch $project/$branch
-            Quiet -n $GIT add -A
-            Quiet -n $GIT stash
-            Quiet -n $GIT pull $project $branch --rebase
+            # --track already lands HEAD on the fetched tip, so the opt-out path
+            # needs no pull to stay current; local edits just read as modified.
+            if [ -f $CUBE_GIT_OPTOUT ] ; then
+                log_warning "git opt-out: keeping uncommitted changes on $HOSTNAME; / stays modified vs $project/$branch"
+            else
+                Quiet -n $GIT add -A
+                Quiet -n $GIT stash
+                Quiet -n $GIT pull $project $branch --rebase
+            fi
             _git_suid_restore
         else
             Error "git server (on VIP node) is not ready"
         fi
     else
-        Error "failed to generate /.gitignore"
+        Error "failed to generate $CUBE_GITIGNORE"
     fi
     Quiet -n popd
     Quiet -n $GIT -P log
@@ -172,10 +184,17 @@ git_push()
 {
     local msg="${@:-n/a}"
 
+    # Opted out, this tree is the operator's in both directions: don't harvest
+    # its local edits into the shared repo.
+    if [ -f $CUBE_GIT_OPTOUT ] ; then
+        log_warning "git opt-out: not pushing $HOSTNAME's local changes"
+        return 0
+    fi
     if git -P status | grep -q modified ; then
         cmd $HEX_SDK git_client_init
         _git_suid_save
-        ( $GIT commit -m "$msg" -a && $GIT push -q && cmd "$GIT stash ; $GIT pull" ) >/dev/null
+        # per-node check: a peer that opted out keeps its own changes
+        ( $GIT commit -m "$msg" -a && $GIT push -q && cmd "[ -f $CUBE_GIT_OPTOUT ] || { $GIT stash ; $GIT pull ; }" ) >/dev/null
         _git_suid_restore
         Quiet -n $GIT -P log -3
     else

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2734,6 +2734,9 @@ health_octavia_check()
                 elif ! is_remote_running $node octavia-health-manager ; then
                     ERR_MSG+="octavia-health-manager on $node is not running\n"
                     ERR_CODE=9
+                elif ! remote_run $node hex_sdk os_octavia_cfg_ids_ok ; then
+                    ERR_MSG+="empty lb-mgmt ids in octavia.conf on $node\n"
+                    ERR_CODE=10
                 fi
             fi
         done
@@ -2766,6 +2769,10 @@ _health_octavia_auto_repair()
                 remote_systemd_restart $node octavia-worker
             elif ! is_remote_running $node octavia-health-manager ; then
                 remote_systemd_restart $node octavia-health-manager
+            elif ! remote_run $node hex_sdk os_octavia_cfg_ids_ok ; then
+                # re-stamp only (code 10); no port recreate, so it stays far
+                # cheaper than the reinit_octavia in health_octavia_repair
+                Quiet -n remote_run $node $HEX_CFG reconfig_octavia
             fi
         fi
     done

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -1605,7 +1605,9 @@ _health_ceph_mds_auto_repair()
     elif [ "$ERR_CODE" == "2" ] ; then
         cmd $HEX_SDK ceph_mount_cephfs
     elif [ "$ERR_CODE" == "3" -o "$ERR_CODE" == "4" -o "$ERR_CODE" == "5" ] ; then
-        cmd -c "systemctl restart nfs-ganesha"
+        # restore grace-DB membership first: ganesha exits fatally without it, so
+        # a bare restart loops forever on that fault
+        cmd -c "$HEX_SDK ceph_ganesha_grace_join ; systemctl restart nfs-ganesha"
     fi
 }
 

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2727,6 +2727,11 @@ health_octavia_check()
     local http_stats=$(influx -host $(shared_id) -database monasca -format json -execute "select last(value) from http_status where service = 'octavia'" | jq .results[0].series[0].values[0][1])
     if [ "$http_stats" != "0" ] ; then
         ERR_CODE=1
+    elif cube_cluster_ready && $HEX_SDK os_planned_maintenance_stale ; then
+        # As in health_masakari_check: reported ahead of the health-manager-down
+        # code, which is only the symptom of the gate still holding.
+        ERR_MSG+="planned-maintenance marker stale (>30min) on a ready cluster; octavia health-manager gated off\n"
+        ERR_CODE=13
     else
         for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
             if ! is_remote_running $node octavia-api ; then
@@ -2959,6 +2964,12 @@ health_masakari_check()
     $CURL -sf http://$HOSTNAME:15868 >/dev/null
     if [ $? -ne 0 ] ; then
         ERR_CODE=1
+    elif cube_cluster_ready && $HEX_SDK os_planned_maintenance_stale ; then
+        # Marker left behind by an interrupted bring-up. Reported ahead of the
+        # monitor-down codes below because those are its symptom: the gate is
+        # holding the monitors off, so instance-HA is silently disabled.
+        ERR_MSG+="planned-maintenance marker stale (>30min) on a ready cluster; instance-HA monitors gated off\n"
+        ERR_CODE=9
     else
         for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
             if ! is_remote_running $node masakari-api ; then

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2586,6 +2586,12 @@ health_manila_check()
     local share_up=$(echo "$service_stats" | grep manila-share | grep -i enabled | grep -i up | wc -l )
     local share_down=$(echo "$service_stats" | grep manila-share | grep -i enabled | grep -i down | wc -l )
     local share_total=$(cubectl node list -r compute -j | jq -r .[].hostname | head -3 | wc -l)
+    # Count HOSTS with a share service up, not service rows: with N backends each
+    # node runs one manila-share per backend (host@generic, host@cephfs, ...), so
+    # comparing rows against a node count reports "share down" on every healthy
+    # multi-backend cluster. Host is the part before '@'.
+    local share_hosts_up=$(echo "$service_stats" | grep manila-share | grep -i enabled | grep -i up \
+        | awk '{for(i=1;i<=NF;i++) if($i ~ /@/) {split($i,a,"@"); print a[1]; break}}' | sort -u | wc -l)
 
     if [ -z "$service_stats" ] ; then
         ERR_LOG="journalctl -n $ERR_LOGSIZE -u openstack-manila-api"
@@ -2593,7 +2599,7 @@ health_manila_check()
     elif [ "$scheduler_up" == "0" -o "$scheduler_down" != "0" ] ; then
         ERR_LOG="journalctl -n $ERR_LOGSIZE -u openstack-manila-scheduler"
         ERR_CODE=3
-    elif [ "$share_up" != "$share_total" -o "$share_down" != "0" ] ; then
+    elif [ "$share_hosts_up" != "$share_total" -o "$share_down" != "0" ] ; then
         ERR_CODE=4
     fi
 

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2368,6 +2368,14 @@ health_neutron_check()
         fi
     fi
 
+    if [ $ERR_CODE -eq 0 ] ; then
+        OVN_STALE_PORTS="$($HEX_SDK os_neutron_ovn_port_status_stale)"
+        if [ -n "$OVN_STALE_PORTS" ] ; then
+            ERR_MSG+="ports up in OVN but DOWN in neutron: $(echo $OVN_STALE_PORTS)\n"
+            ERR_CODE=7
+        fi
+    fi
+
     _health_fail_log
 }
 
@@ -2393,6 +2401,21 @@ _health_neutron_auto_repair()
             for host in $OVN_META_STUCK ; do
                 remote_systemd_restart $host neutron-ovn-metadata-agent
             done
+        elif [ $ERR_CODE -eq 7 ] ; then
+            # re-fire the status event for just the affected ports -- no service
+            # restart, and it notifies nova so an in-flight build still recovers.
+            # (a db_sync can't help here: ovn_db_sync never touches port status)
+            Quiet -n cmd -c -- $HEX_SDK os_neutron_ovn_port_status_resync $OVN_STALE_PORTS
+            sleep 10
+            # only if that didn't take, fall back to bouncing neutron-server one
+            # node at a time: its IDL reconnect re-dumps and re-derives every port
+            if [ -n "$($HEX_SDK os_neutron_ovn_port_status_stale)" ] ; then
+                for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+                    remote_systemd_restart $node neutron-server
+                    sleep 20
+                    [ -n "$($HEX_SDK os_neutron_ovn_port_status_stale)" ] || break
+                done
+            fi
         else
             $HEX_SDK ovn_neutron_db_sync
             readarray entry_array <<<"$(echo -n "$ERR_MSG" | awk '/False/{print $1" "$3}' | sort)"

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2586,10 +2586,9 @@ health_manila_check()
     local share_up=$(echo "$service_stats" | grep manila-share | grep -i enabled | grep -i up | wc -l )
     local share_down=$(echo "$service_stats" | grep manila-share | grep -i enabled | grep -i down | wc -l )
     local share_total=$(cubectl node list -r compute -j | jq -r .[].hostname | head -3 | wc -l)
-    # Count HOSTS with a share service up, not service rows: with N backends each
-    # node runs one manila-share per backend (host@generic, host@cephfs, ...), so
-    # comparing rows against a node count reports "share down" on every healthy
-    # multi-backend cluster. Host is the part before '@'.
+    # Count HOSTS with a share up, not rows: with N backends each node runs one
+    # manila-share per backend, so rows vs a node count reports "share down" on
+    # every healthy multi-backend cluster.
     local share_hosts_up=$(echo "$service_stats" | grep manila-share | grep -i enabled | grep -i up \
         | awk '{for(i=1;i<=NF;i++) if($i ~ /@/) {split($i,a,"@"); print a[1]; break}}' | sort -u | wc -l)
 
@@ -2734,8 +2733,7 @@ health_octavia_check()
     if [ "$http_stats" != "0" ] ; then
         ERR_CODE=1
     elif cube_cluster_ready && $HEX_SDK os_planned_maintenance_stale ; then
-        # As in health_masakari_check: reported ahead of the health-manager-down
-        # code, which is only the symptom of the gate still holding.
+        # Ahead of the health-manager-down code, which is only its symptom.
         ERR_MSG+="planned-maintenance marker stale (>30min) on a ready cluster; octavia health-manager gated off\n"
         ERR_CODE=13
     else
@@ -2833,9 +2831,8 @@ health_octavia_repair()
     # -triggered path -- it can't overlap a periodic round, so the cost is fine.
     local master=$CUBE_NODE_CONTROL_HOSTNAMES node pids=""
 
-    # code 12 first: an LB in ERROR usually just needs octavia's own failover,
-    # and issuing it is async + seconds. Behind the reinit loop it never runs --
-    # that loop takes ~6min, past the repair round's budget.
+    # code 12 first: issuing the failover is async and takes seconds. Behind the
+    # reinit loop it never runs -- that loop outlasts the repair round.
     Quiet -n $HEX_SDK os_octavia_lb_failover_errored
 
     Quiet -n remote_run $master $HEX_CFG reinit_octavia
@@ -2848,9 +2845,8 @@ health_octavia_repair()
     done
     for p in $pids ; do wait "$p" ; done
 
-    # again for any LB whose failover needed the datapath the reinit just
-    # restored; already-recovered ones are not in the ERROR list, so this is a
-    # no-op in the common case.
+    # again for any LB whose failover needed the datapath the reinit restored;
+    # recovered ones are no longer in the ERROR list, so usually a no-op.
     Quiet -n $HEX_SDK os_octavia_lb_failover_errored
 }
 
@@ -2971,9 +2967,7 @@ health_masakari_check()
     if [ $? -ne 0 ] ; then
         ERR_CODE=1
     elif cube_cluster_ready && $HEX_SDK os_planned_maintenance_stale ; then
-        # Marker left behind by an interrupted bring-up. Reported ahead of the
-        # monitor-down codes below because those are its symptom: the gate is
-        # holding the monitors off, so instance-HA is silently disabled.
+        # Reported ahead of the monitor-down codes below: those are its symptom.
         ERR_MSG+="planned-maintenance marker stale (>30min) on a ready cluster; instance-HA monitors gated off\n"
         ERR_CODE=9
     else
@@ -3004,11 +2998,8 @@ health_masakari_check()
             fi
         done
 
-        # A host left in masakari maintenance has instance-HA OFF: every
-        # host-failure notification for it is rejected 409 "already under
-        # maintenance", nothing evacuates, and nothing else says so. Report it --
-        # do NOT auto-clear here, since an operator may have set it deliberately
-        # (os_resume_hypervisor only undoes the platform's own planned-stop flag).
+        # instance-HA is OFF for these. Report only -- an operator may have set
+        # the flag deliberately, so never auto-clear it.
         if [ $ERR_CODE -eq 0 ] ; then
             local maint=$($HEX_SDK os_masakari_maintenance_hosts 2>/dev/null | tr '\n' ' ')
             if [ -n "$(echo $maint)" ] ; then

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -2760,9 +2760,20 @@ health_octavia_check()
                 elif ! remote_run $node hex_sdk os_octavia_cfg_ids_ok ; then
                     ERR_MSG+="empty lb-mgmt ids in octavia.conf on $node\n"
                     ERR_CODE=10
+                elif ! remote_run $node hex_sdk os_octavia_hm_port_bound ; then
+                    ERR_MSG+="octavia-hm0 port not bound in ovn on $node\n"
+                    ERR_CODE=11
                 fi
             fi
         done
+
+        if [ $ERR_CODE -eq 0 ] ; then
+            local lberr=$($HEX_SDK os_octavia_lb_error_list 2>/dev/null | tr '\n' ' ')
+            if [ -n "$(echo $lberr)" ] ; then
+                ERR_MSG+="load balancer(s) in ERROR: $lberr\n"
+                ERR_CODE=12
+            fi
+        fi
     fi
 
     _health_fail_log
@@ -2810,6 +2821,12 @@ health_octavia_repair()
     # (~2min/node incl. ReconfigMain), but this is the serialized, operator/roll
     # -triggered path -- it can't overlap a periodic round, so the cost is fine.
     local master=$CUBE_NODE_CONTROL_HOSTNAMES node pids=""
+
+    # code 12 first: an LB in ERROR usually just needs octavia's own failover,
+    # and issuing it is async + seconds. Behind the reinit loop it never runs --
+    # that loop takes ~6min, past the repair round's budget.
+    Quiet -n $HEX_SDK os_octavia_lb_failover_errored
+
     Quiet -n remote_run $master $HEX_CFG reinit_octavia
     for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
         [ "$node" = "$master" ] && continue
@@ -2819,6 +2836,11 @@ health_octavia_repair()
         fi
     done
     for p in $pids ; do wait "$p" ; done
+
+    # again for any LB whose failover needed the datapath the reinit just
+    # restored; already-recovered ones are not in the ERROR list, so this is a
+    # no-op in the common case.
+    Quiet -n $HEX_SDK os_octavia_lb_failover_errored
 }
 
 health_designate_report()
@@ -2964,6 +2986,19 @@ health_masakari_check()
                 ERR_LOG="journalctl -n $ERR_LOGSIZE -u masakari-instancemonitor"
             fi
         done
+
+        # A host left in masakari maintenance has instance-HA OFF: every
+        # host-failure notification for it is rejected 409 "already under
+        # maintenance", nothing evacuates, and nothing else says so. Report it --
+        # do NOT auto-clear here, since an operator may have set it deliberately
+        # (os_resume_hypervisor only undoes the platform's own planned-stop flag).
+        if [ $ERR_CODE -eq 0 ] ; then
+            local maint=$($HEX_SDK os_masakari_maintenance_hosts 2>/dev/null | tr '\n' ' ')
+            if [ -n "$(echo $maint)" ] ; then
+                ERR_MSG+="instance-HA is off for: $maint (masakari on_maintenance)\n"
+                ERR_CODE=8
+            fi
+        fi
     fi
 
     _health_fail_log

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1752,14 +1752,9 @@ os_octavia_hm0_up()
     fi
 }
 
-# Planned-maintenance marker. Set by `cluster poweroff` on every node before the
-# nodes go down, cleared by `cluster start` once the cluster-wide bring-up is
-# done. Health monitors that trigger destructive recovery (masakari monitors,
-# octavia health-manager) are gated on it by a systemd drop-in, so a planned
-# shutdown is never read as a failure: without it the masakari process monitor
-# reports its own not-yet-started nova-compute and flags the host on_maintenance,
-# and octavia's health-manager rebuilds every amphora on stale heartbeats.
-# Lives in /etc/appliance/state so it survives the reboot it has to span.
+# Set by `cluster poweroff`, cleared once the resume completes. The health
+# monitors are gated on it by a systemd drop-in. In /etc/appliance/state because
+# it has to survive the reboot it spans.
 PLANNED_MAINT_MARKER=/etc/appliance/state/cube_planned_maintenance
 
 os_planned_maintenance_active()
@@ -1767,10 +1762,8 @@ os_planned_maintenance_active()
     [ -e $PLANNED_MAINT_MARKER ]
 }
 
-# Marker left behind by a bring-up that never finished. Age-bounded because the
-# legitimate window runs to the end of cluster_check_repair_async -- a boot that
-# also runs check_repair holds the marker for ~10min, and reporting that as a
-# fault would just be a false alarm on every power cycle.
+# Marker left behind by a bring-up that never finished. Age-bounded: the
+# legitimate window runs to the end of cluster_check_repair_async.
 PLANNED_MAINT_STALE_MIN=30
 
 os_planned_maintenance_stale()
@@ -1779,10 +1772,8 @@ os_planned_maintenance_stale()
     [ -n "$(find $PLANNED_MAINT_MARKER -mmin +$PLANNED_MAINT_STALE_MIN 2>/dev/null)" ]
 }
 
-# Write locally then rsync. Neither a remote_run loop nor `cubectl node exec`
-# carries the marker: remote_run expands "$@" unquoted, and the quoting of an
-# `echo '...' > file` argument does not survive node exec -- it redirects
-# cubectl's own output into the local file instead.
+# Write locally then rsync: neither remote_run nor `node exec` carries a
+# redirect intact (unquoted "$@", and node exec redirects its own output).
 os_planned_maintenance_set()
 {
     echo "set=$(date -Is) by=$(hostname)" > $PLANNED_MAINT_MARKER
@@ -1796,9 +1787,9 @@ os_planned_maintenance_clear()
     log_info "planned maintenance: marker cleared on all nodes"
 }
 
-# This node's health-mgr port must be ACTIVE, i.e. actually bound in OVN. A port
-# left DOWN still has its ovs port, link and route, so the structural hm0 checks
-# all pass while lb-mgmt has no datapath at all.
+# This node's health-mgr port must be ACTIVE, i.e. bound in OVN. A DOWN port
+# still has its ovs port, link and route, so codes 5/6/7 all pass while
+# lb-mgmt has no datapath.
 os_octavia_hm_port_bound()
 {
     [ -f /run/cube_commit_done ] || return 0
@@ -1813,8 +1804,8 @@ os_octavia_lb_error_list()
     $OPENSTACK loadbalancer list --provisioning-status ERROR -f value -c id 2>/dev/null
 }
 
-# Recover them with octavia's own failover: it rebuilds the amphora with the
-# injected config a plain nova rebuild would lose.
+# octavia's own failover: it rebuilds the amphora with the injected config a
+# nova rebuild would lose.
 os_octavia_lb_failover_errored()
 {
     local lb
@@ -2937,12 +2928,9 @@ os_calibrate_nova_resources()
     done
 }
 
-# Echo the first OTHER control node whose galera reports a live PRIMARY
-# component; rc 0 when one exists. Guards the boot path against bootstrapping a
-# second cluster over a running one: two primaries meet later and galera aborts
-# a node FATAL with "conflicting prims: older overrides" (seen 2026-08-23, when a
-# node rebooting from a host failure bootstrapped an empty cluster while the two
-# survivors held quorum). _health_mysql repair has always had this check.
+# Echo the first OTHER control node whose galera reports a live Primary; rc 0
+# when one exists. Bootstrapping over one aborts a node FATAL with
+# "conflicting prims". _health_mysql repair has always had this check.
 os_galera_live_primary()
 {
     local me=$(hostname) node st
@@ -2957,14 +2945,9 @@ os_galera_live_primary()
     return 1
 }
 
-# Hosts currently flagged on_maintenance in ANY masakari segment -- instance-HA
-# is OFF for these: every host-failure notification for them is rejected 409
-# "already under maintenance" and nothing evacuates.
-#
-# Reads the field by name with `segment host show`. Do NOT use
-# `segment host list -c name -c on_maintenance`: -c does not set column order and
-# the output transposes on_maintenance with reserved, which reads plausibly and
-# is wrong (cost a misdiagnosis 2026-08-23).
+# Hosts flagged on_maintenance in ANY segment -- instance-HA is OFF for these.
+# Reads the field by name: `segment host list -c name -c on_maintenance` does not
+# set column order and transposes on_maintenance with reserved.
 os_masakari_maintenance_hosts()
 {
     local u h
@@ -2976,17 +2959,10 @@ os_masakari_maintenance_hosts()
     done
 }
 
-# Stop/start the masakari monitors cluster-wide.
-#
-# Used by `cluster poweroff` so an orderly shutdown is never reported as host
-# failures: with the monitors down no COMPUTE_HOST notification is raised at all,
-# so masakari's DB is left untouched and nothing has to be un-set on the way back
-# up. This replaces flagging every host on_maintenance, which was wrong twice
-# over -- the flag is shared with operator intent (an operator may set it for
-# planned work and must not have it cleared under them), and when it leaked
-# instance-HA was off cluster-wide with `cluster check` still reporting
-# InstanceHa ok. A monitor left stopped, by contrast, is already reported by
-# health_masakari_check (codes 5/6/7), so the failure mode is visible.
+# Stop/start the masakari monitors cluster-wide. `cluster poweroff` stops them so
+# an orderly shutdown raises no host-failure notification at all, leaving nothing
+# to un-set on the way back up -- unlike flagging hosts on_maintenance, which
+# shares a field with operator intent and silently disabled instance-HA.
 os_masakari_monitors()   # $1 = start|stop
 {
     local act=${1:-start} node

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1752,6 +1752,34 @@ os_octavia_hm0_up()
     fi
 }
 
+# This node's health-mgr port must be ACTIVE, i.e. actually bound in OVN. A port
+# left DOWN still has its ovs port, link and route, so the structural hm0 checks
+# all pass while lb-mgmt has no datapath at all.
+os_octavia_hm_port_bound()
+{
+    [ -f /run/cube_commit_done ] || return 0
+
+    local st=$($OPENSTACK port show "octavia-hmgr-port-$(hostname)" -f value -c status 2>/dev/null)
+    [ "x$st" = "xACTIVE" ]
+}
+
+# Load balancers left in ERROR.
+os_octavia_lb_error_list()
+{
+    $OPENSTACK loadbalancer list --provisioning-status ERROR -f value -c id 2>/dev/null
+}
+
+# Recover them with octavia's own failover: it rebuilds the amphora with the
+# injected config a plain nova rebuild would lose.
+os_octavia_lb_failover_errored()
+{
+    local lb
+    for lb in $(os_octavia_lb_error_list) ; do
+        log_info "octavia: failover load balancer $lb in ERROR"
+        Quiet -n $OPENSTACK loadbalancer failover $lb
+    done
+}
+
 os_octavia_nid_get()
 {
     $OPENSTACK network list | awk '/ lb-mgmt-net / {print $2}' | tr -d '\n'
@@ -2885,31 +2913,66 @@ os_galera_live_primary()
     return 1
 }
 
-os_resume_hypervisor()
+# Hosts currently flagged on_maintenance in ANY masakari segment -- instance-HA
+# is OFF for these: every host-failure notification for them is rejected 409
+# "already under maintenance" and nothing evacuates.
+#
+# Reads the field by name with `segment host show`. Do NOT use
+# `segment host list -c name -c on_maintenance`: -c does not set column order and
+# the output transposes on_maintenance with reserved, which reads plausibly and
+# is wrong (cost a misdiagnosis 2026-08-23).
+os_masakari_maintenance_hosts()
 {
-    if nova hypervisor-list | grep -q disabled ; then
-        for u in $($OPENSTACK segment list -f value -c uuid) ; do
-            for n in $($OPENSTACK segment host list $u -f value -c name) ; do
-                if [ "x$n" = "x$(hostname)" ] ; then
-                    $OPENSTACK segment host update $u $(hostname) --on_maintenance False
-                    $OPENSTACK compute service set --enable $(hostname) nova-compute
-                fi
-            done
-        done
-
-        # Let users decide if they want to hard-reboot instances
-        # echo YES | hex_cli -c iaas compute reset All
-    fi
-}
-
-os_maintain_segment_hosts()
-{
-    for u in $($OPENSTACK segment list -f value -c uuid) ; do
-        for n in $($OPENSTACK segment host list $u -f value -c name) ; do
-            $OPENSTACK segment host update $u $n --on_maintenance True
+    local u h
+    for u in $($OPENSTACK segment list -f value -c uuid 2>/dev/null) ; do
+        for h in $($OPENSTACK segment host list $u -f value -c name 2>/dev/null) ; do
+            $OPENSTACK segment host show $u $h 2>/dev/null \
+                | awk '$2 == "on_maintenance" && $4 == "True" { f = 1 } END { exit !f }' && echo "$h"
         done
     done
 }
+
+# Stop/start the masakari monitors cluster-wide.
+#
+# Used by `cluster poweroff` so an orderly shutdown is never reported as host
+# failures: with the monitors down no COMPUTE_HOST notification is raised at all,
+# so masakari's DB is left untouched and nothing has to be un-set on the way back
+# up. This replaces flagging every host on_maintenance, which was wrong twice
+# over -- the flag is shared with operator intent (an operator may set it for
+# planned work and must not have it cleared under them), and when it leaked
+# instance-HA was off cluster-wide with `cluster check` still reporting
+# InstanceHa ok. A monitor left stopped, by contrast, is already reported by
+# health_masakari_check (codes 5/6/7), so the failure mode is visible.
+os_masakari_monitors()   # $1 = start|stop
+{
+    local act=${1:-start} node
+    for node in "${CUBE_NODE_COMPUTE_HOSTNAMES[@]}" ; do
+        log_info "masakari monitors: $act on $node"
+        Quiet -n remote_run $node "systemctl $act masakari-hostmonitor masakari-processmonitor masakari-instancemonitor"
+    done
+}
+
+# Re-enable this node's compute after a planned stop, once the API answers.
+os_resume_hypervisor()
+{
+    local host=$(hostname) i
+
+    for i in $(seq 1 30) ; do
+        $OPENSTACK compute service list --service nova-compute >/dev/null 2>&1 && break
+        sleep 10
+    done
+
+    # no-op when already enabled. Deliberately NOT unconditional: masakari disables
+    # the compute of a host it evacuated, but so does an operator draining a node,
+    # and nova records no reason for either (masakari calls services.disable() with
+    # none) -- so a disabled compute we did not disable is reported by the masakari
+    # health check rather than silently re-enabled here.
+    Quiet -n $OPENSTACK compute service set --enable $host nova-compute
+
+    # Let users decide if they want to hard-reboot instances
+    # echo YES | hex_cli -c iaas compute reset All
+}
+
 
 # put ONE segment host into masakari maintenance so a PLANNED reboot is not
 # cold-evacuated as a host failure

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1762,6 +1762,17 @@ os_octavia_sgid_get()
     $OPENSTACK security group list | awk ' / lb-mgmt-sec-grp / {print $2}' | tr -d '\n'
 }
 
+# Are this node's lb-mgmt ids actually stamped in octavia.conf? An empty
+# amp_boot_network_list makes every amphora build handed to this node's worker
+# fail with nova's misleading "Multiple possible networks found".
+os_octavia_cfg_ids_ok()
+{
+    local conf=/etc/octavia/octavia.conf
+    [ -f $conf ] || return 0
+    grep -qE '^amp_boot_network_list *= *[0-9a-f-]{36}' $conf || return 1
+    grep -qE '^amp_secgroup_list *= *[0-9a-f-]{36}' $conf || return 1
+}
+
 os_octavia_neutron_lbaas_status_sync()
 {
     local sync=${1:-yes}

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1752,6 +1752,50 @@ os_octavia_hm0_up()
     fi
 }
 
+# Planned-maintenance marker. Set by `cluster poweroff` on every node before the
+# nodes go down, cleared by `cluster start` once the cluster-wide bring-up is
+# done. Health monitors that trigger destructive recovery (masakari monitors,
+# octavia health-manager) are gated on it by a systemd drop-in, so a planned
+# shutdown is never read as a failure: without it the masakari process monitor
+# reports its own not-yet-started nova-compute and flags the host on_maintenance,
+# and octavia's health-manager rebuilds every amphora on stale heartbeats.
+# Lives in /etc/appliance/state so it survives the reboot it has to span.
+PLANNED_MAINT_MARKER=/etc/appliance/state/cube_planned_maintenance
+
+os_planned_maintenance_active()
+{
+    [ -e $PLANNED_MAINT_MARKER ]
+}
+
+# Marker left behind by a bring-up that never finished. Age-bounded because the
+# legitimate window runs to the end of cluster_check_repair_async -- a boot that
+# also runs check_repair holds the marker for ~10min, and reporting that as a
+# fault would just be a false alarm on every power cycle.
+PLANNED_MAINT_STALE_MIN=30
+
+os_planned_maintenance_stale()
+{
+    [ -e $PLANNED_MAINT_MARKER ] || return 1
+    [ -n "$(find $PLANNED_MAINT_MARKER -mmin +$PLANNED_MAINT_STALE_MIN 2>/dev/null)" ]
+}
+
+# Write locally then rsync. Neither a remote_run loop nor `cubectl node exec`
+# carries the marker: remote_run expands "$@" unquoted, and the quoting of an
+# `echo '...' > file` argument does not survive node exec -- it redirects
+# cubectl's own output into the local file instead.
+os_planned_maintenance_set()
+{
+    echo "set=$(date -Is) by=$(hostname)" > $PLANNED_MAINT_MARKER
+    Quiet -n cubectl node rsync $PLANNED_MAINT_MARKER
+    log_info "planned maintenance: marker set on all nodes"
+}
+
+os_planned_maintenance_clear()
+{
+    Quiet -n cubectl node exec -p "rm -f $PLANNED_MAINT_MARKER"
+    log_info "planned maintenance: marker cleared on all nodes"
+}
+
 # This node's health-mgr port must be ACTIVE, i.e. actually bound in OVN. A port
 # left DOWN still has its ovs port, link and route, so the structural hm0 checks
 # all pass while lb-mgmt has no datapath at all.

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1762,6 +1762,45 @@ os_octavia_sgid_get()
     $OPENSTACK security group list | awk ' / lb-mgmt-sec-grp / {print $2}' | tr -d '\n'
 }
 
+# Ports OVN has brought up that neutron still calls DOWN. neutron's OVN port
+# status is event-driven with no reconciliation, so a neutron-server whose IDL
+# stops delivering Logical_Switch_Port events leaves them DOWN forever and every
+# nova build routed to it dies on vif_plugging_timeout. Prints the port ids.
+os_neutron_ovn_port_status_stale()
+{
+    local now=$(date -u +%s) p up ts age rc=1
+    # port list has no --status filter; take the json and pick the DOWN ones
+    for p in $($OPENSTACK port list --device-owner compute:nova -f json 2>/dev/null | \
+               python3 -c 'import sys,json;[print(x["ID"]) for x in json.load(sys.stdin) if x.get("Status")=="DOWN"]' 2>/dev/null) ; do
+        up=$(ovn-nbctl --timeout=5 get logical_switch_port $p up 2>/dev/null | tr -d '"')
+        [ "x$up" = "xtrue" ] || continue
+        # skip ports still inside the normal plug window -- a healthy transition
+        # is sub-second, so only a stale one is still inconsistent this late
+        ts=$($OPENSTACK port show $p -f value -c updated_at 2>/dev/null)
+        age=$(( now - $(date -u -d "$ts" +%s 2>/dev/null || echo $now) ))
+        [ $age -ge 90 ] || continue
+        echo $p
+        rc=0
+    done
+    return $rc
+}
+
+# Make neutron re-derive the status of the given ports. The LSP's enabled field
+# is the port's admin_state_up, so toggling it produces the Logical_Switch_Port
+# update neutron's LogicalSwitchPortUpdateUpEvent needs; that calls
+# set_port_status_up, which also notifies nova -- so a build still inside
+# vif_plugging_timeout recovers instead of failing. A neutron-server restart
+# achieves the same only because its IDL reconnect re-dumps every port.
+os_neutron_ovn_port_status_resync()
+{
+    local p
+    for p in "$@" ; do
+        log_info "neutron: re-firing OVN port status for $p"
+        $OPENSTACK port set --disable $p 2>/dev/null
+        $OPENSTACK port set --enable $p 2>/dev/null
+    done
+}
+
 # Are this node's lb-mgmt ids actually stamped in octavia.conf? An empty
 # amp_boot_network_list makes every amphora build handed to this node's worker
 # fail with nova's misleading "Multiple possible networks found".

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2865,6 +2865,26 @@ os_calibrate_nova_resources()
     done
 }
 
+# Echo the first OTHER control node whose galera reports a live PRIMARY
+# component; rc 0 when one exists. Guards the boot path against bootstrapping a
+# second cluster over a running one: two primaries meet later and galera aborts
+# a node FATAL with "conflicting prims: older overrides" (seen 2026-08-23, when a
+# node rebooting from a host failure bootstrapped an empty cluster while the two
+# survivors held quorum). _health_mysql repair has always had this check.
+os_galera_live_primary()
+{
+    local me=$(hostname) node st
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        [ "x$node" = "x$me" ] && continue
+        st=$(remote_run $node "mysql -u root -N -e \"show status like 'wsrep_cluster_status'\" 2>/dev/null | awk '{print \$2}'")
+        if [ "x$st" = "xPrimary" ] ; then
+            echo "$node"
+            return 0
+        fi
+    done
+    return 1
+}
+
 os_resume_hypervisor()
 {
     if nova hypervisor-list | grep -q disabled ; then

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -49,6 +49,15 @@ _power_roll_set_raw() { _power_roll_write --argjson v "$2" ".$1=\$v" ; }
 # shared log lines and events that must name the right operation.
 _power_roll_kind() { jq -r '.kind // "restart"' $ROLLING_JOB 2>/dev/null || echo restart ; }
 
+# CLI verb for a roll kind. The state machine says "upgrade"; the shipped command
+# is `cluster rolling_update`. Operator-facing text only -- log/event tags keep
+# the kind verbatim so existing queries still match.
+_power_roll_cli_verb()
+{
+    local k=${1:-$(_power_roll_kind)}
+    if [ "x$k" = "xupgrade" ] ; then echo update ; else echo restart ; fi
+}
+
 # resolve the dispatch node via the cluster VIP: a static first-node pick keeps
 # addressing exactly the host an upgrade reboots first
 _power_roll_master()
@@ -218,7 +227,7 @@ _power_roll_kick()
     done
     local apierr=$(_power_roll_api_ready)
     if [ -n "$apierr" ] ; then
-        _power_roll_pause "$apierr -- a rejoined node is still starting; wait, then run rolling_$(_power_roll_kind) continue"
+        _power_roll_pause "$apierr -- a rejoined node is still starting; wait, then run rolling_$(_power_roll_cli_verb) continue"
         return 1
     fi
 
@@ -245,7 +254,7 @@ _power_roll_kick()
             if ! remote_run $master "$HEX_SDK power_node_evacuate $host" ; then
                 local stuck=""
                 [ -s "$ROLLING_DIR/.stuck.$host" ] && stuck=": $(tr '\n' ' ' < "$ROLLING_DIR/.stuck.$host")"
-                _power_roll_pause "could not live-migrate all workloads off $host${stuck} -- migrate or stop them, then run rolling_$(_power_roll_kind) continue"
+                _power_roll_pause "could not live-migrate all workloads off $host${stuck} -- migrate or stop them, then run rolling_$(_power_roll_cli_verb) continue"
                 return 1
             fi
             ;;
@@ -647,9 +656,9 @@ power_roll_start()
     # on cephfs, so progress is followable from any node either way.
     if jq -e --arg h "$HOSTNAME" 'any(.nodes[]; .hostname==$h)' $ROLLING_JOB >/dev/null ; then
         echo "NOTE: $HOSTNAME will be rebooted as part of this roll; once it goes down,"
-        echo "      run \"cluster rolling_$kind status\" from another node to follow progress."
+        echo "      run \"cluster rolling_$(_power_roll_cli_verb $kind) status_watch\" from another node to follow progress."
     else
-        echo "follow progress with \"cluster rolling_$kind status\"."
+        echo "follow progress with \"cluster rolling_$(_power_roll_cli_verb $kind) status_watch\"."
     fi
     # arm only now that the job exists (a tick seeing no job self-stops)
     _power_roll_watchdog_arm

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -221,6 +221,14 @@ _power_roll_kick()
             ;;
     esac
 
+    # Hand off the active ceph-mgr before taking its node down: the dashboard
+    # wedges on mgr failover, and auto-repair stands down while rolling, so
+    # the roll fails it over and verifies/bounces the dashboard itself.
+    # UI-only, so a failure is logged, not a pause.
+    echo "handing off ceph-mgr/dashboard if active on $host"
+    remote_run $master "$HEX_SDK ceph_mgr_dashboard_ensure $host" </dev/null || \
+        echo "ceph-mgr dashboard not verified healthy; continuing (cluster check will flag it)"
+
     if ! is_sshable $ip ; then
         _power_roll_pause "$host ($ip) is unreachable"
         return 1

--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -169,6 +169,31 @@ _power_roll_drain_poll()
     done
 }
 
+_power_roll_api_ready()
+{
+    # Every control node must actually SERVE the APIs the drain calls, not just
+    # listen: neutron/nova bind their port early in startup and drop requests
+    # until their workers are up, while haproxy re-enables the rejoined backend
+    # after two passing checks. A live-migration pre-check balanced onto one of
+    # those marks the instance ERROR (no retry in nova's pre-check path), so
+    # gate the next drain on a real response from every node.
+    local deadline=$(( $(date +%s) + ${ROLLING_API_READY_TIMEOUT:-600} ))
+    local bad
+    while : ; do
+        bad=""
+        for n in $(cubectl node list -j | jq -r '.[].ip.management') ; do
+            for p in 9696 8774 ; do
+                Quiet timeout 5 curl -s -o /dev/null http://$n:$p/ || bad="$bad $n:$p"
+            done
+        done
+        [ -z "$bad" ] && return 0
+        [ $(date +%s) -ge $deadline ] && break
+        sleep 10
+    done
+    echo "api endpoints not serving:$bad"
+    return 1
+}
+
 _power_roll_kick()
 {
     # Drain (if compute-bearing) and reboot one node. Pauses the job on any
@@ -191,6 +216,11 @@ _power_roll_kick()
             return 1
         fi
     done
+    local apierr=$(_power_roll_api_ready)
+    if [ -n "$apierr" ] ; then
+        _power_roll_pause "$apierr -- a rejoined node is still starting; wait, then run rolling_$(_power_roll_kind) continue"
+        return 1
+    fi
 
     _power_roll_set_str inflight "$host"
     _power_roll_set_node_num "$host" started $(date +%s)

--- a/core/sdk_sh/tests/test_ganesha_grace_join.sh
+++ b/core/sdk_sh/tests/test_ganesha_grace_join.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Unit test for ceph_ganesha_grace_join (../modules/sdk_ceph.sh) and the
+# ceph_mds auto-repair that must use it (../modules/sdk_health.sh).
+#
+# ganesha's rados_cluster recovery backend exits fatally when the node is not a
+# member of the grace DB ("Cluster membership check failed: -2"), so restarting
+# the daemon can never recover that state -- the membership has to be restored
+# first. Registration is bounded (`timeout 60 ganesha-rados-grace ... add`) so a
+# RADOS stall cannot wedge the config commit, which means it can expire and
+# leave the node unregistered; this is the path that repairs it.
+#
+# Self-contained: extracts the functions and mocks ganesha-rados-grace, timeout
+# and the cmd layer, so it needs no cluster and no ceph.  Run: bash test_...sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+body="$(awk '/^ceph_ganesha_grace_join\(\)/{p=1} p{print} p&&/^}/{exit}' "$DIR/../modules/sdk_ceph.sh")"
+[ -n "$body" ] || { echo "FAIL: ceph_ganesha_grace_join not extracted"; exit 1; }
+eval "$body"
+body="$(awk '/^_health_ceph_mds_auto_repair\(\)/{p=1} p{print} p&&/^}/{exit}' "$DIR/../modules/sdk_health.sh")"
+[ -n "$body" ] || { echo "FAIL: _health_ceph_mds_auto_repair not extracted"; exit 1; }
+eval "$body"
+
+LOG=$(mktemp)
+MEMBERS=$(mktemp)
+pass=0 fail=0
+chk(){ if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: $1: got [$2] want [$3]"; fi; }
+saw(){ grep -qe "$1" "$LOG" && echo y || echo n; }
+
+# --- mocks
+# grace DB: `dump` prints the member table, `add` appends unless ADD_BREAKS=1
+ganesha-rados-grace(){
+    local op="" pool=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -p) pool=$2 ; shift 2 ;;
+            dump) op=dump ; shift ;;
+            add) op=add ; shift ; echo "grace add $1" >> "$LOG" ; [ "${ADD_BREAKS:-0}" = 1 ] || echo "$1" >> "$MEMBERS" ; shift ;;
+            *) shift ;;
+        esac
+    done
+    if [ "$op" = dump ] ; then
+        echo "grace dump pool=$pool" >> "$LOG"
+        echo "cur=1 rec=0"
+        awk '{print $1"\t  "}' "$MEMBERS"
+    fi
+    return 0
+}
+timeout(){ shift ; "$@" ; }            # drop the duration, run the command
+Quiet(){ [ "${1:-}" = "-n" ] && shift ; "$@" ; }
+cmd(){ echo "cmd $*" >> "$LOG" ; }
+HEX_SDK=hex_sdk
+HOSTNAME=c1
+GANESHA_CONF=$(mktemp)
+printf 'NFSv4 {\n\tRecoveryBackend = rados_cluster;\n\tpool = "cephfs_data";\n\tnodeid = c1;\n}\n' > "$GANESHA_CONF"
+
+# 1. already a member: verify only, never re-add
+printf 'c1\nc2\nc3\n' > "$MEMBERS" ; : > "$LOG"
+ceph_ganesha_grace_join ; rc=$?
+chk "1 rc 0"            "$rc"                "0"
+chk "1 no add needed"   "$(saw 'grace add')" "n"
+
+# 2. missing: registers this node, then confirms it took
+printf 'c2\nc3\n' > "$MEMBERS" ; : > "$LOG"
+ceph_ganesha_grace_join ; rc=$?
+chk "2 rc 0"                "$rc"                    "0"
+chk "2 added self"          "$(saw 'grace add c1')"  "y"
+chk "2 used the conf pool"  "$(saw 'pool=cephfs_data')" "y"
+chk "2 member now"          "$(grep -cx c1 "$MEMBERS")" "1"
+
+# 3. add silently does not take (the bounded-call-expired case): must report failure
+printf 'c2\nc3\n' > "$MEMBERS" ; : > "$LOG" ; ADD_BREAKS=1
+ceph_ganesha_grace_join ; rc=$?
+chk "3 nonzero rc"      "$rc"                   "1"
+chk "3 tried to add"    "$(saw 'grace add c1')" "y"
+unset ADD_BREAKS
+
+# 4. the ceph_mds auto-repair for a ganesha fault must restore membership, not
+#    just bounce the daemon -- a bare restart cannot fix a missing member
+for code in 3 4 5 ; do
+    : > "$LOG" ; ERR_CODE=$code
+    _health_ceph_mds_auto_repair
+    chk "4 code $code joins grace"    "$(saw 'grace_join')"               "y"
+    chk "4 code $code restarts after" "$(saw 'restart nfs-ganesha')"      "y"
+done
+
+# 5. unrelated codes keep their own remedies
+: > "$LOG" ; ERR_CODE=1 ; _health_ceph_mds_auto_repair
+chk "5 code 1 untouched" "$(saw 'grace_join')" "n"
+: > "$LOG" ; ERR_CODE=2 ; _health_ceph_mds_auto_repair
+chk "5 code 2 untouched" "$(saw 'grace_join')" "n"
+
+rm -f "$LOG" "$MEMBERS" "$GANESHA_CONF" 2>/dev/null
+echo "----" ; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: ganesha grace join" ; exit 0 ; } || exit 1

--- a/core/sdk_sh/tests/test_git_optout.sh
+++ b/core/sdk_sh/tests/test_git_optout.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Unit test for the hidden git opt-out in ../modules/sdk_git.sh.
+# The rootfs is a git worktree of the image commit, and both _git_client_init
+# (first boot after an upgrade) and git_push (cluster-wide fan-out) stash local
+# modifications away -- silently reverting any hot-patched tracked file. With
+# $CUBE_GIT_OPTOUT present a node must keep its uncommitted changes instead:
+# adopt the image history, skip the add/stash/pull trio, and never publish the
+# node's local edits to the shared repo.
+#
+# Self-contained: extracts just these functions and mocks the git/Quiet/cmd
+# layers, so it needs no cluster, no cephfs and no repo.  Run: bash test_...sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_git.sh"
+
+for fn in _git_client_init git_push ; do
+    body="$(awk -v f="^${fn}\\\\(\\\\)" '$0~f{p=1} p{print} p&&/^}/{exit}' "$SRC")"
+    [ -n "$body" ] || { echo "FAIL: $fn not extracted"; exit 1; }
+    eval "$body"
+done
+
+LOG=$(mktemp)
+pass=0 fail=0
+chk(){ if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: $1: got [$2] want [$3]"; fi; }
+saw(){ grep -qe "$1" "$LOG" && echo y || echo n; }
+
+# --- mocks: record what the git layer is asked to do; succeed at everything.
+# `git log -1` must fail: that is the "no commit yet, needs init" precondition.
+GIT=_gitmock
+_gitmock(){
+    echo "git $*" >> "$LOG"
+    case "${1:-}${2:-}" in
+        log*|-Plog) return 1 ;;
+        -Pstatus) echo "	modified:   usr/sbin/bootstrap" ; return 0 ;;
+    esac
+    return 0
+}
+git(){ _gitmock "$@" ; }
+Quiet(){ [ "${1:-}" = "-n" ] && shift ; "$@" ; }
+cmd(){ echo "cmd $*" >> "$LOG" ; }
+Error(){ echo "Error $*" >> "$LOG" ; return 1 ; }
+log_warning(){ echo "warn $*" >> "$LOG" ; }
+pushd(){ : ; } ; popd(){ : ; }
+git_ignore_file(){ : ; }
+_git_suid_save(){ : ; } ; _git_suid_restore(){ : ; }
+cubectl(){ echo '[]' ; }
+jq(){ echo "10.0.0.1" ; }
+HEX_SDK=_hexsdkmock
+_hexsdkmock(){ return 0 ; }              # cube_node_ready -> ready
+CEPHFS_BACKUP_DIR=$(mktemp -d)
+HOSTNAME=testnode
+
+# the two paths the production code must not hard-code, so a test can point them
+# somewhere writable
+CUBE_GITIGNORE=$(mktemp) ; : > "$CUBE_GITIGNORE"
+OPTOUT=$(mktemp -u)
+CUBE_GIT_OPTOUT=$OPTOUT
+
+# 1. client init WITHOUT the marker: the existing destructive path is unchanged
+: > "$LOG" ; rm -f "$OPTOUT"
+_git_client_init
+chk "1 tracks the image branch" "$(saw 'git branch --track')" "y"
+chk "1 stages everything"       "$(saw 'git add -A')"         "y"
+chk "1 stashes local changes"   "$(saw 'git stash')"          "y"
+chk "1 pulls"                   "$(saw 'git pull')"           "y"
+
+# 2. client init WITH the marker: adopt history, keep the working tree
+: > "$LOG" ; : > "$OPTOUT"
+_git_client_init
+chk "2 still tracks the image branch" "$(saw 'git branch --track')" "y"
+chk "2 does NOT stage"                "$(saw 'git add -A')"         "n"
+chk "2 does NOT stash"                "$(saw 'git stash')"          "n"
+chk "2 does NOT pull"                 "$(saw 'git pull')"           "n"
+chk "2 warns"                         "$(saw 'warn ')"              "y"
+
+# 3. git_push WITHOUT the marker: commits, pushes, and tells peers to stash+pull
+: > "$LOG" ; rm -f "$OPTOUT"
+git_push "a message"
+chk "3 commits"        "$(saw 'git commit')"  "y"
+chk "3 pushes"         "$(saw 'git push')"    "y"
+chk "3 peers stash"    "$(saw 'cmd .*stash')" "y"
+
+# 4. git_push WITH the marker: never harvests or publishes this node's edits,
+#    and never tells peers to throw theirs away
+: > "$LOG" ; : > "$OPTOUT"
+git_push "a message"
+chk "4 does NOT commit"     "$(saw 'git commit')"  "n"
+chk "4 does NOT push"       "$(saw 'git push')"    "n"
+chk "4 no peer stash"       "$(saw 'cmd .*stash')" "n"
+chk "4 warns"               "$(saw 'warn ')"       "y"
+
+rm -rf "$LOG" "$OPTOUT" "$CUBE_GITIGNORE" "$CEPHFS_BACKUP_DIR" 2>/dev/null
+echo "----" ; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: git opt-out" ; exit 0 ; } || exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Twenty-four defects found validating 3.1.10-rc1 on the sky 3-node lab — rolling restart, cold
powercycle, rolling upgrade, masakari host failures — plus four more from QA's 3c3p powercycle run.
They ride together because they were found as one cascade and nearly all sit on the shared
roll/boot/upgrade path.

**Roll and boot**

| # | Symptom | Fix | commit |
|---|---|---|---|
| 1 | Every roll left `Storage NG [ceph_mgr(5)]` for tens of minutes — the dashboard wedges on any mgr failover | hand the mgr off and verify the dashboard before rebooting that node | `c7ecb02` |
| 2 | A node whose console stopped draining blocked the boot indefinitely | bound every console write | `8328048` |
| 3 | Roll drained the next node before the rebooted one served, so VMs went `ERROR` and the roll paused | gate each drain on every node's neutron/nova answering directly, not via the VIP | `b2eca68` |
| 4 | `cluster poweroff` on a repair-opted-out cluster came back with every VM `SHUTOFF`, silently | the opt-out suppresses health repair, not VM restore | `a8aa168` |
| 5 | ceph commit burned 389 s inside one `ceph_fs_mds_init`, all 16 workers idle behind it | `timeout -k` the ceph CLI; skip MDS placement when the mgr is unavailable | `d04c273` |
| 6 | Whole bootstrap ran against paused storage after a cold poweroff — MDS stuck `up:replay` | lift only the client-I/O blocks once the mons answer | `e07ec05` |
| 7 | `systemctl restart nfs-ganesha` loops forever when grace-DB membership is missing | rejoin the grace DB first | `8b5923c` |

**Upgrade**

| # | Symptom | Fix | commit |
|---|---|---|---|
| 8 | Every upgraded node lost nova-compute — `/var/lib/nova/compute_id` lives in the root slot the upgrade boots away from | declare it for migration, as ceph already does for its keyring | `441257d` |
| 9 | Upgrade silently re-enabled auto-repair under an operator who had disabled it | migrate the opt-out markers | `df27cf4` |
| 10 | A deliberately hot-patched node reverted mid-boot via `_git_client_init` | hidden `cube_git_optout` marker | `54ac712` |

**Storage plumbing**

| # | Symptom | Fix | commit |
|---|---|---|---|
| 11 | ceph-csi never installed on any cluster with a separate storage VLAN, and 821 MiB of images re-imported every commit | monitors bind the storage network, so drop the mgmt-IP filter; import only what is missing | `fdd9c33` |

**Octavia and neutron** — all five look identical to an operator: an LB create or failover landing at
`provisioning_status ERROR` that works when retried. Five different defects; the discriminator is the
error text in `worker.log`.

| # | Error text | Defect and fix | commit |
|---|---|---|---|
| 12 | `operating_status OFFLINE` while forwarding fine | `controller_ip_port_list` came from the amphora topology, not cluster HA, so each node wrote only its own endpoint | `938db39` |
| 13 | `ERROR` after a host failure | masakari evacuated amphorae, losing the injected config; they now carry `HA_Enabled=False` and octavia's own health-manager recovers them | `19bdfcc` |
| 14 | `Failed to load CA Cert` | `scp -r src/ dst/` onto an existing destination lands the tree at `certs/certs/` | `793d5f0` |
| 15 | `Multiple possible networks found (409)` | the commit path authored the lb-mgmt ids gated on a master-only marker, so every non-master control commit blanked them | `6e34e3b` |
| 16 | `ComputeWaitTimeoutException` | ML2/OVN port status comes only from IDL events and nothing reconciles it; new code 7 detects and re-fires per port | `a8d31b5` |

**Planned stops read as failures**

| # | Symptom | Fix | commit |
|---|---|---|---|
| 17 | Every power cycle rebuilt every amphora and flagged a host `on_maintenance` (instance-HA then off for it) — masakari's monitor starts ~2 min before nova-compute, octavia's health-manager arms while amphorae are still SHUTOFF | mark the stop planned before anything stops; gate both monitors on that marker with a systemd drop-in that retries until it clears | `23e89d9` |
| 18 | Three ways to lose HA or load balancing while `cluster check` reads `ok`: a host `on_maintenance`; the octavia hm port back from a cold boot as an orphaned OVN **virtual** port (ovs port/link/route all still pass codes 5/6/7); load balancers in `ERROR`, never checked | masakari code 8, octavia codes 11 and 12, the last repaired by octavia's own failover | `765ba73` |
| 19 | A node rejoining after a host failure bootstrapped an empty galera cluster over a live primary, aborting a node FATAL `conflicting prims` | join a peer that already holds a primary — the check `_health_mysql` repair always had | `d01ba79` |

**Full-cluster powercycle, found by QA (@chase-chou) against #1074** — four recovery blockers.

| # | Symptom | Fix | commit |
|---|---|---|---|
| 20 | A non-master control node's bootstrap runs `cluster stop`, landing in `ceph_osd_compact`, whose per-OSD `ceph tell` has no timeout — during a powercycle it blocks forever and `/run/cube_commit_done` never appears | bound each compact | `c35a346` |
| 21 | `FileStor NG manila(N share down)` on every healthy **multi-backend** cluster — the check compared service *rows* against a *node* count | count hosts with a share up, not rows | `b2c864e` |
| 22 | Master sat 10+ min in `pipe_read` on `cube_cluster_start \| tee …`, blocking the cluster's recovery — the earlier console fix bounded `bootstrap_status` but not the two long pipelines | write the log directly, put each console line through the bounded writer | `8749ee3` |
| 23 | Past bootstrap's readiness window it skips the async repair and tells the operator to run `cluster check_repair` — which reported all 27 services `ok` while the recorded VMs stayed `SHUTOFF`, and left the gate holding the monitors | make finishing a planned stop its own marker-gated step the boot path runs on its own clock; window 30min → 1h | `70f935a` |
| 24 | The roll printed `cluster rolling_upgrade …` in its follow-progress hints and in both paused-roll reasons — the CLI verb is `rolling_update`, so every one of them is rejected as an unknown command | map the internal kind to the CLI verb for operator text; log tags keep the kind | `27df138` |

#### Which issue(s) this PR fixes

Fixes #1299 (1) · Fixes #1303 (2) · Fixes #1300 (3) · Fixes #1320 (4) · Fixes #1318 (5, 6) ·
Fixes #1311 (7) · Fixes #1319 (8, 9) · Fixes #1306 (10) · Fixes #1321 (11) · Fixes #1322 (12, 14, 15) ·
Fixes #1323 (13) · Fixes #1324 (16) · Fixes #1326 (17) · Fixes #1327 (18) · Fixes #1328 (19) ·
Fixes #1329 (20) · Fixes #1317 (21) · Fixes #1330 (23) · Fixes #1334 (24)

Fix 10 was folded in from PR #1307, which this supersedes. Fix 22 is tracked only in the #1303 thread.

#### Special notes for your reviewer

- **Fix 23 also repairs fix 17** — the gate release sat in the same block bootstrap skips. It is
  deliberately *not* folded into `check_repair`: that is a health sweep an operator may run at any
  time, the recorded VM list outlives the restore, and the sweep cannot vouch for services anyway
  (it reports FAIL and moves on). The resume waits for the nova API and no-ops without the marker. The gate release landed in the same block bootstrap skips, so a run
  past the 30-min window left the monitors gated off indefinitely. Both steps are idempotent, so the
  automatic path is unchanged.
- **Fix 15's cause was proven, not inferred.** Restoring the pre-fix binary on a non-master node and
  rebooting blanked the ids; the fixed binary preserved them. A rival explanation (`ReconfigMain`'s
  lookup returning empty) is real but separate, and guarded in the same commit.
- **Fix 11 changes what runs on the cluster** — ceph-csi has never applied on a separate storage VLAN,
  so this is the first deployment of those charts anywhere.
- **Fix 6 clears `nodown` deliberately.** It only makes a stale osdmap truthful; nothing is marked out
  and nothing re-replicates. Not validated above ~20 OSDs.
- **Fixes 16 and 18 are detect-and-recover**, not root-cause fixes.
- **Fix 21 could not have been caught on our lab** — it has a single manila backend, where rows equal
  nodes and the check passes.

**Verified on the sky 3cc lab.** Five clean rolling restarts; the full resilience suite (roll, cold
powercycle, masakari host failure on a VIP and a non-VIP host); ceph-csi installing for the first
time; `cluster check` all `ok` with ceph HEALTH_OK after each.

Fix 17 took three power cycles to get right — cycle 1 failed because the fix edited the wrong one of
two near-identical twins (`ClusterPowercycleMain` vs `ClusterPoweroffMain`, now sharing one
preamble), cycle 2 because the gate released before the VM restore:

| | cycle 1 | cycle 2 | cycle 3 |
|---|---|---|---|
| marker set at poweroff | never | yes | yes |
| gate rejections during boot | 0 | 80 | 88 |
| amphorae after | ERROR, rebuilt | ALLOCATED, rebuilt | **ALLOCATED, ids unchanged** |
| host flagged `on_maintenance` | yes | no | no |

Fix 23 verified directly: with a VM recorded `stopped` and the gate held, `cluster check_repair`
brought it back `ACTIVE` and cleared the marker. **Fixes 20 and 22 are code-bounded and reviewed but
not reproduced on hardware** — the powercycle wedge is QA's environment.

#### Additional documentation

Six known-issue notes in bigstack-handbook, each with a scenario sidecar carrying the layer-by-layer
evidence and a re-runnable reproduction (PRs #327-#354, #359):

```docs
kb/cubecos/known-issues/ceph-mgr-dashboard-failover-wedge.md
kb/cubecos/known-issues/octavia-lb-mgmt-ids-wiped-on-non-master.md
kb/cubecos/known-issues/neutron-ovn-port-status-stuck-down.md
kb/cubecos/known-issues/planned-stop-rebuilds-amphorae.md
kb/cubecos/known-issues/octavia-hm-port-orphaned-virtual-lsp.md
kb/cubecos/known-issues/galera-bootstrap-over-live-primary.md
```



