### PR TITLE
fix(advisor): enrol as the cluster, from a control node only

### DIFF
--- a/core/sdk_sh/modules/sdk_advisor.sh
+++ b/core/sdk_sh/modules/sdk_advisor.sh
@@ -137,6 +137,27 @@ advisor_enroll()
         echo "Error: cannot read the pairing token file: $token_file" >&2
         return 1
     fi
+
+    # Enrolment is a cluster-level act, and the agent's tools are the control
+    # plane's: cluster check, the CLI, the cube-cos-api reads. A compute or
+    # storage node can neither answer those nor speak for the cluster, so it
+    # must not hold the cluster's identity.
+    if ! is_control_node ; then
+        echo "Error: enrol from a control node; this node's role is ${T_cubesys_role:-unknown}" >&2
+        return 1
+    fi
+
+    # The cluster's identity, not this node's. cubesys.controller is the
+    # operator-chosen controller name: the VIP's name on an HA cluster and the
+    # single node's name otherwise, and identical on every node of the cluster
+    # -- so enrolling from any control node yields the same identity, where the
+    # agent's own default (the hostname) would mint one identity per node.
+    local cluster
+    cluster=$(source /usr/sbin/hex_tuning /etc/settings.txt 2>/dev/null ; echo "$T_cubesys_controller")
+    if [ -z "$cluster" ] ; then
+        echo "Error: cubesys.controller is not set; cannot tell which cluster this node belongs to" >&2
+        return 1
+    fi
     arch=$(advisor_agent_arch) || return 1
     artifact="cube-advisor-agent_linux_$arch"
 
@@ -162,7 +183,7 @@ advisor_enroll()
     advisor_install_release "$tmp" "$artifact" /usr/local/bin/cube-advisor-agent || return 1
 
     /usr/local/bin/cube-advisor-agent enroll \
-        -server "$server" -token-file "$token_file"
+        -server "$server" -token-file "$token_file" -cluster "$cluster"
     rc=$?
     case $rc in
         0) ;;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`advisor_enroll` never passed `-cluster`, so the agent used its own default — the node hostname. Two consequences, both seen on a real cluster:

- A pairing token issued for the cluster is refused: `the request does not match the cluster this token was issued for`. The operator's only way through was to create an Advisor record named after a node, so the fleet lists a *node* as a cluster.
- Run it from two control nodes and you get two identities for one cluster. The SaaS keeps one live identity per cluster (`cluster_identities_one_live`) and re-enrolment revokes the previous one, so the second node silently breaks the first.

This passes `cubesys.controller` as the cluster id instead. It is the operator-chosen controller name — the VIP's name on an HA cluster, the single node's name otherwise — written for every control-requiring role, so it is identical on every node of the cluster. Verified on the 3-node sky lab: sky141, sky142 and sky143 all derive `sky140`.

It also refuses to enrol from a non-control role. Enrolment is a cluster-level act and the agent's tools are the control plane's (`cluster check`, the CLI, the cube-cos-api reads), so a compute or storage node can neither answer them nor speak for the cluster. `advisor status` and `advisor verify` stay available everywhere, since both are useful on any node.

#### Which issue(s) this PR fixes

Fixes #1356

#### Special notes for your reviewer

> Note

Both guards were exercised against the live 3.1.20 lab before committing: `hex_sdk is_control_node` returns true on `control-converged`, and the `cubesys.controller` derivation returns `sky140` identically from all three nodes.

`is_control_node` lives in `modules.pre`, so it is already loaded by the time `sdk_advisor.sh` runs — no ordering change needed.

Worth a reviewer's opinion on one thing I left alone: the `enroll` command is still *offered* on non-control nodes and refuses when run. Hiding it via the CLI mode predicate would be tidier, but the predicate covers the whole `advisor` mode, and `status`/`verify` should stay everywhere.

Related, not fixed here: nothing starts `cube-advisor-agent run`, so an enrolled cluster never connects until someone runs it by hand (bigstack-oss/cube-advisor-agent#19).

#### Additional documentation

```docs

```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5EppnHrpbAYHCxPjN7t64