### PR TITLE
fix(ssh): scope ControlMaster to root so service users can ssh

### DIFF
--- a/core/modules/config_cubesys.cpp
+++ b/core/modules/config_cubesys.cpp
@@ -116,12 +116,16 @@ WriteSshConfig(void)
     fprintf(fout, "UserKnownHostsFile /dev/null\n");
     // Multiplex repeated connections so health checks (one ssh per service per
     // node) reuse a single session instead of flooding sshd/logind/sudo.
-    fprintf(fout, "ControlMaster auto\n");
-    // control socket is root-only in /run (tmpfs, cleared on reboot) on a
-    // single-tenant appliance; 120s outlives the ~40s health poll so masters
-    // don't expire between cycles.
-    fprintf(fout, "ControlPath /run/cube-ssh-%%C\n");
-    fprintf(fout, "ControlPersist 120s\n");
+    // Scoped to root: the socket lives in /run (tmpfs, cleared on reboot),
+    // which only root can write, so leaving this global made every ssh by a
+    // service user fail with "unix_listener: cannot bind to path" -- taking
+    // out nova's cold resize and cold migration. 120s outlives the ~40s
+    // health poll so masters don't expire between cycles.
+    fprintf(fout, "Match User root\n");
+    fprintf(fout, "    ControlMaster auto\n");
+    fprintf(fout, "    ControlPath /run/cube-ssh-%%C\n");
+    fprintf(fout, "    ControlPersist 120s\n");
+    fprintf(fout, "Match all\n");
     fclose(fout);
 
     return true;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`/etc/ssh/ssh_config` enabled connection multiplexing globally, but the control socket lives in
`/run`, which only root can write. Every ssh by a non-root user died before connecting:

```
unix_listener: cannot bind to path /run/cube-ssh-<hash>: Permission denied
Exit code: 255
```

nova runs as its own user and shells out over ssh to prepare the destination, so **cold resize
and cold migration were broken cluster-wide**. Live migration was unaffected — it uses libvirt's
own transport as root — which is why this stayed hidden.

Scope the block to `Match User root` so health checks keep multiplexing and service users fall
back to plain ssh.

#### Which issue(s) this PR fixes

Fixes #1367

#### Special notes for your reviewer

The source comment already stated the socket is *"root-only in /run"*, so the constraint was
understood — the block just was not scoped. This does not remove multiplexing from anything that
had it working: root is the only user that could ever create the socket.

Verified on the sky 3-node lab, all three nodes: `nova` can now ssh to peers, root still gets its
multiplexed socket in `/run`, and a cold resize completed `RESIZE` → `VERIFY_RESIZE` in ~10 s
(sky141 → sky143, new flavor applied, confirm → ACTIVE). Before the change the same resize failed
with `ResizeError` and left the instance untouched.

Found while running spike #1366, which was blocked on it.

#### Additional documentation

```docs
kb/cubecos/known-issues/ — cold resize/migration blocked by root-only ssh control socket (+ sidecar)
```
