### PR TITLE
feat(gpu): carve vGPUs of different framebuffer sizes on one SR-IOV card

### DIFF
--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -789,6 +789,17 @@ IsVfBackedType(const json11::Json& type)
 // of every sriovVgpu/migBackedVgpu GPU. Regenerating everything from the
 // truth file means entries for GPUs switched away from either type
 // disappear without any dedicated cleanup logic.
+//
+// Every entry carries a vgpu_type tag naming the profile its VF was carved
+// to. Nova keeps unrecognised device_spec keys as pool tags and matches them
+// against the keys present in a request's spec, so this tag is the only thing
+// that stops two aliases on one card from being interchangeable: without it
+// every vGPU VF on the node reports the same vendor:product and an alias has
+// no address field, so a flavor gets whichever VF the pool's free list hands
+// out. Measured wrong 4 times out of 4 on cn13 2026-08-21, in both boot
+// orders. The tag has to appear on *every* entry, including single-profile
+// cards - an alias without it is unconstrained by that key and will match a
+// tagged pool belonging to a different card.
 static std::string
 BuildNovaGpuConfContent(const json11::Json& gpuConfig,
                         const std::map<std::string, std::vector<PciVf>>& vfsByGpuId)
@@ -810,19 +821,42 @@ BuildNovaGpuConfContent(const json11::Json& gpuConfig,
 
         const std::vector<PciVf>& vfs = vfsIt->second;
 
+        // Walks the profiles in request order and consumes that many VFs each -
+        // the same expansion BuildVfAssignmentPlan performs when it writes the
+        // types, so profiles[0] owns the first block of VFs, profiles[1] the
+        // next, and so on. That correspondence is what lets a whitelist entry
+        // be tagged with the profile its VF actually carries.
+        //
+        // vfIndex advances even for a profile whose alias is unusable: skipping
+        // the advance would shift every later profile's VFs by that count and
+        // silently mistag them.
+        size_t vfIndex = 0;
+
         for (const json11::Json& profile : entry["profiles"].array_items()) {
-            if (!profile["alias"].is_string()) {
+            const long count = (long)profile["count"].number_value();
+
+            if (!profile["alias"].is_string() || !profile["id"].is_number()) {
+                HexLogWarning("%s: GPU %s has a profile with no usable alias/id; its %ld VF(s) are "
+                              "left out of the drop-in", NOVA_GPU_CONF,
+                              entry["id"].string_value().c_str(), count);
+                vfIndex += (size_t)((count > 0) ? count : 0);
                 continue;
             }
+
+            const std::string vgpuType = std::to_string((int)profile["id"].number_value());
+
             content += "alias = { \"name\": \"" + profile["alias"].string_value() +
                        "\", \"device_type\": \"type-VF\", \"vendor_id\": \"" + vfs[0].vendorId +
-                       "\", \"product_id\": \"" + vfs[0].productId + "\" }\n";
-        }
+                       "\", \"product_id\": \"" + vfs[0].productId +
+                       "\", \"vgpu_type\": \"" + vgpuType + "\" }\n";
 
-        for (size_t i = 0; i < vfs.size(); i++) {
-            content += "passthrough_whitelist = { \"vendor_id\": \"" + vfs[i].vendorId +
-                       "\", \"product_id\": \"" + vfs[i].productId +
-                       "\", \"address\": \"" + vfs[i].address + "\", \"managed\": \"no\" }\n";
+            for (long i = 0; i < count && vfIndex < vfs.size(); i++, vfIndex++) {
+                content += "passthrough_whitelist = { \"vendor_id\": \"" + vfs[vfIndex].vendorId +
+                           "\", \"product_id\": \"" + vfs[vfIndex].productId +
+                           "\", \"address\": \"" + vfs[vfIndex].address +
+                           "\", \"vgpu_type\": \"" + vgpuType +
+                           "\", \"managed\": \"no\" }\n";
+            }
         }
     }
 

--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -936,6 +936,39 @@ WriteNovaGpuConf(void)
     return true;
 }
 
+// Removes one GPU's entry from the truth file.
+//
+// Used on the failed-apply path. By the time an apply can fail,
+// gpu_unset_current_type has already released the card's previous carve, so the
+// entry that is still in config.json describes hardware state that no longer
+// exists - and the Nova drop-in generated from it whitelists VF addresses that
+// are gone (three-way divergence measured on cn13 2026-08-20, resolved until
+// then only by the next successful carve or a reboot). Dropping the entry
+// records what is actually true: this card has no carve.
+static bool
+DropGpuConfigEntry(const char* gpuId)
+{
+    HexTempFile tmpFile;
+    if (tmpFile.fd() < 0) {
+        HexLogError("gpu_resource_set: failed to create a temporary file");
+        return false;
+    }
+    tmpFile.close();
+
+    if (HexUtilSystemF(0, 0, "jq -c --arg id \"%s\" 'map(select(.id != $id))' %s > %s",
+                       gpuId, GPU_CONFIG_FILE, tmpFile.path()) != 0) {
+        HexLogError("gpu_resource_set: failed to build updated GPU config for %s", gpuId);
+        return false;
+    }
+
+    if (HexUtilSystemF(0, 0, "mv %s %s", tmpFile.path(), GPU_CONFIG_FILE) != 0) {
+        HexLogError("gpu_resource_set: failed to persist GPU %s config", gpuId);
+        return false;
+    }
+
+    return true;
+}
+
 // Looks up GPU gpuId via gpu_device_list, the single source of truth for
 // GPU id/name/type/pciAddress - it already unions live nvidia-smi data with
 // `config.json` entries, specifically for GPUs no longer visible to nvidia-smi
@@ -1440,6 +1473,39 @@ ResourceSetMain(int argc, char* argv[])
 
         if (!ApplySriovVgpu(gpuId, pciAddress, requested)) {
             HexLogError("gpu_resource_set: failed to apply SR-IOV vGPU partitioning on GPU %s", gpuId);
+
+            // Leave the three views of this card agreeing with each other. The
+            // previous carve is unrecoverable at this point - it was torn down
+            // before the apply was attempted - so the honest record is "no
+            // carve", and the drop-in has to be regenerated from that or it
+            // keeps whitelisting VFs that no longer exist.
+            //
+            // Re-applying the previous layout is deliberately not attempted: it
+            // can fail for the same reason this apply did, and a retry loop on
+            // the failure path is a worse place to discover that.
+            if (!DropGpuConfigEntry(gpuId)) {
+                HexLogError("gpu_resource_set: GPU %s also failed to drop its stale config entry; "
+                            "the intent file still describes a carve the hardware no longer has",
+                            gpuId);
+                return EXIT_FAILURE;
+            }
+
+            // Nodes that never had a drop-in are left without one.
+            if (access(NOVA_GPU_CONF, F_OK) != 0) {
+                return EXIT_FAILURE;
+            }
+
+            if (!WriteNovaGpuConf()) {
+                HexLogError("gpu_resource_set: failed to regenerate %s after the failed apply "
+                            "on GPU %s", NOVA_GPU_CONF, gpuId);
+                return EXIT_FAILURE;
+            }
+
+            if (HexUtilSystemF(0, 0, HEX_CFG " restart_nova") != 0) {
+                HexLogError("gpu_resource_set: failed to restart nova services after the failed "
+                            "apply on GPU %s", gpuId);
+            }
+
             return EXIT_FAILURE;
         }
 

--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -132,17 +132,130 @@ TeardownSriov(const std::string& sysfsAddr)
     RunSriovManageWithRetry("-d", sysfsAddr);
 }
 
+// Pulls one "Field Name : value" pair out of an `nvidia-smi -q` dump.
+// Returns false when the field is absent or has no value, which every caller
+// treats as "not confirmed" rather than as a default.
+static bool
+NvidiaSmiFieldValue(const std::string& output, const char* field, std::string* value)
+{
+    const size_t at = output.find(field);
+    if (at == std::string::npos) {
+        return false;
+    }
+
+    const size_t colon = output.find(':', at);
+    if (colon == std::string::npos) {
+        return false;
+    }
+
+    size_t eol = output.find('\n', colon);
+    if (eol == std::string::npos) {
+        eol = output.size();
+    }
+
+    const std::string raw = output.substr(colon + 1, eol - colon - 1);
+    const size_t first = raw.find_first_not_of(" \t\r");
+    if (first == std::string::npos) {
+        return false;
+    }
+    const size_t last = raw.find_last_not_of(" \t\r");
+
+    *value = raw.substr(first, last - first + 1);
+    return true;
+}
+
+// Whether this card can host vGPUs of more than one framebuffer size at once.
+// This is a static capability; the mode that uses it is not (see
+// EnableHeterogeneousVgpuMode).
+//
+// Two spelling traps in one output: the capability is printed as
+// "Heterogenous Multi-vGPU" - upstream is missing an 'e' - while the mode's
+// state a few lines later is spelled "vGPU Heterogeneous Mode" correctly.
+// The value is compared for equality rather than searched for, because the
+// negative form is "Not Supported" and contains "Supported".
+//
+// An unreadable answer is a "no": the caller refuses a mixed-size request
+// rather than reaching a mode switch that must fail after the card's previous
+// carve has already been torn down.
+static bool
+HeterogeneousVgpuSupported(const std::string& gpuId)
+{
+    const std::string output = HexUtilPOpen("%s -q -i %s", NVIDIA_SMI, gpuId.c_str());
+
+    std::string value;
+    if (!NvidiaSmiFieldValue(output, "Heterogenous Multi-vGPU", &value)) {
+        HexLogWarning("gpu_resource_set: could not read the heterogeneous vGPU capability of GPU %s; "
+                      "treating it as unsupported", gpuId.c_str());
+        return false;
+    }
+
+    return value == "Supported";
+}
+
+// Turns on the mode that lets one PF carry vGPUs of different framebuffer
+// sizes. `nvidia-smi vgpu -shm` is the only interface - the PF has no
+// nvidia/ sysfs directory, only its VFs do (cn13, 2026-08-21).
+//
+// The ordering this must be called in is not negotiable: after
+// sriov-manage -e, before any current_vgpu_type write. The mode is *runtime*
+// state and sriov-manage clears it in both directions, so setting it before
+// the VFs are enabled is silently undone by the driver rebind - the mode reads
+// Enabled beforehand and Disabled after, every VF's creatable_vgpu_types stays
+// collapsed to one framebuffer size, and the cross-size write still fails.
+// That failure is indistinguishable from "the hardware cannot do it".
+//
+// The same property is why there is no undo on teardown: releasing the VFs
+// clears the mode by itself, so unlike MIG mode it can never outlive the carve
+// it belongs to and no card is left in a mode nothing records.
+//
+// The exit code is trustworthy (rc=19 "In use by another client" when a vGPU
+// already exists, rc=6 for an unknown -i), and the mode is read back anyway
+// because a silent no-op is the one outcome this must not ship with. The state
+// field reads N/A on a MIG-enabled card, which the equality check rejects.
+static bool
+EnableHeterogeneousVgpuMode(const std::string& gpuId)
+{
+    if (HexUtilSystemF(0, 0, "%s vgpu -shm 1 -i %s", NVIDIA_SMI, gpuId.c_str()) != 0) {
+        HexLogError("gpu_resource_set: failed to enable heterogeneous vGPU mode on GPU %s",
+                    gpuId.c_str());
+        return false;
+    }
+
+    const std::string output = HexUtilPOpen("%s -q -i %s", NVIDIA_SMI, gpuId.c_str());
+
+    std::string value;
+    if (!NvidiaSmiFieldValue(output, "vGPU Heterogeneous Mode", &value) || value != "Enabled") {
+        HexLogError("gpu_resource_set: heterogeneous vGPU mode did not take effect on GPU %s "
+                    "(mode reads '%s')", gpuId.c_str(), value.c_str());
+        return false;
+    }
+
+    return true;
+}
+
 // Enables the PF's VFs and writes each requested profile id into that many
 // VFs' current_vgpu_type - the write is what actually carves the vGPU.
 // profiles must already be validated. sriov-manage -e is idempotent for an
 // already-enabled GPU (verified on cn13, 2026-07-17), so this is safe to
 // re-run from boot-time Commit().
 static bool
-ApplySriovVgpu(const std::string& pciAddress, const json11::Json& profiles)
+ApplySriovVgpu(const std::string& gpuId, const std::string& pciAddress,
+               const json11::Json& profiles)
 {
     const std::string sysfsAddr = SysfsPciAddr(pciAddress);
 
     if (!RunSriovManageWithRetry("-e", sysfsAddr)) {
+        return false;
+    }
+
+    // Has to happen here: the VFs are up and nothing is carved yet. Cards that
+    // do not advertise the capability are left alone - a request that actually
+    // needs the mode is refused by ValidateVgpuProfiles long before this point,
+    // so reaching here without it means a single-size carve, which behaves
+    // identically either way (verified on cn13: same types, same placements,
+    // same 32-vGPU ceiling with the mode on and off).
+    if (HeterogeneousVgpuSupported(gpuId) && !EnableHeterogeneousVgpuMode(gpuId)) {
+        TeardownSriov(sysfsAddr);
         return false;
     }
 
@@ -831,6 +944,14 @@ GetGpuTotalVramMiB(const char* gpuId)
 //   non-negative-integer ids and positive-integer counts
 // - existence: every id must be an available profile of the requested type
 //   on this GPU, as reported by gpu_vgpu_profile_list
+// - heterogeneity (SR-IOV): a request spanning more than one framebuffer size
+//   needs the card's heterogeneous vGPU mode, so the card has to advertise the
+//   capability. Checked here rather than left to apply time because
+//   gpu_unset_current_type has already destroyed the previous carve by then -
+//   an apply-time rejection costs the card its working configuration. It runs
+//   ahead of the capacity rule below because it reads nothing from sysfs: a
+//   card that cannot serve the request at all should say so by name even on a
+//   node where sriov_totalvfs happens to be unreadable.
 // - capacity (SR-IOV): each vGPU instance occupies one VF, so the total
 //   requested count must fit within the PF's sriov_totalvfs
 // - capacity (MIG-backed), three rules:
@@ -846,10 +967,10 @@ GetGpuTotalVramMiB(const char* gpuId)
 //   Rule 3 does not model cross-profile slice coupling (R7: 1g/2g/4g partitions
 //   draw on one shared pool, so mixing partition *shapes* can run out of slices
 //   even when each shape's own instance count is fine). nvidia-smi mig -cgi
-//   enforces that at apply time and ApplyMigVgpu is fail-fast, matching how the
-//   SR-IOV homogeneous-mode restriction (discovered only via cn13 hardware
-//   testing, see spec.md §4b/§8) was handled: apply-time rejection first,
-//   tighten validation later if real hardware shows it's worth pre-checking.
+//   enforces that at apply time and ApplyMigVgpu is fail-fast. The SR-IOV
+//   framebuffer-size restriction started out the same way and has since been
+//   promoted to a pre-check (the heterogeneity rule above), for the reason
+//   given there: by apply time the previous carve is already gone.
 //
 // migTypes is the parsed `nvidia-smi vgpu -s -v` geometry, supplied by the
 // caller so the same output serves validation and persistence; it is empty for
@@ -919,6 +1040,44 @@ ValidateVgpuProfiles(const char* gpuId, const char* newType, const char* profile
     for (const int id : requestedIds) {
         if (availableIds.find(id) == availableIds.end()) {
             HexLogError("gpu_resource_set: profile id %d is not a valid %s profile for GPU %s", id, newType, gpuId);
+            return false;
+        }
+    }
+
+    if (strcmp(newType, "sriovVgpu") == 0) {
+        // Not gated on pciAddress: this rule is about the card's advertised
+        // capability, which nvidia-smi answers by UUID.
+        std::map<int, double> sriovVramMiBById;
+
+        for (const json11::Json& profile : profileList[listKey].array_items()) {
+            if (profile["id"].is_number()) {
+                sriovVramMiBById[(int)profile["id"].number_value()] =
+                    profile["vramMiB"].number_value();
+            }
+        }
+
+        std::set<double> requestedSizes;
+
+        for (const int id : requestedIds) {
+            const std::map<int, double>::const_iterator it = sriovVramMiBById.find(id);
+
+            // Fails closed: without every requested profile's framebuffer size
+            // there is no way to tell whether the request mixes sizes, and
+            // guessing "it doesn't" is the direction that reaches the card.
+            if (it == sriovVramMiBById.end() || it->second <= 0) {
+                HexLogError("gpu_resource_set: could not read the framebuffer size of profile %d "
+                            "on GPU %s; cannot tell whether the request mixes sizes", id, gpuId);
+                return false;
+            }
+
+            requestedSizes.insert(it->second);
+        }
+
+        if (requestedSizes.size() > 1 && !HeterogeneousVgpuSupported(gpuId)) {
+            HexLogError("gpu_resource_set: the request mixes %zu vGPU framebuffer sizes, but GPU %s "
+                        "does not report 'Heterogenous Multi-vGPU : Supported'; a single-size "
+                        "request is required on this card",
+                        requestedSizes.size(), gpuId);
             return false;
         }
     }
@@ -1245,7 +1404,7 @@ ResourceSetMain(int argc, char* argv[])
             });
         }
 
-        if (!ApplySriovVgpu(pciAddress, requested)) {
+        if (!ApplySriovVgpu(gpuId, pciAddress, requested)) {
             HexLogError("gpu_resource_set: failed to apply SR-IOV vGPU partitioning on GPU %s", gpuId);
             return EXIT_FAILURE;
         }
@@ -1451,7 +1610,7 @@ Commit(bool modified, int dryLevel)
             // running VMs.
             if (!VfVgpuApplied(SysfsPciAddr(pciAddress))) {
                 const bool applied = (type == "sriovVgpu")
-                    ? ApplySriovVgpu(pciAddress, entry["profiles"])
+                    ? ApplySriovVgpu(id, pciAddress, entry["profiles"])
                     : ApplyMigVgpu(id, pciAddress, entry["profiles"]);
 
                 if (!applied) {

--- a/core/modules/tests/config_gpu/Makefile
+++ b/core/modules/tests/config_gpu/Makefile
@@ -1,0 +1,13 @@
+# HEX SDK
+
+include ../../../../build.mk
+
+hex_config_LIBS = $(PROJ_LIBDIR)/libcube_sdk.a
+
+TESTS_EXTRA_PROGRAMS = hex_config
+
+hex_config_MODULES = config_dummies.o config_gpu.o
+
+CPPFLAGS += -I$(COREDIR)/modules -I$(TOP_SRCDIR)/hex/src/modules/include -I$(COREDIR)/cube_sdk_library/include
+
+include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/core/modules/tests/config_gpu/config_dummies.cpp
+++ b/core/modules/tests/config_gpu/config_dummies.cpp
@@ -1,0 +1,9 @@
+// CUBE SDK
+
+// config_gpu declares no CONFIG_TUNINGs and calls into no other config module -
+// it talks to nvidia-smi, sriov-manage, hex_sdk and its own truth file, and
+// nothing else. So unlike the other module tests here there is nothing to stub
+// out; this file exists to keep the hex_config_MODULES shape the harness
+// expects.
+
+#include <hex/config_module.h>

--- a/core/modules/tests/config_gpu/mock/hex_sdk/gpu
+++ b/core/modules/tests/config_gpu/mock/hex_sdk/gpu
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Mock hex_sdk for the gpu module's shell-outs.
+#
+# The device is reported as sriovVgpu rather than pgpu on purpose: a pgpu sends
+# ResourceSetMain through gpu_unbind_vfio_pci first, which is a path this test
+# is not about. pciAddress must be non-empty - ResourceSetMain refuses the
+# request outright without one.
+case "$1" in
+    gpu_device_list)
+        echo '[{"id":"GPU-1316-test","name":"Test Card","type":"sriovVgpu","pciAddress":"00000000:42:00.0"}]'
+        ;;
+    gpu_vgpu_profile_list)
+        # two profiles of one size and one of another, so the test can build both
+        # a single-size and a mixed-size request out of the same list
+        # 1599 deliberately carries no vramMiB: the size rule has to refuse a
+        # profile whose framebuffer size the list does not report, rather than
+        # assume it matches the others.
+        echo '{"sriov":[{"id":1519,"name":"Test DC-3Q","vramMiB":3072},{"id":1520,"name":"Test DC-3A","vramMiB":3072},{"id":1523,"name":"Test DC-6Q","vramMiB":6144},{"id":1599,"name":"Test No-VRAM"}],"migBacked":[]}'
+        ;;
+    *)
+        # gpu_resource_set_check, gpu_unset_current_type, bind/unbind: all pass
+        exit 0
+        ;;
+esac

--- a/core/modules/tests/config_gpu/mock/nvidia-smi/capability_driven
+++ b/core/modules/tests/config_gpu/mock/nvidia-smi/capability_driven
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Mock nvidia-smi. Only the `-q` dump matters here: ValidateVgpuProfiles reads
+# the heterogeneous-vGPU capability out of it. The advertised value comes from a
+# marker file so one mock serves every case in the test script:
+#
+#   "Supported"      -> the card can host mixed framebuffer sizes
+#   "Not Supported"  -> it cannot
+#   (empty file)     -> the field is absent, i.e. unreadable
+#
+# Note the upstream spelling: the capability is "Heterogenous Multi-vGPU" with
+# one 'e' missing, while the mode's state field a few lines later spells
+# "Heterogeneous" correctly. config_gpu matches both exactly.
+cap=$(cat /tmp/mock-hetero-capability 2>/dev/null)
+
+case "$*" in
+    *-q*)
+        echo "GPU 00000000:42:00.0"
+        echo "    vGPU Driver Capability"
+        if [ -n "$cap" ]; then
+            echo "        Heterogenous Multi-vGPU           : $cap"
+        fi
+        echo "    vGPU Device Capability"
+        echo "        vGPU Heterogeneous Mode           : Disabled"
+        ;;
+esac
+
+exit 0

--- a/core/modules/tests/config_gpu/test_config_gpu_01.sh
+++ b/core/modules/tests/config_gpu/test_config_gpu_01.sh
@@ -1,0 +1,64 @@
+#
+# TEST - the framebuffer-size rule of gpu_resource_set's validation (#1316)
+#
+#   1. a request mixing sizes on a card that does not advertise the capability is
+#      refused, and the message names both the mix and the capability
+#   2. a capability that cannot be read is a refusal too - the rule fails closed
+# Both refuse from inside the rule itself, so neither reads sysfs.
+#
+# Two cases were tried and removed, for two different reasons worth recording:
+#
+#   - "the rule stays out of the way of a single-size request" cannot live here.
+#     A request that passes the rule goes on to the sriov_totalvfs check and then
+#     the apply path, both of which need real VFs under /sys/bus/pci/devices.
+#     PCI_DEVICES_DIR is a compile-time constant, so a build container cannot
+#     supply them.
+#   - a third case of any kind cannot live here either. Measured in the jail
+#     container: the *third* ./hex_config invocation of a run spins in userspace
+#     (STAT=R, no children) regardless of its arguments, while the first two
+#     complete normally. A hanging case would wedge `make test`, so the file
+#     stops at two. This is likely the same unreliability that put config_etcd in
+#     EXCLUDE_DIRS in ../Makefile.
+#
+# So two things are covered on hardware instead of here: the single-size path,
+# and the vgpu_type tag BuildNovaGpuConfContent emits on each alias/device_spec
+# entry (its input comes from GetPciVfs reading virtfnN symlinks).
+#
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+install -m 755 "$DIR/mock/nvidia-smi/capability_driven" /usr/bin/nvidia-smi
+install -m 755 "$DIR/mock/hex_sdk/gpu" /usr/sbin/hex_sdk
+
+GPU=GPU-1316-test
+MIXED='[{"id":1519,"count":1},{"id":1523,"count":1}]'    # 3072 + 6144
+NO_VRAM='[{"id":1519,"count":1},{"id":1599,"count":1}]'  # 3072 + size not reported
+
+# non-zero exit is expected throughout: every case here is meant to be refused
+run() {
+    ./hex_config -vvve gpu_resource_set "$GPU" sriovVgpu "$1" >"/tmp/gpu_$2.log" 2>&1
+    echo $?
+}
+
+# ---- 1. mixed sizes, card says no ----
+echo "Not Supported" > /tmp/mock-hetero-capability
+[ "$(run "$MIXED" case1)" != "0" ] \
+    || fail "case 1: a mixed-size request on an unsupported card was accepted"
+grep -q "mixes 2 vGPU framebuffer sizes" /tmp/gpu_case1.log \
+    || fail "case 1: refusal did not name the mix -- $(tail -2 /tmp/gpu_case1.log)"
+grep -q "Heterogenous Multi-vGPU" /tmp/gpu_case1.log \
+    || fail "case 1: refusal did not name the capability it needs"
+echo "  ok  mixed sizes + unsupported        -> refused, reason named"
+
+# ---- 2. capability unreadable -> fails closed ----
+: > /tmp/mock-hetero-capability
+[ "$(run "$MIXED" case2)" != "0" ] \
+    || fail "case 2: an unreadable capability must be a refusal, not a pass"
+grep -q "mixes 2 vGPU framebuffer sizes" /tmp/gpu_case2.log \
+    || fail "case 2: refused, but not by the size rule -- $(tail -2 /tmp/gpu_case2.log)"
+echo "  ok  mixed sizes + unreadable         -> refused (fails closed)"
+
+rm -f /tmp/gpu_case1.log /tmp/gpu_case2.log
+echo "config_gpu: framebuffer-size rule passed all cases"

--- a/core/modules/tests/config_gpu/testpost.sh
+++ b/core/modules/tests/config_gpu/testpost.sh
@@ -1,0 +1,10 @@
+for f in /usr/bin/nvidia-smi /usr/sbin/hex_sdk; do
+  if [ -f "$f.bak" ]; then
+    mv "$f.bak" "$f"
+  else
+    rm -f "$f"
+  fi
+done
+
+rm -f /etc/cube/cos/gpu/config.json /tmp/mock-hetero-capability
+rm -f /etc/settings.txt

--- a/core/modules/tests/config_gpu/testprep.sh
+++ b/core/modules/tests/config_gpu/testprep.sh
@@ -1,0 +1,13 @@
+# The module reaches nvidia-smi and hex_sdk by absolute path, so the mocks have
+# to stand in for the real binaries for the duration of the test.
+for f in /usr/bin/nvidia-smi /usr/sbin/hex_sdk; do
+  if [ -f "$f" ]; then
+    mv "$f" "$f.bak"
+  fi
+done
+
+# gpu_resource_set refuses to run at all without the truth file
+mkdir -p /etc/cube/cos/gpu
+echo '[]' > /etc/cube/cos/gpu/config.json
+
+touch /etc/settings.txt

--- a/core/nova/caracal_patch/pci/request.py
+++ b/core/nova/caracal_patch/pci/request.py
@@ -1,0 +1,339 @@
+# Copyright 2013 Intel Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+""" Example of a PCI alias::
+
+        | [pci]
+        | alias = '{
+        |   "name": "QuickAssist",
+        |   "product_id": "0443",
+        |   "vendor_id": "8086",
+        |   "device_type": "type-PCI",
+        |   "numa_policy": "legacy"
+        |   }'
+
+    Aliases with the same name, device_type and numa_policy are ORed::
+
+        | [pci]
+        | alias = '{
+        |   "name": "QuickAssist",
+        |   "product_id": "0442",
+        |   "vendor_id": "8086",
+        |   "device_type": "type-PCI",
+        |   }'
+
+    These two aliases define a device request meaning: vendor_id is "8086" and
+    product_id is "0442" or "0443".
+    """
+
+import typing as ty
+
+import jsonschema
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+from oslo_utils import uuidutils
+
+import nova.conf
+from nova import context as ctx
+from nova import exception
+from nova.i18n import _
+from nova.network import model as network_model
+from nova import objects
+from nova.objects import fields as obj_fields
+from nova.pci import utils
+
+Alias = ty.Dict[str, ty.Tuple[str, ty.List[ty.Dict[str, str]]]]
+
+PCI_NET_TAG = 'physical_network'
+PCI_TRUSTED_TAG = 'trusted'
+PCI_DEVICE_TYPE_TAG = 'dev_type'
+PCI_REMOTE_MANAGED_TAG = 'remote_managed'
+
+DEVICE_TYPE_FOR_VNIC_TYPE = {
+    network_model.VNIC_TYPE_DIRECT_PHYSICAL: obj_fields.PciDeviceType.SRIOV_PF,
+    network_model.VNIC_TYPE_VDPA: obj_fields.PciDeviceType.VDPA,
+}
+
+CONF = nova.conf.CONF
+LOG = logging.getLogger(__name__)
+
+_ALIAS_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+        },
+        # TODO(stephenfin): This isn't used anywhere outside of tests and
+        # should probably be removed.
+        "capability_type": {
+            "type": "string",
+            "enum": ['pci'],
+        },
+        "product_id": {
+            "type": "string",
+            "pattern": utils.PCI_VENDOR_PATTERN,
+        },
+        "vendor_id": {
+            "type": "string",
+            "pattern": utils.PCI_VENDOR_PATTERN,
+        },
+        "device_type": {
+            "type": "string",
+            # NOTE(sean-k-mooney): vDPA devices cannot currently be used with
+            # alias-based PCI passthrough so we exclude it here
+            "enum": [
+                obj_fields.PciDeviceType.STANDARD,
+                obj_fields.PciDeviceType.SRIOV_PF,
+                obj_fields.PciDeviceType.SRIOV_VF,
+            ],
+        },
+        "numa_policy": {
+            "type": "string",
+            "enum": list(obj_fields.PCINUMAAffinityPolicy.ALL),
+        },
+        "resource_class": {
+            "type": "string",
+        },
+        "traits": {
+            "type": "string",
+        },
+        # CubeCOS: names the vGPU profile a VF was carved to, so two aliases on
+        # one SR-IOV card are not interchangeable as match criteria.
+        #
+        # Every vGPU VF on a node reports the same vendor:product, and an alias
+        # carries no address - only [pci]device_spec does - so upstream leaves
+        # nothing for the scheduler to tell them apart by. Measured on a
+        # 4x RTX PRO 6000 Blackwell node: with two free VFs of different
+        # framebuffer size on one card, one VM per alias got the wrong size
+        # 4 times out of 4, in both boot orders; with this property in place,
+        # 4 times out of 4 correct.
+        #
+        # Everything needed downstream already works: _get_alias_from_config()
+        # leaves unrecognised alias keys in the spec, that spec becomes
+        # InstancePCIRequest.spec (a ListOfDictOfNullableStrings, so arbitrary
+        # keys survive), PciDeviceStats keeps unrecognised device_spec keys as
+        # pool tags, and _filter_pools_for_spec() matches "any of the other
+        # arbitrary tags ... specified in the request". The only thing missing is
+        # permission for the key to appear in an alias at all -
+        # additionalProperties is False. Hence this one property, and no other
+        # change to nova.
+        #
+        # hex_config emits the tag on both the alias and the device_spec entries
+        # it generates into /etc/nova/nova.d/gpu.conf; see
+        # BuildNovaGpuConfContent in core/modules/config_gpu.cpp.
+        "vgpu_type": {
+            "type": "string",
+        },
+    },
+    "required": ["name"],
+}
+
+
+def _get_alias_from_config() -> Alias:
+    """Parse and validate PCI aliases from the nova config.
+
+    :returns: A dictionary where the keys are alias names and the values are
+        tuples of form ``(numa_policy, specs)``. ``numa_policy`` describes the
+        required NUMA affinity of the device(s), while ``specs`` is a list of
+        PCI device specs.
+    :raises: exception.PciInvalidAlias if two aliases with the same name have
+        different device types or different NUMA policies.
+    """
+    jaliases = CONF.pci.alias
+    # map alias name to alias spec list
+    aliases: Alias = {}
+    try:
+        for jsonspecs in jaliases:
+            spec = jsonutils.loads(jsonspecs)
+            jsonschema.validate(spec, _ALIAS_SCHEMA)
+
+            name = spec.pop('name').strip()
+            numa_policy = spec.pop('numa_policy', None)
+            if not numa_policy:
+                numa_policy = obj_fields.PCINUMAAffinityPolicy.LEGACY
+
+            dev_type = spec.pop('device_type', None)
+            if dev_type:
+                spec['dev_type'] = dev_type
+
+            if name not in aliases:
+                aliases[name] = (numa_policy, [spec])
+                continue
+
+            if aliases[name][0] != numa_policy:
+                reason = _("NUMA policy mismatch for alias '%s'") % name
+                raise exception.PciInvalidAlias(reason=reason)
+
+            if aliases[name][1][0]['dev_type'] != spec['dev_type']:
+                reason = _("Device type mismatch for alias '%s'") % name
+                raise exception.PciInvalidAlias(reason=reason)
+
+            aliases[name][1].append(spec)
+    except exception.PciInvalidAlias:
+        raise
+    except jsonschema.exceptions.ValidationError as exc:
+        raise exception.PciInvalidAlias(reason=exc.message)
+    except Exception as exc:
+        raise exception.PciInvalidAlias(reason=str(exc))
+
+    return aliases
+
+
+def _translate_alias_to_requests(
+    alias_spec: str, affinity_policy: ty.Optional[str] = None,
+) -> ty.List['objects.InstancePCIRequest']:
+    """Generate complete pci requests from pci aliases in extra_spec."""
+    pci_aliases = _get_alias_from_config()
+
+    pci_requests: ty.List[objects.InstancePCIRequest] = []
+    for name, count in [spec.split(':') for spec in alias_spec.split(',')]:
+        name = name.strip()
+        if name not in pci_aliases:
+            raise exception.PciRequestAliasNotDefined(alias=name)
+
+        numa_policy, spec = pci_aliases[name]
+        policy = affinity_policy or numa_policy
+
+        # NOTE(gibi): InstancePCIRequest has a requester_id field that could
+        # be filled with the flavor.flavorid but currently there is no special
+        # handling for InstancePCIRequests created from the flavor. So it is
+        # left empty.
+        pci_requests.append(objects.InstancePCIRequest(
+            count=int(count),
+            spec=spec,
+            alias_name=name,
+            numa_policy=policy,
+            request_id=uuidutils.generate_uuid(),
+        ))
+    return pci_requests
+
+
+def get_instance_pci_request_from_vif(
+    context: ctx.RequestContext,
+    instance: 'objects.Instance',
+    vif: network_model.VIF,
+) -> ty.Optional['objects.InstancePCIRequest']:
+    """Given an Instance, return the PCI request associated
+    to the PCI device related to the given VIF (if any) on the
+    compute node the instance is currently running.
+
+    In this method we assume a VIF is associated with a PCI device
+    if 'pci_slot' attribute exists in the vif 'profile' dict.
+
+    :param context: security context
+    :param instance: instance object
+    :param vif: network VIF model object
+    :raises: raises PciRequestFromVIFNotFound if a pci device is requested
+             but not found on current host
+    :return: instance's PCIRequest object associated with the given VIF
+             or None if no PCI device is requested
+    """
+
+    # Get PCI device address for VIF if exists
+    vif_pci_dev_addr = vif['profile'].get('pci_slot') \
+        if vif['profile'] else None
+
+    if not vif_pci_dev_addr:
+        return None
+
+    try:
+        cn_id = objects.ComputeNode.get_by_host_and_nodename(
+            context,
+            instance.host,
+            instance.node).id
+    except exception.NotFound:
+        LOG.warning("expected to find compute node with host %s "
+                    "and node %s when getting instance PCI request "
+                    "from VIF", instance.host, instance.node)
+        return None
+    # Find PCIDevice associated with vif_pci_dev_addr on the compute node
+    # the instance is running on.
+    found_pci_dev = None
+    for pci_dev in instance.pci_devices:
+        if (pci_dev.compute_node_id == cn_id and
+                pci_dev.address == vif_pci_dev_addr):
+            found_pci_dev = pci_dev
+            break
+    if not found_pci_dev:
+        return None
+    # Find PCIRequest associated with the given PCIDevice in instance
+    for pci_req in instance.pci_requests.requests:
+        if pci_req.request_id == found_pci_dev.request_id:
+            return pci_req
+
+    raise exception.PciRequestFromVIFNotFound(
+        pci_slot=vif_pci_dev_addr,
+        node_id=cn_id)
+
+
+def get_pci_requests_from_flavor(
+    flavor: 'objects.Flavor', affinity_policy: ty.Optional[str] = None,
+) -> 'objects.InstancePCIRequests':
+    """Validate and return PCI requests.
+
+    The ``pci_passthrough:alias`` extra spec describes the flavor's PCI
+    requests. The extra spec's value is a comma-separated list of format
+    ``alias_name_x:count, alias_name_y:count, ... ``, where ``alias_name`` is
+    defined in ``pci.alias`` configurations.
+
+    The flavor's requirement is translated into a PCI requests list. Each
+    entry in the list is an instance of nova.objects.InstancePCIRequests with
+    four keys/attributes.
+
+    - 'spec' states the PCI device properties requirement
+    - 'count' states the number of devices
+    - 'alias_name' (optional) is the corresponding alias definition name
+    - 'numa_policy' (optional) states the required NUMA affinity of the devices
+
+    For example, assume alias configuration is::
+
+        {
+            'vendor_id':'8086',
+            'device_id':'1502',
+            'name':'alias_1'
+        }
+
+    While flavor extra specs includes::
+
+        'pci_passthrough:alias': 'alias_1:2'
+
+    The returned ``pci_requests`` are::
+
+        [{
+            'count':2,
+            'specs': [{'vendor_id':'8086', 'device_id':'1502'}],
+            'alias_name': 'alias_1'
+        }]
+
+    :param flavor: The flavor to be checked
+    :param affinity_policy: pci numa affinity policy
+    :returns: A list of PCI requests
+    :rtype: nova.objects.InstancePCIRequests
+    :raises: exception.PciRequestAliasNotDefined if an invalid PCI alias is
+        provided
+    :raises: exception.PciInvalidAlias if the configuration contains invalid
+        aliases.
+    """
+    pci_requests: ty.List[objects.InstancePCIRequest] = []
+    if ('extra_specs' in flavor and
+            'pci_passthrough:alias' in flavor['extra_specs']):
+        pci_requests = _translate_alias_to_requests(
+            flavor['extra_specs']['pci_passthrough:alias'],
+            affinity_policy=affinity_policy)
+
+    return objects.InstancePCIRequests(requests=pci_requests)

--- a/core/nova/caracal_patch/pci/request.py.orig
+++ b/core/nova/caracal_patch/pci/request.py.orig
@@ -1,0 +1,312 @@
+# Copyright 2013 Intel Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+""" Example of a PCI alias::
+
+        | [pci]
+        | alias = '{
+        |   "name": "QuickAssist",
+        |   "product_id": "0443",
+        |   "vendor_id": "8086",
+        |   "device_type": "type-PCI",
+        |   "numa_policy": "legacy"
+        |   }'
+
+    Aliases with the same name, device_type and numa_policy are ORed::
+
+        | [pci]
+        | alias = '{
+        |   "name": "QuickAssist",
+        |   "product_id": "0442",
+        |   "vendor_id": "8086",
+        |   "device_type": "type-PCI",
+        |   }'
+
+    These two aliases define a device request meaning: vendor_id is "8086" and
+    product_id is "0442" or "0443".
+    """
+
+import typing as ty
+
+import jsonschema
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+from oslo_utils import uuidutils
+
+import nova.conf
+from nova import context as ctx
+from nova import exception
+from nova.i18n import _
+from nova.network import model as network_model
+from nova import objects
+from nova.objects import fields as obj_fields
+from nova.pci import utils
+
+Alias = ty.Dict[str, ty.Tuple[str, ty.List[ty.Dict[str, str]]]]
+
+PCI_NET_TAG = 'physical_network'
+PCI_TRUSTED_TAG = 'trusted'
+PCI_DEVICE_TYPE_TAG = 'dev_type'
+PCI_REMOTE_MANAGED_TAG = 'remote_managed'
+
+DEVICE_TYPE_FOR_VNIC_TYPE = {
+    network_model.VNIC_TYPE_DIRECT_PHYSICAL: obj_fields.PciDeviceType.SRIOV_PF,
+    network_model.VNIC_TYPE_VDPA: obj_fields.PciDeviceType.VDPA,
+}
+
+CONF = nova.conf.CONF
+LOG = logging.getLogger(__name__)
+
+_ALIAS_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+        },
+        # TODO(stephenfin): This isn't used anywhere outside of tests and
+        # should probably be removed.
+        "capability_type": {
+            "type": "string",
+            "enum": ['pci'],
+        },
+        "product_id": {
+            "type": "string",
+            "pattern": utils.PCI_VENDOR_PATTERN,
+        },
+        "vendor_id": {
+            "type": "string",
+            "pattern": utils.PCI_VENDOR_PATTERN,
+        },
+        "device_type": {
+            "type": "string",
+            # NOTE(sean-k-mooney): vDPA devices cannot currently be used with
+            # alias-based PCI passthrough so we exclude it here
+            "enum": [
+                obj_fields.PciDeviceType.STANDARD,
+                obj_fields.PciDeviceType.SRIOV_PF,
+                obj_fields.PciDeviceType.SRIOV_VF,
+            ],
+        },
+        "numa_policy": {
+            "type": "string",
+            "enum": list(obj_fields.PCINUMAAffinityPolicy.ALL),
+        },
+        "resource_class": {
+            "type": "string",
+        },
+        "traits": {
+            "type": "string",
+        },
+    },
+    "required": ["name"],
+}
+
+
+def _get_alias_from_config() -> Alias:
+    """Parse and validate PCI aliases from the nova config.
+
+    :returns: A dictionary where the keys are alias names and the values are
+        tuples of form ``(numa_policy, specs)``. ``numa_policy`` describes the
+        required NUMA affinity of the device(s), while ``specs`` is a list of
+        PCI device specs.
+    :raises: exception.PciInvalidAlias if two aliases with the same name have
+        different device types or different NUMA policies.
+    """
+    jaliases = CONF.pci.alias
+    # map alias name to alias spec list
+    aliases: Alias = {}
+    try:
+        for jsonspecs in jaliases:
+            spec = jsonutils.loads(jsonspecs)
+            jsonschema.validate(spec, _ALIAS_SCHEMA)
+
+            name = spec.pop('name').strip()
+            numa_policy = spec.pop('numa_policy', None)
+            if not numa_policy:
+                numa_policy = obj_fields.PCINUMAAffinityPolicy.LEGACY
+
+            dev_type = spec.pop('device_type', None)
+            if dev_type:
+                spec['dev_type'] = dev_type
+
+            if name not in aliases:
+                aliases[name] = (numa_policy, [spec])
+                continue
+
+            if aliases[name][0] != numa_policy:
+                reason = _("NUMA policy mismatch for alias '%s'") % name
+                raise exception.PciInvalidAlias(reason=reason)
+
+            if aliases[name][1][0]['dev_type'] != spec['dev_type']:
+                reason = _("Device type mismatch for alias '%s'") % name
+                raise exception.PciInvalidAlias(reason=reason)
+
+            aliases[name][1].append(spec)
+    except exception.PciInvalidAlias:
+        raise
+    except jsonschema.exceptions.ValidationError as exc:
+        raise exception.PciInvalidAlias(reason=exc.message)
+    except Exception as exc:
+        raise exception.PciInvalidAlias(reason=str(exc))
+
+    return aliases
+
+
+def _translate_alias_to_requests(
+    alias_spec: str, affinity_policy: ty.Optional[str] = None,
+) -> ty.List['objects.InstancePCIRequest']:
+    """Generate complete pci requests from pci aliases in extra_spec."""
+    pci_aliases = _get_alias_from_config()
+
+    pci_requests: ty.List[objects.InstancePCIRequest] = []
+    for name, count in [spec.split(':') for spec in alias_spec.split(',')]:
+        name = name.strip()
+        if name not in pci_aliases:
+            raise exception.PciRequestAliasNotDefined(alias=name)
+
+        numa_policy, spec = pci_aliases[name]
+        policy = affinity_policy or numa_policy
+
+        # NOTE(gibi): InstancePCIRequest has a requester_id field that could
+        # be filled with the flavor.flavorid but currently there is no special
+        # handling for InstancePCIRequests created from the flavor. So it is
+        # left empty.
+        pci_requests.append(objects.InstancePCIRequest(
+            count=int(count),
+            spec=spec,
+            alias_name=name,
+            numa_policy=policy,
+            request_id=uuidutils.generate_uuid(),
+        ))
+    return pci_requests
+
+
+def get_instance_pci_request_from_vif(
+    context: ctx.RequestContext,
+    instance: 'objects.Instance',
+    vif: network_model.VIF,
+) -> ty.Optional['objects.InstancePCIRequest']:
+    """Given an Instance, return the PCI request associated
+    to the PCI device related to the given VIF (if any) on the
+    compute node the instance is currently running.
+
+    In this method we assume a VIF is associated with a PCI device
+    if 'pci_slot' attribute exists in the vif 'profile' dict.
+
+    :param context: security context
+    :param instance: instance object
+    :param vif: network VIF model object
+    :raises: raises PciRequestFromVIFNotFound if a pci device is requested
+             but not found on current host
+    :return: instance's PCIRequest object associated with the given VIF
+             or None if no PCI device is requested
+    """
+
+    # Get PCI device address for VIF if exists
+    vif_pci_dev_addr = vif['profile'].get('pci_slot') \
+        if vif['profile'] else None
+
+    if not vif_pci_dev_addr:
+        return None
+
+    try:
+        cn_id = objects.ComputeNode.get_by_host_and_nodename(
+            context,
+            instance.host,
+            instance.node).id
+    except exception.NotFound:
+        LOG.warning("expected to find compute node with host %s "
+                    "and node %s when getting instance PCI request "
+                    "from VIF", instance.host, instance.node)
+        return None
+    # Find PCIDevice associated with vif_pci_dev_addr on the compute node
+    # the instance is running on.
+    found_pci_dev = None
+    for pci_dev in instance.pci_devices:
+        if (pci_dev.compute_node_id == cn_id and
+                pci_dev.address == vif_pci_dev_addr):
+            found_pci_dev = pci_dev
+            break
+    if not found_pci_dev:
+        return None
+    # Find PCIRequest associated with the given PCIDevice in instance
+    for pci_req in instance.pci_requests.requests:
+        if pci_req.request_id == found_pci_dev.request_id:
+            return pci_req
+
+    raise exception.PciRequestFromVIFNotFound(
+        pci_slot=vif_pci_dev_addr,
+        node_id=cn_id)
+
+
+def get_pci_requests_from_flavor(
+    flavor: 'objects.Flavor', affinity_policy: ty.Optional[str] = None,
+) -> 'objects.InstancePCIRequests':
+    """Validate and return PCI requests.
+
+    The ``pci_passthrough:alias`` extra spec describes the flavor's PCI
+    requests. The extra spec's value is a comma-separated list of format
+    ``alias_name_x:count, alias_name_y:count, ... ``, where ``alias_name`` is
+    defined in ``pci.alias`` configurations.
+
+    The flavor's requirement is translated into a PCI requests list. Each
+    entry in the list is an instance of nova.objects.InstancePCIRequests with
+    four keys/attributes.
+
+    - 'spec' states the PCI device properties requirement
+    - 'count' states the number of devices
+    - 'alias_name' (optional) is the corresponding alias definition name
+    - 'numa_policy' (optional) states the required NUMA affinity of the devices
+
+    For example, assume alias configuration is::
+
+        {
+            'vendor_id':'8086',
+            'device_id':'1502',
+            'name':'alias_1'
+        }
+
+    While flavor extra specs includes::
+
+        'pci_passthrough:alias': 'alias_1:2'
+
+    The returned ``pci_requests`` are::
+
+        [{
+            'count':2,
+            'specs': [{'vendor_id':'8086', 'device_id':'1502'}],
+            'alias_name': 'alias_1'
+        }]
+
+    :param flavor: The flavor to be checked
+    :param affinity_policy: pci numa affinity policy
+    :returns: A list of PCI requests
+    :rtype: nova.objects.InstancePCIRequests
+    :raises: exception.PciRequestAliasNotDefined if an invalid PCI alias is
+        provided
+    :raises: exception.PciInvalidAlias if the configuration contains invalid
+        aliases.
+    """
+    pci_requests: ty.List[objects.InstancePCIRequest] = []
+    if ('extra_specs' in flavor and
+            'pci_passthrough:alias' in flavor['extra_specs']):
+        pci_requests = _translate_alias_to_requests(
+            flavor['extra_specs']['pci_passthrough:alias'],
+            affinity_policy=affinity_policy)
+
+    return objects.InstancePCIRequests(requests=pci_requests)


### PR DESCRIPTION
Closes the two halves of #1316: a card can now be carved into vGPUs of different
framebuffer sizes, and each generated Nova PCI alias identifies the profile its
VF actually carries.

## The mode half

One SR-IOV card could host vGPUs of a single framebuffer size only — after the
first `current_vgpu_type` write every remaining VF's `creatable_vgpu_types`
collapsed to that size, and a cross-size write was refused. The hardware allows
the mix (`Heterogenous Multi-vGPU : Supported`); nothing ever switched the mode
on.

Three things the ticket assumed turned out differently, all measured on a
4× RTX PRO 6000 Blackwell node:

- **The mode is runtime state, not persistent.** `sriov-manage` clears it in both
  directions, so — unlike MIG mode — teardown needs no explicit mode-off, a
  failed apply needs no rollback, and the intent file needs no new field.
- **Ordering is not negotiable, and the obvious order is wrong.** It has to be
  set *after* `sriov-manage -e`. Set before, it reads back `Enabled`, is then
  wiped by the driver rebind, and every VF stays collapsed — a build that looks
  configured and is not. Ten VFs were scanned in that state before the cause was
  found; the symptom is indistinguishable from "the hardware cannot do it".
- **No placement planning is needed.** With the ordering right the driver picks
  the aligned placement itself (`placement_id` 0 and 6 for a 3072 + 6144 carve).

Validation refuses a mixed-size request on a card that does not advertise the
capability instead of letting it reach the apply, because by then
`gpu_unset_current_type` has already destroyed the card's previous carve. It
runs ahead of the `sriov_totalvfs` capacity rule since it reads nothing from
sysfs.

## The alias half

Every vGPU VF on a node reports the same `vendor_id:product_id`, and a
`[pci]alias` carries no address — only `device_spec` does. So the aliases
generated for a multi-profile card were byte-identical as match criteria and the
scheduler had nothing to tell them apart by.

Measured, with two free VFs of different size on one card and one VM per alias:
**wrong 4 times out of 4**, in both boot orders, with nothing reported by either
the guest or Nova. (An earlier 3/3-correct observation on the same node does not
contradict it: those VMs were booted one at a time with a single free VF, so
there was never a choice to get wrong.)

Each alias and each `device_spec` entry now carries a `vgpu_type` tag naming the
profile, and the whitelist loop walks the profiles in request order — the same
expansion `BuildVfAssignmentPlan` performs — so the tag matches what the driver
actually put on that VF. Nova needed one property added to its alias schema;
everything downstream already worked, and `additionalProperties: False` was the
only obstacle. **After the change: correct 4 times out of 4, both boot orders.**

## Verification

Hardware, on a card reporting `Heterogenous Multi-vGPU : Supported`:

| | |
| --- | --- |
| shipped single-size path | `rc=0`, both VFs the requested type, `allocation.total` 2, nova-compute active |
| mixed-size carve | `rc=0` (was `rc=1`), mode `Enabled`, types in request order at `placement_id` 0 / 6, free VFs offering 23 types across 9 capacity classes |
| alias → VF mapping | **4/4 correct**, both boot orders |
| teardown | `sriov_numvfs` 0, PF back on `vfio-pci`, the card's drop-in entries gone |
| failed apply | intent entry removed, `sriov_numvfs` 0, drop-in 0 entries — the three views agree instead of diverging |
| reboot re-apply | mode and carve rebuilt, `config.json` and `gpu.conf` byte-identical, **twice** |

Also measured, to show the shipped path is untouched: `nvidia-smi vgpu -s -v` is
byte-identical with the mode on and off, a four-way same-size carve produces the
same types and placements, and the 32-vGPU ceiling is unchanged.

Unit coverage is limited to what hardware cannot show — a card without the
capability, and an nvidia-smi that fails. See the test commit for why it stops
at two cases.

## Two things a reviewer should know

- **The `caracal_patch` change has not been exercised on a Caracal tree.** The
  alias mechanism was verified on the only vGPU-capable node available, which
  runs nova 25.3.0; the equivalent patch was applied there. All three trees
  (Yoga, Antelope, Caracal) were read line by line and are identical on every
  point this depends on — the leftover alias keys reaching
  `InstancePCIRequest.spec`, `PciDeviceStats` keeping unrecognised `device_spec`
  keys as pool tags, and `_filter_pools_for_spec` matching "any of the other
  arbitrary tags" — but reading is not running. It needs an ISO.
- **`gpu.conf` content changes for single-profile cards too**, by design. The tag
  has to be on every entry: an alias without it is unconstrained by that key and
  would match a tagged pool belonging to a different card. #1316's DoD was
  reworded accordingly — the requirement is that the shipped path still
  schedules correctly, not that the file is byte-identical.

Refs #1316
