### PR TITLE
fix(license): import a license whose name has a space or extra dots

### DIFF
--- a/core/modules/cli_license.cpp
+++ b/core/modules/cli_license.cpp
@@ -16,10 +16,13 @@ LicenseCheckMain(int argc, const char** argv)
     if (argc > 1 /* [0]="check" */)
         return CLI_INVALID_ARGS;
 
+    // flush before spawning: the child writes straight to fd 1
     CliPrintf("\n====== CubeCOS ======\n");
+    fflush(stdout);
     HexSpawn(0, HEX_SDK, "license_cluster_check", NULL);
 
     CliPrintf("\n====== CubeCMP ======\n");
+    fflush(stdout);
     HexSpawn(0, HEX_SDK, "license_cluster_check", "cmp", NULL);
 
     return CLI_SUCCESS;
@@ -32,9 +35,11 @@ LicenseShowMain(int argc, const char** argv)
         return CLI_INVALID_ARGS;
 
     CliPrintf("\n====== CubeCOS ======\n");
+    fflush(stdout);
     HexSpawn(0, HEX_SDK, "license_cluster_show", NULL);
 
     CliPrintf("\n====== CubeCMP ======\n");
+    fflush(stdout);
     HexSpawn(0, HEX_SDK, "license_cluster_show", "cmp", NULL);
 
     return CLI_SUCCESS;

--- a/core/sdk_sh/modules.pre/sdk_license.sh
+++ b/core/sdk_sh/modules.pre/sdk_license.sh
@@ -12,6 +12,9 @@ LICENSE_SIG=$LICENSE_DIR/license.sig
 CMP_LICENSE_DAT=$LICENSE_DIR/license-cmp.dat
 CMP_LICENSE_SIG=$LICENSE_DIR/license-cmp.sig
 
+# space-free stem an imported license is normalized to
+LICENSE_STAGE=/var/support/license_import
+
 # license error codes
 LICENSE_BADSOURCE=2
 LICENSE_VALID=1
@@ -43,8 +46,8 @@ license_value_get()
     local key=$1
     local license=${2:-$LICENSE_DAT}
 
-    if [ -f $license ] ; then
-        cat $license | grep "$key" | awk -F'=' '{print $2}' | tr -d '\n'
+    if [ -f "$license" ] ; then
+        grep "$key" "$license" | awk -F'=' '{print $2}' | tr -d '\n'
     fi
 }
 
@@ -59,7 +62,7 @@ license_error_string()
     local days=$2
     local license=$3
     if [ $err -eq $LICENSE_VALID ] ; then
-        local type=$(license_value_get "license.type" $license)
+        local type=$(license_value_get "license.type" "$license")
         echo "License (type: $type) is valid for $days days"
     elif [ $err -eq $LICENSE_BADSYS ] ; then
         echo "License system is compromised"
@@ -88,23 +91,55 @@ license_check()
         if [ "x$app" = "xcmp" ] ; then
             license=$CMP_LICENSE_DAT
         fi
-        license_error_string $r $days $license
+        license_error_string $r $days "$license"
         printf "\n"
     fi
 
     return $r
 }
 
-license_import_check()
+# extract $dir/$name.license to $LICENSE_STAGE.dat/.sig, locating the members
+# by extension rather than by name
+license_import_stage()
 {
     local dir=$1
     local name=$2
+    local work=$LICENSE_STAGE.d
 
-    if [ -f $dir/$name.license ] ; then
-        unzip -o -q $dir/$name.license -d /var/support
+    [ -f "$dir/$name.license" ] || return $LICENSE_BADSOURCE
 
+    rm -rf "$work" && mkdir -p "$work" || return $LICENSE_BADSOURCE
+    unzip -o -q "$dir/$name.license" -d "$work" || return $LICENSE_BADSOURCE
+
+    local dat=
+    dat=$(find "$work" -maxdepth 1 -type f -name '*.dat' | head -1)
+    if [ -z "$dat" ] || [ ! -f "${dat%.dat}.sig" ] ; then
+        rm -rf "$work"
+        return $LICENSE_BADSOURCE
+    fi
+
+    cp -f "$dat" "$LICENSE_STAGE.dat" && cp -f "${dat%.dat}.sig" "$LICENSE_STAGE.sig"
+    local r=$?
+    rm -rf "$work"
+
+    [ $r -eq 0 ] || return $LICENSE_BADSOURCE
+    return 0
+}
+
+license_import_unstage()
+{
+    rm -rf "$LICENSE_STAGE.dat" "$LICENSE_STAGE.sig" "$LICENSE_STAGE.d" 2>/dev/null
+}
+
+# report current vs staged license. No arguments: it runs on peers too, and a
+# name must not cross an ssh/scp hop.
+license_staged_check()
+{
+    local new_ret=$LICENSE_BADSOURCE
+
+    if [ -f "$LICENSE_STAGE.dat" ] && [ -f "$LICENSE_STAGE.sig" ] ; then
         local app="def"
-        local product=$(license_value_get "product" /var/support/$name.dat)
+        local product=$(license_value_get "product" "$LICENSE_STAGE.dat")
         if [ "x$product" = "xCubeCMP" ] ; then
             app="cmp"
         else
@@ -121,20 +156,30 @@ license_import_check()
         local curr_ret=$?
 
         local new_days=
-        new_days=$($HEX_CFG license_check $app /var/support/$name)
-        local new_ret=$?
+        new_days=$($HEX_CFG license_check $app "$LICENSE_STAGE")
+        new_ret=$?
 
         printf "\nHostname: %s" "$HOSTNAME"
         printf "\nProduct: %s\n" "$product"
         printf "+%10s+%64s+\n" | tr " " "-"
-        printf "| %8s | %-62s |\n" "Current" "$(license_error_string $curr_ret $curr_days $license)"
-        printf "| %8s | %-62s |\n" "New" "$(license_error_string $new_ret $new_days /var/support/$name.dat)"
+        printf "| %8s | %-62s |\n" "Current" "$(license_error_string $curr_ret $curr_days "$license")"
+        printf "| %8s | %-62s |\n" "New" "$(license_error_string $new_ret $new_days "$LICENSE_STAGE.dat")"
         printf "+%10s+%64s+\n" | tr " " "-"
-
-        rm -f /var/support/$name.dat /var/support/$name.sig 2>/dev/null
     fi
 
     return $new_ret
+}
+
+license_import_check()
+{
+    local dir=$1
+    local name=$2
+
+    license_import_stage "$dir" "$name" || return $LICENSE_BADSOURCE
+    license_staged_check
+    local r=$?
+    license_import_unstage
+    return $r
 }
 
 license_show()
@@ -153,17 +198,17 @@ license_show()
     if [ "$FORMAT" == "json" ] ; then
         printf "{ \"hostname\": \"$HOSTNAME\", \"serial\": \"$serial\", \"check\": $r "
         if [ $r -eq $LICENSE_VALID -o $r -eq $LICENSE_BADHW -o $r -eq $LICENSE_EXPIRED ] ; then
-            local name=$(license_value_get "license.name" $license)
-            local type=$(license_value_get "license.type" $license)
-            local issueby=$(license_value_get "issue.by" $license)
-            local issueto=$(license_value_get "issue.to" $license)
-            local hardware=$(license_value_get "issue.hardware" $license)
-            local product=$(license_value_get "product" $license)
-            local feature=$(license_value_get "feature" $license)
-            local quantity=$(license_value_get "quantity" $license)
-            local supportplan=$(license_value_get "support.plan" $license)
-            local date=$(license_value_get "issue.date" $license)
-            local expiry=$(license_value_get "expiry.date" $license)
+            local name=$(license_value_get "license.name" "$license")
+            local type=$(license_value_get "license.type" "$license")
+            local issueby=$(license_value_get "issue.by" "$license")
+            local issueto=$(license_value_get "issue.to" "$license")
+            local hardware=$(license_value_get "issue.hardware" "$license")
+            local product=$(license_value_get "product" "$license")
+            local feature=$(license_value_get "feature" "$license")
+            local quantity=$(license_value_get "quantity" "$license")
+            local supportplan=$(license_value_get "support.plan" "$license")
+            local date=$(license_value_get "issue.date" "$license")
+            local expiry=$(license_value_get "expiry.date" "$license")
             printf ", \"name\": \"$name\", \"type\": \"$type\", \"issueby\": \"$issueby\", \"issueto\": \"$issueto\", \"hardware\": \"$hardware\", \"product\": \"$product\", \"feature\": \"$feature\", \"quantity\": \"$quantity\", \"supportplan\": \"$supportplan\", \"date\": \"$date\", \"expiry\": \"$expiry\" "
             if [ $r -eq $LICENSE_VALID ] ; then
                 printf ", \"days\": $days "
@@ -175,19 +220,23 @@ license_show()
         printf "serial: %s\n" "$serial"
         if [ $r -eq $LICENSE_VALID -o $r -eq $LICENSE_BADHW -o $r -eq $LICENSE_EXPIRED ] ; then
             printf "%64s\n" | tr " " "-"
-            cat $license
+            cat "$license"
             printf "%64s\n" | tr " " "-"
         fi
-        printf "state: %s\n" "$(license_error_string $r $days $license)"
+        printf "state: %s\n" "$(license_error_string $r $days "$license")"
     fi
 }
 
 license_import_list()
 {
     local dir=$1
+    local f=
 
-    cd $dir
-    ls -la *.license 2>/dev/null | awk '{print $9}' | awk -F'.' '{print $1}'
+    for f in "$dir"/*.license ; do
+        [ -f "$f" ] || continue
+        f=$(basename "$f")
+        printf "%s\n" "${f%.license}"
+    done
 }
 
 license_cluster_import_check()
@@ -195,21 +244,34 @@ license_cluster_import_check()
     local dir=$1
     local name=$2
     local ret=0
+
+    if ! license_import_stage "$dir" "$name" ; then
+        echo "license files .license is missing or malformed: $dir/$name.license"
+        return $LICENSE_BADSOURCE
+    fi
+
     readarray node_array <<<"$(cubectl node list -j | jq -r .[].hostname | sort)"
     declare -p node_array > /dev/null
     for node_entry in "${node_array[@]}" ; do
         local node=$(echo $node_entry | head -c -1)
-        scp $dir/$name.license root@$node:$dir/$name.license 2>/dev/null
 
         if [ "$node" == "$(hostname)" ] ; then
-            $HEX_SDK license_import_check $dir $name
+            $HEX_SDK license_staged_check
         else
-            host_remote_run $node $HEX_SDK license_import_check $dir $name
+            scp "$LICENSE_STAGE.dat" root@$node:$LICENSE_STAGE.dat 2>/dev/null
+            scp "$LICENSE_STAGE.sig" root@$node:$LICENSE_STAGE.sig 2>/dev/null
+            host_remote_run $node $HEX_SDK license_staged_check
         fi
         local r=$?
         if [ $r -le 255 -a $r -ge 245 ] ; then
             ret=-1
         fi
+    done
+
+    license_import_unstage
+    for node_entry in "${node_array[@]}" ; do
+        local node=$(echo $node_entry | head -c -1)
+        [ "$node" == "$(hostname)" ] || host_remote_run $node $HEX_SDK license_import_unstage
     done
 
     return $ret
@@ -268,12 +330,10 @@ license_cluster_import()
     local name=$2
     local ret=$LICENSE_VALID
 
-    if [ -f $dir/$name.license ] ; then
-        unzip -o -q $dir/$name.license -d /var/support
-
+    if license_import_stage "$dir" "$name" ; then
         local app="def"
         local suffix=
-        local product=$(license_value_get "product" /var/support/$name.dat)
+        local product=$(license_value_get "product" "$LICENSE_STAGE.dat")
         if [ "x$product" = "xCubeCMP" ] ; then
             app="cmp"
             suffix="-$app"
@@ -287,11 +347,11 @@ license_cluster_import()
             local node=$(echo $node_entry | head -c -1)
             if [ "$node" == "$(hostname)" ] ; then
                 mkdir -p $LICENSE_DIR
-                $HEX_CFG license_check $app /var/support/$name >/dev/null
+                $HEX_CFG license_check $app "$LICENSE_STAGE" >/dev/null
                 ret=$?
                 if [ $ret -eq $LICENSE_VALID ] ; then
-                    cp -f /var/support/$name.dat $LICENSE_DIR/license$suffix.dat 2>/dev/null
-                    cp -f /var/support/$name.sig $LICENSE_DIR/license$suffix.sig 2>/dev/null
+                    cp -f "$LICENSE_STAGE.dat" $LICENSE_DIR/license$suffix.dat 2>/dev/null
+                    cp -f "$LICENSE_STAGE.sig" $LICENSE_DIR/license$suffix.sig 2>/dev/null
                     echo "Imported $product license files for $node"
                     ret=0
                 else
@@ -299,13 +359,13 @@ license_cluster_import()
                 fi
             else
                 host_remote_run $node mkdir -p $LICENSE_DIR
-                scp /var/support/$name.dat root@$node:/var/support/$name.dat 2>/dev/null
-                scp /var/support/$name.sig root@$node:/var/support/$name.sig 2>/dev/null
-                host_remote_run $node $HEX_CFG license_check $app /var/support/$name >/dev/null
+                scp "$LICENSE_STAGE.dat" root@$node:$LICENSE_STAGE.dat 2>/dev/null
+                scp "$LICENSE_STAGE.sig" root@$node:$LICENSE_STAGE.sig 2>/dev/null
+                host_remote_run $node $HEX_CFG license_check $app $LICENSE_STAGE >/dev/null
                 ret=$?
                 if [ $ret -eq $LICENSE_VALID ] ; then
-                    scp /var/support/$name.dat root@$node:$LICENSE_DIR/license$suffix.dat 2>/dev/null
-                    scp /var/support/$name.sig root@$node:$LICENSE_DIR/license$suffix.sig 2>/dev/null
+                    scp "$LICENSE_STAGE.dat" root@$node:$LICENSE_DIR/license$suffix.dat 2>/dev/null
+                    scp "$LICENSE_STAGE.sig" root@$node:$LICENSE_DIR/license$suffix.sig 2>/dev/null
                     echo "Imported $product license files for $node"
                     ret=0
                 else
@@ -313,9 +373,14 @@ license_cluster_import()
                 fi
             fi
         done
-        rm -f /var/support/$name.dat /var/support/$name.sig 2>/dev/null
+
+        license_import_unstage
+        for node_entry in "${node_array[@]}" ; do
+            local node=$(echo $node_entry | head -c -1)
+            [ "$node" == "$(hostname)" ] || host_remote_run $node $HEX_SDK license_import_unstage
+        done
     else
-        echo "license files .license is missing"
+        echo "license files .license is missing or malformed: $dir/$name.license"
         ret=$LICENSE_BADSOURCE
     fi
     return $ret

--- a/core/sdk_sh/tests/test_license_import_name.sh
+++ b/core/sdk_sh/tests/test_license_import_name.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Unit test for license name handling in ../modules.pre/sdk_license.sh:
+#   license_import_list  -- enumerates *.license and derives each name
+#   license_import_stage -- extracts an archive to the fixed $LICENSE_STAGE stem
+#
+# A license name is free text from the portal ("NYCU ADFP3.0"), and it reaches
+# the SDK as a filename.  These assertions pin the two ways that used to break:
+# a space (word splitting) and a dot (truncation at the first '.').
+#
+# Self-contained: extracts just those functions, builds real zips, so it needs
+# no cluster.  Run: bash test_license_import_name.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules.pre/sdk_license.sh"
+eval "$(awk '/^license_import_list\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+eval "$(awk '/^license_import_stage\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+eval "$(awk '/^license_import_unstage\(\)/{f=1} f{print} f&&/^}/{exit}' "$SRC")"
+
+grep -q '^license_staged_check()' "$SRC" || { echo "FAIL: license_staged_check missing"; exit 1; }
+for f in license_import_list license_import_stage license_import_unstage ; do
+    [ "$(type -t $f)" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
+done
+command -v zip >/dev/null || { echo "SKIP: zip not installed"; exit 0; }
+
+LICENSE_BADSOURCE=2
+WORK=$(mktemp -d)
+LICENSE_STAGE=$WORK/stage/license_import
+mkdir -p "$WORK/stage" "$WORK/store"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0 fail=0
+ck(){ [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+
+# build a .license whose members are named after $1, as the portal generates them
+mklic(){
+    local name=$1 hw=${2:-J2RSMK2}
+    local d=$WORK/build; rm -rf "$d"; mkdir -p "$d"
+    printf 'license.name=%s\nlicense.type=enterprise\nissue.hardware=%s\nproduct=CubeCOS\n' "$name" "$hw" > "$d/$name.dat"
+    head -c 1024 /dev/zero | tr '\0' 'x' > "$d/$name.sig"
+    ( cd "$d" && zip -q "$WORK/store/$name.license" "$name.dat" "$name.sig" )
+    rm -rf "$d"
+}
+
+# ---- license_import_list: every name survives enumeration verbatim ----
+mklic 'cube42-lab'
+mklic 'NYCU ADFP3.0'
+mklic 'NYCU_ADFP3.0'
+got=$(license_import_list "$WORK/store" | LC_ALL=C sort | tr '\n' '|')
+ck "$got" 'NYCU ADFP3.0|NYCU_ADFP3.0|cube42-lab|' "list keeps spaces and dots"
+
+# ---- license_import_stage: the archive is found and normalized ----
+for name in 'cube42-lab' 'NYCU ADFP3.0' 'NYCU_ADFP3.0' 'a b.c d.0' ; do
+    [ -f "$WORK/store/$name.license" ] || mklic "$name"
+    license_import_unstage
+    license_import_stage "$WORK/store" "$name"
+    ck "$?" 0 "stage [$name]"
+    ck "$([ -f "$LICENSE_STAGE.dat" ] && echo y)" y "staged .dat for [$name]"
+    ck "$([ -f "$LICENSE_STAGE.sig" ] && echo y)" y "staged .sig for [$name]"
+    ck "$(grep -c "^license.name=$name$" "$LICENSE_STAGE.dat" 2>/dev/null)" 1 "staged .dat is the right license for [$name]"
+done
+
+# the stem the peers and hex_config see never carries the name
+ck "$(basename "$LICENSE_STAGE")" license_import "staged stem is name-independent"
+case "$LICENSE_STAGE" in *[[:space:]]*) ck space nospace "staged stem has no whitespace";; *) pass=$((pass+1));; esac
+
+# ---- members need not match the archive name (a renamed download) ----
+mklic 'orig-name'
+mv "$WORK/store/orig-name.license" "$WORK/store/renamed by user.license"
+license_import_unstage
+license_import_stage "$WORK/store" 'renamed by user'
+ck "$?" 0 "stage a renamed archive"
+ck "$(grep -c '^license.name=orig-name$' "$LICENSE_STAGE.dat" 2>/dev/null)" 1 "members located by extension, not by name"
+
+# ---- refusals ----
+license_import_unstage
+license_import_stage "$WORK/store" 'no such license'
+ck "$?" "$LICENSE_BADSOURCE" "absent archive -> LICENSE_BADSOURCE"
+
+: > "$WORK/store/empty.license"
+license_import_stage "$WORK/store" 'empty' 2>/dev/null
+ck "$?" "$LICENSE_BADSOURCE" "unreadable archive -> LICENSE_BADSOURCE"
+
+d=$WORK/build; mkdir -p "$d"; echo x > "$d/only.dat"
+( cd "$d" && zip -q "$WORK/store/sigless.license" only.dat ); rm -rf "$d"
+license_import_stage "$WORK/store" 'sigless'
+ck "$?" "$LICENSE_BADSOURCE" "archive without .sig -> LICENSE_BADSOURCE"
+
+# ---- unstage leaves nothing behind ----
+license_import_stage "$WORK/store" 'cube42-lab' >/dev/null
+license_import_unstage
+ck "$(ls "$WORK/stage" | wc -l)" 0 "unstage removes the staged pair"
+
+# the cluster paths must not interpolate $name into a remote path
+for fn in license_cluster_import_check license_cluster_import ; do
+    body=$(awk -v f="^$fn[(][)]$" '$0 ~ f{s=1} s{print} s&&/^}/{exit}' "$SRC")
+    ck "$(printf '%s' "$body" | grep -c 'root@\$node:.*\$name')" 0 "$fn: no \$name in a remote path"
+    ck "$(printf '%s' "$body" | grep -c 'printf .%q')" 0 "$fn: no shell-escaped remote path (scp is sftp-backed)"
+done
+ck "$(grep -c 'root@\$node:\$LICENSE_STAGE' "$SRC")" 4 "peers only ever receive the fixed stem"
+
+# whatever is copied to a peer must be removed from it again
+for fn in license_cluster_import_check license_cluster_import ; do
+    body=$(awk -v f="^$fn[(][)]$" '$0 ~ f{s=1} s{print} s&&/^}/{exit}' "$SRC")
+    ck "$(printf '%s' "$body" | grep -c 'host_remote_run $node $HEX_SDK license_import_unstage')" 1 "$fn: unstages peers"
+done
+
+echo "passed=$pass failed=$fail"
+[ $fail -eq 0 ]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

A license whose name contains a space cannot be imported — UI or CLI — and the failure blames the file: `license files .license is missing`. Reported by @ren.lai for `NYCU ADFP3.0`, which is why it reached us as "格式似乎有問題". The artifact was valid; the name was the only thing wrong with it.

The license name is free text from the portal that arrives as a filename, and `sdk_license.sh` used it as a shell token:

```sh
if [ -f $dir/$name.license ]      # [ -f /var/support/NYCU ADFP3.0.license ]
# bash: [: /var/support/NYCU: binary operator expected -> else -> "missing"

license_import_list() { ls -la *.license | awk '{print $9}' | awk -F'.' '{print $1}'; }
# "NYCU ADFP3.0.license" -> NYCU        (awk $9 stops at the space)
# "NYCU_ADFP3.0.license" -> NYCU_ADFP3  (-F'.' truncates at the first dot)
```

A space breaks both paths; a dot breaks the CLI alone, since the API derives the name with Go's `TrimSuffix(Base, Ext)`.

This PR:

- enumerates with a glob and `${f%.license}`, so spaces and dots survive
- quotes every path expansion
- normalizes a staged license to the fixed, space-free stem `/var/support/license_import.{dat,sig}` **before** `license_check` or any `scp`/`ssh` hop. This is the part that matters beyond quoting: `scp` remote paths and `host_remote_run` are re-parsed by the *remote* shell, so local quoting alone would not have been sufficient. No license name crosses a node boundary now.
- locates the archive members by extension rather than by name, so an archive the user renamed also imports — that is exactly the workaround support hands out, and it should not then fail
- returns `LICENSE_BADSOURCE` from `license_import_check` instead of an unset `$new_ret`, and says "missing or malformed: <path>" instead of claiming a file that exists is absent

Also folded in, found while verifying the above on a live cluster: `license check`/`show` print `====== CubeCOS ======` / `====== CubeCMP ======` with `CliPrintf` and then spawn a child that writes straight to fd 1. On a pipe the buffered headers flush last, so both product blocks appear unlabelled and CubeCMP's ordinary `License files are not installed` reads as a CubeCOS failure:

```
hostname: cc1
License files are not installed     <- actually CubeCMP, no header in sight

====== CubeCOS ======

====== CubeCMP ======
```

`fflush(stdout)` before each spawn.

#### Which issue(s) this PR fixes

Fixes #1351

#### Special notes for your reviewer

- New unit test `core/sdk_sh/tests/test_license_import_name.sh` — 25 assertions over `license_import_list` / `license_import_stage`: spaces, multiple dots, `a b.c d.0`, a renamed archive, absent/unreadable/`.sig`-less archives, and that the staged stem is name-independent. Builds real zips, needs no cluster. Mutation-checked: it fails against the pre-fix module, and the old derivation yields `NYCU` / `NYCU_ADFP3` on the same fixtures.
- The portal half — a CRM field becoming a filename at all — is bigstack-oss/cube-license-portal#5. Its slug deliberately strips dots as well as spaces so a newly issued license still imports on **unpatched** clusters running the old `awk -F'.'` menu.
- Verified against the real customer artifact (`NYCU ADFP3.0.license`, byte-identical to the portal's stored payload), not a synthetic one.
- Not yet re-run on a cluster end to end: the fix is in `hex_sdk` shell modules plus one CLI binary, so it needs a `pxedeploy` or a hot-swap to validate on hardware. Lab validation of QA rows 2–8 is owed before this leaves review.


#### Lab validation (cube42, 3 × control-converged, 2026-08-26)

Hot-swapped `sdk_license.sh` onto cc1/cc2/cc3 (deployed md5 matched `origin/develop` exactly, so no version drift) and ran the rebuilt `hex_cli` side-by-side with the installed one. Backups kept as `sdk_license.sh.pre-name-fix` on each node.

| # | Result |
|---|---|
| 1 | `passed=32 failed=0` |
| 2 | UI import of `qa space 3.0.license` from an unlicensed cluster → succeeded; banner cleared; `license.name` present on all three nodes |
| 3 | menu (`license_import_list`) lists `cube42-lab`, `qa space 3.0`, `renamed by user` verbatim; `hex_cli … import local "qa space 3.0"` resolved the spaced name and ran the check on all three nodes; `license_cluster_import` → `Imported CubeCOS license files for cc1/cc2/cc3`, exit 0 |
| 4 | `license show` → all three nodes valid for 36 days |
| 5 | `renamed by user.license` (members still `cube42-lab.*`) imported on all three nodes |
| 6 | `license_cluster_import /var/support 'no such file'` → `license files .license is missing or malformed: /var/support/no such file.license`, exit 2 |
| 7 | installed binary piped → output starts with `hostname: cc1`; rebuilt binary → starts with `====== CubeCOS ======` |
| 8 | `cluster check` → 27 groups `ok`, incl. `ClusterSys ok [ bootstrap(v) license(v) ]` |

Two defects in the first version of this fix were found by that run and are folded in:

1. **`scp` remote-path escaping was wrong.** I quoted the peer path with `printf %q`, but OpenSSH ≥ 9 `scp` is SFTP-backed and does **not** shell-expand the remote path, so the peer received a file literally named `qa\ space\ 3.0.license` and every non-local node failed `BADSOURCE` — the cluster check printed only cc1. Fixed by removing name-dependent remote paths entirely: `license_cluster_import_check` now stages locally once and ships only the fixed stem, and the per-node half (`license_staged_check`) takes **no arguments**, so no license name crosses an ssh/scp hop at all. `host_remote_run_q` is gone with it.
2. **Staged material was left on peers.** `license_cluster_import` unstaged only locally, leaving `license_import.{dat,sig}` in `/var/support` on cc2/cc3. Both cluster functions now unstage peers too.

Both are pinned by new assertions (no `$name` in a remote path, no `printf %q` remote path, peers receive only the fixed stem, both cluster functions unstage peers) — mutation-checked: reintroducing the bad `scp` line fails 3 of them.

Row 3's final interactive confirmation (`Enter 'YES'`) is tty-gated and I could not drive it headlessly — piped stdin cancels, and a `script` pty hung. That prompt is untouched by this PR, and the import it guards is proven three other ways (direct `hex_sdk` on all nodes, the UI path, and the CLI up to the prompt with correct name resolution). Flagging rather than claiming it.

cube42 is left with the patched module and its real license active.

#### Additional documentation

```docs
bigstack-handbook#398 — kb/cubecos/known-issues/license-name-is-a-shell-token.{md,scenario.yaml}
```

