### PR TITLE
feat(barbican): upgrade barbican from openstack antelope to caracal

### DIFF
--- a/core/barbican/barbican.conf.sample
+++ b/core/barbican/barbican.conf.sample
@@ -28,30 +28,6 @@
 # (string value)
 #host_href = http://localhost:9311
 
-# SQLAlchemy connection string for the reference implementation
-# registry server. Any valid SQLAlchemy connection string is fine.
-# See:
-# http://www.sqlalchemy.org/docs/05/reference/sqlalchemy/connections.html#sqlalchemy.create_engine.
-# Note: For absolute addresses, use '////' slashes after 'sqlite:'.
-# (string value)
-#sql_connection = sqlite:///barbican.sqlite
-
-# Period in seconds after which SQLAlchemy should reestablish its
-# connection to the database. MySQL uses a default `wait_timeout` of 8
-# hours, after which it will drop idle connections. This can result in
-# 'MySQL Gone Away' exceptions. If you notice this, you can lower this
-# value to ensure that SQLAlchemy reconnects before MySQL can drop the
-# connection. (integer value)
-#sql_idle_timeout = 3600
-
-# Maximum number of database connection retries during startup. Set to
-# -1 to specify an infinite retry count. (integer value)
-#sql_max_retries = 60
-
-# Interval between retries of opening a SQL connection. (integer
-# value)
-#sql_retry_interval = 1
-
 # Create the Barbican database on service startup. (boolean value)
 #db_auto_create = false
 
@@ -75,41 +51,6 @@
 # Show SQLAlchemy pool-related debugging output in logs (sets DEBUG
 # log level output) if specified. (boolean value)
 #sql_pool_logging = false
-
-# Size of pool used by SQLAlchemy. This is the largest number of
-# connections that will be kept persistently in the pool. Can be set
-# to 0 to indicate no size limit. To disable pooling, use a NullPool
-# with sql_pool_class instead. Comment out to allow SQLAlchemy to
-# select the default. (integer value)
-#sql_pool_size = 5
-
-# # The maximum overflow size of the pool used by SQLAlchemy. When the
-# number of checked-out connections reaches the size set in
-# sql_pool_size, additional connections will be returned up to this
-# limit. It follows then that the total number of simultaneous
-# connections the pool will allow is sql_pool_size +
-# sql_pool_max_overflow. Can be set to -1 to indicate no overflow
-# limit, so no limit will be placed on the total number of concurrent
-# connections. Comment out to allow SQLAlchemy to select the default.
-# (integer value)
-#sql_pool_max_overflow = 10
-
-# Enable eventlet backdoor.  Acceptable values are 0, <port>, and
-# <start>:<end>, where 0 results in listening on a random tcp port
-# number; <port> results in listening on the specified port number
-# (and not enabling backdoor if that port is in use); and
-# <start>:<end> results in listening on the smallest unused port
-# number within the specified range of port numbers.  The chosen port
-# is displayed in the service's log file. (string value)
-#backdoor_port = <None>
-
-# Enable eventlet backdoor, using the provided path as a unix socket
-# that can receive connections. This option is mutually exclusive with
-# 'backdoor_port' in that only one should be provided. If both are
-# provided then the existence of this option overrides the usage of
-# that option. Inside the path {pid} will be replaced with the PID of
-# the current process. (string value)
-#backdoor_socket = <None>
 
 #
 # From oslo.log
@@ -178,7 +119,10 @@
 # log_config_append is set. (boolean value)
 #use_stderr = false
 
-# Log output to Windows Event Log. (boolean value)
+# DEPRECATED: Log output to Windows Event Log. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Windows support is no longer maintained.
 #use_eventlog = false
 
 # The amount of time before the log files are rotated. This option is
@@ -312,14 +256,6 @@
 #rpc_ping_enabled = false
 
 #
-# From oslo.service.periodic_task
-#
-
-# Some periodic tasks can be run in a separate process. Should we run
-# them here? (boolean value)
-#run_external_periodic_tasks = true
-
-#
 # From oslo.service.service
 #
 
@@ -347,46 +283,6 @@
 # Specify a timeout after which a gracefully shutdown server will
 # exit. Zero value means endless wait. (integer value)
 #graceful_shutdown_timeout = 60
-
-#
-# From oslo.service.wsgi
-#
-
-# File name for the paste.deploy config for api service (string value)
-#api_paste_config = api-paste.ini
-
-# A python format string that is used as the template to generate log
-# lines. The following values can beformatted into it: client_ip,
-# date_time, request_line, status_code, body_length, wall_seconds.
-# (string value)
-#wsgi_log_format = %(client_ip)s "%(request_line)s" status: %(status_code)s  len: %(body_length)s time: %(wall_seconds).7f
-
-# Sets the value of TCP_KEEPIDLE in seconds for each server socket.
-# Not supported on OS X. (integer value)
-#tcp_keepidle = 600
-
-# Size of the pool of greenthreads used by wsgi (integer value)
-#wsgi_default_pool_size = 100
-
-# Maximum line size of message headers to be accepted. max_header_line
-# may need to be increased when using large tokens (typically those
-# generated when keystone is configured to use PKI tokens with big
-# service catalogs). (integer value)
-#max_header_line = 16384
-
-# If False, closes the client socket connection explicitly. (boolean
-# value)
-#wsgi_keep_alive = true
-
-# Timeout for client connections' socket operations. If an incoming
-# connection is idle for this number of seconds it will be closed. A
-# value of '0' means wait forever. (integer value)
-#client_socket_timeout = 900
-
-# True if the server should send exception tracebacks to the clients
-# on 500 errors. If False, the server will respond with empty bodies.
-# (boolean value)
-#wsgi_server_debug = false
 
 
 [audit_middleware_notifications]
@@ -416,32 +312,6 @@
 # specified, we fall back to the same configuration used for RPC.
 # (string value)
 #transport_url = <None>
-
-
-[certificate]
-
-#
-# From barbican.certificate.plugin
-#
-
-# Extension namespace to search for plugins. (string value)
-#namespace = barbican.certificate.plugin
-
-# List of certificate plugins to load. (multi valued)
-#enabled_certificate_plugins = simple_certificate
-
-
-[certificate_event]
-
-#
-# From barbican.certificate.plugin
-#
-
-# Extension namespace to search for eventing plugins. (string value)
-#namespace = barbican.certificate.event.plugin
-
-# List of certificate plugins to load. (multi valued)
-#enabled_certificate_event_plugins = simple_certificate_event
 
 
 [cors]
@@ -489,6 +359,60 @@
 #enabled_crypto_plugins = simple_crypto
 
 
+[database]
+
+#
+# From barbican.common.config
+#
+
+# SQLAlchemy connection string for the reference implementation
+# registry server. Any valid SQLAlchemy connection string is fine.
+# See:
+# http://www.sqlalchemy.org/docs/05/reference/sqlalchemy/connections.html#sqlalchemy.create_engine.
+# Note: For absolute addresses, use '////' slashes after 'sqlite:'.
+# (string value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+#connection = sqlite:///barbican.sqlite
+
+# Period in seconds after which SQLAlchemy should reestablish its
+# connection to the database. MySQL uses a default `wait_timeout` of 8
+# hours, after which it will drop idle connections. This can result in
+# 'MySQL Gone Away' exceptions. If you notice this, you can lower this
+# value to ensure that SQLAlchemy reconnects before MySQL can drop the
+# connection. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_idle_timeout
+#connection_recycle_time = 3600
+
+# Maximum number of database connection retries during startup. Set to
+# -1 to specify an infinite retry count. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+#max_retries = 60
+
+# Interval between retries of opening a SQL connection. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+#retry_interval = 1
+
+# Size of pool used by SQLAlchemy. This is the largest number of
+# connections that will be kept persistently in the pool. Can be set
+# to 0 to indicate no size limit. To disable pooling, use a NullPool
+# with sql_pool_class instead. Comment out to allow SQLAlchemy to
+# select the default. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_pool_size
+#max_pool_size = 5
+
+# # The maximum overflow size of the pool used by SQLAlchemy. When the
+# number of checked-out connections reaches the size set in
+# max_pool_size, additional connections will be returned up to this
+# limit. It follows then that the total number of simultaneous
+# connections the pool will allow is max_pool_size + max_overflow. Can
+# be set to -1 to indicate no overflow limit, so no limit will be
+# placed on the total number of concurrent connections. Comment out to
+# allow SQLAlchemy to select the default. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_pool_max_overflow
+#max_overflow = 10
+
+
 [dogtag_plugin]
 
 #
@@ -511,18 +435,6 @@
 
 # Password for the NSS certificate databases (string value)
 #nss_password = <None>
-
-# Profile for simple CMC requests (string value)
-#simple_cmc_profile = caOtherCert
-
-# List of automatically approved enrollment profiles (string value)
-#auto_approved_profiles = caServerCert
-
-# Time in days for CA entries to expire (integer value)
-#ca_expiration_time = 1
-
-# Working directory for Dogtag plugin (string value)
-#plugin_working_dir = /etc/barbican/dogtag
 
 # User friendly plugin name (string value)
 #plugin_name = Dogtag KRA
@@ -552,6 +464,14 @@
 # Additional backends that can perform health checks and report that
 # information back as part of a request. (list value)
 #backends =
+
+# A list of network addresses to limit source ip allowed to access
+# healthcheck information. Any request from ip outside of these
+# network addresses are ignored. (list value)
+#allowed_source_ranges =
+
+# Ignore requests with proxy headers. (boolean value)
+#ignore_proxied_requests = false
 
 # Check the presence of a file to determine if an application is
 # running on a port. Used by DisableByFileHealthcheck plugin. (string
@@ -1243,10 +1163,15 @@
 # replicated FIFO queue based on the Raft consensus algorithm. It is
 # available as of RabbitMQ 3.8.0. If set this option will conflict
 # with the HA queues (``rabbit_ha_queues``) aka mirrored queues, in
-# other words the HA queues should be disabled, quorum queues durable
-# by default so the amqp_durable_queues opion is ignored when this
-# option enabled. (boolean value)
+# other words the HA queues should be disabled. Quorum queues are also
+# durable by default so the amqp_durable_queues option is ignored when
+# this option is enabled. (boolean value)
 #rabbit_quorum_queue = false
+
+# Use quorum queues for transients queues in RabbitMQ. Enabling this
+# option will then make sure those queues are also using quorum kind
+# of rabbit queues, which are HA by default. (boolean value)
+#rabbit_transient_quorum_queue = false
 
 # Each time a message is redelivered to a consumer, a counter is
 # incremented. Once the redelivery count exceeds the delivery limit
@@ -1274,8 +1199,11 @@
 # Positive integer representing duration in seconds for queue TTL
 # (x-expires). Queues which are unused for the duration of the TTL are
 # automatically deleted. The parameter affects only reply and fanout
-# queues. (integer value)
-# Minimum value: 1
+# queues. Setting 0 as value will disable the x-expires. If doing so,
+# make sure you have a rabbitmq policy to delete the queues or you
+# deployment will create an infinite number of queue over time.
+# (integer value)
+# Minimum value: 0
 #rabbit_transient_queues_ttl = 1800
 
 # Specifies the number of messages to prefetch. Setting to zero allows
@@ -1289,7 +1217,7 @@
 
 # How often times during the heartbeat_timeout_threshold we check the
 # heartbeat. (integer value)
-#heartbeat_rate = 2
+#heartbeat_rate = 3
 
 # DEPRECATED: (DEPRECATED) Enable/Disable the RabbitMQ mandatory flag
 # for direct send. The direct send is used as reply, so the
@@ -1306,6 +1234,23 @@
 # Enable x-cancel-on-ha-failover flag so that rabbitmq server will
 # cancel and notify consumerswhen queue is down (boolean value)
 #enable_cancel_on_failover = false
+
+# Should we use consistant queue names or random ones (boolean value)
+#use_queue_manager = false
+
+# Hostname used by queue manager (string value)
+#hostname = centos9-jail
+
+# Process name used by queue manager (string value)
+#processname = oslo-config-generator
+
+# Use stream queues in RabbitMQ (x-queue-type: stream). Streams are a
+# new persistent and replicated data structure ("queue type") in
+# RabbitMQ which models an append-only log with non-destructive
+# consumer semantics. It is available as of RabbitMQ 3.9.0. If set
+# this option will replace all fanout queues with only one stream
+# queue. (boolean value)
+#rabbit_stream_fanout = false
 
 
 [oslo_middleware]
@@ -1331,7 +1276,7 @@
 # scopes do not match, an ``InvalidScope`` exception will be raised.
 # If ``False``, a message will be logged informing operators that
 # policies are being invoked with mismatching scope. (boolean value)
-#enforce_scope = false
+#enforce_scope = true
 
 # This option controls whether or not to use old deprecated defaults
 # when evaluating policies. If ``True``, the old deprecated defaults
@@ -1343,7 +1288,7 @@
 # policy check string is logically OR'd with the new policy check
 # string, allowing for a graceful upgrade experience between releases
 # with new policies, which is the default behavior. (boolean value)
-#enforce_new_defaults = false
+#enforce_new_defaults = true
 
 # The relative or absolute path of a file that maps roles to
 # permissions for a given service. Relative paths must be specified in
@@ -1385,6 +1330,16 @@
 #remote_ssl_client_key_file = <None>
 
 
+[oslo_versionedobjects]
+
+#
+# From oslo.versionedobjects
+#
+
+# Make exception message format errors fatal (boolean value)
+#fatal_exception_format_errors = false
+
+
 [p11_crypto_plugin]
 
 #
@@ -1398,16 +1353,10 @@
 # value)
 #token_serial_number = <None>
 
-# DEPRECATED: Use token_labels instead. Token label used to identify
-# the token to be used. (string value)
-# This option is deprecated for removal.
-# Its value may be silently ignored in the future.
-#token_label = <None>
-
 # List of labels for one or more tokens to be used. Typically this is
 # a single label, but some HSM devices may require more than one label
 # for Load Balancing or High Availability configurations. (list value)
-#token_labels = <None>
+#token_labels =
 
 # Password to login to PKCS11 session (string value)
 #login = <None>
@@ -1569,59 +1518,6 @@
 #plugin_name = Software Only Crypto
 
 
-[snakeoil_ca_plugin]
-
-#
-# From barbican.certificate.plugin.snakeoil
-#
-
-# Path to CA certificate file (string value)
-#ca_cert_path = <None>
-
-# Path to CA certificate key file (string value)
-#ca_cert_key_path = <None>
-
-# Path to CA certificate chain file (string value)
-#ca_cert_chain_path = <None>
-
-# Path to CA chain pkcs7 file (string value)
-#ca_cert_pkcs7_path = <None>
-
-# Directory in which to store certs/keys for subcas (string value)
-#subca_cert_key_directory = /etc/barbican/snakeoil-cas
-
-
-[ssl]
-
-#
-# From oslo.service.sslutils
-#
-
-# CA certificate file to use to verify connecting clients. (string
-# value)
-# Deprecated group/name - [DEFAULT]/ssl_ca_file
-#ca_file = <None>
-
-# Certificate file to use when starting the server securely. (string
-# value)
-# Deprecated group/name - [DEFAULT]/ssl_cert_file
-#cert_file = <None>
-
-# Private key file to use when starting the server securely. (string
-# value)
-# Deprecated group/name - [DEFAULT]/ssl_key_file
-#key_file = <None>
-
-# SSL version to use (valid only if SSL enabled). Valid values are
-# TLSv1 and SSLv23. SSLv2, SSLv3, TLSv1_1, and TLSv1_2 may be
-# available on some distributions. (string value)
-#version = <None>
-
-# Sets the list of available ciphers. value should be a string in the
-# OpenSSL cipher list format. (string value)
-#ciphers = <None>
-
-
 [vault_plugin]
 
 #
@@ -1650,3 +1546,7 @@
 
 # SSL Enabled/Disabled (boolean value)
 #use_ssl = false
+
+# Vault Namespace to use for all requests. Namespaces is a feature
+# available in HasiCorp Vault Enterprise only. (string value)
+#namespace = <None>

--- a/core/barbican/barbican.mk
+++ b/core/barbican/barbican.mk
@@ -3,20 +3,27 @@
 
 BARBICAN_CONFDIR := $(ROOTDIR)/etc/barbican
 
-# install barbican inside the python 3.10 virtual environment
+# barbican runs out of the caracal venv, not the antelope one it shared with every other
+# openstack service. 18.0.0 is the 2024.1 release (verified as the newest tag that is an
+# ancestor of upstream's unmaintained/2024.1; 19.0.0 has already diverged onto 2024.2), and
+# it needs python 3.11, so the service moves into $(CARACAL_OPENSTACK_HOME_DIR) -- skyline
+# was the first occupant, then keystone, glance, cinder, nova/placement and neutron.
+#
 # PyKMIP: the kmip_secret_store plugin imports it unconditionally, oslo-config-generator
-#   fails without it even when the plugin is unused
-# PyMySQL: config_barbican.cpp writes a mysql+pymysql:// sql_connection
+#   fails without it even when the plugin is unused. Still true in 18.0.0 -- the
+#   kmip_plugin entry point and the barbican.plugin.secret_store.kmip generator namespace
+#   both survive the hop.
+# PyMySQL: config_barbican.cpp writes a mysql+pymysql:// connection URI
 # oslo.messaging[kafka]: config_barbican.cpp points the notification transport at kafka
-# neither of the last two is a barbican requirement, pip won't pull them in transitively,
-# so they must stay listed here even though the shared venv happens to already carry them
+# python-keystoneclient / gunicorn: keystone.mk already installs both into this venv, but
+#   they stay named here for the same reason the two above do -- a dependency nothing asks
+#   for is one that disappears silently, and keystone is free to stop needing gunicorn.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-		barbican==16.0.2 \
-		python-barbicanclient \
+	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		barbican==18.0.0 \
 		python-keystoneclient \
 		gunicorn \
 		PyKMIP \
@@ -24,15 +31,43 @@ rootfs_install::
 		\"oslo.messaging[kafka]\""
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-db-manage /usr/bin/barbican-db-manage
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-manage /usr/bin/barbican-manage
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-retry /usr/bin/barbican-retry
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-status /usr/bin/barbican-status
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/pkcs11-kek-rewrap /usr/bin/pkcs11-kek-rewrap
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/pkcs11-key-generation /usr/bin/pkcs11-key-generation
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-wsgi-api /usr/bin/barbican-wsgi-api
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-worker /usr/bin/barbican-worker
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/barbican-keystone-listener /usr/bin/barbican-keystone-listener
+
+# python-barbicanclient stays in the *antelope* venv -- TEMPORARY, see below
+#
+# It is the only part of barbican that does not follow the service into the caracal venv,
+# because it is the one part the openstack cli loads rather than the one barbican runs.
+# python-barbicanclient contributes an [openstack.cli.extension] entry point plus sixteen
+# [openstack.key_manager.v1] commands (secret store/get/list/delete/update, the container
+# and consumer families, and the order family), and a stevedore entry point is only visible
+# to the interpreter it was installed under. /usr/bin/openstack is the antelope venv's
+# (core/heavyfs/Makefile links it there), so installing the client into the caracal venv
+# would take `openstack secret ...` off the node entirely.
+#
+# This is the first caracal hop to hit that. keystone, glance, cinder and nova escaped it
+# because `openstack image|volume|server ...` are osc built-ins -- python-keystoneclient and
+# python-cinderclient contribute no [openstack.cli.extension] at all -- so their clients
+# could move with the service. The same split is already spelled out for designate in
+# core/designate/designate.mk, from the era when the cli was the system python's.
+#
+# TEMPORARY: this goes away when the cli itself reaches the caracal venv, at which point
+# this install block moves back into the one above.
+rootfs_install::
+	$(Q)# enable dns in the rootfs for downloading packages
+	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)chroot $(ROOTDIR) bash -c "source $(OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		python-barbicanclient"
+	$(Q)# clean up dns configurations after downloading packages
+	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-db-manage /usr/bin/barbican-db-manage
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-manage /usr/bin/barbican-manage
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-retry /usr/bin/barbican-retry
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-status /usr/bin/barbican-status
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/pkcs11-kek-rewrap /usr/bin/pkcs11-kek-rewrap
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/pkcs11-key-generation /usr/bin/pkcs11-key-generation
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-wsgi-api /usr/bin/barbican-wsgi-api
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-worker /usr/bin/barbican-worker
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/barbican-keystone-listener /usr/bin/barbican-keystone-listener
 
 # prepare the build directory
 rootfs_install::

--- a/core/barbican/config-generator.conf
+++ b/core/barbican/config-generator.conf
@@ -1,7 +1,5 @@
 [DEFAULT]
 output_file = etc/barbican/barbican.conf.sample
-namespace = barbican.certificate.plugin
-namespace = barbican.certificate.plugin.snakeoil
 namespace = barbican.common.config
 namespace = barbican.plugin.crypto
 namespace = barbican.plugin.crypto.p11
@@ -18,7 +16,5 @@ namespace = oslo.middleware.cors
 namespace = oslo.middleware.healthcheck
 namespace = oslo.middleware.http_proxy_to_wsgi
 namespace = oslo.policy
-namespace = oslo.service.periodic_task
 namespace = oslo.service.service
-namespace = oslo.service.sslutils
-namespace = oslo.service.wsgi
+namespace = oslo.versionedobjects

--- a/core/barbican/openstack-barbican-api.service
+++ b/core/barbican/openstack-barbican-api.service
@@ -9,7 +9,9 @@ User=barbican
 Group=barbican
 RuntimeDirectory=barbican
 RuntimeDirectoryMode=770
-ExecStart=/opt/openstack-antelope/bin/gunicorn --pid /run/barbican/pid -c /etc/barbican/gunicorn-config.py --paste /etc/barbican/barbican-api-paste.ini
+# Executes gunicorn from the caracal venv using python 3.11 -- barbican moved there in
+# #632, so a python 3.10 gunicorn can no longer import it.
+ExecStart=/opt/openstack-caracal/bin/gunicorn --pid /run/barbican/pid -c /etc/barbican/gunicorn-config.py --paste /etc/barbican/barbican-api-paste.ini
 ExecReload=/usr/bin/kill -s HUP $MAINPID
 ExecStop=/usr/bin/kill -s TERM $MAINPID
 StandardError=journal

--- a/core/modules/config_barbican.cpp
+++ b/core/modules/config_barbican.cpp
@@ -176,7 +176,25 @@ UpdateDbConn(std::string sharedId, std::string password)
         dbconn += sharedId;
         dbconn += "/barbican";
 
-        cfg["DEFAULT"]["sql_connection"] = dbconn;
+        // [database] connection, not [DEFAULT] sql_connection: barbican 18.0.0 moved the
+        // database options into their own group (barbican/common/config.py registers
+        // core_db_opts under OptGroup(name='database')). The old spelling survives as a
+        // deprecated alias, so writing it would still work today -- but the regenerated
+        // barbican.conf.sample only documents the new one, and leaving the two disagreeing
+        // hands the next hop a failure that produces no error at all: the option's default
+        // is `sqlite:///barbican.sqlite`, so once the alias goes barbican does not complain
+        // about a missing URI, it quietly opens a per-node sqlite file. Each control node
+        // would then serve its own empty key store while every service and health check
+        // reported success.
+        //
+        // No mysql_wsrep_sync_wait here, unlike the eleven other upgraded modules. It
+        // would be a dead key: barbican does not use oslo.db's enginefacade and does not
+        // register oslo.db's [database] options. barbican/model/repositories.py builds
+        // engine_args itself from exactly three values -- connection_recycle_time,
+        // max_pool_size, max_overflow -- and hands them to
+        // oslo_db.sqlalchemy.session.create_engine(), which only applies
+        // mysql_wsrep_sync_wait when it arrives as a kwarg. Nothing would read it.
+        cfg["database"]["connection"] = dbconn;
     }
 
     return true;

--- a/project.mk
+++ b/project.mk
@@ -71,9 +71,13 @@ NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT :=
 # (25.0.0) is the second -- #631, the first openstack service to make the hop -- and
 # glance (28.2.0) the third (#630), cinder (24.5.0) the fourth (#629), nova with
 # placement (29.4.0 / 11.0.1) the fifth (#627), neutron (24.2.2) the sixth (#628),
-# manila (18.3.0) the seventh (#638) and octavia (14.0.2) the eighth (#640).
-# The services move one at a time and OPENSTACK_RELEASE is promoted once they all
-# have.
+# manila (18.3.0) the seventh (#638), octavia (14.0.2) the eighth (#640) and
+# barbican (18.0.0) the ninth (#632). The services move one at a time and
+# OPENSTACK_RELEASE is promoted once they all have.
+#
+# barbican leaves a piece behind, the same way octavia does: python-barbicanclient owns
+# the `openstack secret ...` commands and has to stay in the antelope venv for as long as
+# /usr/bin/openstack does. See core/barbican/barbican.mk.
 CARACAL_OPENSTACK_RELEASE := caracal
 CARACAL_OPENSTACK_HOME_DIR := /opt/openstack-$(CARACAL_OPENSTACK_RELEASE)
 CARACAL_OPS_GITHUB_BRANCH_01 := stable/2024.1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

barbican moves from the antelope venv's 16.0.2 to **18.0.0 in `/opt/openstack-caracal`** — the seventh service to make the hop, after keystone, glance, cinder, nova/placement and neutron. 18.0.0 is the 2024.1 release, verified as the newest tag that is an ancestor of upstream's `unmaintained/2024.1` (19.0.0 has already diverged onto 2024.2).

What ends up where:

| Component | venv | Version |
| -- | -- | -- |
| `barbican` (api, worker, retry, keystone-listener) | `/opt/openstack-caracal` | 18.0.0 |
| `python-barbicanclient` | `/opt/openstack-antelope` | 5.5.0 — **stays** |

`python-barbicanclient` does not follow the service. It owns the `openstack secret ...` commands as stevedore entry points, and those are only visible to the interpreter they were installed under, so they have to stay where `/usr/bin/openstack` is. This is the first caracal hop to hit that — keystone's and cinder's clients contribute no `[openstack.cli.extension]` at all, because `openstack image|volume|server` are osc built-ins. Marked `TEMPORARY`; it goes once the CLI itself reaches the caracal venv.

Nothing had to be added to `os-caracal-pip-upper-constraints.txt`: every package named here is already pinned there, gunicorn at 21.2.0, which still accepts `--paste` and every key in `gunicorn-config.py`. The nine console scripts are unchanged between the two releases, so the symlinks only change target.

`config-generator.conf` is resynced to upstream 18.0.0's namespace list and `barbican.conf.sample` regenerated against it — four sections disappear (`[certificate]`, `[certificate_event]`, `[snakeoil_ca_plugin]`, `[ssl]`) and two arrive (`[database]`, `[oslo_versionedobjects]`). The file still carries no uncommented key, so every effective value continues to come from `config_barbican.cpp`.

One change in `config_barbican.cpp`:

**`[database] connection` instead of `[DEFAULT] sql_connection`.** barbican 18.0.0 registers `core_db_opts` under `OptGroup(name='database')`. The old spelling survives as a deprecated alias, so writing it would still work *today* — but the option's default is `sqlite:///barbican.sqlite`, so once the alias goes, barbican does not complain about a missing URI, it quietly opens a per-node sqlite file. Each control node would serve its own empty key store while every service and health check reported success.

#### Secure RBAC: the community default is taken as it comes

An earlier revision of this PR pinned `[oslo_policy] enforce_new_defaults` and `enforce_scope` back to `false`, to hold antelope's authorization behaviour across the hop. **Per review that is dropped** — barbican 18.0.0's own defaults now stand, on the grounds that no CubeCOS deployment currently uses barbican as a vault and staying on the community's policy set is the lower maintenance burden.

The effective change is that `secrets:post` moves from `rule:admin_or_creator` to `role:member`, so any user holding `member` in a project can store secrets in that project. Two consequences, both checked against the 18.0.0 source rather than assumed:

- **`enforce_scope=true` is inert here.** Every rule in all eight policy modules (`secrets`, `containers`, `orders`, `quotas`, `secretstores`, `acls`, `consumers`, `transportkeys`) is `scope_types=['project']` — there is no system-scoped rule to fail against, and `/etc/admin-openrc.sh` is project-scoped.
- **admin now passes `secrets:post` only through keystone's implied-role chain.** The new rule is `True:%(enforce_new_defaults)s and role:member` (`barbican/common/policies/secrets.py:137`), so an admin token must carry `member`. Caracal's `keystone-manage bootstrap` builds `admin → manager → member → reader` and explicitly drops the old direct admin→member link (`keystone/cmd/bootstrap.py:189-198`), so a fresh install is fine. But `os_keystone_legacy_member_role_setup` (`core/sdk_sh/modules/sdk_os.sh:1150`) only repairs `member→reader` and `_member_→member` — it never touches `manager→member`, and `manager` appears nowhere else in this repo. A cluster upgraded from a release that deleted `member` could therefore have a broken chain and get a 403 on secret creation. That is pre-existing, but accepting the new defaults is what makes it load-bearing; flagging it here rather than leaving it implicit. Happy to open a separate ticket for the repair function.

#### Verification

ISO `CUBE_3.1.20_20260827-0445_7be2fe3` (`distclean iso test`, `E2ETST=1cc`) — build, sys/iso (6/6) and e2e (4/4) all green. Then on the 1cc:

| AC | Command | Result |
| -- | -- | -- |
| Services up | `systemctl` / `hex_cli -v -c cluster check` | api + keystone-listener `active running`; cluster check all ok |
| secret CRUD (admin) | `secret store` → `list` → `get --payload` → `delete` | payload returned verbatim, delete leaves list empty |
| Encrypted volume round-trip | LUKS volume type → `volume create` | volume `available`; a new unnamed secret appears in barbican (cinder's LUKS key) |
| `db upgrade` is a no-op | `barbican-manage db upgrade` / `db current` | no migration runs; `8c74e2d7f1ff (head)` |
| No deprecation warnings | `journalctl -u openstack-barbican-api -b` | 0 hits for `deprecat\|sql_connection` |

> [!IMPORTANT]
> **That ISO was built with the policy gate still in place.** It is direct evidence for the venv hop, the `[database] connection` rename, the `db upgrade` no-op and the absence of deprecation warnings — none of which the review change touches. It is **not** evidence for authorization behaviour on this head, and I am not rebuilding for that. What changed and how it was checked instead:
>
> | Row | Status on this head |
> | -- | -- |
> | Services up, `db upgrade` no-op, no deprecation warnings, venv layout | stands as measured |
> | Encrypted volume round-trip | measured under `rule:admin_or_creator`; on this head the same call resolves through `role:member`, which admin holds via `admin → manager → member` |
> | `member`-only user gets `Forbidden` | **inverted by design** — that user now succeeds. Removed from the table rather than re-run. |
>
> The replacement for the removed row is source, not a rerun: `barbican/common/policies/secrets.py:137` for the rule, `keystone/cmd/bootstrap.py:189-198` for the chain that keeps admin working. On a cluster where that chain is intact — every fresh Caracal install — nothing above regresses. The one case worth a QA eye is an upgraded cluster with a broken `manager→member` link, which `openstack implied role list` shows in one command; #632's QA Verification section carries it as a row.

#### Which issue(s) this PR fixes

Close #632

#### Special notes for your reviewer

> Note

This PR's change set is 2 commits over 4 files plus `project.mk`:

| Commit | Change |
| -- | -- |
| `a574ad6d` | `feat(barbican)`: `.mk` + unit + generator input + regenerated sample + `project.mk` note |
| `8e597c5c` | `feat(barbican)`: `[database] connection` |

The policy change was amended out of `8e597c5c` rather than reverted in a third commit, since this line is fast-forward-only and those two keys should not exist in its history at all.

Three things worth knowing:

1. **`openstack secret consumer list` does not work from the CLI — and did not before this PR either.** The client reports `Server does not support secret consumers. Minimum key-manager microversion required: 1.1`, but the server is fine: `curl <secret-href>/consumers` returns `HTTP 200 {"consumers": [], "total": 0}`. The chain is that `core/barbican/barbican-api-paste.ini` carries no microversion middleware in its pipeline, so the version document advertises no max microversion and client 5.5.0 refuses locally without sending a request. That file is checked into this repo and **is not touched by this PR**, so this is pre-existing, not a regression. Adding the middleware is a separate ticket.

2. **barbican is not covered by `hex_cli -c cluster check`.** There is no KeyManager group in the health output (designate has `DNSaaS`, barbican has no counterpart). Also pre-existing; noting it so the green cluster check above is not read as covering barbican.

3. **`/etc/cinder/cinder.conf` has an empty `[key_manager]` section.** The encrypted-volume round-trip works anyway, via castellan's default backend. Unchanged by this PR, but it means the cinder → barbican path has no explicit configuration behind it.
