### PR TITLE
feat(nova): make nested virt (vmx/svm) opt-in via tuning

### DIFF
--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -132,6 +132,7 @@ CONFIG_TUNING_STR(NOVA_OC_CPU_RATIO, "nova.overcommit.cpu.ratio", TUNING_PUB, "S
 CONFIG_TUNING_STR(NOVA_OC_RAM_RATIO, "nova.overcommit.ram.ratio", TUNING_PUB, "Specifiy an allowed RAM overcommitted ratio.", "1.0", ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(NOVA_OC_DISK_RATIO, "nova.overcommit.disk.ratio", TUNING_PUB, "Specifiy an allowed DISK overcommitted ratio.", "1.5", ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(NOVA_HW_TYPE, "nova.hardware.type", TUNING_PUB, "Set default hardware type for hypervisor.", "q35", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_BOOL(NOVA_NESTED_VIRT, "nova.nested.virt.enabled", TUNING_PUB, "Set to true to expose hardware virtualization (vmx/svm) to instances, enabling nested virtualization.", false);
 CONFIG_TUNING_BOOL(NOVA_LR_ENABLED, "nova.live.resize.enabled", TUNING_PUB, "Set to false to boot new instances without live-resize hotplug headroom.", true);
 CONFIG_TUNING_UINT(NOVA_LR_FACTOR, "nova.live.resize.factor", TUNING_PUB, "Default live-resize ceiling as a multiple of the flavor size.", 4, 1, 64);
 CONFIG_TUNING_UINT(NOVA_LR_MAX_VCPUS, "nova.live.resize.max.vcpus", TUNING_PUB, "Absolute cap on the default vCPU live-resize ceiling.", 32, 1, 1024);
@@ -167,6 +168,7 @@ PARSE_TUNING_STR(s_ocCpuRatio, NOVA_OC_CPU_RATIO);
 PARSE_TUNING_STR(s_ocRamRatio, NOVA_OC_RAM_RATIO);
 PARSE_TUNING_STR(s_ocDiskRatio, NOVA_OC_DISK_RATIO);
 PARSE_TUNING_STR(s_hwType, NOVA_HW_TYPE);
+PARSE_TUNING_BOOL(s_nestedVirt, NOVA_NESTED_VIRT);
 PARSE_TUNING_BOOL(s_lrEnabled, NOVA_LR_ENABLED);
 PARSE_TUNING_UINT(s_lrFactor, NOVA_LR_FACTOR);
 PARSE_TUNING_UINT(s_lrMaxVcpus, NOVA_LR_MAX_VCPUS);
@@ -569,9 +571,14 @@ UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::s
         // source of truth for migration parallelism. 3 overlaps migrations on a
         // fast fabric; on a saturated link nova still serializes within the cap.
         cfg["DEFAULT"]["max_concurrent_live_migrations"] = "3";
+        // Instances get vmx/svm only when nested virt is opted in. Exposed by
+        // default, every guest loads kvm_intel/kvm_amd, and that module's
+        // cached VMCS config then rejects vCPUs hot-added after a live
+        // migration until it is reloaded.
         std::string cpuVirtInstr = HexUtilPOpen("echo -n $(egrep -o '(vmx|svm)' /proc/cpuinfo | uniq)");
-        if (cpuVirtInstr == "svm")
-            cfg["libvirt"]["cpu_model_extra_flags"] = cpuVirtInstr;
+        if (!cpuVirtInstr.empty())
+            cfg["libvirt"]["cpu_model_extra_flags"] =
+                (s_nestedVirt.newValue() ? "" : "-") + cpuVirtInstr;
 
         // Ceilometer
         cfg["DEFAULT"]["instance_usage_audit"] = "True";

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -2405,6 +2405,22 @@ os_instance_list()
     done
 }
 
+# Instances whose running domain still exposes vmx/svm to the guest. Those
+# guests load kvm_intel/kvm_amd, and that module cannot online vCPUs hot-added
+# after a live migration until it is reloaded. A domain keeps the CPU features
+# it booted with -- live migration carries them across -- so this clears only
+# when the instance is rebooted.
+os_instance_nested_virt_list()
+{
+    local d feat host
+    host=$(hostname)
+    for d in $(virsh list --name 2>/dev/null) ; do
+        feat=$(virsh dumpxml $d 2>/dev/null | grep -cE "name='(vmx|svm)'")
+        [ "$feat" -gt 0 ] || continue
+        echo "$host $d $(virsh domuuid $d 2>/dev/null)"
+    done
+}
+
 os_instance_id_list()
 {
     local tenant=$1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Every CubeCOS instance is handed hardware virtualization it never asked for: the host runs
`kvm_intel nested=Y` and nova's host-model CPU passes `vmx` straight through, so every EL
guest loads `kvm_intel` whether or not it runs a nested VM.

That module caches a VMCS config at load and then refuses to enable virtualization on a vCPU
hot-added after a live migration (`Inconsistent VMCS config on CPU N`), aborting the CPU
bring-up. A live-resize returns 202 with the new flavor applied while the guest never gains
the CPUs. **A rolling upgrade arms this fleet-wide** — the drain live-migrates every instance
rather than restarting it, and the `<cpu>` block is carried across byte-identically.

New tuning `nova.nested.virt.enabled` (default `false`) masks `vmx`/`svm` off via
`cpu_model_extra_flags`. A guest that never loads the module is unaffected — verified by
unloading `kvm_intel`, migrating, then hot-adding 2 vCPUs, which onlined automatically with a
clean dmesg.

Plus `hex_sdk os_instance_nested_virt_list`, which reports instances whose running domain still
exposes vmx/svm, so operators can see who is still affected after an in-place upgrade.

#### Which issue(s) this PR fixes

Fixes #1361

#### Special notes for your reviewer

Three things I would like your eyes on:

1. **Not retroactive, by construction.** A domain keeps the CPU features it booted with and
   live migration carries them across, so existing instances shed vmx only when they reboot.
   On an upgraded cluster the benefit arrives gradually as VMs cycle. Auto-rebooting tenant
   VMs is not something we should do, so the reporter is the mitigation.
2. **This flips AMD behaviour.** The old code unconditionally set `svm`, so AMD hosts go from
   nested-always-on to opt-in. Intel previously got vmx implicitly via host-model.
3. **The tuning is cluster-wide.** nova has no per-flavor knob to add a single CPU feature
   (`hw:cpu_model` replaces the whole model), so a tenant needing nested virt forces the
   operator to re-enable it for everyone. Called out as a limitation rather than papered over.

I earlier proposed defaulting the tuning `true` on upgraded clusters to preserve behaviour, then
withdrew it: that would keep the fleet-wide arming after every roll, whereas defaulting off lets
a cluster converge toward safety as instances reboot. Needs a release note either way.

The underlying `kvm_intel` behaviour is **contained, not fixed** — the handbook note is filed
`status: open`. All 12 VMX config MSRs are byte-identical between the boot and hot-added CPU and
across all three hosts, so it is not a capability mismatch; the precise reason the cached config
fails its own comparison is an upstream kernel question I did not resolve.

#### Additional documentation

```docs
kb/cubecos/known-issues/ — vCPU hotplug after live migration (status: open, + scenario sidecar)
Release note: nested virt is now opt-in; set nova.nested.virt.enabled=true to restore it.
```
