### PR TITLE
fix(keystone): reload httpd after installing the mellon config

### DIFF
--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1122,6 +1122,15 @@ os_keystone_idp_config()
     mv $fed_dir/https_${shared_id}_5443_v3_mellon_metadata.xml $fed_dir/v3.xml
     cat $fed_dir/v3.xml | xmllint --format - > /etc/keycloak/keystone_sp_metadata.xml
     cp -f /etc/httpd/conf.d/v3_mellon_keycloak_master.conf.def /etc/httpd/conf.d/v3_mellon_keycloak_master.conf
+
+    # keystone_idp commits after the apache2/keystone modules have already started httpd,
+    # so the mellon config above is only on disk -- reload to put it in the running server.
+    # Without this, /v3/auth/OS-FEDERATION/websso/mapped bypasses mellon and keystone
+    # answers 401 until the next unrelated httpd restart.
+    if systemctl is-active --quiet httpd ; then
+        systemctl reload httpd
+    fi
+
     Quiet -n $TERRAFORM_CUBE apply \
           -auto-approve -target=module.keycloak_keystone \
           -var "cube_controller=${shared_id}" \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Skyline SSO is dead from first boot — `/v3/auth/OS-FEDERATION/websso/mapped` returns
`401` instead of redirecting to Keycloak.

`os_keystone_idp_config` installs `/etc/httpd/conf.d/v3_mellon_keycloak_master.conf` and
stops; it never tells httpd about the file it wrote. Both httpd starts in the product
(`keystone` and `apache2` modules) are ordered ahead of `keystone_idp`, so the mellon
`<Location>` blocks are correct on disk and absent from the running server — the request
falls through the `ProxyPass` to keystone, which has no session and answers 401. Nothing
heals it later: after first boot neither module is modified, so `SystemdCommitService`
never runs again.

Fixed by reloading httpd from the function that writes the config, so it fires exactly
when the config changes.

Full root cause and evidence in #1357.

#### Which issue(s) this PR fixes

Fixes #1357

#### Special notes for your reviewer

> **Why not just uncomment `CONFIG_REQUIRES(apache2, keystone_idp)`** (`config_apache2.cpp:305`)?
> It fixes the ordering but not the class of bug — the reload would still be owned by
> another module and gated on `apache2` being modified, which on sky141 it wasn't. Happy
> to land that line too as separate hardening.

> **Why `reload`, not `restart`?** The change only adds `<Location>` blocks.
> `config_apache2.cpp:284` already reloads for logrotate; verified sufficient
> (`ExecMainStartTimestamp` unchanged across a successful test).

> **Testing** on the sky 3-node HA lab (3.1.0 `develop`): recreated the broken state on
> sky143, ran the patched `os_keystone_idp_config` → `401 → 303` and
> `/v3/mellon/metadata` `404 → 200` with no manual restart. End to end through the VIP now
> reaches the Keycloak login page with a signed `SAMLRequest`. `cluster check` all `ok`
> apart from a pre-existing, unrelated `InstanceHa NG`.
>
> Not yet exercised on a from-scratch install — QA steps 1–5 in #1357 cover that.

#### Additional documentation

```docs

```
