### PR TITLE
feat(heat): upgrade heat from antelope to caracal

### DIFF
--- a/core/heat/heat.conf.sample
+++ b/core/heat/heat.conf.sample
@@ -61,6 +61,18 @@
 # stands for unlimited. (integer value)
 #max_stacks_per_tenant = 512
 
+# Maximum number of software configs any one tenant may have active at one
+# time. -1 stands for unlimited. (integer value)
+#max_software_configs_per_tenant = 4096
+
+# Maximum number of software deployments any one tenant may have active at one
+# time.-1 stands for unlimited. (integer value)
+#max_software_deployments_per_tenant = 4096
+
+# Maximum number of snapshot any one stack may have active at one time. -1
+# stands for unlimited. (integer value)
+#max_snapshots_per_stack = 32
+
 # Number of times to retry to bring a resource to a non-error state. Set to 0
 # to disable retries. (integer value)
 #action_retry_limit = 5
@@ -171,9 +183,6 @@
 # given in a comma-delimited list (eg. hidden_stack_tags=hide_me,me_too). (list
 # value)
 #hidden_stack_tags = data-processing-cluster
-
-# Deprecated. (string value)
-#onready = <None>
 
 # When this feature is enabled, scheduler hints identifying the heat stack
 # context of a server or volume resource are passed to the configured
@@ -372,7 +381,10 @@
 # set. (boolean value)
 #use_stderr = false
 
-# Log output to Windows Event Log. (boolean value)
+# DEPRECATED: Log output to Windows Event Log. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+# Reason: Windows support is no longer maintained.
 #use_eventlog = false
 
 # The amount of time before the log files are rotated. This option is ignored
@@ -582,6 +594,7 @@
 # dogpile.cache.bmemcached - <No description provided>
 # dogpile.cache.dbm - <No description provided>
 # dogpile.cache.redis - <No description provided>
+# dogpile.cache.redis_sentinel - <No description provided>
 # dogpile.cache.memory - <No description provided>
 # dogpile.cache.memory_pickle - <No description provided>
 # dogpile.cache.null - <No description provided>
@@ -609,7 +622,7 @@
 # Memcache servers in the format of "host:port". This is used by backends
 # dependent on Memcached.If ``dogpile.cache.memcached`` or
 # ``oslo_cache.memcache_pool`` is used and a given host refer to an IPv6 or a
-# given domain refer to IPv6 then you should prefix the given address withthe
+# given domain refer to IPv6 then you should prefix the given address with the
 # address family (``inet6``) (e.g ``inet6[::1]:11211``,
 # ``inet6:[fd12:3456:789a:1::1]:11211``,
 # ``inet6:[controller-0.internalapi]:11211``). If the address family is not
@@ -647,13 +660,34 @@
 #memcache_sasl_enabled = false
 
 # the user name for the memcached which SASL enabled (string value)
-#memcache_username =
+#memcache_username = <None>
 
 # the password for the memcached which SASL enabled (string value)
-#memcache_password =
+#memcache_password = <None>
 
-# Global toggle for TLS usage when comunicating with the caching servers.
-# (boolean value)
+# Redis server in the format of "host:port" (string value)
+#redis_server = localhost:6379
+
+# the user name for redis (string value)
+#redis_username = <None>
+
+# the password for redis (string value)
+#redis_password = <None>
+
+# Redis sentinel servers in the format of "host:port" (list value)
+#redis_sentinels = localhost:26379
+
+# Timeout in seconds for every call to a server. (dogpile.cache.redis and
+# dogpile.cache.redis_sentinel backends only). (floating point value)
+#redis_socket_timeout = 1.0
+
+# Service name of the redis sentinel cluster. (string value)
+#redis_sentinel_service_name = mymaster
+
+# Global toggle for TLS usage when communicating with the caching servers.
+# Currently supported by ``dogpile.cache.bmemcache``,
+# ``dogpile.cache.pymemcache``, ``oslo_cache.memcache_pool``,
+# ``dogpile.cache.redis`` and ``dogpile.cache.redis_sentinel``. (boolean value)
 #tls_enabled = false
 
 # Path to a file of concatenated CA certificates in PEM format necessary to
@@ -674,7 +708,9 @@
 
 # Set the available ciphers for sockets created with the TLS context. It should
 # be a string in the OpenSSL cipher list format. If not specified, all OpenSSL
-# enabled ciphers will be available. (string value)
+# enabled ciphers will be available. Currently supported by
+# ``dogpile.cache.bmemcache``, ``dogpile.cache.pymemcache`` and
+# ``oslo_cache.memcache_pool``. (string value)
 #tls_allowed_ciphers = <None>
 
 # Global toggle for the socket keepalive of dogpile's pymemcache backend
@@ -722,6 +758,15 @@
 # Time in seconds before attempting to add a node back in the pool in the
 # HashClient's internal mechanisms. (floating point value)
 #dead_timeout = 60
+
+# Global toggle for enforcing the OpenSSL FIPS mode. This feature requires
+# Python support. This is available in Python 3.9 in all environments and may
+# have been backported to older Python versions on select environments. If the
+# Python executable used does not support OpenSSL FIPS mode, an exception will
+# be raised. Currently supported by ``dogpile.cache.bmemcache``,
+# ``dogpile.cache.pymemcache`` and ``oslo_cache.memcache_pool``. (boolean
+# value)
+#enforce_fips_mode = false
 
 
 [clients]
@@ -1220,6 +1265,24 @@
 #insecure = <None>
 
 
+[constraint_validation_cache]
+
+#
+# From heat.common.cache
+#
+
+# TTL, in seconds, for any cached item in the dogpile.cache region used for
+# caching of validation constraints. (integer value)
+#expiration_time = 60
+
+# Toggle to enable/disable caching when Orchestration Engine validates property
+# constraints of stack. During property validation with constraints
+# Orchestration Engine caches requests to other OpenStack services. Please note
+# that the global toggle for oslo.cache(enabled=True in [cache] group) must be
+# enabled to use this feature. (boolean value)
+#caching = true
+
+
 [cors]
 
 #
@@ -1259,14 +1322,10 @@
 #sqlite_synchronous = true
 
 # The back end to use for the database. (string value)
-# Deprecated group/name - [DEFAULT]/db_backend
 #backend = sqlalchemy
 
 # The SQLAlchemy connection string to use to connect to the database. (string
 # value)
-# Deprecated group/name - [DEFAULT]/sql_connection
-# Deprecated group/name - [DATABASE]/sql_connection
-# Deprecated group/name - [sql]/connection
 #connection = <None>
 
 # The SQLAlchemy connection string to use to connect to the slave database.
@@ -1284,14 +1343,6 @@
 # value)
 #mysql_wsrep_sync_wait = <None>
 
-# DEPRECATED: If True, transparently enables support for handling MySQL Cluster
-# (NDB). (boolean value)
-# This option is deprecated for removal since 12.1.0.
-# Its value may be silently ignored in the future.
-# Reason: Support for the MySQL NDB Cluster storage engine has been deprecated
-# and will be removed in a future release.
-#mysql_enable_ndb = false
-
 # Connections which have been present in the connection pool longer than this
 # number of seconds will be replaced with a new one the next time they are
 # checked out from the pool. (integer value)
@@ -1303,33 +1354,24 @@
 
 # Maximum number of database connection retries during startup. Set to -1 to
 # specify an infinite retry count. (integer value)
-# Deprecated group/name - [DEFAULT]/sql_max_retries
-# Deprecated group/name - [DATABASE]/sql_max_retries
 #max_retries = 10
 
 # Interval between retries of opening a SQL connection. (integer value)
-# Deprecated group/name - [DEFAULT]/sql_retry_interval
-# Deprecated group/name - [DATABASE]/reconnect_interval
 #retry_interval = 10
 
 # If set, use this value for max_overflow with SQLAlchemy. (integer value)
-# Deprecated group/name - [DEFAULT]/sql_max_overflow
-# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
 #max_overflow = 50
 
 # Verbosity of SQL debugging information: 0=None, 100=Everything. (integer
 # value)
 # Minimum value: 0
 # Maximum value: 100
-# Deprecated group/name - [DEFAULT]/sql_connection_debug
 #connection_debug = 0
 
 # Add Python stack traces to SQL as comment strings. (boolean value)
-# Deprecated group/name - [DEFAULT]/sql_connection_trace
 #connection_trace = false
 
 # If set, use this value for pool_timeout with SQLAlchemy. (integer value)
-# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
 #pool_timeout = <None>
 
 # Enable the experimental use of database reconnect on connection lost.
@@ -1420,6 +1462,14 @@
 # Additional backends that can perform health checks and report that
 # information back as part of a request. (list value)
 #backends =
+
+# A list of network addresses to limit source ip allowed to access healthcheck
+# information. Any request from ip outside of these network addresses are
+# ignored. (list value)
+#allowed_source_ranges =
+
+# Ignore requests with proxy headers. (boolean value)
+#ignore_proxied_requests = false
 
 # Check the presence of a file to determine if an application is running on a
 # port. Used by DisableByFileHealthcheck plugin. (string value)
@@ -2084,10 +2134,15 @@
 # modern queue type for RabbitMQ implementing a durable, replicated FIFO queue
 # based on the Raft consensus algorithm. It is available as of RabbitMQ 3.8.0.
 # If set this option will conflict with the HA queues (``rabbit_ha_queues``)
-# aka mirrored queues, in other words the HA queues should be disabled, quorum
-# queues durable by default so the amqp_durable_queues opion is ignored when
-# this option enabled. (boolean value)
+# aka mirrored queues, in other words the HA queues should be disabled. Quorum
+# queues are also durable by default so the amqp_durable_queues option is
+# ignored when this option is enabled. (boolean value)
 #rabbit_quorum_queue = false
+
+# Use quorum queues for transients queues in RabbitMQ. Enabling this option
+# will then make sure those queues are also using quorum kind of rabbit queues,
+# which are HA by default. (boolean value)
+#rabbit_transient_quorum_queue = false
 
 # Each time a message is redelivered to a consumer, a counter is incremented.
 # Once the redelivery count exceeds the delivery limit the message gets dropped
@@ -2113,8 +2168,11 @@
 
 # Positive integer representing duration in seconds for queue TTL (x-expires).
 # Queues which are unused for the duration of the TTL are automatically
-# deleted. The parameter affects only reply and fanout queues. (integer value)
-# Minimum value: 1
+# deleted. The parameter affects only reply and fanout queues. Setting 0 as
+# value will disable the x-expires. If doing so, make sure you have a rabbitmq
+# policy to delete the queues or you deployment will create an infinite number
+# of queue over time. (integer value)
+# Minimum value: 0
 #rabbit_transient_queues_ttl = 1800
 
 # Specifies the number of messages to prefetch. Setting to zero allows
@@ -2127,7 +2185,7 @@
 
 # How often times during the heartbeat_timeout_threshold we check the
 # heartbeat. (integer value)
-#heartbeat_rate = 2
+#heartbeat_rate = 3
 
 # DEPRECATED: (DEPRECATED) Enable/Disable the RabbitMQ mandatory flag for
 # direct send. The direct send is used as reply, so the MessageUndeliverable
@@ -2144,6 +2202,22 @@
 # notify consumerswhen queue is down (boolean value)
 #enable_cancel_on_failover = false
 
+# Should we use consistant queue names or random ones (boolean value)
+#use_queue_manager = false
+
+# Hostname used by queue manager (string value)
+#hostname = centos9-jail
+
+# Process name used by queue manager (string value)
+#processname = oslo-config-generator
+
+# Use stream queues in RabbitMQ (x-queue-type: stream). Streams are a new
+# persistent and replicated data structure ("queue type") in RabbitMQ which
+# models an append-only log with non-destructive consumer semantics. It is
+# available as of RabbitMQ 3.9.0. If set this option will replace all fanout
+# queues with only one stream queue. (boolean value)
+#rabbit_stream_fanout = false
+
 
 [oslo_middleware]
 
@@ -2155,13 +2229,6 @@
 # Deprecated group/name - [DEFAULT]/osapi_max_request_body_size
 # Deprecated group/name - [DEFAULT]/max_request_body_size
 #max_request_body_size = 114688
-
-# DEPRECATED: The HTTP Header that will be used to determine what the original
-# request protocol scheme was, even if it was hidden by a SSL termination
-# proxy. (string value)
-# This option is deprecated for removal.
-# Its value may be silently ignored in the future.
-#secure_proxy_ssl_header = X-Forwarded-Proto
 
 # Whether the application is behind a proxy or not. This determines if the
 # middleware should parse the headers or not. (boolean value)
@@ -2183,7 +2250,7 @@
 # match, an ``InvalidScope`` exception will be raised. If ``False``, a message
 # will be logged informing operators that policies are being invoked with
 # mismatching scope. (boolean value)
-#enforce_scope = false
+#enforce_scope = true
 
 # This option controls whether or not to use old deprecated defaults when
 # evaluating policies. If ``True``, the old deprecated defaults are not going
@@ -2194,7 +2261,7 @@
 # deprecated policy check string is logically OR'd with the new policy check
 # string, allowing for a graceful upgrade experience between releases with new
 # policies, which is the default behavior. (boolean value)
-#enforce_new_defaults = false
+#enforce_new_defaults = true
 
 # The relative or absolute path of a file that maps roles to permissions for a
 # given service. Relative paths must be specified in relation to the
@@ -2251,6 +2318,16 @@
 #file_event_handler_interval = 1
 
 
+[oslo_versionedobjects]
+
+#
+# From oslo.versionedobjects
+#
+
+# Make exception message format errors fatal (boolean value)
+#fatal_exception_format_errors = false
+
+
 [paste_deploy]
 
 #
@@ -2299,6 +2376,20 @@
 #   higher level of operations. Single SQL queries cannot be analyzed this way.
 #  (boolean value)
 #trace_sqlalchemy = false
+
+#
+# Enable python requests package profiling.
+#
+# Supported drivers: jaeger+otlp
+#
+# Default value is False.
+#
+# Possible values:
+#
+# * True: Enables requests profiling.
+# * False: Disables requests profiling.
+#  (boolean value)
+#trace_requests = false
 
 #
 # Secret key(s) to use for encrypting context data for performance profiling.
@@ -2380,6 +2471,23 @@
 #filter_error_trace = false
 
 
+[resource_finder_cache]
+
+#
+# From heat.common.cache
+#
+
+# TTL, in seconds, for any cached item in the dogpile.cache region used for
+# caching of OpenStack service finder functions. (integer value)
+#expiration_time = 3600
+
+# Toggle to enable/disable caching when Orchestration Engine looks for other
+# OpenStack service resources using name or id. Please note that the global
+# toggle for oslo.cache(enabled=True in [cache] group) must be enabled to use
+# this feature. (boolean value)
+#caching = true
+
+
 [revision]
 
 #
@@ -2390,6 +2498,23 @@
 # separately, you can move this section to a different file and add it as
 # another config option. (string value)
 #heat_revision = unknown
+
+
+[service_extension_cache]
+
+#
+# From heat.common.cache
+#
+
+# TTL, in seconds, for any cached item in the dogpile.cache region used for
+# caching of service extensions. (integer value)
+#expiration_time = 3600
+
+# Toggle to enable/disable caching when Orchestration Engine retrieves
+# extensions from other OpenStack services. Please note that the global toggle
+# for oslo.cache(enabled=True in [cache] group) must be enabled to use this
+# feature. (boolean value)
+#caching = true
 
 
 [ssl]
@@ -2499,3 +2624,18 @@
 # until cinder-backup service becomes discoverable, see LP#1334856. (boolean
 # value)
 #backups_enabled = true
+
+
+[yaql]
+
+#
+# From heat.engine.hot.functions
+#
+
+# The maximum number of elements in collection expression can take for its
+# evaluation. (integer value)
+#limit_iterators = 200
+
+# The maximum size of memory in bytes that expression can take for its
+# evaluation. (integer value)
+#memory_quota = 10000

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -11,13 +11,23 @@
 # /usr/bin/openstack was `#!/usr/bin/python3` (3.9) and the copy pip put in the 3.10
 # venv was invisible to it -- an entry point is only visible to the interpreter it
 # was installed under. core/heavyfs moved the CLI into the venv, so the plugin
-# follows it: it is named on the pip install below instead, next to the service.
+# followed it.
 #
-# Dropping the rpm also drops /usr/bin/heat, the client's own CLI, which this file had
-# left unlinked on purpose while the rpm was the one supplying it. Nothing in this tree
-# calls it, but it has always been on the image for operators, so the venv's bin/heat is
-# linked below to keep that. /usr/bin/heat-3, the Fedora python3 alias, is not
-# recreated -- no other venv console script here is aliased that way.
+# It stays in the *antelope* venv now that heat itself has moved to caracal, for that
+# same entry-point reason: core/heavyfs still links /usr/bin/openstack at
+# $(OPENSTACK_HOME_DIR), so the `orchestration` plugin has to be installed under that
+# interpreter or health_heat_check() breaks again. heat's own requirements.txt names
+# python-heatclient, so the caracal venv gets a 3.5.0 copy of its own; the antelope
+# one is what /usr/bin/openstack sees, and its 3.2.0 talks to a 22.0.1 API, which is
+# the supported direction -- `orchestration service list` is /v1/{tenant}/services
+# and predates 2023.1. Named explicitly rather than left transitive because nothing
+# in the antelope venv would pull it any more.
+#
+# /usr/bin/heat, the client's own CLI, therefore also stays on the antelope venv: it
+# is python-heatclient's console script, not heat's. Nothing in this tree calls it,
+# but it has always been on the image for operators. /usr/bin/heat-3, the Fedora
+# python3 alias, is not recreated -- no other venv console script here is aliased
+# that way.
 #
 # Nothing else is needed: the RDO spec's only non-python Requires was
 # shadow-utils, for the heat user and group, and core/heavyfs/account/centos9
@@ -26,43 +36,56 @@
 # openstack-heat-ui, the Horizon dashboard plugin, is replaced by the
 # heat-dashboard wheel installed further down. It was dropped when heat moved to
 # pip because horizon was still on python 3.9; #609 moved horizon into the venv, so
-# the Orchestration panels come back here.
+# the Orchestration panels come back here. That wheel does *not* follow heat to
+# caracal -- see the note above it.
 
 HEAT_CONFDIR := $(ROOTDIR)/etc/heat
 
 # the release is needed twice: once to pin the wheel, once for [revision] heat_revision
-HEAT_VER := 20.0.1
+# https://releases.openstack.org/caracal/index.html#caracal-heat -- last numeric
+# 2024.1 revision, the same rule #1191 used to land on 20.0.1.
+HEAT_VER := 22.0.1
 
-# https://releases.openstack.org/antelope/index.html -- last numeric 2023.1
-# revision. Horizon plugins are not in the antelope upper-constraints (that file
-# only covers libraries), so the pin has to be explicit.
+# Deliberately still the 2023.1 pin, and deliberately still in the antelope venv.
+# core/horizon/horizon.mk serves the dashboard out of $(OPENSTACK_HOME_DIR) --
+# openstack-dashboard.service, gunicorn-config.py and the httpd reverse proxy all
+# point at the antelope tree, and every dashboard plugin installs next to it.
+# heat-dashboard follows horizon, not the heat service, so the Orchestration panels
+# stay on 9.0.0 until horizon itself hops; 11.0.1 is the caracal release to move to
+# on that day. It talks to the API over HTTP through heatclient and imports nothing
+# from heat, so the split costs nothing. Horizon plugins are not in the
+# upper-constraints (that file only covers libraries), so the pin has to be explicit.
 HEAT_DASHBOARD_VER := 9.0.0
 
 # install heat
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)# python-heatclient is the "orchestration" osc plugin, named explicitly rather
-	$(Q)# than left transitive -- see the note at the top of this file.
-	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
+	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			openstack-heat==$(HEAT_VER)"
+	$(Q)# and the "orchestration" osc plugin in the antelope venv: that entry point is
+	$(Q)# only visible to the interpreter /usr/bin/openstack runs under, and that is
+	$(Q)# still the antelope one -- see the note at the top of this file.
+	$(Q)chroot $(ROOTDIR) bash -c "source $(OPENSTACK_HOME_DIR)/bin/activate && \
 		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-			openstack-heat==$(HEAT_VER) \
 			python-heatclient"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-	$(Q)# Link the six console scripts heat declares, plus heat itself -- the client
-	$(Q)# CLI, which python3-heatclient used to own at this same path. The venv also
-	$(Q)# gains heat-db-setup and heat-keystone-setup{,-domain} (manual deployment
-	$(Q)# helpers that hex_config replaces) and heat-wsgi-api{,-cfn} (only used when
-	$(Q)# heat is hosted under a wsgi server, which is not the layout here); those
-	$(Q)# are left unlinked on purpose.
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat /usr/bin/heat
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-all /usr/bin/heat-all
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-api /usr/bin/heat-api
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-api-cfn /usr/bin/heat-api-cfn
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-engine /usr/bin/heat-engine
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-manage /usr/bin/heat-manage
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/heat-status /usr/bin/heat-status
+	$(Q)# Link the six console scripts heat declares. The venv also gains
+	$(Q)# heat-db-setup and heat-keystone-setup{,-domain} (manual deployment helpers
+	$(Q)# that hex_config replaces) and heat-wsgi-api{,-cfn} (only used when heat is
+	$(Q)# hosted under a wsgi server, which is not the layout here); those are left
+	$(Q)# unlinked on purpose. 2024.1 adds none and removes none.
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-all /usr/bin/heat-all
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-api /usr/bin/heat-api
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-api-cfn /usr/bin/heat-api-cfn
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-engine /usr/bin/heat-engine
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-manage /usr/bin/heat-manage
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-status /usr/bin/heat-status
+	$(Q)# the heatclient CLI, which is python-heatclient's console script and so
+	$(Q)# follows the antelope install above, not heat.
+	$(Q)chroot $(ROOTDIR) ln -sf $(OPENSTACK_HOME_DIR)/bin/heat /usr/bin/heat
 
 # prepare the build directory
 rootfs_install::
@@ -90,10 +113,12 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) install -p -D -m 640 /tmp/heat/heat.conf.sample /etc/heat/heat.conf
 	$(Q)# api-paste.ini, environment.d and templates ship inside the wheel, so
 	$(Q)# pip lands them under the venv prefix; relocate them into /etc/heat the
-	$(Q)# same way the RDO spec's %install does.
-	$(Q)chroot $(ROOTDIR) cp -f /opt/openstack-antelope/etc/heat/api-paste.ini /etc/heat/api-paste.ini
-	$(Q)chroot $(ROOTDIR) cp -rf /opt/openstack-antelope/etc/heat/environment.d /etc/heat/
-	$(Q)chroot $(ROOTDIR) cp -rf /opt/openstack-antelope/etc/heat/templates /etc/heat/
+	$(Q)# same way the RDO spec's %install does. All three are byte-identical
+	$(Q)# between 20.0.1 and 22.0.1, and heat's data_files list is unchanged, so
+	$(Q)# the hop moves only where they are read from.
+	$(Q)chroot $(ROOTDIR) cp -f $(CARACAL_OPENSTACK_HOME_DIR)/etc/heat/api-paste.ini /etc/heat/api-paste.ini
+	$(Q)chroot $(ROOTDIR) cp -rf $(CARACAL_OPENSTACK_HOME_DIR)/etc/heat/environment.d /etc/heat/
+	$(Q)chroot $(ROOTDIR) cp -rf $(CARACAL_OPENSTACK_HOME_DIR)/etc/heat/templates /etc/heat/
 	$(Q)# install systemd unit files
 	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/heat/openstack-heat-api.service /usr/lib/systemd/system/openstack-heat-api.service
 	$(Q)chroot $(ROOTDIR) install -p -D -m 644 /tmp/heat/openstack-heat-api-cfn.service /usr/lib/systemd/system/openstack-heat-api-cfn.service
@@ -140,11 +165,16 @@ rootfs_install::
 # install the heat web ui plugin, the openstack-heat-ui rpm's replacement.
 # Registering its panels, settings snippet and policy files is core/horizon's job:
 # every dashboard action lives there, because horizon is built last and is what runs
-# collectstatic and compress.
+# collectstatic and compress. Unlike the other components' panels this one needs no
+# entry in HORIZON_POLICY_NS_*: heat-dashboard ships a pre-generated
+# conf/default_policies/heat.yaml, so horizon copies it instead of dumping the
+# `heat` oslo.policy namespace out of a venv.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
+	$(Q)# $(OPENSTACK_HOME_DIR), not the caracal venv: this follows horizon, which
+	$(Q)# has not hopped -- see the note by HEAT_DASHBOARD_VER.
 	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \

--- a/core/heat/openstack-heat-api.service
+++ b/core/heat/openstack-heat-api.service
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 User=heat
-# heat comes from pip inside /opt/openstack-antelope; /usr/bin/heat-api is the
+# heat comes from pip inside /opt/openstack-caracal; /usr/bin/heat-api is the
 # symlink heat.mk creates into that venv. Only /etc/heat/heat.conf is loaded --
 # hex_config generates it in full from heat.conf.def, so there is no
 # distribution-level heat-dist.conf in this layout.

--- a/core/heat/oslo-config-generator/heat.conf
+++ b/core/heat/oslo-config-generator/heat.conf
@@ -1,16 +1,19 @@
 [DEFAULT]
 output_file = etc/heat/heat.conf.sample
 wrap_width = 79
+namespace = heat.common.cache
 namespace = heat.common.config
 namespace = heat.common.context
 namespace = heat.common.crypt
 namespace = heat.engine.clients.os.keystone.heat_keystoneclient
+namespace = heat.engine.hot.functions
 namespace = heat.common.wsgi
 namespace = heat.engine.clients
 namespace = heat.engine.notification
 namespace = heat.engine.resources
 namespace = heat.api.aws.ec2token
 namespace = keystonemiddleware.auth_token
+namespace = oslo.cache
 namespace = oslo.messaging
 namespace = oslo.middleware
 namespace = oslo.cache
@@ -20,3 +23,4 @@ namespace = oslo.reports
 namespace = oslo.service.service
 namespace = oslo.service.periodic_task
 namespace = oslo.service.sslutils
+namespace = oslo.versionedobjects

--- a/core/modules/config_heat.cpp
+++ b/core/modules/config_heat.cpp
@@ -225,8 +225,32 @@ UpdateSharedId(std::string sharedId)
         cfg["keystone_authtoken"]["auth_url"] = "http://" + sharedId + ":5000";
         cfg["keystone_authtoken"]["http_connect_timeout"] = "15";
         cfg["trustee"]["auth_url"] = "http://" + sharedId + ":5000";
-        cfg["clients_keystone"]["www_authenticate_uri"] = "http://" + sharedId + ":5000";
-        cfg["ec2authtoken"]["www_authenticate_uri"] = "http://" + sharedId + ":5000/v3";
+        // auth_uri, not www_authenticate_uri: that name belongs to
+        // keystonemiddleware and exists only in [keystone_authtoken] above. Both
+        // groups below are heat's own -- [clients_keystone] from
+        // heat.common.config, [ec2authtoken] from heat.api.aws.ec2token -- and
+        // both call the option auth_uri, in every release since yoga. oslo.config
+        // drops an unknown key in a registered group without a word, so the two
+        // lines used to be inert.
+        //
+        // [ec2authtoken] was not merely cosmetic. Unset, ec2token.py falls back to
+        // endpoint_utils.get_auth_uri(), which returns the *unversioned*
+        // [keystone_authtoken] www_authenticate_uri, and then appends /ec2tokens
+        // -- so it POSTed to http://<id>:5000/ec2tokens, which keystone 404s with
+        // an HTML body. response.json() then raised JSONDecodeError and the
+        // request 500ed, breaking every AWS-signed call to heat-api-cfn: that is
+        // the path heat_metadata_server_url and heat_waitcondition_server_url
+        // above hand to guests, so AWS::CloudFormation::WaitCondition could never
+        // be signalled and any template using one hung until its timeout.
+        //
+        // [clients_keystone] auth_uri is what heat's own keystone client resolves
+        // from; unset it fell back to the same unversioned URL. Set, heat runs
+        // version discovery against it and gets http://<id>:5000/v3/. Keep this
+        // one unversioned -- the option documents itself as "Unversioned keystone
+        // url" and discovery appends the version -- while [ec2authtoken] keeps the
+        // explicit /v3, because there ec2token.py appends /ec2tokens verbatim.
+        cfg["clients_keystone"]["auth_uri"] = "http://" + sharedId + ":5000";
+        cfg["ec2authtoken"]["auth_uri"] = "http://" + sharedId + ":5000/v3";
         cfg["oslo_messaging_notifications"]["transport_url"] = "kafka://" + sharedId + ":9095";
     }
 

--- a/project.mk
+++ b/project.mk
@@ -71,9 +71,9 @@ NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT :=
 # (25.0.0) is the second -- #631, the first openstack service to make the hop -- and
 # glance (28.2.0) the third (#630), cinder (24.5.0) the fourth (#629), nova with
 # placement (29.4.0 / 11.0.1) the fifth (#627), neutron (24.2.2) the sixth (#628),
-# manila (18.3.0) the seventh (#638), octavia (14.0.2) the eighth (#640) and
-# barbican (18.0.0) the ninth (#632). The services move one at a time and
-# OPENSTACK_RELEASE is promoted once they all have.
+# manila (18.3.0) the seventh (#638), octavia (14.0.2) the eighth (#640),
+# barbican (18.0.0) the ninth (#632), and heat (22.0.1) the tenth (#635).
+# The services move one at a time and OPENSTACK_RELEASE is promoted once they all have.
 #
 # barbican leaves a piece behind, the same way octavia does: python-barbicanclient owns
 # the `openstack secret ...` commands and has to stay in the antelope venv for as long as


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

- **Upgrades Heat from OpenStack Antelope to Caracal.** `openstack-heat 20.0.1 -> 22.0.1`, out of `/opt/openstack-antelope` (python 3.10) and into `/opt/openstack-caracal` (python 3.11), following keystone, glance, cinder, nova with placement, neutron, manila and octavia. 22.0.1 is the last numeric 2024.1 revision, the same rule #1191 used to land on 20.0.1.

- **The config migration is not quite a no-op, and the reason is worth reading.** antelope **471** options -> caracal **495**, and the section count moves **46 -> 51** — which matters more than the option count, because `LoadConfig()` takes its section list out of `heat.conf.def`, so a new section means a new (empty) section header in every regenerated `/etc/heat/heat.conf`. All five are **documentation-only**: `constraint_validation_cache`, `resource_finder_cache`, `service_extension_cache`, `yaql` and `oslo_versionedobjects` all exist in 20.0.1 with the same option names and the same defaults — 2024.1 merely gave the first four a `list_opts()` entry point and added `oslo.versionedobjects` to the generator input, so the sample can finally see them. `heat/common/cache.py` is the clearest case: the three cache `OptGroup`s move from inside `register_cache_configurations()` to module scope and gain a `list_opts()`, and nothing else about them changes. So the only *behavioural* difference in the generated conf is `heat_revision`.

  All **38** keys of the live conf survive. The 8 the generator never enumerates (6 `keystone_authtoken` auth-plugin keys, plus `www_authenticate_uri` in `[clients_keystone]` and `[ec2authtoken]`) are unenumerated *identically* in both releases. Three options are removed — `DEFAULT.onready`, `database.mysql_enable_ndb`, `oslo_middleware.secure_proxy_ssl_header` — and `config_heat.cpp` writes none of them. One becomes newly deprecated (`DEFAULT.use_eventlog`), also unset. Of the 27 added, exactly **3 are new heat features** — the `max_software_configs_per_tenant` / `max_software_deployments_per_tenant` / `max_snapshots_per_stack` quotas — and **none is adopted**, per this issue's "ignore the new features" criterion; the other 24 are newer oslo library options plus the 9 newly-exposed ones above.

- **The generator input had drifted and is refreshed from upstream.** Our copy was a verbatim byte-copy of upstream 20.0.1's `config-generator.conf`; 2024.1 adds `heat.common.cache`, `heat.engine.hot.functions`, `oslo.cache` and `oslo.versionedobjects`. The two files are byte-identical again. Upstream now lists `oslo.cache` **twice** — harmless, and worth stating so nobody "fixes" it into a diff against upstream: `_list_opts()` builds a `stevedore.named.NamedExtensionManager`, which loads each matching entry point once regardless of how many times it is named.

- **2024.1 replaces sqlalchemy-migrate with alembic, and the handover is automatic.** `heat/db/sqlalchemy/migrate_repo` becomes `heat/db/migrations` with a single revision, `c6214ca60943`. `db_sync` looks for the legacy `migrate_version` table and, if alembic has no revision yet, *stamps* the initial one rather than replaying it. That is only safe if the legacy schema at our last antelope migration equals what the initial alembic revision describes — it does: `heat/db/sqlalchemy/models.py` and `heat/db/models.py` are byte-identical bar one import path, so 086 (`drop_watch_rule_watch_data_tables`, the last 20.0.1 migration) *is* `c6214ca60943`. On the node the DB was at 86 and the stamp ran with no DDL. `heat-manage`'s subcommand list is unchanged, so `sdk_migrate.sh`, `config_heat.cpp` and `os_heat_service_clean()` all keep working; `migrate_properties_data` is now a deprecated no-op and nothing in this tree calls it.

- **`python-heatclient` stays in the *antelope* venv, and alone.** It owns the `orchestration` osc plugin, and an entry point is only visible to the interpreter it was installed under — `core/heavyfs` still links `/usr/bin/openstack` at `$(OPENSTACK_HOME_DIR)`, so without it `hex_sdk`'s `health_heat_check()` (`openstack orchestration service list`) breaks and `cluster check` reports `Orchestration NG [ heat(3 engine down) ]` while heat-engine is perfectly healthy — exactly the trap #1191 documented. heat's own `requirements.txt` names `python-heatclient`, so the caracal venv gets a 3.5.0 copy of its own; the antelope 3.2.0 is what the CLI sees, and it talks to a 22.0.1 API, which is the supported direction (`orchestration service list` is `/v1/{tenant}/services` and long predates 2023.1). It is named explicitly rather than left transitive because nothing in the antelope venv would pull it any more. `/usr/bin/heat` is that same package's console script, so it stays antelope too.

- **Leaving the antelope venv costs `/usr/bin/openstack` 377 subcommands, and all of them are dead surface.** heat declares **20** client libraries as hard requirements, and it was the only reason nine of them were in the antelope venv at all. Dropping heat there drops the `aodh`, `blazar`, `magnum`, `sahara`, `trove`, `mistral`, `vitrage`, `zaqar` and `zun` osc plugin groups with it: **1543 -> 1166** commands. None of those services is in the keystone service catalog, no call site in this tree uses any of their subcommands, and nothing left in the venv imports any of the libraries. Tested rather than reasoned about — all eleven orphans were uninstalled on the node, and `orchestration`, `stack`, `loadbalancer`, `share`, `baremetal`, `volume`, `server`, `network` and `image` all still resolve with `cluster check` green. This is why no compensating pip line is added: the surface that disappears is surface for services CubeCOS does not deploy.

- **heat's kafka notification transport is a venv co-tenancy dependency — the same shape as octavia's `kazoo` in #1373, but this one was already covered.** `config_heat.cpp` writes `[oslo_messaging_notifications] transport_url = kafka://`, and oslo.messaging's kafka driver needs `confluent-kafka`, which is an **extra** (`oslo.messaging[kafka]`) that heat does not declare. In the antelope venv it was there by luck, dragged in by **monasca-common** — the caracal venv has no monasca. It works because `core/keystone/keystone.mk` names `oslo.messaging[kafka]` explicitly for that venv, so the dependency is deliberate rather than accidental, and heat follows the six services that hopped before it in not restating it. Proved on the node rather than assumed: `orchestration.stack.{create,delete}.{start,end}` from `publisher_id: orchestration.cc1` were captured live off the `notifications.info` topic.

- **`heat-dashboard` deliberately does not move**, and stays pinned at 9.0.0. It follows horizon, not the heat service — `openstack-dashboard.service`, `gunicorn-config.py` and the httpd reverse proxy all point at the antelope tree, and every dashboard plugin installs next to it. It imports `heatclient` and never `heat`, so the split costs nothing; 11.0.1 is the caracal release to move to on the day horizon hops. Same reasoning `octavia-dashboard` got in #1373 and `manila-ui` in #1353. Verified with heat itself absent from the antelope venv: the five `_16[1-5]0_*` panels are registered, `horizon:project:stacks:index` and `horizon:project:resource_types:index` both reverse, and the dashboard serves 200 with zero errors.

  Unlike every other component's panel, heat needs **no** `HORIZON_POLICY_NS_*` entry: heat-dashboard ships a pre-generated `conf/default_policies/heat.yaml`, so `horizon.mk` copies it instead of dumping the `heat` oslo.policy namespace out of a venv. That is why this PR touches no horizon file, where #1373 had to move `octavia` between the two namespace lists.

- **Nothing heat carries could be replaced by the wheel — because the conversion already happened in #1191.** `api-paste.ini`, `environment.d/default.yaml` and `templates/{AWS_CloudWatch_Alarm,AWS_RDS_DBInstance}.yaml` are `data_files`, so pip lands them under the venv prefix and `heat.mk` relocates them into `/etc/heat` the way the RDO spec's `%install` did; all three are byte-identical between 20.0.1 and 22.0.1 and the `data_files` list itself is unchanged, so the hop moves only *which prefix* they are read from. The four remaining checked-in artifacts cannot come from a wheel: `heat.conf.sample` is oslo-config-generator output, the four `openstack-heat-*.service` units are RDO's and appear in no upstream artifact, and `oslo-config-generator/heat.conf` exists only in the sdist and is build input that is never installed. `etc/heat/README-heat.conf.txt` and `etc/heat/heat-policy-generator.conf` exist in the sdist but are not in `data_files`, so they never reach the venv prefix either.

- **`fix(heat): write auth_uri, not www_authenticate_uri, for heat's own keystone groups`** — a pre-existing defect found while auditing `config_heat.cpp` against the release, and **not** the cosmetic one it first looked like. `UpdateSharedId()` wrote `www_authenticate_uri` into `[clients_keystone]` and `[ec2authtoken]`; that name is keystonemiddleware's and exists only in `[keystone_authtoken]`, while both of those groups are heat's own and call the option `auth_uri` — in 20.0.1 as well as 22.0.1, so this is not caracal fallout. oslo.config drops an unknown key in a registered group without a word, so both lines were dead.

  `[ec2authtoken]` was the one that mattered. Unset, `ec2token.py` falls back to `endpoint_utils.get_auth_uri()`, which returns the **unversioned** `[keystone_authtoken]` URL, and then appends `/ec2tokens` — so heat POSTed to `http://<id>:5000/ec2tokens`, which keystone **404s with an HTML body**; `response.json()` raised `JSONDecodeError` and the request **500ed**. That is the endpoint `heat_metadata_server_url` and `heat_waitcondition_server_url` — written by the same function, two lines above — advertise to guests, so `AWS::CloudFormation::WaitCondition` could never be signalled and any template using one hung until its timeout. A/B tested against a real pre-signed `WaitConditionHandle` URL: **500 → 200**, `AWS authentication successful.`, and the WaitCondition reaching `CREATE_COMPLETE`. Antelope is broken the same way, so this is a fix carried here rather than a regression introduced here.

  `[clients_keystone] auth_uri` genuinely was inert. Corrected, heat runs keystone version discovery against it and `get_auth_uri()` returns `http://<id>:5000/v3/` instead of the unversioned fallback. It stays unversioned in the conf because the option documents itself that way and discovery appends the version, while `[ec2authtoken]` keeps the explicit `/v3` because `ec2token.py` appends `/ec2tokens` verbatim.

- **No downstream patches, and none needed.** `cmd/status.py` is byte-identical across the hop, so heat needs nothing like #1373's `octavia.common.policy` patch — `heat-status upgrade check` runs clean out of the box. There is no `heat_patch/` directory to rebase.

#### Which issue(s) this PR fixes

Fixes #635

#### Special notes for your reviewer

> [!IMPORTANT]
> **This PR is stacked on #1373 (octavia, #640).** `jim.lin/feat/openstack-c-upgrade-heat` branches off `jim.lin/feat/openstack-c-upgrade-octavia`, so until #1373 merges the diff shown against `develop` also contains octavia's five commits. **Only these three are this PR's own:**
>
> | commit | subject |
> |---|---|
> | `e952cbab` | feat(heat): add the caracal config sample and refresh the generator input |
> | `42c7874d` | feat(heat): move heat into the openstack caracal venv |
> | `7eafb0f0` | fix(heat): write auth_uri, not www_authenticate_uri, for heat's own keystone groups |
>
> The two change sets touch **zero files in common** — heat's are `core/heat/*`, `core/modules/config_heat.cpp` and the occupant-list comment in `project.mk`, octavia's are `core/octavia/*`, `core/horizon/horizon.mk` and the same `project.mk` comment line — so review #1373 first and this rebases cleanly onto whatever it lands as. The `project.mk` comment is the one shared line, and it is a pure append (`... octavia (14.0.2) the eighth (#640) and heat (22.0.1) the ninth (#635)`).

> [!NOTE]
> **The heat resource-type surface moves 185 -> 178, and nothing in this tree notices.** Enumerated from `resources.global_env().get_types()` in isolated venvs at both releases, so it is the registry's own answer rather than a docs claim:
>
> ```
> removed   OS::Glance::Image
>           OS::Neutron::LBaaS::{HealthMonitor,L7Policy,L7Rule,Listener,
>                                LoadBalancer,Pool,PoolMember}
> added     OS::Aodh::PrometheusAlarm
> ```
>
> The seven `LBaaS::*` types are neutron-lbaas, dead since Queens and superseded by the `OS::Octavia::*` family, which is unchanged. `OS::Glance::Image` went with the glance v1 API. **There are no heat templates anywhere in the cubecos tree** — `grep -rl heat_template_version` returns nothing, and no `OS::` type name is referenced outside `heat.conf.sample`'s own comments — so no removed type has an in-tree consumer. The live engine exposes 135 of the 178, the rest being types whose service is not deployed here.

> [!IMPORTANT]
> **Heat 22.0.1 turns secure RBAC on by itself, and that denies every AWS-CloudFormation *stack* action. Deliberately not handled in this PR — it needs a decision, not a patch.**
>
> `heat/common/policy.py` at 22.0.1 adds two lines that 20.0.1 does not have:
>
> ```python
> policy_opts.set_defaults(cfg.CONF, enforce_scope=True, enforce_new_defaults=True)
> ```
>
> That retires the deprecated `rule:deny_stack_user` fallbacks, so every heat policy is evaluated on its new secure-RBAC check string only. Most are `PROJECT_READER` — `role:reader and project_id:%(project_id)s` — which needs a **target** carrying `project_id`. The native v1 API supplies one (via `@util.registered_policy_enforce`), but `heat/api/cfn/v1/stacks.py:_enforce()` calls `policy.enforce(req.context, action, is_registered_policy=True)` with no target at all, so `project_id:%(project_id)s` can never match and the action is refused whatever roles the caller holds. Measured back-to-back in isolated venvs at both releases:
>
> ```
> antelope 20.0.1   enforce_scope=False enforce_new_defaults=False   ListStacks/DescribeStacks/CreateStack -> ALLOW
> caracal  22.0.1   enforce_scope=True  enforce_new_defaults=True    ListStacks/DescribeStacks/CreateStack -> DENY
> ```
>
> **This is not #1360.** #1360 is a *service user* missing `role:service`; here the caller is `admin_cli` holding `admin, manager, member, reader` — every role the rule names — and no role grant can satisfy an unresolvable `project_id`. Same family only in that both are 2024.1 secure-RBAC fallout.
>
> **Scope of the impact is narrow, which is why it is deferred rather than rushed:** the native v1 API is unaffected (`openstack stack list` and the whole stack lifecycle work throughout), nothing in this tree drives the AWS-CFN stack API, and `SignalController` — the `/v1/waitcondition/{arn}` and `/v1/signal/{arn}` routes that guests actually use — has **no policy check at all**, so guest signalling is unaffected and is fixed by the `auth_uri` commit above.
>
> Three ways to close it, and the choice is a security-posture decision rather than a packaging one: leave it as documented behaviour; write `[oslo_policy] enforce_new_defaults = false` in `config_heat.cpp` to hold antelope's posture (what this issue's "ignore the new features introduced in the new version" criterion would license, and what keeps heat consistent with the other eight caracal occupants, none of which enables secure RBAC); or carry a patch giving CFN `_enforce()` a target. Happy to do any of them — say which.

> [!NOTE]
> **Two things are not verified.**
>
> 1. **No real `make` through `rootfs_install` for `core/heat`.** The hop was landed *surgically* on the running jim-1cc node — pip into the caracal venv, relink `/usr/bin/*`, relocate the wheel's `etc/heat`, swap the `.def` — which is the established e2e loop but leaves this PR's `.mk` sequencing unexercised: the two chroot pip installs, the symlink pass and the `etc` relocation. It *was* checked to expand correctly, including the `$$`-escaped sed, by parsing `heat.mk` against a stub that defines only the five variables it consumes and diffing the full `make -n rootfs_install` output. Everything downstream of those steps is verified on a live node. Likewise `config_heat.cpp` compiles `-Wall -Werror` clean and `hex_config` links, but the rebuilt binary was **not** installed on the node, so the writer path is verified by the equivalent hand-edit to `/etc/heat/heat.conf` rather than by running it — `config_*.cpp` is statically linked into the setuid `hex_config`, so it cannot be hot-swapped. `Init()` loads the `.def` rather than the live conf, so the stale keys do not survive an upgrade.
> 2. **Single-node only.** `num_engine_workers`, `[heat_api] workers` and `[heat_api_cfn] workers` are all `GetControlWorkers()`-derived and were 1 here; `database/mysql_wsrep_sync_wait = 1` and the `if (ha)` `oslo_messaging_rabbit` block are untested at three-node shape. Non-admin RBAC is also untested — everything ran as admin, and heat carries no `policy.yaml`, so it runs on upstream's in-code defaults in both releases.

**The API version list does not move** — heat serves `v1.0` only, at both releases, and has no microversions.

**`hex_sdk`'s stale-API repair still resolves**, which is not obvious after a python-version change: `health_heat_check()` calls `stale_api_check_repair openstack-heat-api 8004 heat-api python3`, matching `heat-api` in `ss -lntp`'s `users:(("heat-api",...))` and `python3` in `netstat -lntp`'s `<pid>/python3.11`. Both still match, the same way octavia's did in #1373.

**Log collection is unaffected.** `oslo.log` still derives `heat-api.log` / `heat-api-cfn.log` / `heat-engine.log` from the binary names, so `config_logstash.cpp`'s `/var/log/heat/*.log` glob and the logrotate conf `config_heat.cpp` writes both land on the same files, all of them well over filebeat's 1024-byte fingerprint threshold.

#### Additional documentation

```docs
[cc1 ~]# /usr/bin/heat-engine --version
22.0.1

[cc1 ~]# /opt/openstack-caracal/bin/pip show openstack-heat python-heatclient | grep -E "^Name|^Version"
Name: openstack-heat
Version: 22.0.1
Name: python-heatclient
Version: 3.5.0

[cc1 ~]# ps -eo pid,user,args | grep -E "heat-(api|api-cfn|engine)" | grep -v grep
2866236 heat  /opt/openstack-caracal/bin/python3.11 /usr/bin/heat-api-cfn --config-file /etc/heat/heat.conf
2866238 heat  /opt/openstack-caracal/bin/python3.11 /usr/bin/heat-api     --config-file /etc/heat/heat.conf
2866274 heat  /opt/openstack-caracal/bin/python3.11 /usr/bin/heat-engine  --config-file /etc/heat/heat.conf

[cc1 ~]# rpm -qa | grep -i heat | sort
                       <- empty

[cc1 ~]# systemctl is-active openstack-heat-api openstack-heat-api-cfn openstack-heat-engine
active
active
active
[cc1 ~]# for u in openstack-heat-api openstack-heat-api-cfn openstack-heat-engine; do systemctl show -p NRestarts --value $u; done
0
0
0
[cc1 ~]# systemctl is-enabled openstack-heat-all; systemctl is-active openstack-heat-all
disabled                              <- shipped for RDO layout parity, never enabled
inactive

[cc1 ~]# for f in /var/log/heat/*.log; do echo -n "$f "; grep -cE " (ERROR|CRITICAL) " $f; done
/var/log/heat/heat-api.log 0
/var/log/heat/heat-api-cfn.log 0
/var/log/heat/heat-engine.log 0

The 38 engine warnings are all upstream registry notices, not fallout:
      7 OS::<type> is DEPRECATED. Sahara project was marked inactive
      5 OS::<type> is HIDDEN. Use octavia instead.
      5 OS::<type> is DEPRECATED. Senlin project was marked inactive
      4 OS::<type> is HIDDEN. Use LBaaS V2 instead.
      2 OS::<type> is DEPRECATED. Monasca project was marked inactive
     ... 15 more single HIDDEN/UNSUPPORTED lines
      3 amqp: Received method (60, 30) during closing channel 1  <- benign
[cc1 ~]# grep -icE "Failed to load|Unable to import|ModuleNotFoundError|ImportError" /var/log/heat/heat-engine.log
0                                     <- no client plugin failed to import


HEALTH CHECK

[cc1 ~]# hex_sdk health_heat_check; echo "rc=$?"
rc=0
[cc1 ~]# hex_sdk health_heat_report
| status  | error_code | description         |
| healthy |          0 | engine up/down: 1/0 |

[cc1 ~]# hex_cli -v -c boot_mode status
two phase boot... [yes]
standalone services... [ready]
cube services... [ready]
cluster data... [synced]
applying policy... [no]

[cc1 ~]# hex_cli -v -c cluster check
          Service  Status  Report
           IaasDb      ok  [ mysql(v) ]
        HaCluster      ok  [ hacluster(v) ]
       ClusterSys      ok  [ bootstrap(v) license(v) ]
     SingleSignOn      ok  [ k3s(v) keycloak(v) ]
      ClusterLink      ok  [ link(v) clock(v) dns(v) ]
        VirtualIp      ok  [ vip(v) haproxy_ha(v) ]
  ClusterSettings      ok  [ etcd(v) nodelist(v) mongodb(v) ]
       ApiService      ok  [ haproxy(v) httpd(v) nginx(v) api(v) skyline(v) memcache(v) ]
         MsgQueue      ok  [ rabbitmq(v) ]
          Network      ok  [ neutron(v) ]
            Image      ok  [ glance(v) ]
        Baremetal      ok  [ ironic(v) ]
         FileStor      ok  [ manila(v) ]
       ObjectStor      ok  [ swift(v) ]
           K8SaaS      ok  [ rancher(v) ]
    Orchestration      ok  [ heat(v) ]        <- the one this PR moves
        BlockStor      ok  [ cinder(v) ]
           DNSaaS      ok  [ designate(v) ]
    BusinessLogic      ok  [ watcher(v) ]
          Compute      ok  [ nova(v) cyborg(v) ]
         DataPipe      ok  [ zookeeper(v) kafka(v) ]
          Metrics      ok  [ monasca(v) telegraf(v) grafana(v) lachesis(v) ]
       InstanceHa      ok  [ masakari(v) ]
    Notifications      ok  [ influxdb(v) kapacitor(v) ]
     LogAnalytics      ok  [ filebeat(v) auditbeat(v) logstash(v) opensearch(v) opensearch-dashboards(v) ]
            LBaaS      ok  [ octavia(v) ]
          Storage      ok  [ ceph(v) ceph_mon(v) ceph_mgr(v) ceph_mds(v) ceph_osd(v) ceph_rgw(v) rbd_target(v) fc_link(v) ]


THE VENV SPLIT, PER COMPONENT

[cc1 ~]# ls -l /usr/bin/heat /usr/bin/heat-* | awk '{print $9, $10, $11}'
/usr/bin/heat          -> /opt/openstack-antelope/bin/heat       <- python-heatclient's CLI
/usr/bin/heat-all      -> /opt/openstack-caracal/bin/heat-all
/usr/bin/heat-api      -> /opt/openstack-caracal/bin/heat-api
/usr/bin/heat-api-cfn  -> /opt/openstack-caracal/bin/heat-api-cfn
/usr/bin/heat-engine   -> /opt/openstack-caracal/bin/heat-engine
/usr/bin/heat-manage   -> /opt/openstack-caracal/bin/heat-manage
/usr/bin/heat-status   -> /opt/openstack-caracal/bin/heat-status

[cc1 ~]# /opt/openstack-antelope/bin/pip list | grep -i heat
heat-dashboard               9.0.0     <- follows horizon, deliberately not moved
python-heatclient            3.2.0     <- the "orchestration" osc plugin
[cc1 ~]# /opt/openstack-antelope/bin/python -c "import heat"
ModuleNotFoundError: No module named 'heat'
[cc1 ~]# /opt/openstack-caracal/bin/python -c "import heat; print(heat.__file__)"
/opt/openstack-caracal/lib/python3.11/site-packages/heat/__init__.py

The 3.2.0 plugin against the 22.0.1 API, which is what health_heat_check() runs:
[cc1 ~]# head -1 /usr/bin/openstack
#!/opt/openstack-antelope/bin/python3.10
[cc1 ~]# openstack orchestration service list
| Hostname | Binary      | Engine ID    | Host | Topic  | Updated At          | Status |
| cc1      | heat-engine | 2eb848a8-... | cc1  | engine | 2026-08-27T08:17:33 | up     |

Every heat-manage call site in the tree:
[cc1 ~]# hex_sdk os_heat_service_clean; echo "rc=$?"      # sdk_os.sh:2165
Dead engines are removed.
rc=0
[cc1 ~]# su -s /bin/sh -c "/usr/bin/heat-manage purge_deleted 0" heat; echo "rc=$?"
INFO heat.db.api Purging stacks ('11b7b329-...','heat-verify-635'),('39f2deb1-...','heat-notif-635')
rc=0


THE API, AND heat_revision COMING THROUGH THE .def

[cc1 ~]# curl -s -H "X-Auth-Token: $TOKEN" http://10.1.0.1:8004/
{"versions": [{"id": "v1.0", "status": "CURRENT", ...}]}     <- unchanged from antelope

[cc1 ~]# curl -s -H "X-Auth-Token: $TOKEN" http://10.1.0.1:8004/v1/$PROJ/build_info
{"api": {"revision": "22.0.1"}, "engine": {"revision": "22.0.1"}}

That is the whole point of the "[revision] heat_revision" sed in heat.mk: heat serves
the value out of the conf, and hex_config carries it in from the .def. Reporting 22.0.1
proves the sed, the .def copy and LoadConfig()'s key parsing all still line up.

[cc1 ~]# curl -s -o /dev/null -w "unauthenticated GET /v1/.../stacks -> %{http_code}\n" ...
unauthenticated GET /v1/.../stacks -> 401
[cc1 ~]# curl -s "http://10.1.0.1:8000/v1/?Action=ListStacks"
<ErrorResponse><Error><Code>IncompleteSignature</Code>...    <- cfn api wired, 400

[cc1 ~]# /usr/bin/heat-status upgrade check
+-------------------------------------------+
| Check: Policy File JSON to YAML Migration |
| Result: Success                           |
+-------------------------------------------+


THE DATABASE -- sqlalchemy-migrate -> alembic, stamped not replayed

[cc1 ~]# mysql -e "select * from heat.migrate_version"     # before
repository_id  repository_path                                              version
heat           /opt/openstack-antelope/.../heat/db/sqlalchemy/migrate_repo   86

[cc1 ~]# su -s /bin/sh -c "/usr/bin/heat-manage db_sync" heat
INFO heat.db.migration  Applying migration(s)
INFO alembic.runtime.migration  Context impl MySQLImpl.
INFO heat.db.migration  The database is still under sqlalchemy-migrate control;
                        fake applying the initial alembic migration
INFO alembic.runtime.migration  Running stamp_revision  -> c6214ca60943
INFO heat.db.migration  Migration(s) applied

[cc1 ~]# su -s /bin/sh -c "/usr/bin/heat-manage db_version" heat
c6214ca60943
[cc1 ~]# mysql -e "select * from heat.alembic_version"
version_num
c6214ca60943

No DDL ran, which is correct: heat/db/sqlalchemy/models.py at 20.0.1 and
heat/db/models.py at 22.0.1 differ by exactly one line -- `from heat.db.sqlalchemy
import types` -> `from heat.db import types` -- so migration 086 IS c6214ca60943.
The legacy migrate_version row is left behind; heat never drops it.


THE CONFIG, PROVED BY REGENERATION RATHER THAN BY READING THE .def

hex_config's writer was reimplemented (LoadConfig(.def) + WriteConfig, SB_SEC_RFMT)
and *proved before use*: fed the pre-hop .def and the live conf's own key/values it
reproduced /etc/heat/heat.conf byte for byte. Only then was it fed the caracal .def.

[jail]# python3 writeconf.py heat.conf.def.old live-heat.conf regen-old.conf
[jail]# diff live-heat.conf regen-old.conf
PROOF OK: writer reproduces the live conf byte-exactly

[jail]# python3 writeconf.py heat.conf.def.new live-heat.conf regen-new.conf
[jail]# diff live-heat.conf regen-new.conf
> [constraint_validation_cache]           <- 5 new EMPTY section headers
> [oslo_versionedobjects]
> [resource_finder_cache]
< heat_revision = 20.0.1
> heat_revision = 22.0.1                  <- the only value that moves
> [service_extension_cache]
> [yaql]

sections 46 -> 51, keys 38 -> 38.  Every one of the 38 key/value pairs is unchanged.

[cc1 ~]# grep -c "^\[" /etc/heat/heat.conf.def.bak-20260827-pre635 /etc/heat/heat.conf.def
46
51
[cc1 ~]# ls -l /etc/heat/heat.conf /etc/heat/heat.conf.def
-rw-r----- 1 root heat   2071 /etc/heat/heat.conf
-rw-r----- 1 root root  89563 /etc/heat/heat.conf.def

Why all five new sections are inert -- heat/common/cache.py, 20.0.1 vs 22.0.1:
the three cache OptGroups move from inside register_cache_configurations() out to
module scope and gain a list_opts(); option names, types and defaults are identical.
heat/engine/hot/functions.py is the same story: `opts` -> `yaql_opts` plus a
list_opts(), same two options.  oslo.versionedobjects was simply never named in the
generator input before.  So the sample gained 51-46 sections of *documentation*.

Live-conf key survival, both directions:
  live keys not enumerated in the ANTELOPE sample: 8
  live keys not enumerated in the CARACAL  sample: 8   <- the same 8
  live keys that disappear in caracal:              0


WHEEL-CARRIED FILES -- taken from the caracal prefix, and identical

[cc1 ~]# ls /opt/openstack-caracal/etc/heat/
api-paste.ini  environment.d/  templates/          <- heat's whole data_files set
[cc1 ~]# md5sum /opt/openstack-caracal/etc/heat/api-paste.ini /etc/heat/api-paste.ini
14576c8a08303281d4ab4d67a1613ad3  /opt/openstack-caracal/etc/heat/api-paste.ini
14576c8a08303281d4ab4d67a1613ad3  /etc/heat/api-paste.ini
[cc1 ~]# diff -r /tmp/pre635/heat/environment.d /etc/heat/environment.d
environment.d IDENTICAL          <- vs the antelope-era copies
[cc1 ~]# diff -r /tmp/pre635/heat/templates /etc/heat/templates
templates IDENTICAL
[cc1 ~]# ls /etc/heat/
api-paste.ini  environment.d  heat.conf  heat.conf.def  templates
                                 ^ nothing under etc/ is checked in by us

[local]# diff -r openstack-heat-20.0.1/etc openstack-heat-22.0.1/etc && echo IDENTICAL
IDENTICAL
[local]# diff <(sed -n '/^\[files\]/,/^\[entry_points\]/p' .../20.0.1/setup.cfg) \
              <(sed -n '/^\[files\]/,/^\[entry_points\]/p' .../22.0.1/setup.cfg)
                                 <- data_files and scripts unchanged
console_scripts unchanged too, all six: heat-{all,api,api-cfn,engine,manage,status}


NOTIFICATIONS REACH KAFKA FROM THE CARACAL VENV

confluent-kafka is an oslo.messaging *extra*.  In antelope it arrived via
monasca-common; the caracal venv has no monasca, and core/keystone/keystone.mk's
"oslo.messaging[kafka]" is what puts it there.

[cc1 ~]# for v in antelope caracal; do /opt/openstack-$v/bin/pip show confluent-kafka \
           | grep -E "^Version|^Required-by"; done
Version: 1.9.2         Required-by: monasca-common      <- antelope: co-tenancy
Version: 2.3.0         Required-by:                     <- caracal: keystone names it
[cc1 ~]# /opt/openstack-caracal/bin/python -c "from stevedore import driver; \
           print(driver.DriverManager('oslo.messaging.drivers','kafka').driver)"
<class 'oslo_messaging._drivers.impl_kafka.KafkaDriver'>

Consumed off the topic during one stack create+delete -- not inferred from config:
[cc1 ~]# kafka-console-consumer.sh --topic notifications.info ...
publisher_id                          event_type
  4 orchestration.cc1                   orchestration.stack.create.start
                                        orchestration.stack.create.end
                                        orchestration.stack.delete.start
                                        orchestration.stack.delete.end
  4 identity.cc1                        identity.OS-TRUST:trust.created / .deleted
                                        identity.project.created / .deleted
  4 network.cc1                         network.create.start / .end / delete.*

The identity rows are a bonus: they are heat's deferred-auth trust and its stack-user
project, i.e. stack_user_domain_name = heat and [trustee] still working against the
caracal keystone.


FULL STACK LIFECYCLE -- create, update, delete, each confirmed from the OTHER service

Template: OS::Neutron::{Net,Subnet,Port} + OS::Cinder::Volume + OS::Nova::Server +
OS::Cinder::VolumeAttachment -- so the neutron, nova and cinder client plugins are
all exercised inside the new venv.

[cc1 ~]# openstack stack create -t /tmp/heat-verify-635.yaml --wait heat-verify-635
2026-08-27 08:20:42Z [heat-verify-635.net]:         CREATE_COMPLETE
2026-08-27 08:20:43Z [heat-verify-635.subnet]:      CREATE_COMPLETE
2026-08-27 08:20:44Z [heat-verify-635.port]:        CREATE_COMPLETE
2026-08-27 08:20:52Z [heat-verify-635.server]:      CREATE_COMPLETE
2026-08-27 08:20:54Z [heat-verify-635.attachment]:  CREATE_COMPLETE
2026-08-27 08:20:54Z [heat-verify-635]: CREATE_COMPLETE
| stack_status | CREATE_COMPLETE |                              real 0m18.9s

Confirmed from NEUTRON's side, not from heat's report:
[cc1 ~]# openstack network show heat-verify-635-net -f value -c id -c name -c status
6b2b6e02-5578-4374-a7b7-dce6f11e16a7 / heat-verify-635-net / ACTIVE
[cc1 ~]# openstack subnet list --network heat-verify-635-net
heat-verify-635-subnet-h2xklooj4usb  192.0.2.0/24
Confirmed from NOVA's side:
[cc1 ~]# openstack server list --all-projects | grep 635
heat-verify-635-vm  ACTIVE  {'heat-verify-635-net': ['192.0.2.168']}  Cirros
Confirmed from CINDER's side:
[cc1 ~]# openstack volume list | grep 635
heat-verify-635-vol  in-use  device /dev/sdb  server_id f5a855ed-...  host cc1

UPDATE (dns_nameservers 8.8.8.8 -> 8.8.8.8,1.1.1.1), again read back from neutron:
[cc1 ~]# openstack stack update -t ...-upd.yaml --wait heat-verify-635
| stack_status | UPDATE_COMPLETE |
[cc1 ~]# openstack subnet show <id> -f value -c dns_nameservers
before ['8.8.8.8']          after ['8.8.8.8', '1.1.1.1']
[cc1 ~]# server/volume untouched by the update:  ACTIVE / in-use

DELETE -- negative proof, not just a DELETE_COMPLETE:
[cc1 ~]# openstack stack delete --yes --wait heat-verify-635      real 0m27.7s
stacks named heat-verify-635: 0
networks: 0    ports: 0    servers: 0    volumes: 0
[cc1 ~]# openstack stack list --deleted | grep 635
heat-verify-635  DELETE_COMPLETE
[cc1 ~]# journalctl -u openstack-heat-engine --since "-10min" | grep -icE "error|traceback"
0
[cc1 ~]# hex_sdk health_heat_check; echo "rc=$?"
rc=0


RESOURCE-TYPE SURFACE, 185 -> 178

Enumerated from the registry itself in isolated venvs at both releases:
  from heat.engine import resources; sorted(resources.global_env().get_types())

  antelope 20.0.1   185 types
  caracal  22.0.1   178 types

[diff]  + OS::Aodh::PrometheusAlarm
        - OS::Glance::Image
        - OS::Neutron::LBaaS::HealthMonitor
        - OS::Neutron::LBaaS::L7Policy
        - OS::Neutron::LBaaS::L7Rule
        - OS::Neutron::LBaaS::Listener
        - OS::Neutron::LBaaS::LoadBalancer
        - OS::Neutron::LBaaS::Pool
        - OS::Neutron::LBaaS::PoolMember

[repo]# grep -rl "heat_template_version" .            -> nothing
[repo]# grep -rn "OS::Glance::Image\|OS::Neutron::LBaaS" .  -> nothing
[cc1 ~]# openstack orchestration resource type list -f value | wc -l
135                     <- the live engine's available subset; the other 43 are types
                           whose service is not deployed here


THE OSC SURFACE THE ANTELOPE VENV LOSES -- 1543 -> 1166, all of it dead

heat names 20 client libraries as hard requirements; nine of them were in the
antelope venv for no other reason.  After removing heat, nothing there declares
them and nothing there imports them:

[cc1 ~]# for p in aodhclient python-{blazar,magnum,sahara,trove,mistral,vitrage,
           zaqar,zun}client neutron-lib yaql; do pip show $p | grep Required-by; done
Required-by: <none>   (python-mistralclient only by python-troveclient, which also goes)
[cc1 ~]# grep -rlE "^\s*(from|import) <pkg>" site-packages --include=*.py | grep -v self
aodhclient/blazarclient/magnumclient/saharaclient/troveclient/vitrageclient/
zaqarclient/zunclient/neutron_lib/yaql  ->  importers: <none>

So they were uninstalled, to test the claim rather than argue it:
[cc1 ~]# openstack --help | grep -cE "^  [a-z]"
1543          <- before
1166          <- after; 377 subcommands gone

gone     alarm  coe  reservation  "data processing"  database  workflow  rca
         "messaging queue"  appcontainer
present  orchestration  stack  loadbalancer  share  baremetal  volume  server
         network  image

[cc1 ~]# openstack service list -f value -c Type | sort
accelerator baremetal baremetal-introspection cloudformation dns ha identity
image key-manager load-balancer monitoring network object-store orchestration
placement s3 share sharev2 volumev2 volumev3 infra-optim compute
                       ^ no aodh, blazar, magnum, sahara, trove, mistral,
                         vitrage, zaqar or zun -- the plugins were dead surface
[repo]# in-tree call sites for each lost subcommand group:  0, all nine
[cc1 ~]# hex_cli -v -c cluster check          -> all 27 rows ok
[cc1 ~]# openstack orchestration service list -> still resolves


THE ORCHESTRATION DASHBOARD, WITH heat ABSENT FROM ITS VENV

heat-dashboard 9.0.0 stays in the antelope venv and imports heatclient, never heat:

[cc1 ~]# django.setup(); import heat_dashboard, heat_dashboard.api.heat, heatclient
heat_dashboard : /opt/openstack-antelope/.../heat_dashboard/__init__.py
heatclient     : /opt/openstack-antelope/.../heatclient/__init__.py
reverse('horizon:project:stacks:index')          -> /project/stacks/
reverse('horizon:project:resource_types:index')  -> /project/resource_types/

[cc1 ~]# ls .../openstack_dashboard/local/enabled/ | grep -E "16[1-5]0"
_1610_project_orchestration_panel.py   _1620_project_stacks_panel.py
_1630_project_resource_types_panel.py  _1640_project_template_versions_panel.py
_1650_project_template_generator_panel.py
[cc1 ~]# ls -l .../openstack_dashboard/conf/default_policies/heat.yaml
-rw-r--r-- 1 root root 37275 heat.yaml    <- shipped by the wheel, so no
                                             HORIZON_POLICY_NS_* entry is needed
[cc1 ~]# systemctl restart openstack-dashboard httpd; systemctl is-active ...
active / active
[cc1 ~]# curl -sk -o /dev/null -w "%{http_code}\n" https://10.1.0.1/dashboard/auth/login/
200
[cc1 ~]# journalctl -u openstack-dashboard --since "-2min" | grep -icE "error|traceback"
0


CONFIG SAMPLE REGENERATION, METHOD PROVED BEFORE USE

Generated in isolated venvs off the *built rootfs's* base pythons (3.10 and 3.11), so
each sample comes from the interpreter that release actually runs on -- and the
ANTELOPE sample was regenerated the same way first:

[jail]# /usr/local/bin/python3.10 -m venv venv-antelope
[jail]# venv-antelope/bin/pip install -c os-antelope-pip-upper-constraints.txt \
          openstack-heat==20.0.1
[jail]# venv-antelope/bin/oslo-config-generator --config-file gen-antelope.conf
[jail]# md5sum out-antelope/etc/heat/heat.conf.sample
2ab6f938b67bfee5174538f82080f25f
[repo]# md5sum core/heat/heat.conf.sample                       # the checked-in file
2ab6f938b67bfee5174538f82080f25f      <- byte-identical, so the method is trustworthy

Only then the caracal one:
[jail]# /usr/local/bin/python3.11 -m venv venv-caracal
[jail]# venv-caracal/bin/pip install -c os-caracal-pip-upper-constraints.txt \
          openstack-heat==22.0.1
[jail]# venv-caracal/bin/oslo-config-generator --config-file gen-caracal.conf
[jail]# md5sum out-caracal/etc/heat/heat.conf.sample
dbd79811b38d6115967af595e13027b4      89540 bytes    <- now checked in

Generator input vs upstream:
[repo]# diff core/heat/oslo-config-generator/heat.conf \
             openstack-heat-22.0.1/config-generator.conf
                                      <- byte-identical again

Every dependency the hop pulls is pinned by the caracal constraint file, so the
install is reproducible -- 18 new packages, all constrained, openstack-heat itself
pinned in heat.mk because services are not in upper-constraints:
  aodhclient 3.5.1  appdirs 1.4.4  croniter 2.0.1  docker 7.0.0
  python-blazarclient 4.0.1  python-heatclient 3.5.0  python-ironicclient 5.5.1
  python-magnumclient 4.4.0  python-mistralclient 5.2.0  python-monascaclient 2.8.0
  python-octaviaclient 3.7.1  python-openstackclient 6.6.1  python-saharaclient 4.2.0
  python-troveclient 8.4.0  python-vitrageclient 5.0.0  python-zaqarclient 2.7.0
  python-zunclient 5.0.0  yaql 3.0.0

Makefile expansion check (no real build was run -- see Special notes):
[local]# make -n rootfs_install   # heat.mk against a 5-variable stub
chroot $ROOTDIR bash -c "source /opt/openstack-caracal/bin/activate && \
    pip install -c /opt/openstack-caracal/os-caracal-pip-upper-constraints.txt \
        openstack-heat==22.0.1"
chroot $ROOTDIR bash -c "source /opt/openstack-antelope/bin/activate && \
    pip install -c /opt/openstack-antelope/os-antelope-pip-upper-constraints.txt \
        python-heatclient"
chroot $ROOTDIR ln -sf /opt/openstack-caracal/bin/heat-api /usr/bin/heat-api      ...
chroot $ROOTDIR cp -f /opt/openstack-caracal/etc/heat/api-paste.ini /etc/heat/...
sed -i '/^\[revision\]$/a heat_revision = 22.0.1' $ROOTDIR/etc/heat/heat.conf
cp -f $ROOTDIR/etc/heat/heat.conf $ROOTDIR/etc/heat/heat.conf.def
                                      <- all 52 lines expand, $$ escape included

THE auth_uri FIX -- A/B ON THE REAL GUEST-SIGNALLING PATH

The option names, read off the generated samples rather than assumed. Neither
release has www_authenticate_uri in either group:

[cc1 ~]# awk '/^\[clients_keystone\]/,/^\[clients_magnum\]/' /etc/heat/heat.conf.def \
           | grep -E '^#[a-z_]+ ='
#endpoint_type = <None>
#ca_file = <None>
#cert_file = <None>
#key_file = <None>
#insecure = <None>
#auth_uri =                            <- the actual option name
[cc1 ~]# awk '/^\[ec2authtoken\]/,/^\[eventlet_opts\]/' /etc/heat/heat.conf.def \
           | grep -E '^#[a-z_]+ ='
#auth_uri = <None>                     <- likewise, and identical at 20.0.1
#multi_cloud = false
#allowed_auth_uris =
...

Which keystone path actually exists:
[cc1 ~]# for p in /ec2tokens /v3/ec2tokens /v2.0/ec2tokens; do
           curl -s -o /dev/null -w "POST $p -> %{http_code}\n" -X POST \
             -H 'Content-Type: application/json' -d '{}' http://10.1.0.1:5000$p; done
POST /ec2tokens      -> 404      <- HTML body; this is what heat was POSTing to
POST /v3/ec2tokens   -> 400      <- routed and handled ("must include a request body")
POST /v2.0/ec2tokens -> 404

A real AWS::CloudFormation::WaitConditionHandle, signalled at its own pre-signed
url -- i.e. exactly what cfn-signal does inside a guest:

[cc1 ~]# openstack stack output show wc-635 HandleUrl -f value -c output_value
http://10.1.0.1:8000/v1/waitcondition/arn%3Aopenstack%3Aheat%3A%3A...
    ?SignatureMethod=HmacSHA256&SignatureVersion=2&AWSAccessKeyId=fc4081be...

--- BEFORE: [ec2authtoken] www_authenticate_uri (the misnamed key)
[cc1 ~]# curl -X PUT -H "Content-Type: application/json" \
           -d '{"Status":"SUCCESS","Reason":"ok","UniqueId":"1","Data":"done"}' "$URL"
HTTP 500
  INFO heat.api.aws.ec2token  Authenticating with http://10.1.0.1:5000/ec2tokens
  requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
    ... heat/api/aws/ec2token.py line 213, in _authorize -> result = response.json()

--- AFTER: [ec2authtoken] auth_uri
[cc1 ~]# curl -X PUT ... "$URL"
HTTP 200
<resource>Handle</resource>
  INFO heat.api.aws.ec2token  Authenticating with http://10.1.0.1:5000/v3/ec2tokens
  INFO heat.api.aws.ec2token  AWS authentication successful.
[cc1 ~]# openstack stack resource list wc-635 -f value -c resource_name -c resource_status
Handle CREATE_COMPLETE
Wait   CREATE_COMPLETE          <- the WaitCondition was satisfied; it never could be before

Keystone's own view of the same two attempts:
[keystone_access.log] "POST /v3/ec2tokens HTTP/1.1" 200 13479   <- token issued
and the token it issues does carry the roles, so this was never a role problem:
[cc1 ~]# roles on the ec2 token: ['manager', 'admin', 'member', 'reader']   scope: project

[clients_keystone], the genuinely inert half -- what get_auth_uri() resolves to:
[cc1 ~]# /opt/openstack-caracal/bin/python -c "...endpoint_utils.get_auth_uri()"
  before (www_authenticate_uri, key dropped):  http://10.1.0.1:5000     <- unversioned
  after  (auth_uri, discovery branch):         http://10.1.0.1:5000/v3/

Nothing else moved -- re-run with both fixes live:
[cc1 ~]# hex_sdk health_heat_check; echo rc=$?
rc=0
[cc1 ~]# openstack stack create -t heat-verify-635.yaml --wait heat-verify-authuri
| stack_status | CREATE_COMPLETE |     <- trusts + stack-user project still fine with
[cc1 ~]# openstack stack delete --yes --wait heat-verify-authuri    the versioned X-Auth-Url
leftovers: 0
[cc1 ~]# for f in /var/log/heat/*.log; do grep -cE " (ERROR|CRITICAL) " $f; done
0
0
0

The cpp change itself, compiled but not installed (see Special notes):
[jail]# make -C core/modules config_heat.o      # -Wall -Werror
  CXX     config_heat.o
[jail]# make -C core/main hex_config
  LD      hex_config
[jail]# strings core/modules/config_heat.o | grep -oE "auth_uri|auth_url|www_authenticate_uri" \
          | sort | uniq -c
      3 auth_url                 1 www_authenticate_uri          <- original source
      3 auth_uri  3 auth_url     1 www_authenticate_uri          <- modified source
                                    ^ still one, for [keystone_authtoken], which is correct


THE CFN SECURE-RBAC CHANGE, MEASURED (see Special notes -- not handled here)

Evaluated the way heat's own CFN handler calls it, i.e. with no target:

[jail]# chroot .../venv-antelope/bin/python pol.py      # openstack-heat 20.0.1
enforce_scope        = False
enforce_new_defaults = False
  cloudformation:ListStacks       ALLOW
  cloudformation:DescribeStacks   ALLOW
  cloudformation:CreateStack      ALLOW
[jail]# chroot .../venv-caracal/bin/python pol.py       # openstack-heat 22.0.1
enforce_scope        = True
enforce_new_defaults = True
  cloudformation:ListStacks       DENY
  cloudformation:DescribeStacks   DENY
  cloudformation:CreateStack      DENY

Where the True comes from -- heat's own code, not our config and not the library
(oslo.policy defaults are False in both venvs, 4.1.1 and 4.3.0):
[local]# grep -rn "enforce_new_defaults" openstack-heat-{20.0.1,22.0.1}/heat/
openstack-heat-22.0.1/heat/common/policy.py:45:    enforce_new_defaults=True)
                                    <- 20.0.1 has no match at all

And that it is a missing *target*, not a missing role:
  cloudformation ListStacks   no target          DENY
  cloudformation ListStacks   project_id target  ALLOW      <- same context, same roles
  heat (native)  index        no target          DENY
  heat (native)  index        project_id target  ALLOW      <- native passes one, so it works

```
