### PR TITLE
fix(glance): escalate privsep through the caracal venv helper

### DIFF
--- a/core/ceph/ceph.mk
+++ b/core/ceph/ceph.mk
@@ -52,7 +52,8 @@ CEPH_REPO = $(shell cp $(COREDIR)/ceph/ceph.repo $(ROOTDIR)/etc/yum.repos.d/ ; e
 # Building here also means egg_info runs with pbr installed -- pbr registers an
 # egg_info writer that imports pkg_resources -- which is why this step needs the
 # venv's setuptools pinned below 82; see the NOTE in core/heavyfs/Makefile. Both
-# venvs pin it there, so the caracal build takes the same path.
+# venvs pin it below that -- antelope at 65.7.0, caracal at 75.6.0 -- so both builds
+# take the same path; verified to produce the same flat .so layout under either.
 # --no-deps: neither binding declares a dependency, so nothing should be resolved
 # against the index at this point.
 CEPH_PYBIND_SRCDIR := /usr/src/ceph/ceph-17.2.6

--- a/core/glance/glance-sudoers
+++ b/core/glance/glance-sudoers
@@ -1,3 +1,4 @@
 Defaults:glance !requiretty
 
 glance ALL = (root) NOPASSWD: /usr/bin/glance-rootwrap /etc/glance/rootwrap.conf *
+glance ALL = (root) NOPASSWD: /opt/openstack-caracal/bin/privsep-helper *

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -333,10 +333,26 @@ rootfs_install::
 # died at import with ModuleNotFoundError and openstack-keystone never came up (#631).
 #
 # The pin is therefore settled now, as the same one line in the constraints file that
-# antelope uses, and at the same 65.7.0 -- the version that venv has been proving
-# against pbr and pkg_resources all along. It also keeps `setup.py install` working,
-# which setuptools 80 removed: the ceph python bindings still build that way and move
-# into this venv when caracal takes over from antelope.
+# antelope uses -- but at 75.6.0, not antelope's 65.7.0. The two venvs have different
+# reasons for their numbers: antelope's is the version its own upper-constraints
+# names, while caracal's is a local delta with no upstream value to match, so it takes
+# the newest release that clears both ceilings rather than a 2023 one inherited by
+# habit. 75.6.0 is the last setuptools of 2024 (2024-11-20), which puts it in the same
+# year as the release this venv carries.
+#
+# The two ceilings, both still honoured:
+#   - below 82 (2026-02-08), which deleted pkg_resources. That is the hard one, and
+#     it is a runtime requirement as much as a build one -- keystonemiddleware above,
+#     plus pbr's egg_info writer on every --no-build-isolation build in this venv.
+#   - below 80 (2025-04-27), which removed `setup.py install`. Nothing in this venv
+#     needs it today: ceph's bindings moved to `pip install` (see core/ceph/ceph.mk)
+#     and skyline's did too. It is kept as headroom for masakari, designate, watcher
+#     and cyborg, which still install that way in antelope and will bring the command
+#     with them unless they are converted when they hop.
+#
+# Verified in a python 3.11 venv before the bump: horizon 24.0.2's six sdists build
+# under --no-build-isolation, ceph's rados and rbd bindings produce the same flat
+# .so + .dist-info layout as under 65.7.0 and import, and pkg_resources is present.
 
 # Allow admin to be sudoers
 rootfs_install::

--- a/core/heavyfs/os-caracal-pip-upper-constraints.txt
+++ b/core/heavyfs/os-caracal-pip-upper-constraints.txt
@@ -617,4 +617,4 @@ sphinxcontrib-applehelp===1.0.4;python_version=='3.8'
 sphinxcontrib-applehelp===1.0.8;python_version>='3.9'
 scikit-learn===1.3.2;python_version=='3.8'
 scikit-learn===1.4.0;python_version>='3.9'
-setuptools===65.7.0
+setuptools===75.6.0

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -4,6 +4,11 @@
 # https://releases.openstack.org/antelope/index.html#antelope-horizon
 HORIZON_VER := 23.1.1
 
+# The caracal dashboard, installed alongside it in the caracal venv. Nothing serves
+# this one -- see the note by its install block below -- and the version is the one
+# $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) already pins, so the two agree.
+CARACAL_HORIZON_VER := 24.0.2
+
 # Not in the antelope upper-constraints, so pinned here for reproducibility. This is
 # also a source build (see core/mysql/mysql.mk), which is the other reason not to
 # leave it floating.
@@ -78,6 +83,32 @@ rootfs_install::
 		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 			mysqlclient==$(MYSQLCLIENT_VER) \
 			pymemcache"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+
+# the same dashboard again, in the caracal venv
+#
+# Nothing serves this copy. openstack-dashboard.service, gunicorn-config.py and the
+# httpd reverse proxy all point at $(HORIZON_APP_DIR), which is the antelope tree,
+# and every dashboard plugin still installs next to it. This one exists so that
+# dump_default_policies can run under the interpreter that owns the core services'
+# oslo.policy entry points -- see the policy block near the end of this file.
+#
+# It is a down payment rather than scaffolding: 24.0.2 is what horizon's own move to
+# this venv will install, so the dependency set lands once. Verified against a built
+# rootfs: 41 packages, +170MB, and no already-installed caracal package changes
+# version, so keystone/nova/cinder/glance/placement are untouched (pip check clean).
+#
+# --no-build-isolation for the XStatic sdists, exactly as above -- this venv also
+# carries setuptools 65.7.0, so the pkg_resources those setup.py files import is
+# there.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			--no-build-isolation \
+			horizon==$(CARACAL_HORIZON_VER)"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
@@ -187,8 +218,37 @@ rootfs_install::
 # DEFAULT_POLICY_FILES points at came from the openstack-dashboard rpm, and the
 # masakari one from masakari.mk running this same command under python 3.9. Generate
 # them all here instead, from the services that are actually running -- every one of
-# these namespaces is an oslo.policy.policies entry point inside the venv, and
-# manage.py only exists once the step above has installed it.
+# these namespaces is an oslo.policy.policies entry point in one of the two venvs.
+#
+# Which venv is the whole difficulty. stevedore only sees entry points registered in
+# the interpreter it is running under, so one python cannot dump them all any more:
+# keystone, nova, cinder, glance and neutron have moved to caracal while masakari and
+# octavia are still antelope. Each list is therefore dumped by the dashboard that
+# shares its venv. A namespace listed against the venv that does not hold it fails
+# the build with 'The requested namespace "<x>" is not found'; move it to the other
+# list when its service makes the hop.
+HORIZON_POLICY_NS_ANTELOPE := masakari octavia
+HORIZON_POLICY_NS_CARACAL := keystone nova cinder glance neutron
+
+# django-admin rather than $(HORIZON_APP_DIR)/manage.py, for both venvs so the two
+# loops stay one shape. manage.py sits in a directory whose horizon and
+# openstack_dashboard entries are symlinks into the *antelope* venv, and a script's
+# own directory leads sys.path -- so running it with the caracal python imports
+# python3.10 packages under python3.11. A console script has no such directory.
+#
+# --skip-checks because django's system checks instantiate every configured cache
+# backend, and horizon defaults CACHES to django's PyMemcacheCache. The antelope venv
+# has pymemcache (installed above, for the running dashboard); the caracal venv has
+# no reason to. The dump reads oslo.policy entry points and touches no cache.
+# "No local_settings file found." on the caracal side is expected and harmless:
+# openstack_dashboard/settings.py warns and carries on, and only the antelope copy is
+# ever configured.
+#
+# Both loops are noisy on stderr -- the USE_L10N notice, a debreach distutils warning,
+# and oslo.policy grumbling about upstream nova/cinder rules that set deprecated_since
+# on the RuleDefault instead of the DeprecatedRule. It is left alone: PYTHONWARNINGS
+# does not reach it (something under settings resets the filters), and stderr has to
+# stay open anyway for the namespace failure above to be visible.
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -d -m 755 $(HORIZON_POLICY_DIR)
 	$(Q)# || exit 1 per iteration: a for loop only returns the status of its *last*
@@ -197,10 +257,17 @@ rootfs_install::
 	$(Q)# "No policy rules for service '<x>'" and a denied panel. masakari.mk used to
 	$(Q)# state this guarantee explicitly ("that command exits 1 and the build fails");
 	$(Q)# folding the dump into a loop here is what dropped it.
-	$(Q)for ns in keystone nova cinder glance neutron masakari octavia ; do \
-		chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py \
-			dump_default_policies --namespace $$ns \
-			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml 2>&1 > /dev/null || exit 1 ; \
+	$(Q)for ns in $(HORIZON_POLICY_NS_ANTELOPE) ; do \
+		chroot $(ROOTDIR) env DJANGO_SETTINGS_MODULE=openstack_dashboard.settings \
+			$(OPENSTACK_HOME_DIR)/bin/django-admin dump_default_policies --skip-checks \
+			--namespace $$ns \
+			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml || exit 1 ; \
+	done
+	$(Q)for ns in $(HORIZON_POLICY_NS_CARACAL) ; do \
+		chroot $(ROOTDIR) env DJANGO_SETTINGS_MODULE=openstack_dashboard.settings \
+			$(CARACAL_OPENSTACK_HOME_DIR)/bin/django-admin dump_default_policies --skip-checks \
+			--namespace $$ns \
+			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml || exit 1 ; \
 	done
 
 # gunicorn, the systemd unit and the httpd reverse proxy

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -31,6 +31,40 @@ static const char GA_NAME[] = "openstack-glance-api";
 
 static const char OPENRC[] = "/etc/admin-openrc.sh";
 
+/**
+ * The privsep helper glance must escalate through.
+ *
+ * glance reaches privsep only through glance_store's cinder driver, which hands the
+ * upload to os-brick -- so the context is os_brick.privileged.default and, since
+ * os-brick 6.7.3, its cfg_section is `privsep_osbrick` rather than the older
+ * `os_brick_privileged`.
+ *
+ * Left unpinned it resolves the wrong way. glance_store calls
+ * priv_context.init(root_helper=...), so the command becomes
+ * `sudo glance-rootwrap /etc/glance/rootwrap.conf privsep-helper`, and glance-rootwrap
+ * then looks the bare name up in the exec_dirs of rootwrap.conf -- where /bin and
+ * /usr/bin come first and hold the symlink core/nova/nova.mk keeps pointed at the
+ * *antelope* venv. A caracal glance-api on python 3.11 therefore drives a python 3.10
+ * helper. Verified on jim-1cc before this pin: glance-api ran from
+ * /opt/openstack-caracal/bin/python3.11 while its os_brick.privileged.default helper
+ * ran from /opt/openstack-antelope/bin/python3.10.
+ *
+ * That pairing happens to work today -- os_brick.privileged exposes the same 23
+ * callables with the same signatures in the antelope venv's 6.2.5 as in caracal's
+ * 6.7.3, so the image upload succeeds and nothing is logged. It is still wrong, and
+ * it stops working the moment nova hops: /usr/bin/privsep-helper is nova's symlink,
+ * and when it follows nova to caracal or goes away, glance's rootwrap lookup has
+ * nothing left to find. Naming the caracal helper removes the dependency on another
+ * component's symlink; /etc/sudoers.d/glance authorises exactly this path.
+ *
+ * helper_command is what takes rootwrap out of the path -- oslo.privsep documents
+ * root_helper as "ignored if context's helper_command config option is set". It also
+ * drops the auto-generated --config-file, which costs nothing here: the context's
+ * capabilities come from os-brick's own decorator, and the helper was verified to
+ * still start with CAP_SYS_ADMIN either way.
+ */
+static const char PRIVSEP_HELPER[] = "sudo /opt/openstack-caracal/bin/privsep-helper";
+
 static const char USERPASS[] = "0ZsvkS1bHXYsywTx";
 static const char DBPASS[] = "g6CEJCNFT6ufPY22";
 
@@ -292,6 +326,7 @@ InitConfig(Configs& config)
         "oslo_policy",
         "oslo_reports",
         "paste_deploy",
+        "privsep_osbrick",
         "profiler",
         "store_type_location_strategy",
         "task",
@@ -316,6 +351,11 @@ SetDefaults(Configs& config)
     config["DEFAULT"]["node_staging_uri"] = "file:///mnt/cephfs/glance_tmp_transition";
 
     config["os_brick"]["lock_path"] = "/var/lock/os_brick";
+
+    // os_brick.privileged.default, the only privsep context a glance-api reaches. It
+    // is on a live path only for a <volumeType>:cinder store, which exists solely for
+    // an external backend -- the built-in rbd store never attaches anything.
+    config["privsep_osbrick"]["helper_command"] = PRIVSEP_HELPER;
 
     // should be oslo_reports.log_dir, however, the current version does not support it
     config["DEFAULT"]["log_dir"] = "/var/log/glance";


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

- **Fixes the Glance -> Cinder volume-backed image path on Caracal.** glance-api now runs from `/opt/openstack-caracal` (python 3.11, os-brick 6.7.3) but its privsep helper still resolved to `/opt/openstack-antelope` (python 3.10, os-brick 6.2.5). Same venv boundary that broke cinder in #1313 and neutron in #1315, reached by neutron's route: `glance_store` calls `priv_context.init(root_helper=...)`, so the command becomes `sudo glance-rootwrap /etc/glance/rootwrap.conf privsep-helper` and `glance-rootwrap` resolves the bare name off `exec_dirs`, where `/bin` and `/usr/bin` hold the symlink `core/nova/nova.mk` points at the Antelope venv. Pinned `helper_command` in `[privsep_osbrick]` — os-brick 6.7.3's `cfg_section`, not the older `os_brick_privileged` — and authorised that exact path in `/etc/sudoers.d/glance`.
- **Unbreaks the heavyfs build.** `core/horizon/horizon.mk` drove all seven `dump_default_policies` namespaces through the Antelope python, but stevedore only sees `oslo.policy.policies` entry points registered in the interpreter it runs under, and keystone, nova, cinder, glance and neutron have moved to Caracal. The build died on the first of them with `The requested namespace "keystone" is not found`. Installs the Caracal dashboard alongside the Antelope one and gives each namespace list to the dashboard that shares its venv.
- **Moves the Caracal venv's `setuptools` pin off a 2023 release.** It was pinned at `65.7.0` — the version Antelope's own upper-constraints names, inherited by habit. Caracal's copy is a local delta with no upstream value to match, so it takes `75.6.0`, the last setuptools of 2024.

#### Which issue(s) this PR fixes

Fixes #786

#### Special notes for your reviewer

> Note

**This PR stacks on `jim.lin/feat/openstack-c-upgrade-rabbitmq` (#1337), which in turn stacks on `jim.lin/feat/openstack-c-upgrade-neutron` (#1315).** The base here is `develop`, so until those merge this PR's commit list also shows the Keystone, Glance, Cinder, Nova, Neutron, OVN and RabbitMQ commits. `jim.lin/feat/openstack-c-upgrade-rabbitmq` is a strict ancestor of this branch (`599c155` is in this history unchanged), so #1315 and #1337 can merge first and this branch will rebase cleanly. Only the three below belong to this PR:

| Commit | Change |
| -- | -- |
| `5ef7e97` | `fix(horizon)`: dump each service's policy defaults from its own venv's dashboard |
| `8312dcf` | `build(openstack)`: move the caracal venv's setuptools pin to a 2024 release |
| `da4090a` | `fix(glance)`: escalate privsep through the caracal venv helper |

Review it after #1337, or diff against `jim.lin/feat/openstack-c-upgrade-rabbitmq`.

**The glance privsep bug is silent, which is what makes it worth fixing now.** Unlike cinder and neutron, the wrong helper does not fail — the image upload succeeds and nothing is logged. Enumerating every callable under `os_brick.privileged.*` in both venvs returns the same 23 names with the same signatures in 6.2.5 and 6.7.3, so a Caracal parent never calls anything the Antelope helper is missing. That is a property of this version pair, not a guarantee. The defect is the dependency: `/usr/bin/privsep-helper` belongs to **nova**, and when nova hops to Caracal that symlink follows it or goes away, leaving glance's `exec_dirs` lookup with nothing to find. Do not read "the upload worked" as evidence privsep is right — `ps -eo args | grep os_brick.privileged` during an upload names the interpreter.

**Two Caracal dashboards ship in the image, deliberately.** `openstack-dashboard.service`, `gunicorn-config.py` and the httpd reverse proxy all still point at the Antelope tree, and every dashboard plugin installs next to it; the Caracal copy exists so `dump_default_policies` can run under the interpreter that owns the core services' entry points. Measured on a built rootfs: **41 packages, +170 MB, and no already-installed Caracal package changes version** (`pip check` clean), so keystone/nova/cinder/glance/placement are untouched. It is a down payment rather than scaffolding — `24.0.2` is what horizon's own move to that venv will install, so the dependency set lands once. When horizon migrates, the Antelope copy is what goes.

**On the setuptools bump.** Two ceilings, both still honoured: below **82** (2026-02-08), which deleted `pkg_resources` — the hard one, and a runtime requirement as much as a build one, since `keystonemiddleware 10.6.0` imports it (#631) and pbr's egg_info writer needs it on every `--no-build-isolation` build in that venv; and below **80** (2025-04-27), which removed `setup.py install` — headroom only, since every remaining `setup.py install` in `core/` is in the Antelope venv.

**One caveat about the e2e node this was verified on.** Its `/usr/sbin/hex_config` dates from 2026-08-18 and predates the cinder (#1313) and neutron (#1315) privsep commits, so its compiled `config_cinder` does not emit those pins. Registering the NFS backend ends in `hex_config apply`, which regenerated `cinder.conf` and dropped both of cinder's `helper_command` lines; they were restored by hand. The glance pin was likewise applied by hand for the run below. The **emission** mechanism is proven on the same node by cyborg, manila and masakari, whose `helper_command` lines come from a matching binary; `config_glance.o` compiles clean under `-Wall -Werror`.

#### Additional documentation

Validated on the `centos9_cubecos_jim_200.13-1cc` e2e environment (`cc1`), using the Alpine tools image at `/etc/glance/alpine-tools.qcow2` (`md5 9bb205297c3cce98761b29919bca2d2b`, the same image as #617). Both venvs are live on this node, which is what makes the boundary reachable:

```bash
[cc1 ~]# for v in antelope caracal; do ... done
antelope   python 3.10.20  glance 26.1.0  cinder 22.3.0  os-brick 6.2.5
caracal    python 3.11.15  glance 28.2.0  cinder 24.5.0  os-brick 6.7.3
```

**The wrong helper, before the pin.** `glance-api` on 3.11 driving a 3.10 helper:

```bash
[cc1 ~]# python3 -c "<first exec_dirs match for privsep-helper>"
/bin/privsep-helper -> /opt/openstack-antelope/bin/privsep-helper
[cc1 ~]# ps -eo args | grep '[o]s_brick.privileged'     # polled during an upload
/opt/openstack-antelope/bin/python3.10 /bin/privsep-helper --config-file /etc/glance/glance-api.conf \
  --privsep_context os_brick.privileged.default --privsep_sock_path /tmp/tmprb7u31qk/privsep.sock
[cc1 ~]# ps -eo args | grep '[g]lance-api' | head -1 | awk '{print $1}'
/opt/openstack-caracal/bin/python3.11
```

`os_brick.privileged.default` is the only privsep context a glance-api reaches — walking every live `PrivContext` after importing glance, glance_store and os-brick returns exactly one, `cfg_section` `privsep_osbrick`.

**After the pin**, the helper matches the parent, rootwrap is out of the path, and the capabilities are unchanged — `helper_command` drops oslo.privsep's auto-generated `--config-file`, which costs nothing because os-brick's decorator supplies the caps:

```bash
[cc1 ~]# ps -eo args | grep '[o]s_brick.privileged'
/opt/openstack-caracal/bin/python3.11 /opt/openstack-caracal/bin/privsep-helper \
  --privsep_context os_brick.privileged.default --privsep_sock_path /tmp/tmpoud846j7/privsep.sock
[cc1 ~]# grep 'capabilities' /var/log/glance/glance-api.log   # before and after the pin
privsep process running with capabilities (eff/prm/inh): CAP_SYS_ADMIN/CAP_SYS_ADMIN/none
privsep process running with capabilities (eff/prm/inh): CAP_SYS_ADMIN/CAP_SYS_ADMIN/none
```

**AC1 — default backend `CubeStorage` (Ceph).** Neither shape needs the fix; the built-in `rbd` store never attaches a volume, so glance never reaches os-brick.

```bash
[cc1 ~]# hex_sdk os_image_import /etc/glance alpine-tools.qcow2 Alpine
| checksum   | 88de2fc82ac40a070a0cc574565dbb57 |
| direct_url | rbd://c6e64c49-.../glance-images/7a895bbb-33cd-47f3-b1a5-ccf09d0a04f6/snap |
| status     | active |   | stores | cube |

[cc1 ~]# hex_sdk os_image_import_with_attrs linux /etc/glance alpine-tools.qcow2 AlpineVol default admin cinder-volumes public
[cc1 ~]# openstack volume show AlpineVol -c bootable -c type -c os-vol-host-attr:host
| bootable | true |  | type | CubeStorage |  | os-vol-host-attr:host | cube@ceph#ceph |
```

`checksum` and `os_hash_value` are **identical to the Antelope run recorded in #617**, so Caracal glance 28.2.0 produces a byte-identical image from the same source.

**AC2 — external backend.** A `<volumeType>:cinder` Glance store only exists for an external backend, so as in #617 the path was exercised through a generic-NFS backend rather than borrowed SAN hardware:

```bash
[cc1 ~]# hex_sdk cinder_test_storage '{"name":"NFSStorage"}'
{"isCinderServiceUp":true,"isTestVolumeSuccessful":true}
[cc1 ~]# grep ^enabled_backends /etc/glance/glance-api.conf
enabled_backends = http:http,cube:rbd,NFSStorage:cinder

[cc1 ~]# glance image-create --disk-format qcow2 --container-format bare --visibility public \
      --store NFSStorage --file /etc/glance/alpine-tools.qcow2 --name Alpine-NFS --progress
| checksum   | 9bb205297c3cce98761b29919bca2d2b |
| direct_url | cinder://NFSStorage/abc3b39d-1603-4c51-8b06-c1559af2d1c2 |
| size       | 649527296 |  | status | active |  | stores | NFSStorage |

[cc1 ~]# openstack volume show abc3b39d-1603-4c51-8b06-c1559af2d1c2 -c name -c type -c os-vol-host-attr:host
| name | image-7d2083c6-0ba9-4c64-aa1c-f6dd16fb4337 |
| type | NFSStorage |  | os-vol-host-attr:host | NFSStorage@NFSStorage#NFSStorage |

[cc1 ~]# os_image_import /etc/glance alpine-tools.qcow2 AlpineNFSVol \
    "--os-project-domain-name default --os-project-name admin --visibility public" cinder-volumes NFSStorage
[cc1 ~]# openstack volume show AlpineNFSVol -c bootable -c type -c os-vol-host-attr:host
| bootable | true |  | type | NFSStorage |  | os-vol-host-attr:host | NFSStorage@NFSStorage#NFSStorage |
```

The bytes really traversed Glance -> Cinder -> NFS — the same files at the same sizes are visible from the node and from the NFS server itself, and `649527296` is exactly the size of the source qcow2:

```bash
[cc1 ~]# ls -l /store/cinder/mnt/*/ | grep volume-
-rw-rw-rw- 1 root root 1073741824 Aug 25 01:32 volume-0e68f29d-856a-4ef6-b2b6-fa68edc96272
-rw-rw-rw- 1 root root  649527296 Aug 25 01:36 volume-abc3b39d-1603-4c51-8b06-c1559af2d1c2
[cc1 ~]# df -h /store/cinder/mnt/*
10.1.0.200:/srv/nfs   20G  2.5G   17G  14% /store/cinder/mnt/812a5196b6571e8bf439ed4f94fc3108
```

**Horizon policy dump.** Run against a built rootfs, all seven namespaces dump under the python that owns them; the Antelope-side output is byte-identical to what `manage.py dump_default_policies` produced, and Antelope's `oslo.policy` — the one horizon enforces with — loads every Caracal-produced rule (keystone 200/200, nova 202/202, cinder 167/167, glance 60/60 registered and enforceable). `django-admin --skip-checks` rather than `manage.py`, because `manage.py` sits in a directory whose `horizon` and `openstack_dashboard` entries symlink into the Antelope venv and a script's own directory leads `sys.path`.

**Setuptools bump.** Verified in python 3.11 venvs before changing the pin: horizon 24.0.2's six sdists build under `--no-build-isolation`; ceph's `rados` and `rbd` bindings produce the same flat `.so` + `.dist-info` layout as under 65.7.0 and import; the venv bootstrap run verbatim against the edited constraints lands on 75.6.0 with `pkg_resources` present; and the full Caracal service set resolves against it.
