### PR TITLE
fix(nova): reject vCPU live-resize on a guest that has live-migrated

### DIFF
--- a/core/nova/caracal_patch/compute/api.py.patch
+++ b/core/nova/caracal_patch/compute/api.py.patch
@@ -1,6 +1,6 @@
 --- compute/api.py
 +++ compute/api.py
-@@ -49,6 +49,7 @@ from nova.compute import utils as comput
+@@ -49,6 +49,7 @@
  from nova.compute.utils import wrap_instance_event
  from nova.compute import vm_states
  from nova import conductor
@@ -8,7 +8,7 @@
  import nova.conf
  from nova import context as nova_context
  from nova import crypto
-@@ -761,7 +762,8 @@ class API:
+@@ -761,7 +762,8 @@
  
          # Target disk is a volume. Don't check flavor disk size because it
          # doesn't make sense, and check min_disk against the volume size.
@@ -18,7 +18,7 @@
              # There are 2 possibilities here:
              #
              # 1. The target volume already exists but bdm.volume_size is not
-@@ -4160,9 +4162,55 @@ class API:
+@@ -4160,9 +4162,62 @@
  
      # TODO(stephenfin): This logic would be so much easier to grok if we
      # finally split resize and cold migration into separate code paths
@@ -48,6 +48,13 @@
 +        if new.memory_mb > old.memory_mb and new.memory_mb > max_mem:
 +            _bad(_("target memory exceeds this instance's hotplug "
 +                   "ceiling (%d MB)") % max_mem)
++        # a guest that has live-migrated cannot online hot-added vCPUs
++        # until it reboots (#1269); memory hotplug is unaffected
++        if (new.vcpus > old.vcpus and
++                instance.system_metadata.get(clr.SYSMETA_MIGRATED)):
++            _bad(_("this instance has been live-migrated since it last "
++                   "booted; its guest cannot online hot-added vCPUs until "
++                   "it is hard-rebooted (memory-only grows still work)"))
 +
 +    @check_instance_lock
 +    @check_instance_state(vm_state=[vm_states.ACTIVE], task_state=[None])

--- a/core/nova/caracal_patch/compute/manager.py.patch
+++ b/core/nova/caracal_patch/compute/manager.py.patch
@@ -1,6 +1,6 @@
 --- compute/manager.py
 +++ compute/manager.py
-@@ -69,6 +69,7 @@ from nova.compute import utils as comput
+@@ -69,6 +69,7 @@
  from nova.compute.utils import wrap_instance_event
  from nova.compute import vm_states
  from nova import conductor
@@ -8,7 +8,7 @@
  import nova.conf
  import nova.context
  from nova import exception
-@@ -1299,6 +1300,17 @@ class ComputeManager(manager.Manager):
+@@ -1299,6 +1300,17 @@
              # host. Abort ongoing migration if still running and reset state.
              self._reset_live_migration(context, instance)
  
@@ -26,7 +26,17 @@
          db_state = instance.power_state
          drv_state = self._get_power_state(instance)
          expect_running = (db_state == power_state.RUNNING and
-@@ -9058,6 +9070,73 @@ class ComputeManager(manager.Manager):
+@@ -4275,6 +4287,9 @@
+         else:
+             instance.task_state = task_states.REBOOT_PENDING_HARD
+             expected_states = task_states.hard_reboot_states
++            # cube live-resize: a hard reboot rebuilds the domain from fresh
++            # XML, so vCPU hotplug works again (#1269)
++            instance.system_metadata.pop(clr.SYSMETA_MIGRATED, None)
+ 
+         context = context.elevated()
+         LOG.info("Rebooting instance", instance=instance)
+@@ -9058,6 +9073,73 @@
                  self._set_instance_obj_error_state(instance,
                                                     clean_task_state=True)
  
@@ -100,3 +110,13 @@
      @wrap_exception()
      @wrap_instance_event(prefix='compute')
      @errors_out_migration
+@@ -9613,6 +9695,9 @@
+                 instance.node = node_name
+                 instance.compute_id = compute_node and compute_node.id or None
+                 instance.progress = 0
++                # cube live-resize: the guest can no longer online hot-added
++                # vCPUs until it reboots (#1269)
++                instance.system_metadata[clr.SYSMETA_MIGRATED] = '1'
+                 instance.save(expected_task_state=task_states.MIGRATING)
+ 
+         # NOTE(tr3buchet): tear down networks on source host (nova-net)

--- a/core/nova/caracal_patch/cube_live_resize.py
+++ b/core/nova/caracal_patch/cube_live_resize.py
@@ -55,6 +55,10 @@ def headroom(flavor):
 # while a live resize is migrating the instance to a host that fits
 SYSMETA_FLAVOR_ID = "cube_live_resize_flavor_id"
 
+# set once the instance has been live-migrated since its last boot: the guest
+# kernel can no longer online hot-added vCPUs (EIO) until it reboots (#1269)
+SYSMETA_MIGRATED = "cube_live_resize_migrated"
+
 
 def set_allocations(reportclient, context, consumer_uuid, flavor,
                     vcpus=None, memory_mb=None):


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

A live-migrated guest cannot online hot-added vCPUs until it reboots (`present` grows, writing
`online` returns EIO). nova still reported success and swapped the flavor, so the instance was
billed and scheduled for vCPUs the guest never got.

The #1269 CPU-first ordering only covers an instance's **first** migration — it grows the vCPU
half on the source before migrating, which does nothing for a guest that had already migrated
earlier in its life. Confirmed on-cluster: the source-side grow fires exactly as designed
(`live-resize applied: 8->16 vCPU`, migration 3.1 s later) and the guest still ends at 8 of 16.

Track the condition in `system_metadata` (`cube_live_resize_migrated`, set at
`post_live_migration_at_destination`, cleared on hard reboot) and reject the vCPU half at the API
with an actionable message. Memory-only grows are unaffected.

#### Which issue(s) this PR fixes

Fixes #1361

#### Special notes for your reviewer

The judgement call is **reject rather than partially deliver**. Growing memory while silently
dropping the CPU half would keep the billing/capacity lie; a 400 tells the operator that a hard
reboot is the price of more vCPUs, matching the contract the UI tip already states for
pre-feature instances. Happy to switch to "grow memory, report CPU skipped" if you'd rather.

This contains the symptom, it does not fix the underlying qemu/guest-kernel behaviour.

Validated on sky 3cc, hot-deployed to all three nodes:

| case | result |
|---|---|
| never-migrated, CPU grow 6 → 8 | 202, guest onlines `0-7` |
| migrate | flag set, online CPUs survive |
| migrated, CPU grow 8 → 12 | **400** with the new message |
| migrated, memory-only 4 → 8 GB | 202, `MemTotal` 8 GB, `nproc` unchanged |
| hard reboot, then CPU grow | 202, guest onlines |

#### Additional documentation

```docs
kb/cubecos/known-issues/ — vCPU hotplug after live migration (+ scenario sidecar)
```
