### PR TITLE
fix(ceph): verify and retry min_size after ceph_adjust_pool_size

### DIFF
--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -564,7 +564,16 @@ ceph_adjust_pool_size()
         rf)
             echo "set ceph pool $pool_name (size, min_size) to ($size, $min_size)"
             $CEPH osd pool set $pool_name size $size --yes-i-really-mean-it 2>/dev/null || true
-            $CEPH osd pool set $pool_name min_size $min_size 2>/dev/null || true
+            local cur_min_size=
+            for i in {1..15} ; do
+                $CEPH osd pool set $pool_name min_size $min_size 2>/dev/null || true
+                cur_min_size=$($CEPH osd pool get $pool_name min_size -f json 2>/dev/null | jq -r .min_size) || true
+                [ "$cur_min_size" == "$min_size" ] && break
+                sleep 1
+            done
+            if [ "$cur_min_size" != "$min_size" ] ; then
+                log_error "ceph_adjust_pool_size: $pool_name: failed to set min_size to $min_size (currently ${cur_min_size:-unknown})"
+            fi
             ;;
         ec)
             echo "set ceph ec pool $pool_name (chunks, parity) to ($size, $min_size)"


### PR DESCRIPTION
## Summary
Fixes #1332. `ceph_create_node_group()` (invoked by CLI `storage add_group`) delegates pool sizing entirely to the shared helper `ceph_adjust_pool_size()` (`sdk_ceph.sh:536-576`), which already computes the correct `min_size = size - 1` (2 for a size-3 pool). The actual defect is that the `ceph osd pool set ... min_size ...` call was wrapped in `2>/dev/null || true` with no verification it took effect — any transient failure was silently discarded, leaving pools at `size: 3, min_size: 1` with zero trace of why (same "swallow the error, trust it worked" pattern as #1284, just for pool config instead of partition metadata; confirmed via `git log -L` that this code is unchanged since it was first written).

- Add a bounded verify-and-retry (matching the existing `for i in {1..15}; do ...; sleep 1; done` convention already used in `ceph_create_pool()`): re-issue the `min_size` set and check the actual value via `ceph osd pool get` up to 15 times.
- Log an error instead of silently moving on if it never converges.

This fixes the shared helper behind every `ceph_adjust_pool_size()` caller (node-group creation, cache-pool sizing, EC-pool fallback, host removal) — not just `add_group`.

## Test plan
- [x] `bash -n core/sdk_sh/modules/sdk_ceph.sh`
- [ ] On a test cluster: `storage add_group <group> <node...>` with 3+ hosts, then `ceph osd pool get <group>-pool all | grep size` and confirm `size: 3` / `min_size: 2`.