### PR TITLE
fix(keystone): grant role:service to every service user

### DIFF
--- a/core/modules/config_barbican.cpp
+++ b/core/modules/config_barbican.cpp
@@ -135,6 +135,7 @@ SetupBarbican(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s barbican",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user barbican admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user barbican service", env.c_str(), OPENSTACK_CLI);
 
     // Create a creator role
     HexUtilSystemF(0, 0, "%s %s role create creator", env.c_str(), OPENSTACK_CLI);

--- a/core/modules/config_cyborg.cpp
+++ b/core/modules/config_cyborg.cpp
@@ -136,6 +136,7 @@ SetupService(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s cyborg",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user cyborg admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user cyborg service", env.c_str(), OPENSTACK_CLI);
 
     HexUtilSystemF(0, 0, "%s %s service create --name cyborg "
                          "--description \"Acceleration Service\" accelerator",

--- a/core/modules/config_designate.cpp
+++ b/core/modules/config_designate.cpp
@@ -259,6 +259,7 @@ SetupService(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s designate",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user designate admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user designate service", env.c_str(), OPENSTACK_CLI);
 
     HexUtilSystemF(0, 0, "%s %s service create --name designate "
                          "--description \"Openstack DNS Service\" dns",

--- a/core/modules/config_glance.cpp
+++ b/core/modules/config_glance.cpp
@@ -597,6 +597,12 @@ SetupService(const std::string domain, const std::string userPass)
         "%s %s role add --project service --user glance admin",
         env.c_str(),
         OPENSTACK_CLI);
+    HexUtilSystemF(
+        0,
+        0,
+        "%s %s role add --project service --user glance service",
+        env.c_str(),
+        OPENSTACK_CLI);
 
     // create the service entity
     HexUtilSystemF(

--- a/core/modules/config_heat.cpp
+++ b/core/modules/config_heat.cpp
@@ -135,6 +135,7 @@ SetupHeat(std::string domain, std::string userPass, std::string adminPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s heat",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user heat admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user heat service", env.c_str(), OPENSTACK_CLI);
 
     // Create the service entity
     HexUtilSystemF(0, 0, "%s %s service create --name heat "

--- a/core/modules/config_ironic.cpp
+++ b/core/modules/config_ironic.cpp
@@ -252,6 +252,7 @@ SetupIronic(std::string domain, std::string ironicPass, std::string inspPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s ironic",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), ironicPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user ironic admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user ironic service", env.c_str(), OPENSTACK_CLI);
 
     // Create the ironic service entity
     HexUtilSystemF(0, 0, "%s %s service create --name ironic "
@@ -262,6 +263,7 @@ SetupIronic(std::string domain, std::string ironicPass, std::string inspPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s ironic-inspector",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), inspPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user ironic-inspector admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user ironic-inspector service", env.c_str(), OPENSTACK_CLI);
 
     // Create the ironic-inspector service entity
     HexUtilSystemF(0, 0, "%s %s service create --name ironic-inspector "

--- a/core/modules/config_keystone.cpp
+++ b/core/modules/config_keystone.cpp
@@ -529,6 +529,7 @@ Commit(bool modified, int dryLevel)
 
     // check for setup migration
     HexUtilSystemF(0, 0, HEX_SDK " migrate_keystone");
+    HexUtilSystemF(0, 0, HEX_SDK " migrate_keystone_service_role");
 
     // 6. create endpoint
     if (s_bEndpointChanged) {

--- a/core/modules/config_masakari.cpp
+++ b/core/modules/config_masakari.cpp
@@ -159,6 +159,7 @@ SetupMasakari(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s masakari",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user masakari admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user masakari service", env.c_str(), OPENSTACK_CLI);
 
     // Create the service entity
     HexUtilSystemF(0, 0, "%s %s service create --name masakari "

--- a/core/modules/config_monasca.cpp
+++ b/core/modules/config_monasca.cpp
@@ -272,6 +272,7 @@ SetupMonasca(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s monasca",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user monasca admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user monasca service", env.c_str(), OPENSTACK_CLI);
 
     // Create the service entity
     HexUtilSystemF(0, 0, "%s %s service create --name monasca-api "

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -338,6 +338,7 @@ SetupNeutron(std::string domain, std::string password)
     // Create the neutron service credentials
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s neutron", env.c_str(), OPENSTACK_CLI, domain.c_str(), password.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user neutron admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user neutron service", env.c_str(), OPENSTACK_CLI);
 
     // Create the service entity
     HexUtilSystemF(0, 0, "%s %s service create --name %s "

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -272,6 +272,7 @@ SetupNova(std::string domain, std::string novaPass, std::string placePass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s placement",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), placePass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user placement admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user placement service", env.c_str(), OPENSTACK_CLI);
 
     // Create the service entity
     HexUtilSystemF(0, 0, "%s %s service create --name nova "

--- a/core/modules/config_octavia.cpp
+++ b/core/modules/config_octavia.cpp
@@ -169,6 +169,7 @@ SetupService(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s octavia",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user octavia admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user octavia service", env.c_str(), OPENSTACK_CLI);
 
     HexUtilSystemF(0, 0, "%s %s service create --name octavia "
                          "--description \"Openstack Load Balance Service\" load-balancer",

--- a/core/modules/config_skyline.cpp
+++ b/core/modules/config_skyline.cpp
@@ -106,6 +106,7 @@ SetupService(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s skyline",
         env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user skyline admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user skyline service", env.c_str(), OPENSTACK_CLI);
 
     return true;
 }

--- a/core/modules/config_watcher.cpp
+++ b/core/modules/config_watcher.cpp
@@ -134,6 +134,7 @@ SetupService(std::string domain, std::string userPass)
     HexUtilSystemF(0, 0, "%s %s user create --domain %s --password %s watcher",
                          env.c_str(), OPENSTACK_CLI, domain.c_str(), userPass.c_str());
     HexUtilSystemF(0, 0, "%s %s role add --project service --user watcher admin", env.c_str(), OPENSTACK_CLI);
+    HexUtilSystemF(0, 0, "%s %s role add --project service --user watcher service", env.c_str(), OPENSTACK_CLI);
 
     HexUtilSystemF(0, 0, "%s %s service create --name watcher "
                          "--description \"Infrastructure Optimization\" infra-optim",

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -97,6 +97,29 @@ migrate_keystone()
     touch $STATE_DIR/keystone_migrated
 }
 
+# Caracal secure-RBAC: service-to-service APIs check role:service with no admin
+# fallback, but only cinder/nova ever got it. Own marker: keystone_migrated
+# short-circuits on clusters that already ran the v2.4 step.
+migrate_keystone_service_role()
+{
+    if [ -f $STATE_DIR/keystone_service_role_migrated ] ; then
+        return 0
+    fi
+
+    is_control_node || return 0
+
+    $OPENSTACK role show service >/dev/null 2>&1 || $OPENSTACK role create service
+
+    local u
+    for u in barbican cinder cyborg designate glance heat ironic ironic-inspector \
+             masakari monasca neutron nova octavia placement skyline watcher ; do
+        $OPENSTACK user show $u >/dev/null 2>&1 || continue
+        $OPENSTACK role add --project service --user $u service >/dev/null 2>&1
+    done
+
+    touch $STATE_DIR/keystone_service_role_migrated
+}
+
 migrate_barbican_db()
 {
     if [ -f $STATE_DIR/barbican_db_migrated ] ; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Caracal's secure-RBAC defaults gate service-to-service APIs on `role:service` with no `admin`
fallback, but CubeCOS only grants it to cinder and nova. nova talks to neutron as the **neutron**
user, so `create_port_binding` / `update_port:binding:profile` are refused and **every live
migration fails cluster-wide** — stock instances included, which also takes out live-resize
auto-migrate, rolling upgrades and host drain.

Two halves:

- **Fresh installs** — grant `service` alongside the existing `admin` grant for the remaining 14
  service users (barbican, cyborg, designate, glance, heat, ironic, ironic-inspector, masakari,
  monasca, neutron, octavia, placement, skyline, watcher).
- **Existing clusters** — new `migrate_keystone_service_role` with its **own** marker.
  `migrate_keystone` short-circuits on `keystone_migrated`, and its v2.4 block that created the
  role is itself guarded by `if ! role show service`, so neither can ever hand the role out again.

#### Which issue(s) this PR fixes

Fixes #1360

#### Special notes for your reviewer

The migration is idempotent and additive — it only ever adds a role, skips users that do not
exist, and writes `/etc/appliance/state/keystone_service_role_migrated` when done.

Validated on sky 3cc (`CUBE_3.1.20_20260825-1849_b0162f9`): before the run the 14 users had
`admin` only; after, all hold `admin` + `service` (barbican keeps `creator`); re-run is a no-op
via the marker. With the role in place a stock instance live-migrated cleanly for the first time
on this image.

**Upstream references**, at the exact version we ship — the line numbers match the deployed file
byte-for-byte, so this is unmodified upstream neutron 24.2.2 rather than anything we did:

- [`port_bindings.py`](https://opendev.org/openstack/neutron/src/tag/24.2.2/neutron/conf/policies/port_bindings.py) — `create_port_binding` at lines 36-38, `check_str=base.SERVICE`
- [`base.py`](https://opendev.org/openstack/neutron/src/tag/24.2.2/neutron/conf/policies/base.py) — `SERVICE = 'rule:service_api'` at line 18 -> `role:service` at lines 97-99
- [neutron 2024.1 policy reference](https://docs.openstack.org/neutron/2024.1/configuration/policy.html) · [keystone service API protection](https://docs.openstack.org/keystone/2024.1/admin/service-api-protection.html)

The decisive detail is an **absence**: that rule has no `deprecated_rule`, so unlike most of
neutron's secure-RBAC migration there is no `admin` fallback. An operator token with `admin`
cannot satisfy it however privileged it is — which is why this fails on a cluster where everything
else works.

#### Additional documentation

```docs
kb/cubecos/known-issues/ — caracal secure-RBAC service-role gap (+ scenario sidecar)
```
