### PR TITLE
feat(git): opt-out flag so a node keeps its uncommitted rootfs changes

### DIFF
--- a/core/sdk_sh/modules/sdk_git.sh
+++ b/core/sdk_sh/modules/sdk_git.sh
@@ -6,9 +6,15 @@ if [ -z "$PROG" ] ; then
     exit 1
 fi
 
+# Paths named, not inlined: the tests point them somewhere writable.
+CUBE_GITIGNORE=${CUBE_GITIGNORE:-/.gitignore}
+# Hidden opt-out, like cube_repair_optout: keep this node's uncommitted changes
+# instead of stashing them away, and never publish them to the shared repo.
+CUBE_GIT_OPTOUT=${CUBE_GIT_OPTOUT:-/etc/appliance/state/cube_git_optout}
+
 git_ignore_file()
 {
-    cat >/.gitignore <<EOF
+    cat >$CUBE_GITIGNORE <<EOF
 *.pyc
 *.po
 *.mo
@@ -57,7 +63,7 @@ _git_server_init()
         Quiet -n git init -b $branch
         # local cephfs path, not ssh://VIP (stalls during set_ready reconfig). #1195
         Quiet -n $GIT remote add $project ${cube_git_dir}
-        if [ -e "/.gitignore" ] ; then
+        if [ -e "$CUBE_GITIGNORE" ] ; then
             if ! git log -1 >/dev/null 2>&1 ; then
                 Quiet -n git add -A
                 Quiet -n git commit -m "$(hex_cli -c firmware list | grep ACTIVE | awk '{print $2}')" -a
@@ -65,7 +71,7 @@ _git_server_init()
             Quiet -n git push --set-upstream $project $branch
             git -P branch -r | grep -q "${project}/${branch}"
         else
-            Error "failed to generate /.gitignore"
+            Error "failed to generate $CUBE_GITIGNORE"
         fi
         Quiet -n popd
         $GIT -P log || Error "failed to initialize GIT server"
@@ -120,19 +126,25 @@ _git_client_init()
     Quiet -n $GIT init -b $branch
     # local cephfs path, not ssh://VIP (stalls during set_ready reconfig). #1195
     Quiet -n $GIT remote add $project ${cube_git_dir}
-    if [ -e "/.gitignore" ] ; then
+    if [ -e "$CUBE_GITIGNORE" ] ; then
         if $GIT fetch ; then
             _git_suid_save
             Quiet -n $GIT branch --track $branch $project/$branch
-            Quiet -n $GIT add -A
-            Quiet -n $GIT stash
-            Quiet -n $GIT pull $project $branch --rebase
+            # --track already lands HEAD on the fetched tip, so the opt-out path
+            # needs no pull to stay current; local edits just read as modified.
+            if [ -f $CUBE_GIT_OPTOUT ] ; then
+                log_warning "git opt-out: keeping uncommitted changes on $HOSTNAME; / stays modified vs $project/$branch"
+            else
+                Quiet -n $GIT add -A
+                Quiet -n $GIT stash
+                Quiet -n $GIT pull $project $branch --rebase
+            fi
             _git_suid_restore
         else
             Error "git server (on VIP node) is not ready"
         fi
     else
-        Error "failed to generate /.gitignore"
+        Error "failed to generate $CUBE_GITIGNORE"
     fi
     Quiet -n popd
     Quiet -n $GIT -P log
@@ -172,10 +184,17 @@ git_push()
 {
     local msg="${@:-n/a}"
 
+    # Opted out, this tree is the operator's in both directions: don't harvest
+    # its local edits into the shared repo.
+    if [ -f $CUBE_GIT_OPTOUT ] ; then
+        log_warning "git opt-out: not pushing $HOSTNAME's local changes"
+        return 0
+    fi
     if git -P status | grep -q modified ; then
         cmd $HEX_SDK git_client_init
         _git_suid_save
-        ( $GIT commit -m "$msg" -a && $GIT push -q && cmd "$GIT stash ; $GIT pull" ) >/dev/null
+        # per-node check: a peer that opted out keeps its own changes
+        ( $GIT commit -m "$msg" -a && $GIT push -q && cmd "[ -f $CUBE_GIT_OPTOUT ] || { $GIT stash ; $GIT pull ; }" ) >/dev/null
         _git_suid_restore
         Quiet -n $GIT -P log -3
     else

--- a/core/sdk_sh/tests/test_git_optout.sh
+++ b/core/sdk_sh/tests/test_git_optout.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Unit test for the hidden git opt-out in ../modules/sdk_git.sh.
+# The rootfs is a git worktree of the image commit, and both _git_client_init
+# (first boot after an upgrade) and git_push (cluster-wide fan-out) stash local
+# modifications away -- silently reverting any hot-patched tracked file. With
+# $CUBE_GIT_OPTOUT present a node must keep its uncommitted changes instead:
+# adopt the image history, skip the add/stash/pull trio, and never publish the
+# node's local edits to the shared repo.
+#
+# Self-contained: extracts just these functions and mocks the git/Quiet/cmd
+# layers, so it needs no cluster, no cephfs and no repo.  Run: bash test_...sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_git.sh"
+
+for fn in _git_client_init git_push ; do
+    body="$(awk -v f="^${fn}\\\\(\\\\)" '$0~f{p=1} p{print} p&&/^}/{exit}' "$SRC")"
+    [ -n "$body" ] || { echo "FAIL: $fn not extracted"; exit 1; }
+    eval "$body"
+done
+
+LOG=$(mktemp)
+pass=0 fail=0
+chk(){ if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: $1: got [$2] want [$3]"; fi; }
+saw(){ grep -qe "$1" "$LOG" && echo y || echo n; }
+
+# --- mocks: record what the git layer is asked to do; succeed at everything.
+# `git log -1` must fail: that is the "no commit yet, needs init" precondition.
+GIT=_gitmock
+_gitmock(){
+    echo "git $*" >> "$LOG"
+    case "${1:-}${2:-}" in
+        log*|-Plog) return 1 ;;
+        -Pstatus) echo "	modified:   usr/sbin/bootstrap" ; return 0 ;;
+    esac
+    return 0
+}
+git(){ _gitmock "$@" ; }
+Quiet(){ [ "${1:-}" = "-n" ] && shift ; "$@" ; }
+cmd(){ echo "cmd $*" >> "$LOG" ; }
+Error(){ echo "Error $*" >> "$LOG" ; return 1 ; }
+log_warning(){ echo "warn $*" >> "$LOG" ; }
+pushd(){ : ; } ; popd(){ : ; }
+git_ignore_file(){ : ; }
+_git_suid_save(){ : ; } ; _git_suid_restore(){ : ; }
+cubectl(){ echo '[]' ; }
+jq(){ echo "10.0.0.1" ; }
+HEX_SDK=_hexsdkmock
+_hexsdkmock(){ return 0 ; }              # cube_node_ready -> ready
+CEPHFS_BACKUP_DIR=$(mktemp -d)
+HOSTNAME=testnode
+
+# the two paths the production code must not hard-code, so a test can point them
+# somewhere writable
+CUBE_GITIGNORE=$(mktemp) ; : > "$CUBE_GITIGNORE"
+OPTOUT=$(mktemp -u)
+CUBE_GIT_OPTOUT=$OPTOUT
+
+# 1. client init WITHOUT the marker: the existing destructive path is unchanged
+: > "$LOG" ; rm -f "$OPTOUT"
+_git_client_init
+chk "1 tracks the image branch" "$(saw 'git branch --track')" "y"
+chk "1 stages everything"       "$(saw 'git add -A')"         "y"
+chk "1 stashes local changes"   "$(saw 'git stash')"          "y"
+chk "1 pulls"                   "$(saw 'git pull')"           "y"
+
+# 2. client init WITH the marker: adopt history, keep the working tree
+: > "$LOG" ; : > "$OPTOUT"
+_git_client_init
+chk "2 still tracks the image branch" "$(saw 'git branch --track')" "y"
+chk "2 does NOT stage"                "$(saw 'git add -A')"         "n"
+chk "2 does NOT stash"                "$(saw 'git stash')"          "n"
+chk "2 does NOT pull"                 "$(saw 'git pull')"           "n"
+chk "2 warns"                         "$(saw 'warn ')"              "y"
+
+# 3. git_push WITHOUT the marker: commits, pushes, and tells peers to stash+pull
+: > "$LOG" ; rm -f "$OPTOUT"
+git_push "a message"
+chk "3 commits"        "$(saw 'git commit')"  "y"
+chk "3 pushes"         "$(saw 'git push')"    "y"
+chk "3 peers stash"    "$(saw 'cmd .*stash')" "y"
+
+# 4. git_push WITH the marker: never harvests or publishes this node's edits,
+#    and never tells peers to throw theirs away
+: > "$LOG" ; : > "$OPTOUT"
+git_push "a message"
+chk "4 does NOT commit"     "$(saw 'git commit')"  "n"
+chk "4 does NOT push"       "$(saw 'git push')"    "n"
+chk "4 no peer stash"       "$(saw 'cmd .*stash')" "n"
+chk "4 warns"               "$(saw 'warn ')"       "y"
+
+rm -rf "$LOG" "$OPTOUT" "$CUBE_GITIGNORE" "$CEPHFS_BACKUP_DIR" 2>/dev/null
+echo "----" ; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: git opt-out" ; exit 0 ; } || exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

A node's `/` is a git worktree of the image commit, with the bare repo on shared cephfs (`/mnt/cephfs/backup/cube.git`, remote `cube`). Two paths in `sdk_git.sh` discard a node's uncommitted changes:

- `_git_client_init` — on the first boot after an upgrade: `git add -A` then `git stash` (then `git pull --rebase`). Since `add -A` stages untracked files too, the stash takes modified tracked files *and* newly added ones, so the working tree snaps back to the image commit and untracked files vanish from the tree.
- `git_push` — after commit+push it fans out `cmd "git stash ; git pull"`, doing the same on every peer.

For production that is right: the rootfs should match the image. For a lab or dev cluster it means a deliberately hot-patched node silently reverts mid-boot with no warning. Nothing is destroyed — it all lands in `stash@{0}` — but you only find that out afterwards, and by then the boot that needed the patch has already run without it.

This adds a hidden opt-out marker, `/etc/appliance/state/cube_git_optout`, mirroring the existing repair opt-out (`cube_repair_optout`, checked inline at `sdk_health.sh:135`, #1225):

- `_git_client_init` keeps `branch --track` (HEAD still adopts the image commit) and skips the `add -A` / `stash` / `pull` trio, logging a warning. Local edits then simply read as ` M` — the state a node lands in anyway when patched after its init.
- `git_push` returns early with a warning, so an opted-out node's edits are never harvested into the shared repo. Its peer fan-out tests the marker **per node**, so an opted-out peer keeps its changes while the rest follow the new commit.

Dropping the `pull` on the opted-out path costs nothing — `branch --track $branch $project/$branch` already lands the local branch on the fetched tip — and it avoids `git pull --rebase` failing outright on a dirty tree.

Found while diagnosing #1303: a hot-patched `/usr/sbin/bootstrap` was reverted at the end of the upgrade boot, with `/.git/index` mtime matching the file's to the second, and the patch plus its backup sitting in `stash@{0}`.

#### Which issue(s) this PR fixes

Fixes #1306

#### Special notes for your reviewer

- **Test-first.** `core/sdk_sh/tests/test_git_optout.sh` follows the existing `sdk_sh` test convention (extract the functions with awk, mock the git/`Quiet`/`cmd` layers, no cluster or cephfs needed). It asserts both directions for both functions: without the marker the current destructive path is unchanged; with it, `branch --track` still runs while `add -A`/`stash`/`pull` do not, and `git_push` neither commits, pushes, nor tells peers to stash. It was watched failing 8/8 on the new behaviour before the gates existed, and the 8 baseline assertions passed at that point — so the test demonstrably exercises the change rather than the mocks. `PASS=16 FAIL=0` now, and the other five `sdk_sh` tests still exit 0.
- **`/.gitignore` behind `$CUBE_GITIGNORE`** (default unchanged) so `_git_client_init` can be exercised off-node — otherwise its `[ -e "/.gitignore" ]` guard makes the function untestable anywhere but a real node. Behaviour-preserving.
- **The marker survives the mechanism it disables:** it lives under `/etc`, which the rootfs repo's own `.gitignore` excludes (see `git_ignore_file`).
- **Scope limit:** this stops an existing tree being reverted to its own HEAD. It does not preserve local changes across a *new* image install — a fresh pkg legitimately replaces the rootfs.
- **Trade-off, deliberately:** an opted-out node diverges from the shared repo and stops following pushed commits. That is what a lab wants and what production does not, which is why this is a hidden marker rather than a documented tuning — same call as the repair opt-out.
- Not addressed here, worth its own look: `git_push` commits with `-a` and publishes cluster-wide, so on a non-opted-out node any local edit anywhere in the tracked rootfs rides along into the image history whenever someone pushes.

#### Additional documentation

```docs
kb/cubecos/known-issues/rootfs-git-reset-reverts-hot-patches.md (+ scenario sidecar) — to file for #1306/#1303
```
