### PR TITLE
feat(advisor): keep the tunnel up, and prefer the driver's cluster id

### DIFF
--- a/core/advisor/advisor.mk
+++ b/core/advisor/advisor.mk
@@ -1,0 +1,18 @@
+# Cube SDK
+# Cube AI Advisor agent unit installation into the node OS image.
+#
+# The agent binary itself is not shipped here: it arrives at enrolment as a
+# signed release, verified against the key compiled into hex_config (ADR 0003).
+# Only its unit ships with the image, and it is deliberately NOT enabled at
+# build time -- an un-enrolled node has no identity and the unit would
+# crash-loop from first boot. hex_sdk's advisor_enroll enables it once a node
+# has actually enrolled.
+
+ADVISOR_AGENT_SERVICE := cube-advisor-agent.service
+
+rootfs_install::
+	$(Q)cp -f $(COREDIR)/advisor/$(ADVISOR_AGENT_SERVICE) $(ROOTDIR)/usr/lib/systemd/system/
+
+# for RC builds
+heavyfs_install::
+	$(Q)cp -f $(COREDIR)/advisor/$(ADVISOR_AGENT_SERVICE) $(ROOTDIR)/usr/lib/systemd/system/

--- a/core/advisor/cube-advisor-agent.service
+++ b/core/advisor/cube-advisor-agent.service
@@ -1,0 +1,23 @@
+# Installed by the CubeCOS OS image, but enabled only after `cube-advisor-agent
+# enroll` succeeds — an un-enrolled node has no identity and nothing to connect
+# with, so enabling this unit before that point would just crash-loop.
+#
+# `run` takes no arguments: enrolment persists the tunnel address (see
+# internal/identity.SaveServer), and the agent reconnects with its own backoff
+# on every flap or SaaS restart. This unit's only job is to keep the process
+# alive across reboots and crashes — bigstack-oss/cube-advisor-agent#19.
+
+[Unit]
+Description=CubeCOS AI Advisor agent
+Documentation=https://github.com/bigstack-oss/cube-advisor-agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/cube-advisor-agent run
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/core/main/Makefile
+++ b/core/main/Makefile
@@ -66,6 +66,7 @@ include $(SRCDIR)/cube.mk
 
 ROOT_COMPONENTS += cubectl
 ROOT_COMPONENTS += phone-home-agent
+ROOT_COMPONENTS += advisor
 include $(shell for m in $(ROOT_COMPONENTS); do ls $(COREDIR)/$$m/$$m.mk; done)
 
 # cube finalizer

--- a/core/sdk_sh/modules/sdk_advisor.sh
+++ b/core/sdk_sh/modules/sdk_advisor.sh
@@ -35,6 +35,11 @@ fi
 ADVISOR_MANIFEST_NAME=manifest.txt
 ADVISOR_SIGNATURE_NAME=manifest.txt.sig
 
+# The agent's own unit, shipped by cube-advisor-agent and installed with the
+# image. Enabled only once a node has enrolled -- see advisor_agent_service_enable.
+ADVISOR_AGENT_UNIT_NAME=cube-advisor-agent.service
+ADVISOR_AGENT_UNIT=/usr/lib/systemd/system/$ADVISOR_AGENT_UNIT_NAME
+
 # advisor_verify_release <dir> [artifact]
 #
 # Verifies the release in <dir>: the manifest's signature against the key
@@ -95,6 +100,78 @@ advisor_install_release()
     return 0
 }
 
+# advisor_agent_service_enable
+#
+# Start the tunnel and keep it started. Enrolment leaves the node holding a
+# valid certificate; without this it would hold one and never connect, which
+# looks from the Advisor exactly like a broken tunnel.
+#
+# Enabled here rather than at image build: an un-enrolled node has no identity,
+# so the unit would crash-loop from first boot until someone enrolled it.
+advisor_agent_service_enable()
+{
+    if [ ! -r "$ADVISOR_AGENT_UNIT" ] ; then
+        echo "Warning: $ADVISOR_AGENT_UNIT is missing; the tunnel will not start on its own" >&2
+        return 0
+    fi
+
+    systemctl daemon-reload
+    if systemctl enable --now "$ADVISOR_AGENT_UNIT_NAME" >/dev/null 2>&1 ; then
+        echo "Tunnel service enabled; the agent will reconnect on its own after a reboot."
+    else
+        # The identity is saved and enrolment did succeed, so this must not
+        # fail the command -- say what is wrong and let the operator start it.
+        echo "Warning: could not enable $ADVISOR_AGENT_UNIT_NAME; start it manually with: systemctl enable --now $ADVISOR_AGENT_UNIT_NAME" >&2
+    fi
+    return 0
+}
+
+# advisor_cluster_id
+#
+# The cluster's identity for enrolment -- this cluster's, never this node's.
+# The Advisor makes it the certificate's common name and the primary key five
+# of its tables reference, none with ON UPDATE CASCADE, so it is chosen once
+# and effectively permanently. Two sources, in order:
+#
+#   1. CUBE_CLUSTER_ID, written by cube-cos-driver at deploy time. Derived from
+#      the cluster UUID the driver assigns, so it is unique by construction --
+#      and the Advisor's fleet then shows the same id the driver shows.
+#   2. cubesys.controller, the operator-chosen controller name: the VIP's name
+#      on an HA cluster and the single node's name otherwise. Identical on
+#      every node of the cluster, so enrolling from any control node yields
+#      one identity -- but a name, so two sites can collide on it.
+#
+# Never the hostname: a 3-node cluster would then enrol as whichever node the
+# operator happened to type the command on.
+advisor_cluster_id()
+{
+    local id=""
+
+    if [ -r /etc/cube/phone-home-agent.env ] ; then
+        id=$(sed -n 's/^CUBE_CLUSTER_ID=//p' /etc/cube/phone-home-agent.env | head -1)
+    fi
+    if [ -z "$id" ] ; then
+        id=$(source /usr/sbin/hex_tuning /etc/settings.txt 2>/dev/null ; echo "$T_cubesys_controller")
+    fi
+    if [ -z "$id" ] ; then
+        echo "Error: cannot tell which cluster this node belongs to (no CUBE_CLUSTER_ID, no cubesys.controller)" >&2
+        return 1
+    fi
+
+    # It becomes a certificate CN and a URL path segment, and nothing on the
+    # Advisor side validates either -- so refuse the shapes that would break
+    # them here, where the message can still be useful.
+    case $id in
+        */*|*\ *) echo "Error: cluster id contains a character that cannot appear in a URL path: $id" >&2 ; return 1 ;;
+    esac
+    if [ ${#id} -gt 64 ] ; then
+        echo "Error: cluster id is longer than 64 characters, which strict X.509 tooling rejects: $id" >&2
+        return 1
+    fi
+
+    echo "$id"
+}
+
 # advisor_agent_arch
 #
 # Maps this machine to the artifact naming the release manifest uses. Unknown
@@ -147,17 +224,8 @@ advisor_enroll()
         return 1
     fi
 
-    # The cluster's identity, not this node's. cubesys.controller is the
-    # operator-chosen controller name: the VIP's name on an HA cluster and the
-    # single node's name otherwise, and identical on every node of the cluster
-    # -- so enrolling from any control node yields the same identity, where the
-    # agent's own default (the hostname) would mint one identity per node.
     local cluster
-    cluster=$(source /usr/sbin/hex_tuning /etc/settings.txt 2>/dev/null ; echo "$T_cubesys_controller")
-    if [ -z "$cluster" ] ; then
-        echo "Error: cubesys.controller is not set; cannot tell which cluster this node belongs to" >&2
-        return 1
-    fi
+    cluster=$(advisor_cluster_id) || return 1
     arch=$(advisor_agent_arch) || return 1
     artifact="cube-advisor-agent_linux_$arch"
 
@@ -186,7 +254,7 @@ advisor_enroll()
         -server "$server" -token-file "$token_file" -cluster "$cluster"
     rc=$?
     case $rc in
-        0) ;;
+        0) advisor_agent_service_enable ;;
         3) echo "This node is already enrolled; nothing was changed." >&2 ;;
         4) echo "The pairing token was refused -- ask for a fresh one." >&2 ;;
         5) echo "The Advisor service was unreachable from this node." >&2 ;;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Two gaps left over from verifying Advisor enrolment end to end on the sky lab.

**Nothing started the tunnel.** Enrolment installed the agent and saved an identity, then stopped. The node held a valid certificate and never connected — which, seen from the Advisor, is indistinguishable from a broken tunnel, and the operator had no documented command to fix it. The agent now ships a systemd unit (bigstack-oss/cube-advisor-agent#21, merged); this installs it with the image via a new `core/advisor` component, and `advisor_enroll` enables it **only after enrolment succeeds** — an un-enrolled node has no identity and the unit would crash-loop from first boot. A missing unit warns rather than failing, because the identity is saved and enrolment did succeed.

**The cluster id was a name.** #1356 moved it off the node hostname onto `cubesys.controller`, which is correct at the cluster-versus-node level but is still operator-chosen, so two sites can collide. That matters more than it looks: the Advisor makes the id a certificate CN and the primary key five of its tables reference, none with `ON UPDATE CASCADE` (bigstack-oss/cube-ai-advisor#108), so it is chosen once and effectively permanently.

This prefers `CUBE_CLUSTER_ID` from `/etc/cube/phone-home-agent.env` — written by cube-cos-driver at deploy time, derived from the cluster UUID it assigns, unique by construction — and falls back to `cubesys.controller` for clusters the driver did not deploy. It also refuses ids that would break a URL path or an X.509 CN, since the Advisor validates neither.

Side benefit: the Advisor's fleet now shows the same cluster id the driver shows the operator.

#### Which issue(s) this PR fixes

Refs #1356
Refs bigstack-oss/cube-advisor-agent#19

#### Special notes for your reviewer

> Note

Verified against the live 3.1.20 lab: `hex_sdk advisor_cluster_id` resolves to the driver's `ky3haclust01`, and with the unit absent (as it is until an image rebuild) the enable step warns and returns 0 rather than failing an otherwise successful enrolment.

`core/advisor` follows the file-installing component pattern (`barbican`, `designate`): a bare `advisor.mk`, no Makefile, registered in `ROOT_COMPONENTS` so `core/main/Makefile` picks it up. The unit is installed but deliberately **not** `systemctl enable`d at build time, which is where it differs from `phone-home-agent`.

One duplication worth naming: the unit file now exists both here and in the agent repo's `contrib/systemd/`. The tidier long-term home is the signed release itself — the manifest already covers every file it lists, so the unit would be verified by the same signature as the binary and could never drift from the `run` interface it depends on. That needs the release build to carry it, which is not automated yet.

Note for anyone testing on the sky lab: the already-enrolled identity there is `sky141` from before #1356. New enrolments will use `ky3haclust01`, so the fleet will show both until the old record is removed.

#### Additional documentation

```docs

```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5EppnHrpbAYHCxPjN7t64