### PR TITLE
feat(swift): move python-swiftclient to the caracal venv

### DIFF
--- a/core/swift/swift.mk
+++ b/core/swift/swift.mk
@@ -1,33 +1,52 @@
 # Cube SDK
 # swift installation
 
-# install the swift client inside the python 3.10 virtual environment.
+# install the swift client inside the caracal virtual environment.
 # note: the pypi package is python-swiftclient; the "swift" package is the
-# swift *server*, which CubeCOS does not ship (ceph rgw serves object-store).
+# swift *server*, which CubeCOS does not ship (ceph rgw serves object-store --
+# config_swift.cpp:145-147 points all three endpoints at rgw's 8888).
 #
-# The pip-installed yoga copy under /usr/local/lib/python3.9/site-packages is gone as
-# of #609: it was dragged in by the dashboard plugins, which all required horizon
-# 22.1.1 and therefore python-swiftclient under the yoga constraint, and none of them
-# installs into python 3.9 any more.
+# #642 moves the client from the antelope venv to the caracal one. There is no server
+# to move, so the client and the /usr/bin/swift symlink below are the whole of it.
 #
-# The python3-swiftclient rpm survives in the system python, but nothing asks for it
-# any longer: it was pulled in as a dependency of python3-heatclient (retired with the
-# osc move), python3-troveclient and openstack-ironic-common. It is not named here
-# either way -- this file installs the venv client, and the rpm's /usr/bin/swift is
-# overwritten by the symlink below.
+# The install is a re-declaration rather than a first install. horizon 24.0.2's down
+# payment into this venv (core/horizon/horizon.mk, the second rootfs_install::) runs
+# without --no-deps, and horizon 24.0.2 declares python-swiftclient >=3.2.0, so the
+# ===4.5.0 pinned in os-caracal-pip-upper-constraints.txt:103 is already installed by
+# the time this file runs. Naming it here keeps the object-store client an explicit
+# part of the object-store story rather than an accident of horizon's dependency set
+# -- the same reason it was named while it lived in the antelope venv.
 #
-# The venv install below is what cinder's SwiftBackupDriver imports; naming it here
-# makes that explicit rather than relying on cinder to pull it in transitively.
+# Two library consumers keep it from being a convenience CLI only, and both live in
+# the caracal venv as of #629: the `cube-swift` cinder backup type
+# (config_cinder.cpp:651-652) and, more importantly, cinder's *default* backup driver
+# (config_cinder.cpp:671-672), which is SwiftBackupDriver as well. Leaving the client
+# behind in antelope would have pointed this file's install and cinder's import at
+# two different copies.
+#
+# History, in case the paths below read as over-specified: the pip-installed yoga copy
+# under /usr/local/lib/python3.9/site-packages went away in #609. It had been dragged
+# in by the dashboard plugins, which all required horizon 22.1.1 and therefore
+# python-swiftclient under the yoga constraint, and none of them installs into python
+# 3.9 any more.
+#
+# The python3-swiftclient rpm is gone too, and the comment that used to say it "survives
+# in the system python" was stale: it only ever arrived as a dependency of
+# python3-heatclient (retired with the osc move), python3-troveclient and
+# openstack-ironic-common, and all three have since left the rpm set. Verified on the
+# built rootfs -- `rpm -q python3-swiftclient` reports not installed, the system python
+# cannot import swiftclient, and the only two copies on disk are the two venvs'. So the
+# symlink below no longer overwrites an rpm-owned path; it creates /usr/bin/swift.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-		python-swiftclient==4.2.0"
+	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		python-swiftclient==4.5.0"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-	$(Q)# Link binaries. This overwrites a path owned by the python3-swiftclient
-	$(Q)# rpm, and it now wins PATH as well: the pip-installed yoga copy that owned
-	$(Q)# /usr/local/bin/swift -- which precedes /usr/bin -- came in with horizon,
-	$(Q)# and #609 moved horizon into the venv, so a bare "swift" is antelope 4.2.0.
-	$(Q)chroot $(ROOTDIR) ln -sf /opt/openstack-antelope/bin/swift /usr/bin/swift
+	$(Q)# Link binaries. Nothing else owns this path any more, and it wins PATH as
+	$(Q)# well: the pip-installed yoga copy that owned /usr/local/bin/swift -- which
+	$(Q)# precedes /usr/bin -- came in with horizon, and #609 moved horizon into the
+	$(Q)# venv, so a bare "swift" is caracal 4.5.0.
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/swift /usr/bin/swift


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

**CubeCOS does not ship the swift server.** Ceph RGW answers object-store on 8888, and `config_swift.cpp:145-147` registers all three keystone endpoints against it. `core/swift/swift.mk` does exactly two things — 13 non-comment lines — and both now point at `/opt/openstack-caracal`: the `python-swiftclient` pip install, and the `/usr/bin/swift` symlink.

What ends up where:

| Component | venv | Version |
| -- | -- | -- |
| `python-swiftclient` (declared by `swift.mk`) | `/opt/openstack-caracal` | 4.5.0 |
| `/usr/bin/swift` | → `/opt/openstack-caracal/bin/swift` | 4.5.0 |
| `python-swiftclient` (horizon 23.1.1's dependency) | `/opt/openstack-antelope` | 4.2.0 — **stays, undeclared** |

**The pip install is a re-declaration, not a first install — the caracal venv already had 4.5.0.** `core/horizon/horizon.mk`'s second `rootfs_install::` — the 24.0.2 down payment `5ed7ef2b` added so each venv's dashboard could dump its own services' policy defaults — runs without `--no-deps`, horizon 24.0.2 declares `python-swiftclient >=3.2.0`, and `os-caracal-pip-upper-constraints.txt:103` pins it at `===4.5.0`. Naming it in `swift.mk` keeps the object-store client an explicit part of the object-store story instead of an accident of horizon's dependency set — which is the same reason it was named while it lived in the antelope venv, in the comment this PR rewrites.

**That also means the library consumers were never broken, and one of them is the default path.** cinder moved to the caracal venv in #629, and its backup driver is `SwiftBackupDriver` both for the `cube-swift` backup type (`config_cinder.cpp:651-652`) *and* by default (`config_cinder.cpp:671-672`). Had the caracal venv genuinely lacked the client, that default path would have been importing from a venv it does not run in. `cinder.mk` does not name `python-swiftclient`, so nothing there needs a matching change.

**Nothing is left behind in the antelope venv by this commit.** The 4.2.0 copy there is horizon 23.1.1's dependency — both horizon releases carry the same `python-swiftclient >=3.2.0` — so it goes when horizon goes (#636), and neither venv gets an explicit removal.

**One inherited comment was stale and is corrected rather than carried.** `swift.mk` claimed the `python3-swiftclient` rpm "survives in the system python" and that the symlink overwrites an rpm-owned `/usr/bin/swift`. Neither is true on a built rootfs: `rpm -q python3-swiftclient` reports not installed, the system python cannot import `swiftclient`, and the only two copies on disk are the two venvs'. The rpm only ever arrived as a dependency of `python3-heatclient`, `python3-troveclient` and `openstack-ironic-common`, and all three have left the rpm set since that comment was written — so the symlink now *creates* `/usr/bin/swift` rather than overwriting anything.

**`config_swift.cpp` and `health_swift_check()` are deliberately untouched.** `config_swift.cpp` only creates the keystone service, endpoints and S3 credentials, and never names a venv path — 258 lines with no mention of python or swiftclient. `sdk_health.sh:2660` drives `$OPENSTACK object store account show`, and `object_store_account_show` is python-openstackclient's **own** entry point, not one contributed by python-swiftclient, so it does not follow the client across venvs. The stevedore entry-point visibility problem that forces some clients to stay behind does not arise here.

#### Verification

ISO `CUBE_3.1.20_20260827-1028_27b4093` (`distclean iso test`, `E2ETST=1cc`) — build green, e2e 4/4 (`test_01_cc1`, `test_01_dot1_cc1-fts`, `test_29_cc1_setready`, `test_30_cc1_license`). **This PR's `.mk` sequencing was exercised for real** — the chroot pip install and the symlink pass both ran inside `rootfs_install`, not applied by hand to a running node — and everything below was read off the resulting rootfs.

Then on the 1cc:

| AC | Command | Result |
| -- | -- | -- |
| Client is in the caracal venv | `ls -d /opt/openstack-caracal/lib/python3.11/site-packages/python_swiftclient-*.dist-info` | `python_swiftclient-4.5.0.dist-info` |
| Symlink follows | `ls -la /usr/bin/swift` | `-> /opt/openstack-caracal/bin/swift` |
| **A bare `swift` is caracal** | `which swift; swift --version` | `/usr/bin/swift`; `python-swiftclient 4.5.0` |
| The yoga copy is really gone | `ls /usr/local/bin/swift` | `No such file or directory` — nothing precedes `/usr/bin` on PATH |
| **Authenticates against RGW 8888** | `swift stat` | `rc=0`, 1 container / 1 object / 87 bytes; `default-placement` policy and an RGW-shaped `X-Trans-Id` |
| Read round-trip | `swift list` | `log` |
| cinder's default backup path imports | `/opt/openstack-caracal/bin/python -c "from cinder.backup.drivers import swift"` | `SwiftBackupDriver` resolves; `/usr/bin/cinder-backup` → caracal venv |
| The antelope copy is horizon's, not an orphan | `dist-info` in both venvs + horizon `METADATA` | antelope: `python_swiftclient-4.2.0` + `horizon-23.1.1`; caracal: `4.5.0` + `horizon-24.0.2` |
| Health check unaffected | `hex_sdk -v health_swift_check` | account JSON, `rc=0` — still served by antelope's `/usr/bin/openstack` |
| No stale references | `grep -rl openstack-antelope/bin/swift /usr/lib/systemd/system /etc /usr/lib/hex_sdk` | no hits |

The RGW row is the one that matters most: it is the only check that proves the *relinked* client can still talk to the object-store this product actually ships, rather than merely reporting a version.

#### Which issue(s) this PR fixes

Close #642

#### Special notes for your reviewer

> Note

This PR is **one commit over one file** — `core/swift/swift.mk`, `+40 / -21`. It sits directly on `develop` and depends on no other open PR.

Three things worth knowing:

1. **The verified ISO carries more than this PR.** Build #51 was cut from a branch that also contained the barbican (#632), designate (#634) and cyborg (#633) work, so the rootfs the table above was read from is not `develop` + this commit alone. None of those touch `swift.mk`, `/usr/bin/swift` or either venv's swiftclient, and this commit applies to `develop` unchanged — but the evidence came off a wider ISO, so it is worth stating rather than letting someone find it.

2. **`SKIP_SYSTEST=True` on that build, so there is no sys/iso evidence for this PR.** The e2e install suite did run in full. Nothing in this change is reachable from the sys/iso tier (there is no swift server to start and no unit to order), so this is a gap in coverage rather than a known risk, but it is a gap.

3. **`/opt/openstack-antelope/bin/swift` still exists on the node**, as horizon 23.1.1's console script. It is no longer on any PATH and nothing references it; it disappears with horizon in #636. Deliberately not removed — deleting a file the antelope venv's own dependency owns would be reaching outside this ticket.

#### Additional documentation

```docs
[cc1 ~]# ls -la /usr/bin/swift
lrwxrwxrwx 1 root root 32 Aug 27 18:21 /usr/bin/swift -> /opt/openstack-caracal/bin/swift

[cc1 ~]# which swift ; swift --version
/usr/bin/swift
python-swiftclient 4.5.0

[cc1 ~]# ls -d /opt/openstack-*/lib/python3.*/site-packages/python_swiftclient-*.dist-info
/opt/openstack-antelope/lib/python3.10/site-packages/python_swiftclient-4.2.0.dist-info
/opt/openstack-caracal/lib/python3.11/site-packages/python_swiftclient-4.5.0.dist-info

[cc1 ~]# ls -d /opt/openstack-*/lib/python3.*/site-packages/horizon-*.dist-info
/opt/openstack-antelope/lib/python3.10/site-packages/horizon-23.1.1.dist-info
/opt/openstack-caracal/lib/python3.11/site-packages/horizon-24.0.2.dist-info

[cc1 ~]# openstack endpoint list --service swift -f value -c Interface -c URL
public http://10.1.0.1:8888/swift/v1/%(project_id)s
admin http://10.1.0.1:8888/swift/v1/%(project_id)s
internal http://10.1.0.1:8888/swift/v1/%(project_id)s

[cc1 ~]# swift stat
                                    Account: ac8818a01c9c4728a4f6a52d0aa63568
                                 Containers: 1
                                    Objects: 1
                                      Bytes: 87
   Containers in policy "default-placement": 1
      Objects in policy "default-placement": 1
                                 X-Trans-Id: tx00000e40f95be66253efc-006a90f98d-3870-default
                     X-Openstack-Request-Id: tx00000e40f95be66253efc-006a90f98d-3870-default

[cc1 ~]# swift list
log

[cc1 ~]# ls -la /usr/bin/cinder-backup
lrwxrwxrwx 1 root root 40 Aug 27 18:21 /usr/bin/cinder-backup -> /opt/openstack-caracal/bin/cinder-backup

[cc1 ~]# /opt/openstack-caracal/bin/python -c "import swiftclient, sys; print(swiftclient.__version__, sys.version.split()[0])"
4.5.0 3.11.15

[cc1 ~]# /opt/openstack-caracal/bin/python -c "from cinder.backup.drivers import swift as s; print(s.SwiftBackupDriver.__name__)"
SwiftBackupDriver

[cc1 ~]# hex_sdk -v health_swift_check
{
  "Account": "ac8818a01c9c4728a4f6a52d0aa63568",
  "Bytes": "87",
  "Containers": "1",
  "Objects": "1"
}

[cc1 ~]# grep -rl "openstack-antelope/bin/swift" /usr/lib/systemd/system/ /etc/ /usr/lib/hex_sdk/
                       <- empty
```
