### PR TITLE
fix(cyborg): report only the cards hex assigned to passthrough

### DIFF
--- a/core/cyborg/antelope_patch/accelerator/drivers/gpu/nvidia/sysinfo.py
+++ b/core/cyborg/antelope_patch/accelerator/drivers/gpu/nvidia/sysinfo.py
@@ -1,0 +1,395 @@
+# Modifications Copyright (C) 2021 ZTE Corporation
+# Copyright 2018 Beijing Lenovo Software Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+"""
+Cyborg NVIDIA GPU driver implementation.
+"""
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+
+import collections
+import os
+
+import cyborg.conf
+import cyborg.privsep
+
+from cyborg.accelerator.common import utils
+from cyborg.accelerator.drivers.gpu import utils as gpu_utils
+from cyborg.common import constants
+from cyborg.common import exception
+from cyborg.conf import CONF
+from cyborg.objects.driver_objects import driver_attach_handle
+from cyborg.objects.driver_objects import driver_attribute
+from cyborg.objects.driver_objects import driver_controlpath_id
+from cyborg.objects.driver_objects import driver_deployable
+from cyborg.objects.driver_objects import driver_device
+
+LOG = logging.getLogger(__name__)
+
+# CubeCOS owns GPU resource-type configuration through hex_config. This file is
+# its source of truth: one entry per physical card, carrying the type the
+# operator assigned to it (pgpu / sriovVgpu / migBackedVgpu). A card not
+# recorded here as "pgpu" is not available for whole-card passthrough, so
+# cyborg must not advertise it.
+HEX_GPU_CONFIG_FILE = "/etc/cube/cos/gpu/config.json"
+SYS_PCI_DEVICES = "/sys/bus/pci/devices"
+
+
+@cyborg.privsep.sys_admin_pctxt.entrypoint
+def _read_hex_gpu_config_privileged():
+    """Read hex's GPU truth file. It is root-owned 0600; the agent is not.
+
+    Goes through the same privsep context lspci already uses, so this needs no
+    privilege the driver did not already have.
+    """
+    with open(HEX_GPU_CONFIG_FILE, 'r') as f:
+        return f.read()
+
+
+def _normalize_pci_address(address):
+    """hex writes an 8-digit domain and an upper-case bus ("00000001:C8:00.0");
+    lspci -D prints a 4-digit domain in lower case ("0001:c8:00.0"). Compare on
+    the lspci form.
+    """
+    parts = address.strip().lower().split(':')
+    if len(parts) != 3:
+        return address.strip().lower()
+    try:
+        domain = int(parts[0], 16)
+    except ValueError:
+        return address.strip().lower()
+    return "%04x:%s:%s" % (domain, parts[1], parts[2])
+
+
+def _get_passthrough_addresses():
+    """Addresses of the cards hex has assigned to whole-card passthrough.
+
+    Returns None when the truth file cannot be read at all, which the caller
+    treats the same way as an empty set - report nothing. Under-reporting fails
+    scheduling cleanly; over-reporting hands out a device another VM holds.
+    """
+    try:
+        raw = _read_hex_gpu_config_privileged()
+    except Exception as e:
+        LOG.error("cannot read %s (%s); reporting no GPUs rather than risking "
+                  "a device that is already in use", HEX_GPU_CONFIG_FILE, e)
+        return None
+
+    try:
+        entries = jsonutils.loads(raw)
+    except ValueError as e:
+        LOG.error("%s is not valid JSON (%s); reporting no GPUs",
+                  HEX_GPU_CONFIG_FILE, e)
+        return None
+
+    if not isinstance(entries, list):
+        LOG.error("%s is not a JSON array; reporting no GPUs",
+                  HEX_GPU_CONFIG_FILE)
+        return None
+
+    return set(
+        _normalize_pci_address(e["pciAddress"])
+        for e in entries
+        if isinstance(e, dict) and e.get("type") == "pgpu"
+        and e.get("pciAddress")
+    )
+
+
+def _is_virtual_function(address):
+    """A VF carries a physfn link back to its physical function.
+
+    A VF is never a whole-card passthrough target, whatever its lspci class
+    says - SR-IOV vGPU VFs report as "3D controller" exactly like the card
+    itself.
+    """
+    return os.path.exists(os.path.join(SYS_PCI_DEVICES, address, "physfn"))
+
+
+def _get_traits(vendor_id, product_id, vgpu_type_name=None):
+    """Generate traits for GPUs.
+    : param vendor_id: vendor_id of PGPU/VGPU, eg."10de"
+    : param product_id: product_id of PGPU/VGPU, eg."1eb8".
+    : param vgpu_type_name: vgpu type name, eg."T4_1B".
+    Example VGPU traits:
+    {traits:["OWNER_CYBORG", "CUSTOM_NVIDIA_1EB8_T4_2B"]}
+    Example PGPU traits:
+    {traits:["OWNER_CYBORG", "CUSTOM_NVIDIA_1EB8"]}
+    """
+    traits = ["OWNER_CYBORG"]
+    # PGPU trait
+    gpu_trait = "_".join(
+        ('CUSTOM', gpu_utils.VENDOR_MAPS.get(vendor_id, "").upper(),
+         product_id.upper()))
+    # VGPU trait
+    if vgpu_type_name:
+        gpu_trait = "_".join((gpu_trait, vgpu_type_name.upper()))
+    traits.append(gpu_trait)
+    return {"traits": traits}
+
+
+def _generate_attribute_list(gpu):
+    attr_list = []
+    index = 0
+    for k, v in gpu.items():
+        if k == "rc":
+            driver_attr = driver_attribute.DriverAttribute()
+            driver_attr.key, driver_attr.value = k, v
+            attr_list.append(driver_attr)
+        if k == "traits":
+            values = gpu.get(k, [])
+            for val in values:
+                driver_attr = driver_attribute.DriverAttribute(
+                    key="trait" + str(index), value=val)
+                index = index + 1
+                attr_list.append(driver_attr)
+    return attr_list
+
+
+def _generate_attach_handle(gpu, num=None):
+    driver_ah = driver_attach_handle.DriverAttachHandle()
+    driver_ah.in_use = False
+    if gpu["rc"] == "PGPU":
+        driver_ah.attach_type = constants.AH_TYPE_PCI
+        driver_ah.attach_info = utils.pci_str_to_json(gpu["devices"])
+    else:
+        vgpu_mark = gpu["vGPU_type"] + '_' + str(num)
+        driver_ah.attach_type = constants.AH_TYPE_MDEV
+        driver_ah.attach_info = utils.mdev_str_to_json(
+            gpu["devices"], gpu["vGPU_type"], vgpu_mark)
+    return driver_ah
+
+
+def _generate_dep_list(gpu):
+    dep_list = []
+    driver_dep = driver_deployable.DriverDeployable()
+    driver_dep.attribute_list = _generate_attribute_list(gpu)
+    driver_dep.attach_handle_list = []
+    # NOTE(wangzhh): The name of deployable should be unique, its format is
+    # under disscussion, may looks like
+    # <ComputeNodeName>_<NumaNodeName>_<CyborgName>_<NumInHost>
+    # NOTE(yumeng) Since Wallaby release, the deplpyable_name is named as
+    # <Compute_hostname>_<Device_address>
+    driver_dep.name = gpu.get('hostname', '') + '_' + gpu["devices"]
+    driver_dep.driver_name = \
+        gpu_utils.VENDOR_MAPS.get(gpu["vendor_id"], '').upper()
+    # if is pGPU, num_accelerators = 1
+    if gpu["rc"] == "PGPU":
+        driver_dep.num_accelerators = 1
+        driver_dep.attach_handle_list = \
+            [_generate_attach_handle(gpu)]
+    else:
+        # if is vGPU, num_accelerators is the total vGPU capability of
+        # the asked vGPU type
+        vGPU_path = os.path.expandvars(
+            '/sys/bus/pci/devices/{0}/mdev_supported_types/{1}/'
+            .format(gpu["devices"], gpu["vGPU_type"]))
+        num_available = 0
+        with open(vGPU_path + 'available_instances', 'r') as f:
+            num_available = int(f.read().strip())
+        num_created = len(os.listdir(vGPU_path + 'devices'))
+        driver_dep.num_accelerators = num_available + num_created
+        # example: 1 pGPU has 16 vGPUs is represented as
+        # 16 attach_handles, 1 deployable, 1 resource_provider
+        # NOTE(yumeng): cyborg use attach_handle_uuid
+        # to create each vGPU without the need to generate a new uuid
+        # example: echo "attach_handle_uuid" > nvidia-223/create
+        for num in range(driver_dep.num_accelerators):
+            driver_dep.attach_handle_list.append(
+                _generate_attach_handle(gpu, num))
+    dep_list.append(driver_dep)
+    return dep_list
+
+
+def _generate_controlpath_id(gpu):
+    driver_cpid = driver_controlpath_id.DriverControlPathID()
+    driver_cpid.cpid_type = "PCI"
+    driver_cpid.cpid_info = utils.pci_str_to_json(gpu["devices"])
+    return driver_cpid
+
+
+def _generate_driver_device(gpu):
+    driver_device_obj = driver_device.DriverDevice()
+    driver_device_obj.vendor = gpu['vendor_id']
+    driver_device_obj.model = gpu.get('model', 'miss model info')
+    std_board_info = {'product_id': gpu.get('product_id'),
+                      'controller': gpu.get('controller'), }
+    vendor_board_info = {'vendor_info': gpu.get('vendor_info',
+                         'gpu_vb_info')}
+    driver_device_obj.std_board_info = jsonutils.dumps(std_board_info)
+    driver_device_obj.vendor_board_info = jsonutils.dumps(
+        vendor_board_info)
+    driver_device_obj.type = constants.DEVICE_GPU
+    driver_device_obj.stub = gpu.get('stub', False)
+    driver_device_obj.controlpath_id = _generate_controlpath_id(gpu)
+    driver_device_obj.deployable_list = _generate_dep_list(gpu)
+    return driver_device_obj
+
+
+def _get_supported_vgpu_types():
+    """Gets supported vgpu_types from cyborg.conf.
+
+    Retrieves supported vgpu_types set by the operator and generates a
+    record of vgpu_type and pgpu in the dict constant: pgpu_type_mapping.
+
+    Returns:
+        A list of all vgpu_types set in CONF.gpu_devices.enabled_vgpu_types.
+
+    Raises:
+        InvalidGPUConfig: An error occurred if same PCI appear twice
+        or PCI address is not valid.
+    """
+    pgpu_type_mapping = collections.defaultdict(str)
+    pgpu_type_mapping.clear()
+    if not CONF.gpu_devices.enabled_vgpu_types:
+        return [], pgpu_type_mapping
+
+    for vgpu_type in CONF.gpu_devices.enabled_vgpu_types:
+        group = getattr(CONF, 'vgpu_%s' % vgpu_type, None)
+        if group is None or not group.device_addresses:
+            # Device addresses must be configured explictly now for every
+            # enabled vgpu type. Will improve after the disable and enable
+            # devices interfaces implemented.
+            raise exception.InvalidvGPUConfig(
+                reason="Missing device addresses config for vgpu type %s"
+                % vgpu_type
+            )
+        for device_address in group.device_addresses:
+            if device_address in pgpu_type_mapping:
+                raise exception.InvalidvGPUConfig(
+                    reason="Duplicate types for PCI address %s"
+                    % device_address
+                )
+            # Just checking whether the operator fat-fingered the address.
+            # If it's wrong, it will return an exception
+            try:
+                # Validates whether it's a PCI ID...
+                utils.parse_address(device_address)
+            except exception.PciDeviceWrongAddressFormat:
+                raise exception.InvalidvGPUConfig(
+                    reason="Incorrect PCI address: %s" % device_address
+                )
+            pgpu_type_mapping[device_address] = vgpu_type
+    return CONF.gpu_devices.enabled_vgpu_types, pgpu_type_mapping
+
+
+def _get_vgpu_type_per_pgpu(device_address, supported_vgpu_types,
+                            pgpu_type_mapping):
+    """Provides the vGPU type the pGPU supports.
+
+    :param device_address: the PCI device address in config,
+                           eg.'0000:af:00.0'
+    """
+    supported_vgpu_types, pgpu_type_mapping = _get_supported_vgpu_types()
+    # Bail out quickly if we don't support vGPUs
+    if not supported_vgpu_types:
+        LOG.error('Unable to load vGPU_type from [gpu_devices] '
+                  'Ensure "enabled_vgpu_types" is set.')
+        return
+
+    try:
+        # Validates whether it's a PCI ID...
+        utils.parse_address(device_address)
+    except (exception.PciDeviceWrongAddressFormat, IndexError):
+        # this is not a valid PCI address
+        LOG.warning("The PCI address %s was invalid for getting the"
+                    "related vGPU type", device_address)
+        return
+    return pgpu_type_mapping.get(device_address)
+
+
+def _discover_gpus(vendor_id):
+    """param: vendor_id=VENDOR_ID means only discover Nvidia GPU on the host
+
+    Reports only the cards CubeCOS has assigned to whole-card passthrough.
+
+    Upstream labels every NVIDIA function lspci reports as a GPU with rc=PGPU
+    (its own "TODO(yumeng) support and test VGPU rc generation soon" sits at
+    the same spot). On CubeCOS that is wrong twice over: SR-IOV vGPU VFs report
+    as "3D controller" and would each be advertised as a whole card, and a card
+    hex_config has already carved into sriovVgpu / migBackedVgpu would stay
+    advertised while it is in fact unavailable. Either one lets the scheduler
+    place a resources:PGPU=1 request onto a device that is already in use,
+    which placement accepts and libvirt then refuses with
+    "PCI device <addr> is in use by driver QEMU".
+
+    The filter uses two facts the product already owns, so no new state is
+    introduced: a VF carries a physfn link in sysfs, and
+    /etc/cube/cos/gpu/config.json records the type hex assigned to each card.
+    """
+    # init vGPU conf
+    cyborg.conf.devices.register_dynamic_opts(CONF)
+    supported_vgpu_types, pgpu_type_mapping = _get_supported_vgpu_types()
+    # discover gpu devices by "lspci"
+    gpu_list = []
+    passthrough = _get_passthrough_addresses()
+    if not passthrough:
+        return gpu_list
+    gpus = gpu_utils.get_pci_devices(gpu_utils.GPU_FLAGS, vendor_id)
+    # report trait,rc and generate driver object
+    for gpu in gpus:
+        m = gpu_utils.GPU_INFO_PATTERN.match(gpu)
+        if m:
+            gpu_dict = m.groupdict()
+            address = gpu_dict["devices"].lower()
+
+            if _is_virtual_function(address):
+                continue
+
+            if address not in passthrough:
+                LOG.debug("skipping %s: not assigned to passthrough in %s",
+                          address, HEX_GPU_CONFIG_FILE)
+                continue
+
+            # get hostname for deployable_name usage
+            gpu_dict['hostname'] = CONF.host
+            # get vgpu_type from cyborg.conf, otherwise vgpu_type=None
+            vgpu_type = _get_vgpu_type_per_pgpu(
+                gpu_dict["devices"], supported_vgpu_types, pgpu_type_mapping)
+            # generate rc and trait for pGPU
+            if not vgpu_type:
+                gpu_dict["rc"] = constants.RESOURCES["PGPU"]
+                traits = _get_traits(gpu_dict["vendor_id"],
+                                     gpu_dict["product_id"])
+            # generate rc and trait for vGPU
+            else:
+                # get rc
+                gpu_dict["rc"] = constants.RESOURCES["VGPU"]
+                mdev_path = os.path.expandvars(
+                    '/sys/bus/pci/devices/{0}/mdev_supported_types'.
+                    format(gpu_dict["devices"]))
+                valid_types = os.listdir(mdev_path)
+                if vgpu_type not in valid_types:
+                    raise exception.InvalidVGPUType(name=vgpu_type)
+                gpu_dict["vGPU_type"] = vgpu_type
+                vGPU_path = os.path.expandvars(
+                    '/sys/bus/pci/devices/{0}/mdev_supported_types/{1}/'
+                    .format(gpu_dict["devices"], gpu_dict["vGPU_type"]))
+                # transfer vgpu_type to vgpu_type_name.
+                # eg. transfer 'nvidia-223' to 'T4_1B'
+                with open(vGPU_path + 'name', 'r') as f:
+                    name = f.read().strip()
+                vgpu_type_name = name.split(' ')[1].replace('-', '_')
+                traits = _get_traits(gpu_dict["vendor_id"],
+                                     gpu_dict["product_id"],
+                                     vgpu_type_name)
+            gpu_dict.update(traits)
+            gpu_list.append(_generate_driver_device(gpu_dict))
+    return gpu_list
+
+
+def discover(vendor_id):
+    devs = _discover_gpus(vendor_id)
+    return devs

--- a/core/cyborg/antelope_patch/accelerator/drivers/gpu/nvidia/sysinfo.py.orig
+++ b/core/cyborg/antelope_patch/accelerator/drivers/gpu/nvidia/sysinfo.py.orig
@@ -1,0 +1,287 @@
+# Modifications Copyright (C) 2021 ZTE Corporation
+# Copyright 2018 Beijing Lenovo Software Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+"""
+Cyborg NVIDIA GPU driver implementation.
+"""
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+
+import collections
+import os
+
+import cyborg.conf
+
+from cyborg.accelerator.common import utils
+from cyborg.accelerator.drivers.gpu import utils as gpu_utils
+from cyborg.common import constants
+from cyborg.common import exception
+from cyborg.conf import CONF
+from cyborg.objects.driver_objects import driver_attach_handle
+from cyborg.objects.driver_objects import driver_attribute
+from cyborg.objects.driver_objects import driver_controlpath_id
+from cyborg.objects.driver_objects import driver_deployable
+from cyborg.objects.driver_objects import driver_device
+
+LOG = logging.getLogger(__name__)
+
+
+def _get_traits(vendor_id, product_id, vgpu_type_name=None):
+    """Generate traits for GPUs.
+    : param vendor_id: vendor_id of PGPU/VGPU, eg."10de"
+    : param product_id: product_id of PGPU/VGPU, eg."1eb8".
+    : param vgpu_type_name: vgpu type name, eg."T4_1B".
+    Example VGPU traits:
+    {traits:["OWNER_CYBORG", "CUSTOM_NVIDIA_1EB8_T4_2B"]}
+    Example PGPU traits:
+    {traits:["OWNER_CYBORG", "CUSTOM_NVIDIA_1EB8"]}
+    """
+    traits = ["OWNER_CYBORG"]
+    # PGPU trait
+    gpu_trait = "_".join(
+        ('CUSTOM', gpu_utils.VENDOR_MAPS.get(vendor_id, "").upper(),
+         product_id.upper()))
+    # VGPU trait
+    if vgpu_type_name:
+        gpu_trait = "_".join((gpu_trait, vgpu_type_name.upper()))
+    traits.append(gpu_trait)
+    return {"traits": traits}
+
+
+def _generate_attribute_list(gpu):
+    attr_list = []
+    index = 0
+    for k, v in gpu.items():
+        if k == "rc":
+            driver_attr = driver_attribute.DriverAttribute()
+            driver_attr.key, driver_attr.value = k, v
+            attr_list.append(driver_attr)
+        if k == "traits":
+            values = gpu.get(k, [])
+            for val in values:
+                driver_attr = driver_attribute.DriverAttribute(
+                    key="trait" + str(index), value=val)
+                index = index + 1
+                attr_list.append(driver_attr)
+    return attr_list
+
+
+def _generate_attach_handle(gpu, num=None):
+    driver_ah = driver_attach_handle.DriverAttachHandle()
+    driver_ah.in_use = False
+    if gpu["rc"] == "PGPU":
+        driver_ah.attach_type = constants.AH_TYPE_PCI
+        driver_ah.attach_info = utils.pci_str_to_json(gpu["devices"])
+    else:
+        vgpu_mark = gpu["vGPU_type"] + '_' + str(num)
+        driver_ah.attach_type = constants.AH_TYPE_MDEV
+        driver_ah.attach_info = utils.mdev_str_to_json(
+            gpu["devices"], gpu["vGPU_type"], vgpu_mark)
+    return driver_ah
+
+
+def _generate_dep_list(gpu):
+    dep_list = []
+    driver_dep = driver_deployable.DriverDeployable()
+    driver_dep.attribute_list = _generate_attribute_list(gpu)
+    driver_dep.attach_handle_list = []
+    # NOTE(wangzhh): The name of deployable should be unique, its format is
+    # under disscussion, may looks like
+    # <ComputeNodeName>_<NumaNodeName>_<CyborgName>_<NumInHost>
+    # NOTE(yumeng) Since Wallaby release, the deplpyable_name is named as
+    # <Compute_hostname>_<Device_address>
+    driver_dep.name = gpu.get('hostname', '') + '_' + gpu["devices"]
+    driver_dep.driver_name = \
+        gpu_utils.VENDOR_MAPS.get(gpu["vendor_id"], '').upper()
+    # if is pGPU, num_accelerators = 1
+    if gpu["rc"] == "PGPU":
+        driver_dep.num_accelerators = 1
+        driver_dep.attach_handle_list = \
+            [_generate_attach_handle(gpu)]
+    else:
+        # if is vGPU, num_accelerators is the total vGPU capability of
+        # the asked vGPU type
+        vGPU_path = os.path.expandvars(
+            '/sys/bus/pci/devices/{0}/mdev_supported_types/{1}/'
+            .format(gpu["devices"], gpu["vGPU_type"]))
+        num_available = 0
+        with open(vGPU_path + 'available_instances', 'r') as f:
+            num_available = int(f.read().strip())
+        num_created = len(os.listdir(vGPU_path + 'devices'))
+        driver_dep.num_accelerators = num_available + num_created
+        # example: 1 pGPU has 16 vGPUs is represented as
+        # 16 attach_handles, 1 deployable, 1 resource_provider
+        # NOTE(yumeng): cyborg use attach_handle_uuid
+        # to create each vGPU without the need to generate a new uuid
+        # example: echo "attach_handle_uuid" > nvidia-223/create
+        for num in range(driver_dep.num_accelerators):
+            driver_dep.attach_handle_list.append(
+                _generate_attach_handle(gpu, num))
+    dep_list.append(driver_dep)
+    return dep_list
+
+
+def _generate_controlpath_id(gpu):
+    driver_cpid = driver_controlpath_id.DriverControlPathID()
+    driver_cpid.cpid_type = "PCI"
+    driver_cpid.cpid_info = utils.pci_str_to_json(gpu["devices"])
+    return driver_cpid
+
+
+def _generate_driver_device(gpu):
+    driver_device_obj = driver_device.DriverDevice()
+    driver_device_obj.vendor = gpu['vendor_id']
+    driver_device_obj.model = gpu.get('model', 'miss model info')
+    std_board_info = {'product_id': gpu.get('product_id'),
+                      'controller': gpu.get('controller'), }
+    vendor_board_info = {'vendor_info': gpu.get('vendor_info',
+                         'gpu_vb_info')}
+    driver_device_obj.std_board_info = jsonutils.dumps(std_board_info)
+    driver_device_obj.vendor_board_info = jsonutils.dumps(
+        vendor_board_info)
+    driver_device_obj.type = constants.DEVICE_GPU
+    driver_device_obj.stub = gpu.get('stub', False)
+    driver_device_obj.controlpath_id = _generate_controlpath_id(gpu)
+    driver_device_obj.deployable_list = _generate_dep_list(gpu)
+    return driver_device_obj
+
+
+def _get_supported_vgpu_types():
+    """Gets supported vgpu_types from cyborg.conf.
+
+    Retrieves supported vgpu_types set by the operator and generates a
+    record of vgpu_type and pgpu in the dict constant: pgpu_type_mapping.
+
+    Returns:
+        A list of all vgpu_types set in CONF.gpu_devices.enabled_vgpu_types.
+
+    Raises:
+        InvalidGPUConfig: An error occurred if same PCI appear twice
+        or PCI address is not valid.
+    """
+    pgpu_type_mapping = collections.defaultdict(str)
+    pgpu_type_mapping.clear()
+    if not CONF.gpu_devices.enabled_vgpu_types:
+        return [], pgpu_type_mapping
+
+    for vgpu_type in CONF.gpu_devices.enabled_vgpu_types:
+        group = getattr(CONF, 'vgpu_%s' % vgpu_type, None)
+        if group is None or not group.device_addresses:
+            # Device addresses must be configured explictly now for every
+            # enabled vgpu type. Will improve after the disable and enable
+            # devices interfaces implemented.
+            raise exception.InvalidvGPUConfig(
+                reason="Missing device addresses config for vgpu type %s"
+                % vgpu_type
+            )
+        for device_address in group.device_addresses:
+            if device_address in pgpu_type_mapping:
+                raise exception.InvalidvGPUConfig(
+                    reason="Duplicate types for PCI address %s"
+                    % device_address
+                )
+            # Just checking whether the operator fat-fingered the address.
+            # If it's wrong, it will return an exception
+            try:
+                # Validates whether it's a PCI ID...
+                utils.parse_address(device_address)
+            except exception.PciDeviceWrongAddressFormat:
+                raise exception.InvalidvGPUConfig(
+                    reason="Incorrect PCI address: %s" % device_address
+                )
+            pgpu_type_mapping[device_address] = vgpu_type
+    return CONF.gpu_devices.enabled_vgpu_types, pgpu_type_mapping
+
+
+def _get_vgpu_type_per_pgpu(device_address, supported_vgpu_types,
+                            pgpu_type_mapping):
+    """Provides the vGPU type the pGPU supports.
+
+    :param device_address: the PCI device address in config,
+                           eg.'0000:af:00.0'
+    """
+    supported_vgpu_types, pgpu_type_mapping = _get_supported_vgpu_types()
+    # Bail out quickly if we don't support vGPUs
+    if not supported_vgpu_types:
+        LOG.error('Unable to load vGPU_type from [gpu_devices] '
+                  'Ensure "enabled_vgpu_types" is set.')
+        return
+
+    try:
+        # Validates whether it's a PCI ID...
+        utils.parse_address(device_address)
+    except (exception.PciDeviceWrongAddressFormat, IndexError):
+        # this is not a valid PCI address
+        LOG.warning("The PCI address %s was invalid for getting the"
+                    "related vGPU type", device_address)
+        return
+    return pgpu_type_mapping.get(device_address)
+
+
+def _discover_gpus(vendor_id):
+    """param: vendor_id=VENDOR_ID means only discover Nvidia GPU on the host
+    """
+    # init vGPU conf
+    cyborg.conf.devices.register_dynamic_opts(CONF)
+    supported_vgpu_types, pgpu_type_mapping = _get_supported_vgpu_types()
+    # discover gpu devices by "lspci"
+    gpu_list = []
+    gpus = gpu_utils.get_pci_devices(gpu_utils.GPU_FLAGS, vendor_id)
+    # report trait,rc and generate driver object
+    for gpu in gpus:
+        m = gpu_utils.GPU_INFO_PATTERN.match(gpu)
+        if m:
+            gpu_dict = m.groupdict()
+            # get hostname for deployable_name usage
+            gpu_dict['hostname'] = CONF.host
+            # get vgpu_type from cyborg.conf, otherwise vgpu_type=None
+            vgpu_type = _get_vgpu_type_per_pgpu(
+                gpu_dict["devices"], supported_vgpu_types, pgpu_type_mapping)
+            # generate rc and trait for pGPU
+            if not vgpu_type:
+                gpu_dict["rc"] = constants.RESOURCES["PGPU"]
+                traits = _get_traits(gpu_dict["vendor_id"],
+                                     gpu_dict["product_id"])
+            # generate rc and trait for vGPU
+            else:
+                # get rc
+                gpu_dict["rc"] = constants.RESOURCES["VGPU"]
+                mdev_path = os.path.expandvars(
+                    '/sys/bus/pci/devices/{0}/mdev_supported_types'.
+                    format(gpu_dict["devices"]))
+                valid_types = os.listdir(mdev_path)
+                if vgpu_type not in valid_types:
+                    raise exception.InvalidVGPUType(name=vgpu_type)
+                gpu_dict["vGPU_type"] = vgpu_type
+                vGPU_path = os.path.expandvars(
+                    '/sys/bus/pci/devices/{0}/mdev_supported_types/{1}/'
+                    .format(gpu_dict["devices"], gpu_dict["vGPU_type"]))
+                # transfer vgpu_type to vgpu_type_name.
+                # eg. transfer 'nvidia-223' to 'T4_1B'
+                with open(vGPU_path + 'name', 'r') as f:
+                    name = f.read().strip()
+                vgpu_type_name = name.split(' ')[1].replace('-', '_')
+                traits = _get_traits(gpu_dict["vendor_id"],
+                                     gpu_dict["product_id"],
+                                     vgpu_type_name)
+            gpu_dict.update(traits)
+            gpu_list.append(_generate_driver_device(gpu_dict))
+    return gpu_list
+
+
+def discover(vendor_id):
+    devs = _discover_gpus(vendor_id)
+    return devs


### PR DESCRIPTION
Redo of the cyborg half of #1280, which was closed because it was written
against `core/cyborg/yoga_patch/`. #1266 landed on 08-17, `OPENSTACK_RELEASE` is
`antelope`, and `CYBORG_PATCHDIR = $(COREDIR)/cyborg/$(OPENSTACK_RELEASE)_patch`
— `yoga_patch/` no longer exists in the tree.

## The bug

`_discover_gpus()` labels every NVIDIA function `lspci` reports as a GPU with
`rc=PGPU`, unconditionally — upstream leaves a
`TODO(yumeng) support and test VGPU rc generation soon` at the same spot. On
CubeCOS that is wrong twice over: SR-IOV vGPU VFs report as `3D controller`
exactly like the card itself, and a card `hex_config` has already carved into
`sriovVgpu` / `migBackedVgpu` stays advertised as available for whole-card
passthrough. Either one lets the scheduler place a `resources:PGPU=1` request
onto a device another VM already holds — placement accepts it, libvirt then
refuses with `PCI device <addr> is in use by driver QEMU`.

## The filter

Two facts the product already owns, so **no new state is introduced**: a VF
carries a `physfn` link in sysfs, and `/etc/cube/cos/gpu/config.json` records
the type hex assigned to each card. That file is root-owned `0600` while the
agent runs as `cyborg`, so it is read through the same privsep entrypoint
`lspci` already uses — **no new privilege**. If it cannot be read, the driver
reports nothing rather than falling back to the old behaviour: under-reporting
fails scheduling cleanly, over-reporting hands out a device that is in use.

## Where it lands has changed since #1280

Antelope moved GPU discovery out of `accelerator/drivers/gpu/utils.py` (86 lines
now — just the lspci/mdev helpers) into
`accelerator/drivers/gpu/nvidia/sysinfo.py`. The patch is therefore **one file**
there plus its `.orig`, instead of `utils.py` as under Yoga.

The `.orig` convention was checked rather than assumed: the existing
`antelope_patch/api/controllers/v2/arqs.py.orig` is byte-identical to upstream
`openstack/cyborg` `unmaintained/2023.1`, which is `OPS_GITHUB_BRANCH_02` —
the same branch this `.orig` was taken from.

## Verification — cn13 (4× RTX PRO 6000 Blackwell)

cn13's own state *is* the bug. **No card is assigned to passthrough at all**,
and placement still carries 52 `cn13_*` providers offering `PGPU` — every one of
them bogus:

```
hex config.json : 00000001:C8:00.0  sriovVgpu   (the other three unset)
placement       : cn13_* providers = 52
cyborg devices  : 52
```

(The issue reports 148; the count tracks how many VFs exist at the time.)

### Read-only harness — this PR's file, verbatim, on live hardware

`ast`-extracted `_normalize_pci_address` / `_is_virtual_function` **from the
patched file in this PR**, fed real `lspci -nnn -D`, real sysfs and the real
`config.json`. Nothing restarted:

| config | lspci GPUs | dropped: VF | dropped: not `pgpu` | kept as PGPU |
|---|---|---|---|---|
| real (0 pgpu cards) | 52 | 48 | 4 | **0** |
| one card marked `pgpu` | 52 | 48 | 3 | **1** (`0000:42:00.0`) |

### End to end — cyborg-agent restarted, placement observed

cn13 runs **Yoga** cyborg (`/usr/local/lib/python3.9/site-packages/cyborg`, no
`/opt/openstack-antelope`), so the antelope file cannot be dropped in as-is. The
end-to-end run used the Yoga-shaped equivalent — and the equivalence is
mechanical, not asserted: the three helpers' executable code is **identical AST
node for AST node**, differing only in docstring wrapping and the leading
underscore.

| | providers | cyborg devices | agent |
|---|---|---|---|
| before | 52 | 52 | active |
| after (real config, 0 pgpu) | **0** | 0 | active, no traceback |
| after (one card `pgpu`) | **1**, `PGPU total=1` | 1 | active, no traceback |

The positive case was driven from a **root-owned `0600`** copy of `config.json`,
so it proves the riskiest assumption in the change directly: the agent, running
as `cyborg`, reads that file through `sys_admin_pctxt` without new privilege.
The journal shows `privsep-helper --privsep_context cyborg.privsep.sys_admin_pctxt`
and **no** `cannot read …` line — so the 0 above is "no pgpu cards", not "could
not read, reporting nothing".

cn13 was restored afterwards: `utils.py` back to `e8b1bb74…` (upstream yoga),
the temporary config removed, agent restarted, providers back to 52.

## Not in this PR

The second half of the issue's suggested fix — **reconciling a stale `Bound` ARQ
after a host reboot** — is untouched. A pgpu VM comes back with no device
attached while cyborg (`state=Bound`) and placement (`usage=1`) both still show
it allocated and hex reports the card `idle`. The PCI-alias path does not have
this problem because the `gpu` hex module re-applies it every boot; the cyborg
path has no equivalent. That needs its own change, so **#1262 stays open** and
this PR is `Refs`, not `Fixes`.

Refs #1262
