### PR TITLE
fix(gpu): stop hiding a failed nvidia-smi probe behind exit 0

### DIFF
--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -434,6 +434,22 @@ gpu_vm_stats()
     fi
 }
 
+# What to put in a log line about a failed nvidia-smi probe. nvidia-smi prints
+# "No devices were found" on stdout and leaves stderr empty (measured on cn13:
+# a nonexistent GPU is exit 6, empty stderr), so a message built from stderr
+# alone says nothing. Prefer stderr, fall back to stdout, both flattened to one
+# line for the journal.
+gpu_probe_diagnosis()
+{
+    local err_file="$1" std_out="$2"
+
+    local text
+    text=$(tr '\n' ' ' < "$err_file" 2>/dev/null | sed 's/[[:space:]]*$//')
+    [ -n "$text" ] || text=$(echo "$std_out" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+
+    echo "${text:-(no output)}"
+}
+
 # Returns a stringified JSON array conforming to the following schema:
 # {
 #   id: string
@@ -550,8 +566,21 @@ gpu_device_list()
         name=$(echo "$name" | xargs)
         pci_bus_id=$(echo "$pci_bus_id" | xargs)
 
-        local vgpu_support_out
-        vgpu_support_out=$($NVIDIA_SMI vgpu -s -v -i "$pci_bus_id" 2>/dev/null)
+        # Keep the probe's exit status instead of dropping it. On failure
+        # support_types stays at its hardcoded ["pgpu"] below, so a
+        # vGPU-capable card reports as passthrough-only; without this the node
+        # carries no trace of why. One card's failed probe must not fail the
+        # node, so the list is still built - the reason is just on the record.
+        local vgpu_support_out vgpu_support_rc vgpu_support_err vgpu_support_err_file
+        vgpu_support_err_file=$(mktemp)
+        vgpu_support_out=$($NVIDIA_SMI vgpu -s -v -i "$pci_bus_id" 2>"$vgpu_support_err_file")
+        vgpu_support_rc=$?
+        vgpu_support_err=$(gpu_probe_diagnosis "$vgpu_support_err_file" "$vgpu_support_out")
+        rm -f "$vgpu_support_err_file"
+
+        if [ "$vgpu_support_rc" -ne 0 ]; then
+            log_error "gpu_device_list: nvidia-smi vgpu -s -v -i $pci_bus_id exited $vgpu_support_rc: $vgpu_support_err; supportTypes for this card falls back to [\"pgpu\"]"
+        fi
 
         local profile_names
         profile_names=$(echo "$vgpu_support_out" | grep "Name" | awk '{print $NF}')
@@ -853,8 +882,16 @@ gpu_vgpu_profile_list()
     # Verified on cn13 2026-08-04; see spec.md §2c/§5b (#905).
     local mig_profiles="[]"
 
-    local vgpu_output
-    vgpu_output=$($NVIDIA_SMI vgpu -s -v -i "$gpu_id" 2>/dev/null)
+    # Keep the probe's exit status and its diagnosis. Dropping both -
+    # 2>/dev/null and no test of $? - is what let a failed probe reach the
+    # caller as exit 0 with empty lists, indistinguishable from "this card has
+    # no vGPU types".
+    local vgpu_output vgpu_probe_rc vgpu_probe_err vgpu_probe_err_file
+    vgpu_probe_err_file=$(mktemp)
+    vgpu_output=$($NVIDIA_SMI vgpu -s -v -i "$gpu_id" 2>"$vgpu_probe_err_file")
+    vgpu_probe_rc=$?
+    vgpu_probe_err=$(gpu_probe_diagnosis "$vgpu_probe_err_file" "$vgpu_output")
+    rm -f "$vgpu_probe_err_file"
 
     # Same vfio-pci blindness as in gpu_device_list: a pgpu reports no profiles
     # at all, which reads as "this card cannot do vGPU" and leaves a client with
@@ -888,6 +925,23 @@ gpu_vgpu_profile_list()
         done <<EOF
 $(gpu_vgpu_types_from_xml "$pci_address")
 EOF
+    fi
+
+    # A failed probe is only fatal once nothing else has answered. A pgpu bound
+    # to vfio-pci fails the probe exactly the way a nonexistent GPU does - both
+    # are "No devices were found", exit 6 - and for that card the static table
+    # above is the intended answer, so keying on the exit status alone would
+    # undo the vfio-pci fallback and turn every poll of a healthy pgpu into an
+    # error. What must never happen is empty lists with exit 0 when no source
+    # answered at all: the caller reads that as "this card has no vGPU types"
+    # and offers the operator nothing to pick.
+    if [ "$vgpu_probe_rc" -ne 0 ]; then
+        if [ "$sriov_profiles" = "[]" ] && [ "$mig_profiles" = "[]" ]; then
+            echo "Error: gpu_vgpu_profile_list: no profile source answered for $gpu_id" >&2
+            log_error "gpu_vgpu_profile_list: nvidia-smi vgpu -s -v -i $gpu_id exited $vgpu_probe_rc: $vgpu_probe_err; $VGPU_CONFIG_XML listed no type either, refusing to report empty profile lists as a healthy answer"
+            return 1
+        fi
+        log_debug "gpu_vgpu_profile_list: nvidia-smi vgpu -s -v -i $gpu_id exited $vgpu_probe_rc: $vgpu_probe_err; answered from $VGPU_CONFIG_XML instead"
     fi
 
     local vgpu_type_id_hex

--- a/core/sdk_sh/tests/test_gpu_vgpu_profile_probe.sh
+++ b/core/sdk_sh/tests/test_gpu_vgpu_profile_probe.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Unit test for the nvidia-smi probe handling in ../modules/sdk_gpu.sh:
+#   gpu_vgpu_profile_list -- must not report empty profile lists with exit 0
+#                            when its `nvidia-smi vgpu -s -v` probe failed
+#                            (#1247), while still honouring the vfio-pci
+#                            fallback to the static vGPU type table (#1282).
+#
+# Self-contained: extracts just that function, stubs nvidia-smi, log_error and
+# the XML table reader, so it needs no GPU and no NVIDIA driver.
+#   Run: bash test_gpu_vgpu_profile_probe.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_gpu.sh"
+eval "$(awk '/^gpu_vgpu_profile_list\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+eval "$(awk '/^gpu_probe_diagnosis\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+[ "$(type -t gpu_vgpu_profile_list)" = function ] || { echo "FAIL: function not extracted"; exit 1; }
+[ "$(type -t gpu_probe_diagnosis)" = function ] || { echo "FAIL: gpu_probe_diagnosis not extracted"; exit 1; }
+
+# constants the extracted function reads, copied from the top of sdk_gpu.sh
+SRIOV_PROFILE_NAME_REGEX="^[A-Za-z0-9]+-[0-9]+[A-Za-z]+$"
+MIG_PROFILE_NAME_REGEX="^[A-Za-z0-9]+-[0-9]+-[0-9]+[A-Za-z]+$"
+VGPU_CONFIG_XML="/nonexistent/vgpuConfig.xml"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+GPU_CONFIG_FILE_PATH="$TMP/config.json"
+cat > "$GPU_CONFIG_FILE_PATH" <<'EOF'
+[{"id":"GPU-aaaa","name":"NVIDIA RTX PRO 6000","pciAddress":"00000000:42:00.0","type":"sriovVgpu",
+  "profiles":[{"id":1561,"count":2,"alias":"vgpu-DC-12Q"}]}]
+EOF
+
+# nvidia-smi stub: prints $MOCK_OUT on stdout, $MOCK_ERR on stderr, exits $MOCK_RC
+NVIDIA_SMI="$TMP/nvidia-smi"
+cat > "$NVIDIA_SMI" <<'EOF'
+#!/bin/bash
+[ -n "${MOCK_ERR:-}" ] && printf '%s\n' "$MOCK_ERR" >&2
+printf '%s' "${MOCK_OUT:-}"
+exit "${MOCK_RC:-0}"
+EOF
+chmod +x "$NVIDIA_SMI"
+export MOCK_OUT="" MOCK_ERR="" MOCK_RC=0
+
+# log_error stub: records what the function would have sent to the journal.
+# Through a file, not a variable - the function under test runs in a command
+# substitution, so a variable it sets would not survive back to the caller.
+LOGFILE="$TMP/log"
+DEBUGFILE="$TMP/debug"
+: > "$LOGFILE"; : > "$DEBUGFILE"
+log_error() { printf '%s\n' "$1" >> "$LOGFILE"; }
+log_debug() { printf '%s\n' "$1" >> "$DEBUGFILE"; }
+
+# gpu_vgpu_types_from_xml stub: emits "$MOCK_XML" (id<TAB>name<TAB>vramMiB rows)
+MOCK_XML=""
+gpu_vgpu_types_from_xml() { printf '%s' "$MOCK_XML"; }
+
+pass=0 fail=0
+ck() { [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+
+run() { # sets OUT / RC / LOGGED / DEBUGGED for the current MOCK_* state
+    : > "$LOGFILE"; : > "$DEBUGFILE"
+    OUT=$(gpu_vgpu_profile_list "${1-}" 2>/dev/null); RC=$?
+    LOGGED=$(cat "$LOGFILE"); DEBUGGED=$(cat "$DEBUGFILE")
+}
+
+SMI_OK='    vGPU Type ID                      : 0x619
+        Name                              : NVIDIA RTX Pro 6000 Blackwell DC-12Q
+        FB Memory                         : 12288 MiB
+    vGPU Type ID                      : 0x61a
+        Name                              : NVIDIA RTX Pro 6000 Blackwell DC-1-24Q
+        FB Memory                         : 24576 MiB
+        Max Instances                     : 4'
+
+# ---- 1. healthy probe: exit 0, both lists built, config count/alias merged ----
+MOCK_RC=0 MOCK_OUT="$SMI_OK" MOCK_ERR="" MOCK_XML=""
+run GPU-aaaa
+ck "$RC" 0 "healthy probe exits 0"
+ck "$(echo "$OUT" | jq -r '.sriov[0].name')" "DC-12Q"  "healthy probe: sriov type parsed"
+ck "$(echo "$OUT" | jq -r '.migBacked[0].name')" "DC-1-24Q" "healthy probe: mig type parsed"
+ck "$(echo "$OUT" | jq -r '.sriov[0].count')" "2"      "healthy probe: count merged from config (0x619 = 1561)"
+ck "$LOGGED" "" "healthy probe logs no error"
+
+# ---- 2. failed probe with nothing else to answer: exit non-zero + logged ----
+# Shaped like the real thing: nvidia-smi puts "No devices were found" on
+# stdout and leaves stderr empty (cn13: nonexistent GPU -> exit 6, no stderr),
+# so a message built from stderr alone would say nothing.
+MOCK_RC=6 MOCK_OUT="No devices were found" MOCK_ERR="" MOCK_XML=""
+run GPU-does-not-exist
+ck "$([ "$RC" -ne 0 ] && echo nonzero || echo zero)" nonzero "failed probe exits non-zero"
+ck "$(echo "$LOGGED" | grep -c 'exited 6')" "1" "failed probe logs the exit status"
+ck "$(echo "$LOGGED" | grep -c 'No devices were found')" "1" "failed probe logs the diagnosis, taken from stdout"
+ck "$(echo "$LOGGED" | grep -c 'refusing to report empty profile lists')" "1" "failed probe says why it refused"
+
+# stderr wins when nvidia-smi does use it
+MOCK_RC=6 MOCK_OUT="" MOCK_ERR="Unable to find device" MOCK_XML=""
+run GPU-does-not-exist
+ck "$(echo "$LOGGED" | grep -c 'Unable to find device')" "1" "failed probe prefers stderr when present"
+
+# ---- 3. failed probe but the static table answers (pgpu on vfio-pci) ----
+# Same exit 6 as case 2 - the fallback, not the exit status, decides.
+MOCK_RC=6 MOCK_OUT="No devices were found" MOCK_ERR="Unable to find device" \
+    MOCK_XML=$'1561\tDC-12Q\t12288\n1585\tDC-1-24Q\t24576'
+run GPU-aaaa
+ck "$RC" 0 "vfio-pci fallback still exits 0"
+ck "$(echo "$OUT" | jq -r '.sriov[0].name')" "DC-12Q" "vfio-pci fallback: sriov from XML table"
+ck "$(echo "$OUT" | jq -r '.migBacked[0].name')" "DC-1-24Q" "vfio-pci fallback: mig from XML table"
+ck "$(echo "$OUT" | jq -r '.sriov[0].count')" "2" "vfio-pci fallback: count merged from config"
+ck "$(echo "$OUT" | jq -r '.sriov[0].alias')" "vgpu-DC-12Q" "vfio-pci fallback: alias merged from config"
+ck "$LOGGED" "" "vfio-pci fallback logs no error - a healthy pgpu is polled constantly"
+ck "$(echo "$DEBUGGED" | grep -c 'exited 6')" "1" "vfio-pci fallback still records the failed probe at debug level"
+
+# ---- 4. healthy probe on a card that genuinely has no vGPU types ----
+# Empty lists with exit 0 must stay reachable, otherwise the caller can no
+# longer trust exit 0 to mean anything.
+MOCK_RC=0 MOCK_OUT="" MOCK_ERR="" MOCK_XML=""
+run GPU-aaaa
+ck "$RC" 0 "no vGPU types: exits 0"
+ck "$(echo "$OUT" | jq -c '[.sriov, .migBacked]')" "[[],[]]" "no vGPU types: empty lists"
+
+# ---- 5. missing argument ----
+MOCK_RC=0 MOCK_OUT="$SMI_OK" MOCK_ERR="" MOCK_XML=""
+run ""
+ck "$RC" 1 "missing gpuId exits 1"
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: gpu_vgpu_profile_list probe handling"; exit 0; } || exit 1


### PR DESCRIPTION
`gpu_vgpu_profile_list` ran its `nvidia-smi` probe as

```bash
vgpu_output=$($NVIDIA_SMI vgpu -s -v -i "$gpu_id" 2>/dev/null)
```

— error text discarded, `$?` never tested. Every probe failure fell through to
the normal `jq` output path and printed empty lists with exit 0, so a caller
could not tell *"this card has no vGPU types"* from *"the probe failed"*.
`cube-cos-api` then answered `profiles: {sriovVgpu: [], migBackedVgpu: []}` with
`degraded: false`, and the Edit GPU Resource modal offered nothing to pick.

## What changed

The probe's exit status and its diagnosis are kept, and **a failure is fatal
only once nothing else has answered**.

That second half matters: a `pgpu` bound to `vfio-pci` fails the probe *exactly*
the way a nonexistent GPU does — both are `No devices were found`, exit 6 — and
for that card the static `vgpuConfig.xml` table added in #1282 is the intended
answer. Keying on the exit status alone would undo that fallback and turn every
poll of a healthy pgpu into an error. So:

| probe | fallback table | result |
|---|---|---|
| ok | — | exit 0, profiles as before |
| ok, card has no vGPU types | — | exit 0, empty lists — still a trustworthy answer |
| failed | answered | exit 0, profiles from the table; failed probe recorded at **debug** |
| failed | nothing | **exit 1**, one `error:` line in the journal |

`gpu_device_list` keeps returning the whole card list — one card's failed probe
must not fail the node — but now logs the probe's exit status and diagnosis
instead of silently leaving `supportTypes` at `["pgpu"]`.

One measured detail shaped the implementation: **`nvidia-smi` prints
`No devices were found` on stdout and leaves stderr empty** (cn13: nonexistent
GPU → exit 6, no stderr). A log message built from stderr alone would have said
nothing, so `gpu_probe_diagnosis` prefers stderr and falls back to stdout.

## Verification

Deployed to **cn13** (4× RTX PRO 6000 Blackwell). The node's `sdk_gpu.sh` was
byte-identical to `develop` beforehand (`693a4356…`), so the before/after
comparison has a real baseline.

| QA | command | before | after |
|---|---|---|---|
| 1 | `hex_sdk gpu_vgpu_profile_list <nonexistent>` | **exit 0**, `{"sriov":[],"migBacked":[]}` | **exit 1**, journal line below |
| 2 | `hex_sdk gpu_vgpu_profile_list <real vGPU-capable GPU>` | exit 0 | exit 0, `jq -S` output **identical** |
| 3 | `hex_sdk gpu_device_list` | exit 0 | exit 0, `jq -S` output **identical** |

```
Aug 25 11:37:36 cn13 hex_sdk[2108889]: error: gpu_vgpu_profile_list: nvidia-smi vgpu -s -v -i
GPU-deadbeef-0000-0000-0000-000000000000 exited 6: No devices were found;
/usr/share/nvidia/vgpu/vgpuConfig.xml listed no type either, refusing to report empty profile
lists as a healthy answer
```

`core/sdk_sh/tests/test_gpu_vgpu_profile_probe.sh` — 20 assertions, run on cn13
(the Mac's `awk` has no `strtonum`, so the extracted function cannot run there):

```
PASS=20 FAIL=0
OK: gpu_vgpu_profile_list probe handling
```

It stubs `nvidia-smi` and covers the healthy probe, the failed probe with
nothing else to answer, the failed probe rescued by the XML table, a card that
genuinely has no vGPU types, a missing argument, and both diagnosis sources
(stdout vs stderr).

cn13 was restored to `693a4356…` afterwards; no hot patch left behind.

## Not verified in this pass

QA items 4 and 5 need `cube-cos-api`, and it **does not start on cn13** for
reasons unrelated to this change — `NRestarts=1386`, Keycloak metadata returns
503, runtime init fails, `GET /gpuCards` answers 503. What can be said without
it: `gpu_device_list`'s output is byte-identical, and both `cube-cos-api` call
sites already treat a non-zero exit as an error (per the issue's own table), so
the API contract is unchanged and `degraded: true` follows from the exit status
alone. Exercising them needs a GPU node whose Keycloak is healthy.

## Notes for the reviewer

- No `cube-cos-api` change is needed — `buildLocalGpuCard` degrades the card and
  `updateLocalGpuCard` fails the `PUT` as soon as the exit status is honest.
- The debug-level line for a vfio-pci pgpu is deliberate: that card is polled
  constantly, and an `error:` per poll would be a false alarm.

Fixes #1247
