### PR TITLE
fix(ceph,health): detect a damaged OSD and remount just that one, without auto-repairing storage

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -313,7 +313,10 @@ cube_cluster_start_node()
     # nova-compute as a failure and masakari flags the host on_maintenance.
     # They are armed once, cluster-wide, in cube_cluster_start_cluster.
     Quiet -n killall /usr/sbin/hex_banner # refresh console banner
-    ( $HEX_SDK toggle_health_check | grep ceph_osd | grep -q disabled ) || Quiet -n $HEX_SDK toggle_health_check ceph_osd
+    # keep ceph_osd detection on: a disabled check reports ok, which also silences
+    # health_ceph_osd_repair and the roll's essential gate. Nothing auto-repairs
+    # storage -- there is no _health_ceph_osd_auto_repair.
+    ( $HEX_SDK toggle_health_check | grep ceph_osd | grep -q disabled ) && Quiet -n $HEX_SDK toggle_health_check ceph_osd
     iptables-save > /run/iptables
     cmd "$HEX_SDK migrate_git" # init this node's /.git before it's marked synced
     touch $CLUSTER_SYNC

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -141,6 +141,7 @@ SRV="ceph_osd"
 eval "ERR_DESC_$SRV[1]='not all up'"
 eval "ERR_DESC_$SRV[2]='not all in'"
 eval "ERR_DESC_$SRV[3]='disk failing'"
+eval "ERR_DESC_$SRV[4]='osd on-disk state damaged'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="ceph_rgw"

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2564,6 +2564,119 @@ ceph_osd_get_datapartuuid()
     echo -n "$datapart_partuuid"
 }
 
+# Ask udev to re-read a disk and re-populate its /dev/disk entries. This is a
+# view refresh only: it writes nothing to the disk, does not touch the partition
+# table, and leaves every partition node in place (cubecos#1284).
+# params: $1 - partition device path (e.g. /dev/sde4, /dev/nvme0n1p4)
+# returns: 0 if the partition's PARTUUID is resolvable afterwards, 1 otherwise
+ceph_osd_refresh_links()
+{
+    local datapart=$1
+    local disk=
+
+    [ -n "$(GetBlkPartUuid "$datapart")" ] && return 0
+
+    if [[ "$datapart" =~ ^(.*[0-9]+)p[0-9]+$ ]] ; then
+        disk="${BASH_REMATCH[1]}"
+    elif [[ "$datapart" =~ ^(.*[a-z])[0-9]+$ ]] ; then
+        disk="${BASH_REMATCH[1]}"
+    else
+        log_error "ceph_osd_refresh_links: cannot derive parent disk from $datapart"
+        return 1
+    fi
+
+    log_warning "ceph_osd_refresh_links: $datapart has no live PARTUUID, re-triggering udev on $disk"
+    udevadm trigger --action=change "$disk" "$datapart" 2>/dev/null
+    udevadm settle --timeout=30 2>/dev/null
+
+    if [ -n "$(GetBlkPartUuid "$datapart")" ] ; then
+        return 0
+    fi
+
+    log_error "ceph_osd_refresh_links: $datapart still has no live PARTUUID after a udev refresh -- inspect the disk before taking any repair action"
+    return 1
+}
+
+# Remount a single down OSD whose metadata dir is missing or unmounted. Scoped
+# to one OSD: unlike refresh_ceph_osd / ceph_osd_remount it never stops or
+# unmounts any other OSD on the host. Non-destructive -- it only mounts and
+# re-links, and refuses to act if the data partition cannot be resolved.
+# params: $1 - osd id
+# returns: 0 on success, 1 if it could not be repaired safely
+ceph_osd_remount_one()
+{
+    local osd_id=$1
+    local osdpth=/var/lib/ceph/osd
+    local osd_dir=$osdpth/ceph-$osd_id
+
+    local line=$(awk -v id="$osd_id" '$2 == id { print ; exit }' $CEPH_OSD_MAP 2>/dev/null)
+    if [ -z "$line" ] ; then
+        log_error "ceph_osd_remount_one: osd.$osd_id: no entry in $CEPH_OSD_MAP"
+        return 1
+    fi
+    local metapart=$(echo "$line" | cut -d" " -f1)
+    local datauuid=$(echo "$line" | cut -d" " -f4)
+
+    if [ ! -e "$metapart" ] ; then
+        log_error "ceph_osd_remount_one: osd.$osd_id: metapart $metapart is absent"
+        return 1
+    fi
+    # confirm the data device is really there before touching anything
+    if ! ceph_osd_datapart_resolve "$datauuid" >/dev/null 2>&1 ; then
+        log_error "ceph_osd_remount_one: osd.$osd_id: datapart $datauuid resolves to no device -- not repairing"
+        return 1
+    fi
+    # the udev link may be missing even though the device is fine
+    if [ ! -e "/dev/disk/by-partuuid/$datauuid" ] ; then
+        ceph_osd_refresh_links "$(ceph_osd_datapart_resolve "$datauuid")" || return 1
+    fi
+
+    if systemctl is-active ceph-osd@$osd_id -q ; then
+        $CEPH tell osd.$osd_id compact >/dev/null 2>&1 || true
+        systemctl stop ceph-osd@$osd_id || true
+    fi
+    umount $osd_dir 2>/dev/null || true
+
+    mkdir -p $osd_dir
+    chmod 0755 $osd_dir
+    if ! mount $metapart $osd_dir ; then
+        log_error "ceph_osd_remount_one: osd.$osd_id: failed to mount $metapart"
+        return 1
+    fi
+
+    if [ "x$(readlink $osd_dir/block)" != "x/dev/disk/by-partuuid/$datauuid" ] ; then
+        unlink $osd_dir/block 2>/dev/null
+        (cd $osd_dir && ln -sf /dev/disk/by-partuuid/$datauuid block)
+        chown -h ceph:ceph $osd_dir/block 2>/dev/null
+    fi
+
+    log_warning "ceph_osd_remount_one: osd.$osd_id remounted from $metapart"
+    return 0
+}
+
+# List local OSDs whose on-disk state is damaged but which ceph may still report
+# as merely down: metadata dir unmounted/empty, or block missing/dangling while
+# the data device is demonstrably still present. Reports, never repairs.
+ceph_osd_damaged_list()
+{
+    local osdpth=/var/lib/ceph/osd
+    local line dev id metauuid datauuid osd_dir
+
+    [ -s $CEPH_OSD_MAP ] || return 0
+    while read -r dev id metauuid datauuid ; do
+        [ -n "${id:-}" ] || continue
+        osd_dir=$osdpth/ceph-$id
+        ceph_osd_datapart_resolve "$datauuid" >/dev/null 2>&1 || continue
+        if [ ! -f "$osd_dir/type" ] ; then
+            echo "osd.$id metadata dir not mounted ($osd_dir)"
+        elif [ ! -L "$osd_dir/block" ] ; then
+            echo "osd.$id block symlink missing ($osd_dir/block)"
+        elif ! readlink -e "$osd_dir/block" >/dev/null 2>&1 ; then
+            echo "osd.$id block symlink dangling -> $(readlink $osd_dir/block)"
+        fi
+    done < $CEPH_OSD_MAP
+}
+
 ceph_osd_remount()
 {
     local osdpth=/var/lib/ceph/osd

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -1639,10 +1639,17 @@ health_ceph_osd_check()
     local total=$(echo $stats | jq -r .osdmap.num_osds)
     local uposd=$(echo $stats | jq -r .osdmap.num_up_osds)
     local inosd=$(echo $stats | jq -r .osdmap.num_in_osds)
+    local damaged="$($HEX_SDK ceph_osd_damaged_list 2>/dev/null)"
+
     if cmd "$HEX_SDK ceph_osd_list" | sort -t. -n -k2 | egrep -q "warning|fail" ; then
         # device hardware fault -- always a fault, even mid-recovery
         ERR_CODE=3
         ERR_LOG="dmesg | grep -i -e fail -e error"
+    elif [ -n "$damaged" ] ; then
+        # on-disk state damaged while the data device is still present; ceph can
+        # report this host healthy after marking the OSD out (cubecos#1284)
+        ERR_CODE=4
+        ERR_MSG+="$damaged\n"
     elif [ "$total" != "$uposd" ] ; then
         # OSDs still rejoining -- only a fault if data is unavailable
         _ceph_blocking_health "$stats" && ERR_CODE=1
@@ -1656,15 +1663,28 @@ health_ceph_osd_check()
 
 health_ceph_osd_repair()
 {
-    if [ $($CEPH osd tree down | grep host | awk '{print $4}' | sort -u | wc -l) -gt 0 ] ; then
-        readarray osd_array <<<"$($CEPH osd tree | awk '/ down /{print $1}' | sort)"
-        declare -p osd_array > /dev/null
-        for osd_entry in "${osd_array[@]}" ; do
-            local osd=$(echo $osd_entry | head -c -1)
-            local host=$(ceph_get_host_by_id $osd)
-            remote_run $host "timeout $SRVLTO $HEX_SDK ceph_osd_restart $osd"
-        done
+    if [ $($CEPH osd tree down | grep host | awk '{print $4}' | sort -u | wc -l) -eq 0 ] ; then
+        return 0
     fi
+
+    readarray osd_array <<<"$($CEPH osd tree | awk '/ down /{print $1}' | sort)"
+    declare -p osd_array > /dev/null
+    for osd_entry in "${osd_array[@]}" ; do
+        local osd=$(echo $osd_entry | head -c -1)
+        local host=$(ceph_get_host_by_id $osd)
+
+        # A down OSD whose metadata dir isn't mounted will fail the same way on
+        # every restart ("missing 'type' file"), so restarting it is not a
+        # repair -- it is a loop. Remount just this OSD first; if that cannot be
+        # done safely, report and leave it alone rather than churn (cubecos#1284).
+        if ! remote_run $host "test -f /var/lib/ceph/osd/ceph-$osd/type" ; then
+            if ! remote_run $host "$HEX_SDK ceph_osd_remount_one $osd" ; then
+                log_error "health_ceph_osd_repair: osd.$osd on $host cannot be remounted safely; leaving it down for inspection"
+                continue
+            fi
+        fi
+        remote_run $host "timeout $SRVLTO $HEX_SDK ceph_osd_restart $osd"
+    done
 }
 
 health_ceph_rgw_report()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Reworked to complement #1399 rather than overlap it. #1399 (**merged**) owns **prevention** —
`create_map` no longer discards an OSD when udev loses a `/dev` link, and `prepareOsdDirectories`
no longer re-creates one whose directory went missing. This PR owns **detection and narrow
recovery**: find an OSD that is already damaged, and repair exactly that one, without writing to
anything.

Rebased onto `develop` after #1399 merged; `ceph_osd_remount_one` and `ceph_osd_damaged_list` build
on its `ceph_osd_datapart_resolve` helper.

The premise is that automatic repair of storage papers over data loss. In the reported incident
four independent layers reported "fine" over one dead OSD: `create_map` destroyed state believing it
was tidying up; `health_ceph_osd_repair` restarted the OSD blindly (69,000 times, never escalating);
`ceph.mk` comments out `StartLimitInterval` so the loop is invisible rather than a failed unit; and
ceph marked the OSD out, returning the cluster to HEALTH_OK. Underneath all of it,
`health_ceph_osd_check` was force-disabled on every boot, so nothing was being detected at all.

- **`ceph_osd_refresh_links`** — re-trigger udev for a partition whose live PARTUUID is missing.
  A view refresh only: no partition-table write, no partition node removed. Reports failure instead
  of escalating to anything destructive.
- **`ceph_osd_remount_one`** — mount and re-link a single OSD. Refuses to act unless the data device
  actually resolves, and never touches another OSD on the host, unlike `ceph_osd_remount` /
  `refresh_ceph_osd` which stop and unmount every OSD there.
- **`ceph_osd_damaged_list`** — report local OSDs whose metadata dir is unmounted, or whose `block`
  symlink is missing or dangling, while the data device is demonstrably still present. Reports;
  never repairs.
- **`health_ceph_osd_check`** — new `ERR_CODE 4` for that state. Ceph's own view goes green once an
  unusable OSD is marked out, so this was previously invisible.
- **`health_ceph_osd_repair`** — remount the OSD before restarting it. An OSD whose metadata dir is
  not mounted fails identically on every attempt, so restarting it is a loop, not a repair. If it
  cannot be remounted safely, log and leave it down for inspection rather than churn.
- **`cube_cluster_start_node`** — stop force-disabling the check every boot.

There is deliberately **no** `_health_ceph_osd_auto_repair`. Detection is worth having on by
default; automatic repair of storage is not.

#### Which issue(s) this PR fixes

Related to #1284
Related to #1398

#### Special notes for your reviewer

**Dropped from the previous revision of this PR**, with reasons:

- the `create_map` PARTUUID-refresh hunk — #1399 resolves the uuid off the disk, so there is
  nothing left to refresh for that decision, and its `else` branch still dropped the OSD from the
  map on failure.
- `partprobe` as the recovery mechanism. On a live OSD disk `BLKRRPART` returns EBUSY and libparted
  falls back to per-partition BLKPG delete+add — the operation that produces a partition node with
  no GPT-derived metadata, and in this layout it would touch the sibling OSD on the same disk.
  `udevadm trigger` restores the links without mutating anything, which is what actually worked in
  every lab run.
- `_health_ceph_osd_auto_repair` — it re-armed blind restart looping, and was inert anyway while the
  check was disabled.

`ceph_osd_remount_one` is @leechienpang's idea from the previous revision and the reason this PR is
worth keeping rather than closing; it is reworked here (device-resolution guard, no partprobe, honest
return codes) rather than replaced.

**Third commit is a behaviour change worth its own look.** `ceph_osd` is in
`ROLLING_ESSENTIAL_TIER2`, so re-enabling detection means the rolling restart's essential gate will
actually evaluate OSDs instead of always passing. The existing check already tolerates rejoining
OSDs (`_ceph_blocking_health`), so this should be safe, but it can surface NG during rolls that
previously ran blind. Kept as a separate commit so it can be dropped independently.

**Validated on the sky 3-node lab (sky143), 2026-09-01.** No false positives on a healthy cluster;
detection names the damaged OSD; `ceph_osd_remount_one` repairs it while the other five OSDs on the
host stay untouched; the OSD then starts and detection clears; and it refuses to repair a phantom
OSD whose device resolves nowhere, creating no directory for it. Cluster returned to HEALTH_OK 18/18
after every round.

The before/after that motivates the third commit, same damaged OSD:

```
with the disabled marker present (today):  health_ceph_osd_check rc=0    <- reports OK
with the marker lifted (this change):      health_ceph_osd_check rc=4
  error desc: osd on-disk state damaged
  osd.8 metadata dir not mounted (/var/lib/ceph/osd/ceph-8)
```

Not covered: LVM-backed (encrypted/mpath) OSDs — the lab cluster has none, so the `lvs` branch of
`ceph_osd_datapart_resolve` (merged in #1399, relied on here) has no hardware behind it.

#### Additional documentation

```docs

```

