### PR TITLE
fix(build): install sdk_advisor.sh into the image

### DIFF
--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -24,6 +24,7 @@ hex_shell_MODULES += $(HEX_SHMODDIR)/sdk_preset.sh
 hex_shell_MODULES += $(HEX_SHMODDIR)/sdk_util.sh
 hex_shell_MODULES += $(HEX_SHMODDIR)/sdk_tuning.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/errcodes
+hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_advisor.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_alert.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_api.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_app.sh


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`core/main/cube.mk` registered the advisor CLI (`cli_advisor.o`) and its hex_config verifier (`config_advisor.o`) but never added `sdk_advisor.sh` to `hex_shell_MODULES`. Only listed modules get copied into `/usr/lib/hex_sdk/modules`, so the shell half — `advisor_enroll`, `advisor_verify_release`, `advisor_install_release` and their helpers — never shipped.

Every built image therefore had `hex_cli -c advisor -c enroll` as a mode that prompts for the service URL, version and pairing token, then spawns a hex_sdk function that does not exist: hex_sdk prints its function list and the CLI reports "Enrolment did not complete." One line, inserted in alphabetical order with the other modules.

#### Which issue(s) this PR fixes

Fixes #1354

#### Special notes for your reviewer

> Note

Found while verifying cluster enrollment end to end against a live Advisor SaaS on the sky lab, on `CUBE_3.1.20_20260825-1849_b0162f9`. With the module copied onto the nodes by hand, the whole documented chain worked on the first try: the signed release was fetched, verified against the key compiled into hex_config, and installed; an identity was issued (`enroll: issued identity for sky141`); the agent connected the tunnel; and a `cluster_check` tool call executed on the node over it. So this really is the only thing standing between the shipped CLI and a working enrolment.

Worth noting for review: nothing in CI can catch this class of bug, because the module is only exercised on a real image — the C++ side compiles and links either way.

#### Additional documentation

```docs

```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5EppnHrpbAYHCxPjN7t64