### PR TITLE
feat(nova): resize plan endpoint and unified cube-resize action

### DIFF
--- a/core/nova/caracal_patch/api/openstack/compute/cube_live_resize.py
+++ b/core/nova/caracal_patch/api/openstack/compute/cube_live_resize.py
@@ -36,12 +36,8 @@ cube_resize_schema = {
             'properties': {
                 'flavorRef': {'type': ['string', 'integer'],
                               'minLength': 1},
-                # The caller states the mode it was shown and consented to.
-                # There is deliberately no 'auto': falling back from live to
-                # cold on the operator's behalf would reboot the guest, move
-                # it to another host and strand it in VERIFY_RESIZE holding
-                # allocations on two hosts. Cold is downtime, and downtime is
-                # consented to, never inferred.
+                # No 'auto': cold means downtime, and downtime is
+                # consented to, never inferred. See cubecos#1372.
                 'mode': {'type': 'string', 'enum': ['live', 'cold']},
             },
             'required': ['flavorRef', 'mode'],

--- a/core/nova/caracal_patch/api/openstack/compute/cube_live_resize.py
+++ b/core/nova/caracal_patch/api/openstack/compute/cube_live_resize.py
@@ -8,6 +8,7 @@ from nova.api import validation
 from nova.compute import api as compute
 from nova import exception
 from nova.policies import live_resize as lr_policies
+from nova.policies import servers as server_policies
 
 live_resize_schema = {
     'type': 'object',
@@ -23,6 +24,31 @@ live_resize_schema = {
         },
     },
     'required': ['live-resize'],
+    'additionalProperties': False,
+}
+
+
+cube_resize_schema = {
+    'type': 'object',
+    'properties': {
+        'cube-resize': {
+            'type': 'object',
+            'properties': {
+                'flavorRef': {'type': ['string', 'integer'],
+                              'minLength': 1},
+                # The caller states the mode it was shown and consented to.
+                # There is deliberately no 'auto': falling back from live to
+                # cold on the operator's behalf would reboot the guest, move
+                # it to another host and strand it in VERIFY_RESIZE holding
+                # allocations on two hosts. Cold is downtime, and downtime is
+                # consented to, never inferred.
+                'mode': {'type': 'string', 'enum': ['live', 'cold']},
+            },
+            'required': ['flavorRef', 'mode'],
+            'additionalProperties': False,
+        },
+    },
+    'required': ['cube-resize'],
     'additionalProperties': False,
 }
 
@@ -57,3 +83,61 @@ class LiveResizeController(wsgi.Controller):
                 e, 'live-resize', id)
         except exception.ComputeHostNotFound as e:
             raise exc.HTTPConflict(explanation=e.format_message())
+
+    @wsgi.response(202)
+    @wsgi.expected_errors((400, 403, 404, 409))
+    @wsgi.action('cube-resize')
+    @validation.schema(cube_resize_schema)
+    def _cube_resize(self, req, id, body):
+        """One resize action; the caller states the mode it consented to.
+
+        The mode is re-checked here rather than trusted: the caller decided
+        from a resize-plan envelope fetched when its dialog opened, and the
+        instance may have moved on since. A 'live' request that is no longer
+        possible fails with the reason -- it is never quietly served cold.
+        """
+        context = req.environ['nova.context']
+        instance = common.get_instance(self.compute_api, context, id)
+        args = body['cube-resize']
+        flavor_ref = str(args['flavorRef'])
+
+        if args['mode'] == 'live':
+            context.can(lr_policies.BASE_POLICY_NAME,
+                        target={'project_id': instance.project_id})
+            try:
+                self.compute_api.live_resize(context, instance, flavor_ref)
+            except exception.FlavorNotFound as e:
+                raise exc.HTTPBadRequest(explanation=e.format_message())
+            except exception.LiveResizeError as e:
+                raise exc.HTTPBadRequest(explanation=e.format_message())
+            except exception.OverQuota as e:
+                raise exc.HTTPForbidden(explanation=e.format_message())
+            except exception.InstanceIsLocked as e:
+                raise exc.HTTPConflict(explanation=e.format_message())
+            except exception.InstanceInvalidState as e:
+                common.raise_http_conflict_for_instance_invalid_state(
+                    e, 'cube-resize', id)
+            except exception.ComputeHostNotFound as e:
+                raise exc.HTTPConflict(explanation=e.format_message())
+            return
+
+        # cold: the upstream resize policy governs, so a deployment can grant
+        # live-resize without also granting the right to reboot someone's guest
+        context.can(server_policies.SERVERS % 'resize',
+                    target={'user_id': instance.user_id,
+                            'project_id': instance.project_id})
+        try:
+            self.compute_api.resize(context, instance, flavor_ref)
+        except exception.OverQuota as e:
+            raise exc.HTTPForbidden(explanation=e.format_message())
+        except (exception.InstanceIsLocked,
+                exception.InstanceNotReady,
+                exception.ServiceUnavailable) as e:
+            raise exc.HTTPConflict(explanation=e.format_message())
+        except exception.InstanceInvalidState as e:
+            common.raise_http_conflict_for_instance_invalid_state(
+                e, 'cube-resize', id)
+        except (exception.CannotResizeDisk,
+                exception.CannotResizeToSameFlavor,
+                exception.FlavorNotFound) as e:
+            raise exc.HTTPBadRequest(explanation=e.format_message())

--- a/core/nova/caracal_patch/api/openstack/compute/cube_resize_plan.py
+++ b/core/nova/caracal_patch/api/openstack/compute/cube_resize_plan.py
@@ -1,10 +1,5 @@
-# Cube downstream: resize plan -- the capability envelope an operator-facing
-# resize dialog needs to decide LIVE vs COLD for every candidate flavor.
-#
-# Deliberately returns the INSTANCE's envelope once rather than a verdict per
-# flavor: the caller evaluates candidates locally. A per-flavor endpoint would
-# cost a round-trip each (~46ms measured) times the size of the flavor list,
-# every time the dialog opens. See spike cubecos#1366.
+# Cube downstream: the instance's hotplug envelope, returned once so a caller
+# can decide LIVE vs COLD per flavor locally. See cubecos#1370.
 
 from nova.api.openstack import common
 from nova.api.openstack import wsgi

--- a/core/nova/caracal_patch/api/openstack/compute/cube_resize_plan.py
+++ b/core/nova/caracal_patch/api/openstack/compute/cube_resize_plan.py
@@ -1,0 +1,57 @@
+# Cube downstream: resize plan -- the capability envelope an operator-facing
+# resize dialog needs to decide LIVE vs COLD for every candidate flavor.
+#
+# Deliberately returns the INSTANCE's envelope once rather than a verdict per
+# flavor: the caller evaluates candidates locally. A per-flavor endpoint would
+# cost a round-trip each (~46ms measured) times the size of the flavor list,
+# every time the dialog opens. See spike cubecos#1366.
+
+from nova.api.openstack import common
+from nova.api.openstack import wsgi
+from nova.compute import api as compute
+from nova.compute import utils as compute_utils
+from nova import cube_live_resize as clr
+from nova.policies import live_resize as lr_policies
+
+
+class ResizePlanController(wsgi.Controller):
+    def __init__(self):
+        super(ResizePlanController, self).__init__()
+        self.compute_api = compute.API()
+
+    @wsgi.expected_errors((403, 404))
+    def index(self, req, server_id):
+        context = req.environ['nova.context']
+        instance = common.get_instance(self.compute_api, context, server_id)
+        context.can(lr_policies.BASE_POLICY_NAME,
+                    target={'project_id': instance.project_id})
+
+        flavor = instance.flavor
+        recorded = clr.recorded_headroom(instance)
+        if recorded is None:
+            # booted before the ceiling was recorded; the config-derived value
+            # is an estimate and is wrong when the flavor carried an override
+            max_vcpus, max_mem_mb = clr.headroom(flavor)
+            exact = False
+        else:
+            max_vcpus, max_mem_mb = recorded
+            exact = True
+
+        # same helper _lr_validate uses, so the plan and the action agree
+        is_bfv = compute_utils.is_volume_backed_instance(context, instance)
+
+        return {
+            'resize_plan': {
+                'max_vcpus': max_vcpus,
+                'max_memory_mb': max_mem_mb,
+                'ceiling_is_exact': exact,
+                'boot_from_volume': is_bfv,
+                'blocked_by_spec': clr.blocked(flavor),
+                'current': {
+                    'vcpus': flavor.vcpus,
+                    'memory_mb': flavor.memory_mb,
+                    'root_gb': flavor.root_gb,
+                    'ephemeral_gb': flavor.ephemeral_gb,
+                },
+            },
+        }

--- a/core/nova/caracal_patch/api/openstack/compute/routes.py.patch
+++ b/core/nova/caracal_patch/api/openstack/compute/routes.py.patch
@@ -1,14 +1,15 @@
 --- api/openstack/compute/routes.py
 +++ api/openstack/compute/routes.py
-@@ -32,6 +32,7 @@ from nova.api.openstack.compute import c
+@@ -32,6 +32,8 @@
  from nova.api.openstack.compute import console_output
  from nova.api.openstack.compute import consoles
  from nova.api.openstack.compute import create_backup
 +from nova.api.openstack.compute import cube_live_resize
++from nova.api.openstack.compute import cube_resize_plan
  from nova.api.openstack.compute import deferred_delete
  from nova.api.openstack.compute import evacuate
  from nova.api.openstack.compute import extension_info
-@@ -253,6 +254,7 @@ server_controller = functools.partial(_c
+@@ -253,6 +255,7 @@
          admin_password.AdminPasswordController,
          console_output.ConsoleOutputController,
          create_backup.CreateBackupController,
@@ -16,3 +17,23 @@
          deferred_delete.DeferredDeleteController,
          evacuate.EvacuateController,
          floating_ips.FloatingIPActionController,
+@@ -280,6 +283,9 @@
+ server_diagnostics_controller = functools.partial(_create_controller,
+     server_diagnostics.ServerDiagnosticsController, [])
+ 
++cube_resize_plan_controller = functools.partial(_create_controller,
++    cube_resize_plan.ResizePlanController, [])
++
+ 
+ server_external_events_controller = functools.partial(_create_controller,
+     server_external_events.ServerExternalEventsController, [])
+@@ -765,6 +771,9 @@
+     ('/servers/{server_id}/diagnostics', {
+         'GET': [server_diagnostics_controller, 'index']
+     }),
++    ('/servers/{server_id}/resize-plan', {
++        'GET': [cube_resize_plan_controller, 'index']
++    }),
+     ('/servers/{server_id}/ips', {
+         'GET': [ips_controller, 'index']
+     }),

--- a/core/nova/caracal_patch/cube_live_resize.py
+++ b/core/nova/caracal_patch/cube_live_resize.py
@@ -55,9 +55,8 @@ def headroom(flavor):
 # while a live resize is migrating the instance to a host that fits
 SYSMETA_FLAVOR_ID = "cube_live_resize_flavor_id"
 
-# Ceiling actually baked into the running domain, recorded at spawn so the API
-# can answer a resize plan from the instance object -- no compute RPC. The
-# config default is only a fallback for instances booted before this shipped.
+# Ceiling baked into the running domain, recorded at spawn so the plan needs no
+# compute RPC. headroom() is only a fallback for instances booted before this.
 SYSMETA_MAX_VCPUS = "cube_live_resize_max_vcpus"
 SYSMETA_MAX_MEM_MB = "cube_live_resize_max_memory_mb"
 

--- a/core/nova/caracal_patch/cube_live_resize.py
+++ b/core/nova/caracal_patch/cube_live_resize.py
@@ -55,6 +55,34 @@ def headroom(flavor):
 # while a live resize is migrating the instance to a host that fits
 SYSMETA_FLAVOR_ID = "cube_live_resize_flavor_id"
 
+# Ceiling actually baked into the running domain, recorded at spawn so the API
+# can answer a resize plan from the instance object -- no compute RPC. The
+# config default is only a fallback for instances booted before this shipped.
+SYSMETA_MAX_VCPUS = "cube_live_resize_max_vcpus"
+SYSMETA_MAX_MEM_MB = "cube_live_resize_max_memory_mb"
+
+
+def record_headroom(instance, max_vcpus, max_mem_mb):
+    """Stash the domain's real ceiling on the instance at domain-build time."""
+    instance.system_metadata[SYSMETA_MAX_VCPUS] = str(max_vcpus)
+    instance.system_metadata[SYSMETA_MAX_MEM_MB] = str(max_mem_mb)
+
+
+def recorded_headroom(instance):
+    """The recorded ceiling, or None when the instance predates the record.
+
+    Callers fall back to headroom(instance.flavor); that is the config-derived
+    estimate and can be wrong when the flavor carried an extra-spec override,
+    which is exactly why the recorded value exists.
+    """
+    sysmeta = instance.system_metadata
+    if SYSMETA_MAX_VCPUS not in sysmeta or SYSMETA_MAX_MEM_MB not in sysmeta:
+        return None
+    try:
+        return (int(sysmeta[SYSMETA_MAX_VCPUS]), int(sysmeta[SYSMETA_MAX_MEM_MB]))
+    except (TypeError, ValueError):
+        return None
+
 
 def set_allocations(reportclient, context, consumer_uuid, flavor,
                     vcpus=None, memory_mb=None):

--- a/core/nova/caracal_patch/virt/libvirt/driver.py.patch
+++ b/core/nova/caracal_patch/virt/libvirt/driver.py.patch
@@ -1,6 +1,6 @@
 --- virt/libvirt/driver.py
 +++ virt/libvirt/driver.py
-@@ -86,6 +86,7 @@ from nova.console import serial as seria
+@@ -86,6 +86,7 @@
  from nova.console import type as ctype
  from nova import context as nova_context
  from nova import crypto
@@ -8,7 +8,7 @@
  from nova.db import constants as db_const
  from nova import exception
  from nova.i18n import _
-@@ -6001,19 +6002,22 @@ class LibvirtDriver(driver.ComputeDriver
+@@ -6001,19 +6002,22 @@
  
          return sysinfo
  
@@ -34,20 +34,20 @@
  
          return dev
  
-@@ -7413,6 +7417,8 @@ class LibvirtDriver(driver.ComputeDriver
+@@ -7413,6 +7417,8 @@
  
          self._guest_add_iommu_device(guest, image_meta, flavor)
  
-+        self._guest_add_live_resize_headroom(guest, flavor)
++        self._guest_add_live_resize_headroom(guest, flavor, instance)
 +
          return guest
  
      def _get_ordered_vpmems(self, instance, flavor):
-@@ -7430,6 +7436,99 @@ class LibvirtDriver(driver.ComputeDriver
+@@ -7430,6 +7436,103 @@
              for resource in vpmem_resources]
          return vpmems
  
-+    def _guest_add_live_resize_headroom(self, guest, flavor):
++    def _guest_add_live_resize_headroom(self, guest, flavor, instance=None):
 +        # cube live-resize: declare the hotplug ceiling at boot; (0, 0)
 +        # means the flavor is blocked or opted out.
 +        max_vcpus, max_mem_mb = clr.headroom(flavor)
@@ -77,6 +77,10 @@
 +                numa = vconfig.LibvirtConfigGuestCPUNUMA()
 +                numa.cells = [cell]
 +                guest.cpu.numa = numa
++        if instance is not None:
++            # record what was actually baked in, after the sockets-divisibility
++            # adjustment above may have zeroed the vCPU half
++            clr.record_headroom(instance, max_vcpus, max_mem_mb)
 +
 +    def check_live_resize(self, instance, new_flavor):
 +        # cube live-resize: can the RUNNING domain grow to new_flavor?
@@ -143,7 +147,7 @@
      def _guest_add_vpmems(self, guest, vpmems):
          guest.max_memory_size = guest.memory
          guest.max_memory_slots = 0
-@@ -7598,7 +7697,7 @@ class LibvirtDriver(driver.ComputeDriver
+@@ -7598,7 +7701,7 @@
              dev.domain, dev.bus, dev.slot, dev.function = (
                  pci_addr['domain'], pci_addr['bus'],
                  pci_addr['device'], pci_addr['function'])

--- a/core/nova/tests/README.md
+++ b/core/nova/tests/README.md
@@ -1,0 +1,28 @@
+# Unit tests for the cube nova patches
+
+These live here rather than in `core/nova/<release>_patch/` on purpose: `nova.mk`'s
+`rootfs_install` installs **everything** in the patch dir that is not `*.patch` / `*.orig`
+verbatim onto the rootfs, so a test file placed there would ship to every node.
+
+## Running them
+
+Against a node's caracal venv, where nova is already importable:
+
+```bash
+scp test_cube_live_resize.py root@<node>:/tmp/
+ssh root@<node> 'cd /tmp && /opt/openstack-caracal/bin/python -m unittest test_cube_live_resize -v'
+```
+
+Or in a local venv built the way the port was verified:
+
+```bash
+python3.11 -m venv /tmp/nova-test && . /tmp/nova-test/bin/activate
+pip install -c core/heavyfs/os-caracal-pip-upper-constraints.txt nova==29.4.0
+# apply core/nova/caracal_patch over site-packages/nova, then run unittest
+```
+
+The constraints file matters: without it the venv picks up an oslo.utils / setuptools
+newer than caracal expects and nova will not import.
+
+`unittest` and `unittest.mock` are stdlib; the venv has neither pytest nor the standalone
+`mock` package, so tests should not reach for them.

--- a/core/nova/tests/test_cube_live_resize.py
+++ b/core/nova/tests/test_cube_live_resize.py
@@ -1,0 +1,146 @@
+# Unit tests for the cube live-resize helpers.
+#
+# Deliberately outside core/nova/caracal_patch/: nova.mk installs everything in
+# the patch dir verbatim onto the rootfs, so tests placed there would ship to
+# every node.
+#
+# Run against a node's caracal venv (nova already importable):
+#   /opt/openstack-caracal/bin/python -m unittest discover -s . -p 'test_*.py' -v
+
+import unittest
+
+from nova import cube_live_resize as clr
+
+CONF = clr.CONF
+
+
+class FakeFlavor(object):
+    def __init__(self, vcpus=2, memory_mb=4096, extra_specs=None):
+        self.vcpus = vcpus
+        self.memory_mb = memory_mb
+        self.extra_specs = extra_specs or {}
+
+
+class FakeInstance(object):
+    def __init__(self, system_metadata=None):
+        self.system_metadata = system_metadata if system_metadata is not None else {}
+
+
+class TestBlocked(unittest.TestCase):
+    def test_plain_flavor_is_not_blocked(self):
+        self.assertIsNone(clr.blocked(FakeFlavor()))
+
+    def test_numa_nodes_blocks(self):
+        f = FakeFlavor(extra_specs={'hw:numa_nodes': '2'})
+        self.assertEqual('hw:numa_nodes', clr.blocked(f))
+
+    def test_mem_page_size_blocks(self):
+        f = FakeFlavor(extra_specs={'hw:mem_page_size': 'large'})
+        self.assertEqual('hw:mem_page_size', clr.blocked(f))
+
+    def test_dedicated_cpu_policy_blocks(self):
+        f = FakeFlavor(extra_specs={'hw:cpu_policy': 'dedicated'})
+        self.assertEqual('hw:cpu_policy=dedicated', clr.blocked(f))
+
+    def test_shared_cpu_policy_does_not_block(self):
+        f = FakeFlavor(extra_specs={'hw:cpu_policy': 'shared'})
+        self.assertIsNone(clr.blocked(f))
+
+
+class TestHeadroom(unittest.TestCase):
+    def setUp(self):
+        super(TestHeadroom, self).setUp()
+        CONF.set_override('live_resize_default_headroom', True, group='cube')
+        CONF.set_override('live_resize_headroom_factor', 4, group='cube')
+        CONF.set_override('live_resize_max_vcpus', 32, group='cube')
+        CONF.set_override('live_resize_max_memory_mb', 131072, group='cube')
+        self.addCleanup(CONF.clear_override,
+                        'live_resize_default_headroom', group='cube')
+        self.addCleanup(CONF.clear_override,
+                        'live_resize_headroom_factor', group='cube')
+        self.addCleanup(CONF.clear_override,
+                        'live_resize_max_vcpus', group='cube')
+        self.addCleanup(CONF.clear_override,
+                        'live_resize_max_memory_mb', group='cube')
+
+    def test_default_is_the_configured_multiple(self):
+        self.assertEqual((8, 16384), clr.headroom(FakeFlavor(2, 4096)))
+
+    def test_absolute_caps_bound_the_default(self):
+        # 16 vCPU * 4 = 64 -> capped at 32; 65536 * 4 = 262144 -> capped
+        self.assertEqual((32, 131072), clr.headroom(FakeFlavor(16, 65536)))
+
+    def test_extra_spec_override_wins_over_the_default(self):
+        f = FakeFlavor(2, 4096, {'hw:max_vcpus': '6', 'hw:max_memory_mb': '8192'})
+        self.assertEqual((6, 8192), clr.headroom(f))
+
+    def test_override_may_exceed_the_config_caps(self):
+        # the override branch is not clamped by live_resize_max_*
+        f = FakeFlavor(2, 4096, {'hw:max_vcpus': '64',
+                                 'hw:max_memory_mb': '393216'})
+        self.assertEqual((64, 393216), clr.headroom(f))
+
+    def test_zero_override_opts_the_flavor_out(self):
+        f = FakeFlavor(2, 4096, {'hw:max_vcpus': '0', 'hw:max_memory_mb': '0'})
+        self.assertEqual((0, 0), clr.headroom(f))
+
+    def test_one_sided_override_zeroes_the_unset_half(self):
+        # only memory is overridden; the vCPU half defaults to 0 and is then
+        # rejected for being below the flavor, so CPU growth is refused
+        f = FakeFlavor(2, 4096, {'hw:max_memory_mb': '8192'})
+        self.assertEqual((0, 8192), clr.headroom(f))
+
+    def test_ceiling_below_the_flavor_is_treated_as_no_headroom(self):
+        f = FakeFlavor(8, 8192, {'hw:max_vcpus': '4', 'hw:max_memory_mb': '4096'})
+        self.assertEqual((0, 0), clr.headroom(f))
+
+    def test_blocked_flavor_gets_no_headroom(self):
+        f = FakeFlavor(2, 4096, {'hw:numa_nodes': '2'})
+        self.assertEqual((0, 0), clr.headroom(f))
+
+    def test_headroom_disabled_by_config(self):
+        CONF.set_override('live_resize_default_headroom', False, group='cube')
+        self.assertEqual((0, 0), clr.headroom(FakeFlavor(2, 4096)))
+
+    def test_garbage_override_is_not_trusted(self):
+        f = FakeFlavor(2, 4096, {'hw:max_vcpus': 'lots'})
+        self.assertEqual((0, 0), clr.headroom(f))
+
+
+class TestRecordedHeadroom(unittest.TestCase):
+    def test_round_trip(self):
+        inst = FakeInstance()
+        clr.record_headroom(inst, 8, 16384)
+        self.assertEqual((8, 16384), clr.recorded_headroom(inst))
+
+    def test_values_are_stored_as_strings(self):
+        # system_metadata is a string->string map; ints would not survive
+        inst = FakeInstance()
+        clr.record_headroom(inst, 8, 16384)
+        for v in inst.system_metadata.values():
+            self.assertIsInstance(v, str)
+
+    def test_absent_record_returns_none(self):
+        # an instance booted before the ceiling was recorded
+        self.assertIsNone(clr.recorded_headroom(FakeInstance()))
+
+    def test_half_written_record_returns_none(self):
+        inst = FakeInstance({clr.SYSMETA_MAX_VCPUS: '8'})
+        self.assertIsNone(clr.recorded_headroom(inst))
+
+    def test_corrupt_record_returns_none_rather_than_raising(self):
+        # a caller falling back to the estimate is recoverable; a 500 is not
+        inst = FakeInstance({clr.SYSMETA_MAX_VCPUS: 'eight',
+                             clr.SYSMETA_MAX_MEM_MB: '16384'})
+        self.assertIsNone(clr.recorded_headroom(inst))
+
+    def test_zero_ceiling_is_recorded_not_mistaken_for_absent(self):
+        # an opted-out instance genuinely has a 0/0 ceiling; that must be
+        # reported as exact, not fall back to the config estimate
+        inst = FakeInstance()
+        clr.record_headroom(inst, 0, 0)
+        self.assertEqual((0, 0), clr.recorded_headroom(inst))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

The first two increments of #1369 (unified resize with plan-then-confirm). They are in one PR
because the second builds directly on the first — the action re-checks the mode the caller derived
from the plan envelope, so reviewing them apart would mean reviewing half a contract.

**1. Record the ceiling, expose a plan** (#1370). A resize dialog has to decide LIVE vs COLD per
candidate flavor, and the deciding input — the ceiling actually baked into the running domain —
was not reachable from the API at all. Skyline therefore assumes the deployment default (4x the
flavor) and is wrong whenever the flavor carried an `hw:max_vcpus` / `hw:max_memory_mb` override.
Record it at domain-build time and serve it from `GET /servers/{id}/resize-plan`.

**2. One action with explicit mode consent** (#1372). `cube-resize` takes a flavor plus the mode
the caller was shown and consented to, and re-checks it rather than trusting it.

#### Which issue(s) this PR fixes

Fixes #1370
Fixes #1372

#### Special notes for your reviewer

**Why the envelope is per-instance, not per-flavor.** Spike #1366 measured a synchronous compute
RPC at ~46 ms. A per-flavor endpoint would cost that per row, every time the dialog opens. Serving
from `system_metadata` costs no RPC; the caller evaluates candidates locally.

**`ceiling_is_exact`.** Instances booted before this ships have no recorded ceiling, so the
endpoint falls back to the config estimate and says so. Without the flag a caller would silently
trust a number that is wrong for override flavors — the very bug this exists to fix.

**No `auto` mode, by design.** The schema enum is `['live','cold']`, so a silent fallback cannot be
requested. The spike measured what one would do: reboot the guest, cold-migrate it, and land in
`VERIFY_RESIZE` with auto-confirm disabled, holding allocations on two hosts. Downtime should be
consented to, not inferred. VMware and Nutanix behave the same way; where Nutanix's Terraform
provider does silently restart a VM, users filed it as a bug.

**`boot_from_volume`** uses `compute_utils.is_volume_backed_instance`, the same helper
`_lr_validate` uses, so plan and action cannot disagree about the root-disk rule — the failure mode
in skyline-console#127.

Verified on the sky 3-node lab, hot-deployed to all three nodes.

Plan endpoint, checked against `virsh`:

| instance | plan | real domain |
|---|---|---|
| `lr.small` fresh | `8 / 16384`, `exact=true` | `maxMemory 16777216 KiB`, `<vcpu>8</vcpu>` |
| `lr.override` (max 6 / 8192) | **`6 / 8192`**, `exact=true` | `maxMemory 8388608 KiB`, `<vcpu>6</vcpu>` |
| boot-from-volume | `bfv=true` | root is a cinder volume |
| pre-existing | `exact=false` + estimate | — |

Action contract:

| request | result |
|---|---|
| `mode=live`, within ceiling | `202`, applied, ACTIVE, no reboot |
| `mode=live`, a shrink | **`400 live resize is grow-only`**, instance untouched |
| `mode=auto` | `400 'auto' is not one of ['live','cold']` |
| `mode=cold`, same shrink | `202` -> `VERIFY_RESIZE` -> confirm -> ACTIVE |
| non-admin `mode=live` | **`403`** live_resize policy |
| non-admin `mode=cold` | **`202`** upstream resize policy |

The last two rows are the policy separability #1369 requires: a tenant can resize their own
instance the normal way without holding the admin-only live-resize right.

**Unit tests: 21, in `core/nova/tests/`.** Covering `headroom()` (config default, absolute caps,
extra-spec override including one-sided and garbage values, opt-out, blocking specs) and the new
ceiling record. Two of them guard silent-wrong-answer risks rather than crashes: a corrupt record
returns `None` so the caller falls back to the estimate instead of 500-ing a resize dialog, and a
genuine `0/0` ceiling (opted-out instance) is reported as recorded rather than mistaken for "no
record" and replaced by an estimate that would wrongly offer headroom.

They sit outside `caracal_patch/` on purpose — `nova.mk` installs everything in the patch dir
verbatim onto the rootfs, so tests placed there would ship to every node. `core/nova/tests/README.md`
documents how to run them.

Verified 21/21 against a node's caracal venv, and mutation-checked: stubbing `recorded_headroom`
to return `None` fails 2 of them, so they are not passing vacuously.

The old `live-resize` action stays for now; removing it is a separate call once Skyline migrates.

#### Additional documentation

```docs
kb/cubecos/ — plan-call contract, mode-resolution rules and the policy split land with #1369
```
