### PR TITLE
fix(build): fail and re-run image mirroring instead of shipping an incomplete bundle

### DIFF
--- a/core/docker/Makefile
+++ b/core/docker/Makefile
@@ -9,7 +9,17 @@ REGISTRY_TAR := registry@2.tar
 $(REGISTRY_TAR):
 	$(Q)skopeo copy docker://registry:2 docker-archive:$(REGISTRY_TAR):registry:2 --retry-times 3 >/dev/null
 
-registry: $(REGISTRY_TAR)
+# Gated on a stamp written only after every copy succeeded: `registry` matched the
+# directory run-registry creates, so a stage that aborted midway looked done (#1346).
+# A stamp, not .PHONY -- re-copying every build would re-resolve every upstream
+# manifest. The image lists are dependencies, so editing one re-copies.
+REGISTRY_STAMP := .registry-copied
+
+$(REGISTRY_STAMP): $(REGISTRY_TAR) \
+                   $(COREDIR)/appctl/images/list.txt \
+                   $(COREDIR)/rancher/images.txt \
+                   $(COREDIR)/rancher/rancher-images.txt \
+                   $(COREDIR)/k3s/images.txt
 	$(Q)make build-image -C ../k3s
 	$(call RUN_CMD_TIMED, make run-registry,"  RUN     docker registry")
 	$(Q)make copy-image -C ../k3s
@@ -17,6 +27,11 @@ registry: $(REGISTRY_TAR)
 	$(Q)make copy-image -C ../rancher FULL=$(FULL)
 	$(Q)make copy-image -C ../appctl
 	$(Q)make rm-registry
+	$(Q)touch $@
+
+registry: $(REGISTRY_STAMP)
+
+CLEAN += $(REGISTRY_STAMP)
 
 k8s-full-registry.tar:
 	$(Q)make registry FULL=true
@@ -33,10 +48,8 @@ run-registry: $(REGISTRY_TAR)
 rm-registry:
 	$(Q)podman rm -ivf registry $(QEND)
 
-# Not .IGNORE: an image that fails to reach the bundled registry is missing from
-# the shipped bundle, and the install only finds out when the pod cannot pull it
-# with no egress. Retry first -- the failures seen are transient (upstream EOF,
-# registry 400 mid-upload) -- then fail the build (#1346).
+# Not .IGNORE: an image missing from the bundle only surfaces when a pod cannot
+# pull it with no egress. Retry the transient failures, then fail the build (#1346).
 .PHONY: push-image
 push-image:
 	$(call RUN_CMD_TIMED, make run-registry,"  RUN     docker registry")

--- a/core/docker/Makefile
+++ b/core/docker/Makefile
@@ -33,15 +33,19 @@ run-registry: $(REGISTRY_TAR)
 rm-registry:
 	$(Q)podman rm -ivf registry $(QEND)
 
-.PHONY .IGNORE: push-image
+# Not .IGNORE: an image that fails to reach the bundled registry is missing from
+# the shipped bundle, and the install only finds out when the pod cannot pull it
+# with no egress. Retry first -- the failures seen are transient (upstream EOF,
+# registry 400 mid-upload) -- then fail the build (#1346).
+.PHONY: push-image
 push-image:
 	$(call RUN_CMD_TIMED, make run-registry,"  RUN     docker registry")
 	$(call RUN_CMD_TIMED, \
-		podman push $(IMG) --tls-verify=false \
+		podman push $(IMG) --tls-verify=false --retry 3 \
 		,"  PUSH    $(IMG)")
 	$(Q)make rm-registry
 
-.PHONY .IGNORE: copy-image
+.PHONY: copy-image
 copy-image:
 	$(call RUN_CMD_TIMED, make run-registry,"  RUN     docker registry")
 	$(call RUN_CMD_TIMED, \

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -66,9 +66,15 @@ rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(OPS_GITHUB_BRANCH_02) --depth 1 $(MASAKARI_MONITORS_REPO_URL) /tmp/masakari/masakari-monitors
+	$(Q)# libvirt-python is named here rather than left transitive: masakarimonitors
+	$(Q)# imports libvirt directly (instancemonitor/instance.py), its requirements.txt
+	$(Q)# does not list it, and it used to arrive because nova shared this venv. The
+	$(Q)# caracal hop moved nova and its libvirt-python to /opt/openstack-caracal, so
+	$(Q)# instancemonitor crash-loops on ModuleNotFoundError without this (#1347).
 	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install \
 		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-		-r /tmp/masakari/masakari-monitors/requirements.txt
+		-r /tmp/masakari/masakari-monitors/requirements.txt \
+		libvirt-python
 	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/masakari/masakari-monitors && \
 		/opt/openstack-antelope/bin/python setup.py install"
 	$(Q)# clean up dns configurations after downloading packages


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Two build/packaging defects found by the zero-touch 3cc air-gap validation run (sky141/142/143, image `CUBE_3.1.20_20260825-1849_b0162f9`, `simulateAirgap` + `optOutRepair`). Both make an image that installs fine *with* internet fail offline.

1. **A failed image mirror shipped a broken bundle** (#1346). `copy-image`/`push-image` were `.IGNORE`, so a transient `skopeo` failure left `ingress-nginx/controller` out of the bundled registry while the build still reported success. Retry three times, then fail.
2. **A resumed build silently kept the incomplete bundle** (#1346, second half). `registry` was a non-PHONY target whose name matches the directory `run-registry` creates, so once `registry/` existed make called the stage up to date — including after a copy aborted midway. Gated on a stamp written only after every copy succeeds, with the image lists as dependencies.
3. **masakari lost `libvirt-python`** (#1348). masakarimonitors runs from the antelope venv and imports `libvirt`; it arrived for free while nova shared that venv, and the caracal hop moved nova out. Instance HA monitored nothing on every node. Named explicitly, like `nova.mk` does for oslo.privsep.

#### Which issue(s) this PR fixes

Fixes #1346, fixes #1348

The keycloak half of this run's findings (#1344, #1345) is **already covered by #1347**, which does it better than this PR originally did — its `isDatabaseSetup()` checks the schema *and* the user, and it reads the credentials from the `keycloak-db-secret` instead of hardcoding them. That commit was dropped from here.

#### Special notes for your reviewer

- **How the two build defects combine, from this run's log.** Attempt 1 died at `core/docker/Makefile:17` (`make copy-image -C ../rancher`) on a transient upstream 400 — and `core/rancher/cpo`'s `copy-image` is *not* `.IGNORE`, so it aborted the stage. Line 18 is `../appctl`, which therefore never ran, so appctl's vendored EOL image tars were never copied. My retry then skipped the whole stage because `registry/` existed. The resulting image had no `bitnami/postgresql:11.11.0-debian-10-r31` — a tag Bitnami has since deleted upstream, which is exactly why it is vendored — so `framework_create` hung for 45 minutes on `keycloak-postgresql-0` in ImagePullBackOff. The word "appctl" appears nowhere in that build log.
- **Why a stamp and not `.PHONY`.** `.PHONY: registry` would re-resolve every upstream manifest on every build: slower, and *more* exposed to the transient failures this fixes. The stamp keeps incrementality — verified both ways in the jail: stamp fresh → `Nothing to be done for 'registry'`; touch any image list → the four `copy-image` invocations queue again.
- **Overlap with #1347.** It adds `--retry-times 3` to the same two skopeo lines while keeping `.IGNORE`. Whichever merges second will hit a trivial textual conflict there; keep one copy of the retry flag and drop `.IGNORE`. The retries and the failing-loudly belong together — removing `.IGNORE` without retries would turn every upstream flake into a failed build.
- **Verification.** `hex_config` builds and links; the stamp behaviour is verified in the jail as above. #1348's fix is build-time, so it needs a fresh image — that reimage is the next run, and it also closes #1346 end to end. On the current cluster both were repaired by hand (staged tar loaded into all three node registries; `libvirt-python` still missing, so `InstanceHa` remains NG there).
