### PR TITLE
fix(elk,kafka): verify tarballs with gpgv, which needs no gpg-agent

### DIFF
--- a/core/elk/elk.mk
+++ b/core/elk/elk.mk
@@ -68,20 +68,23 @@ LOGSTASH_DL_URL := https://artifacts.elastic.co/downloads/logstash
 # what makes the check worth anything: the key travels the same channel as the tarball,
 # so accepting whatever key that channel hands back would verify nothing.
 LOGSTASH_GPG_FPR := 46095ACC8548582C1A2699A9D27D666CD88E42B4
-LOGSTASH_GNUPGHOME := $(ARCS_DIR)/logstash-gnupg
 
+# Checked with gpgv against a throwaway keyring rather than `gpg --verify` against a
+# homedir: gpg wants gpg-agent even to read a public keyring, and the agent does not
+# reliably start under mountrootfs -- it failed a build in one jail while the same command
+# worked by hand in the same container. gpgv needs no agent, no homedir and no keyring
+# mutation, which is what it exists for.
+#
 # Download to .part and only rename once the detached signature checks out, so neither a
 # truncated object from a caching proxy nor a tampered one is ever left where the next
 # run would extract it as a finished download.
 $(ARCS_DIR)/$(LOGSTASH_TGZ):
 	$(Q)wget $(LOGSTASH_DL_URL)/$(LOGSTASH_TGZ) -O $@.part
 	$(Q)wget $(LOGSTASH_DL_URL)/$(LOGSTASH_TGZ).asc -O $@.asc
-	$(Q)rm -rf $(LOGSTASH_GNUPGHOME) && mkdir -p -m 700 $(LOGSTASH_GNUPGHOME)
-	$(Q)wget -qO- https://artifacts.elastic.co/GPG-KEY-elasticsearch | \
-		GNUPGHOME=$(LOGSTASH_GNUPGHOME) gpg --batch --quiet --import
-	$(Q)GNUPGHOME=$(LOGSTASH_GNUPGHOME) gpg --batch --status-fd 1 --verify $@.asc $@.part | \
+	$(Q)wget -qO- https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor > $@.gpg
+	$(Q)gpgv --keyring $@.gpg --status-fd 1 $@.asc $@.part | \
 		grep -q '^\[GNUPG:\] VALIDSIG $(LOGSTASH_GPG_FPR) '
-	$(Q)rm -rf $(LOGSTASH_GNUPGHOME) $@.asc
+	$(Q)rm -f $@.asc $@.gpg
 	$(Q)mv $@.part $@
 
 rootfs_install:: $(ARCS_DIR)/$(LOGSTASH_TGZ)

--- a/core/kafka/kafka.mk
+++ b/core/kafka/kafka.mk
@@ -14,20 +14,21 @@ KAFKA_DL_URL := https://archive.apache.org/dist/kafka/$(KAFKA_VER)
 # it fails the build instead of quietly trusting whatever the KEYS file carries. Find the
 # new one with: gpg --verify <tgz>.asc <tgz>
 KAFKA_GPG_FPR := D9472951E133753353DCE20D72E522CC9FCBBAC9
-KAFKA_GNUPGHOME := $(ARCS_DIR)/kafka-gnupg
 
+# Checked with gpgv rather than `gpg --verify` -- see the note on the logstash rule in
+# core/elk/elk.mk; gpg needs gpg-agent to read a keyring and the agent does not reliably
+# start under mountrootfs.
+#
 # Download to .part and only rename once the detached signature checks out, so a truncated
 # or tampered object is never left where the next run would unpack it as a finished
 # download. KEYS comes from downloads.apache.org, a different host to the tarball's.
 $(ARCS_DIR)/$(KAFKA_TGZ):
 	$(Q)wget $(KAFKA_DL_URL)/$(KAFKA_TGZ) -O $@.part
 	$(Q)wget $(KAFKA_DL_URL)/$(KAFKA_TGZ).asc -O $@.asc
-	$(Q)rm -rf $(KAFKA_GNUPGHOME) && mkdir -p -m 700 $(KAFKA_GNUPGHOME)
-	$(Q)wget -qO- https://downloads.apache.org/kafka/KEYS | \
-		GNUPGHOME=$(KAFKA_GNUPGHOME) gpg --batch --quiet --import
-	$(Q)GNUPGHOME=$(KAFKA_GNUPGHOME) gpg --batch --status-fd 1 --verify $@.asc $@.part | \
+	$(Q)wget -qO- https://downloads.apache.org/kafka/KEYS | gpg --dearmor > $@.gpg
+	$(Q)gpgv --keyring $@.gpg --status-fd 1 $@.asc $@.part | \
 		grep -q '^\[GNUPG:\] VALIDSIG $(KAFKA_GPG_FPR) '
-	$(Q)rm -rf $(KAFKA_GNUPGHOME) $@.asc
+	$(Q)rm -f $@.asc $@.gpg
 	$(Q)mv $@.part $@
 
 rootfs_install:: $(ARCS_DIR)/$(KAFKA_TGZ)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

**Part of #645.** The tarball signature check that story added ([#1383](https://github.com/bigstack-oss/cubecos/pull/1383), merged) breaks the build in some jails. `centos9_cubecos_seki_200.13` [#52](https://10.32.200.10/job/centos9_cubecos_seki_200.13/52/) failed at `core/elk/elk.mk:80`:

```
gpg: error running '/usr/bin/gpg-agent': exit status 2
gpg: failed to start gpg-agent '/usr/bin/gpg-agent': General error
gpg: can't connect to the gpg-agent: General error
make[5]: *** [core/elk/elk.mk:80: .../ARCS/logstash-9.5.2-linux-x86_64.tar.gz] Error 2
```

**`gpg --import` needs `gpg-agent` even to write a public keyring**, and the agent does not reliably start under `mountrootfs`. Both downloads had succeeded; only the keyring import failed.

**The cause is a deterministic `GNUPGHOME` path-length ceiling** — corrected from an earlier version of this description, which called it an intermittent agent spawn. Thanks to @SekiXu for the measurement that caught it; his numbers reproduce exactly.

`gpg-agent` binds five sockets in the homedir, and the longest is `S.gpg-agent.browser` at `len(homedir) + 20`. GnuPG rejects a socket path at `>= sizeof(sun_path) - 1`, i.e. 107, so the ceiling is **homedir ≤ 86**. Measured in the failing jail, fresh homedir per iteration, the original `elk.mk` import command verbatim:

| homedir len | `S.gpg-agent.browser` | rc | agent error | sockets bound |
|---|---|---|---|---|
| 80 | 100 | 0 | no | 5 |
| 84 | 104 | 0 | no | 5 |
| 86 | 106 | **0** | no | 5 |
| 87 | 107 | **2** | yes | 0 |
| 89 | 109 | 2 | yes | 0 |
| 92 | 112 | 2 | yes | 0 |

Deterministic, threshold between 86 and 87. My earlier "falsification" was wrong three ways, all worth naming so the record is useful:

- **The bisect range 88–91 sat entirely above the threshold**, so it contained no passing case and could not falsify anything.
- **The success probe was invalid.** It ran `gpg --list-keys` and treated rc=0 as "import OK" — but `--list-keys` exits 0 on an empty keyring. (The key does in fact land in the pubring even when gpg exits 2; the build dies on the exit code, not a missing key.)
- **The "works by hand" control used `GNUPGHOME=/tmp/gtest`** — 10 characters, browser socket 30. That is the passing side of the threshold, not a control.

**Jim's jail was never a passing case either.** Its `ARCS` still holds only `logstash-9.2.3-linux-x86_64.tar.gz` from December, so the bumped filename means the rule never re-ran there. Run at that jail's real path (`len=89`, browser 109) the original import fails with the identical rc=2 — same as Seki's.

So both rules now use **`gpgv`**, which verifies a detached signature against a keyring with no agent, no homedir and no keyring mutation — which is what it exists for:

```make
$(Q)wget -qO- https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor > $@.gpg
$(Q)gpgv --keyring $@.gpg --status-fd 1 $@.asc $@.part | \
	grep -q '^\[GNUPG:\] VALIDSIG $(LOGSTASH_GPG_FPR) '
```

`gpg --dearmor` is a pure armor decode — no keyring, no agent. `LOGSTASH_GNUPGHOME` and `KAFKA_GNUPGHOME` go with the change, and with them the whole path-length exposure: `gpgv` binds no sockets at all. The pinned fingerprints, the `.part` staging and the failure behaviour are unchanged; only the tool doing the checking is different.

**How close the original was to failing everywhere.** The homedir is `/home/jenkins/workspace/<jenkins-job>/build/core/heavyfs/ARCS/logstash-gnupg`, i.e. `63 + len(job)`, and the Jenkins job name carries the developer, host and topology. Against the ≤86 ceiling:

| jenkins job | homedir | `S.browser` | |
|---|---|---|---|
| `centos9_cubecos_accept` | 85 | 105 | passes |
| `centos9_cubecos_jim_200.13` | 89 | 109 | fails |
| `centos9_cubecos_seki_200.13` | 90 | 110 | fails |
| `centos9_cubecos_prod_200.11` | 90 | 110 | fails |
| `centos9_cubecos_arashi_200.13` | 92 | 112 | fails |
| `centos9_cubecos_steven_200.13` | 92 | 112 | fails |

One of six jails clears it. The original check was not fragile in one jail — it was broken in five, and only ever looked fine where a cached tarball kept the rule from running.

`kafka.mk` gets the same treatment. It has not failed a build yet only because its tarball is cached far more often, so the rule has not re-run — the ceiling applies to it identically.

#### Which issue(s) this PR fixes

Fixes #

Part of #645 (already closed by #1383). No closing keyword on purpose — this is a follow-up fix to that story's change, not a separate story.

#### Special notes for your reviewer

> Note

**The `.part` staging did its job and is worth keeping in mind while reviewing.** The failed build left `logstash-9.5.2-linux-x86_64.tar.gz.part` in `ARCS` and never promoted it, so no half-verified tarball was unpacked — the build failed loudly instead. That is the behaviour this change preserves.

**Nothing in Seki's workspace was modified.** Diagnosis read his `ARCS` artifacts and used a `/tmp` scratch directory that was removed. The stale `ARCS/logstash-gnupg/` his failed build left behind clears on his next run — that job runs `distclean iso` and `PKGCLEAN` includes `ARCS_DIR`.

**`gpgv` ships in `gnupg2`**, which is already in the `quay.io/centos/centos:stream9` base image, so this adds no build dependency — same as the original check.

The handbook runbook's landing snippet still showed the old `gpg --verify` form; that is corrected in bigstack-handbook alongside this, together with a known-issue for the agent trap itself.

#### Additional documentation

```docs
Verified in centos9_cubecos_seki_200.13 -- the jail that failed -- against the artifacts
its failed build left in ARCS.


1. WHAT FAILED, AND WHERE

[jenkins] centos9_cubecos_seki_200.13 #52, stage cube_build
  ...tar.gz.part' saved [486769123/486769123]      <- tarball downloaded fine
  ...tar.gz.asc'  saved [488/488]                  <- signature downloaded fine
  gpg: error running '/usr/bin/gpg-agent': exit status 2
  gpg: failed to start gpg-agent: General error
  gpg: can't connect to the gpg-agent: General error
  make[5]: *** [core/elk/elk.mk:80: .../logstash-9.5.2-linux-x86_64.tar.gz] Error 2

  the failing line is the `gpg --batch --quiet --import` in the download rule.


2. IT IS THE PATH LENGTH, AND IT IS DETERMINISTIC

gpg-agent binds five sockets in the homedir; the longest is S.gpg-agent.browser at
len(homedir)+20. gnupg rejects a socket path at >= sizeof(sun_path)-1 = 107.

[seki]# fresh homedir per iteration, the original elk.mk import command verbatim
  LEN   S.extra  S.browser  rc   agent-err  sockets  key-present
  80    98       100        0    no         5        YES
  82    100      102        0    no         5        YES
  84    102      104        0    no         5        YES
  85    103      105        0    no         5        YES
  86    104      106        0    no         5        YES     <- threshold
  87    105      107        2    YES        0        YES
  88    106      108        2    YES        0        YES
  89    107      109        2    YES        0        YES
  90    108      110        2    YES        0        YES
  92    110      112        2    YES        0        YES

  ceiling: homedir <= 86.  key-present=YES on BOTH sides -- the key does reach the
  pubring; gpg exits 2 on the agent connection, and that exit is what make sees.

An earlier version of this description called this intermittent. It was wrong, and the
three reasons are worth recording:

[seki]# gpg --homedir <empty dir> --batch --list-keys ; echo rc=$?
  rc=0                        <- --list-keys exits 0 on an EMPTY keyring, so the
                                 original "import OK" probe proved nothing
  the original bisect range 88-91 lies entirely above the threshold -- no passing case
  the "works by hand" control used GNUPGHOME=/tmp/gtest, len 10, browser socket 30,
    which is the passing side of the threshold rather than a control

and jim's jail was not a passing case, just an unexercised one:
[jim]#  ls ARCS/ | grep logstash
  logstash-9.2.3-linux-x86_64.tar.gz    Dec 18 2025   <- 9.5.2 never downloaded,
                                                        so the rule never ran there
[jim]#  P=.../centos9_cubecos_jim_200.13/build/core/heavyfs/ARCS/logstash-gnupg
        len=89  S.browser=109
[jim]#  GNUPGHOME=$P gpg --batch --quiet --import /tmp/KEY
  gpg: error running '/usr/bin/gpg-agent': exit status 2
  gpg: can't connect to the gpg-agent: General error
  rc=2                        <- identical failure

why the length differs per jail: the homedir is
  /home/jenkins/workspace/<jenkins-job>/build/core/heavyfs/ARCS/logstash-gnupg
= 63 + len(job), and the job name carries developer + host + topology:
  centos9_cubecos_accept          85  browser 105   passes
  centos9_cubecos_jim_200.13      89  browser 109   fails
  centos9_cubecos_seki_200.13     90  browser 110   fails
  centos9_cubecos_prod_200.11     90  browser 110   fails
  centos9_cubecos_arashi_200.13   92  browser 112   fails
  centos9_cubecos_steven_200.13   92  browser 112   fails
                                  ^ one of six clears the ceiling


3. THE gpgv CHAIN, IN THAT JAIL, ON THOSE ARTIFACTS

[seki]# A=.../centos9_cubecos_seki_200.13/build/core/heavyfs/ARCS
[seki]# wget -qO- .../GPG-KEY-elasticsearch | gpg --dearmor > /tmp/elastic.gpg
  dearmor rc=0 size=1265                 <- no agent, no keyring
[seki]# gpgv --keyring /tmp/elastic.gpg --status-fd 1 $A/...tar.gz.asc $A/...tar.gz.part
  gpgv: Signature made Tue Aug 18 21:24:39 2026 CST
  gpgv:                using RSA key 46095ACC8548582C1A2699A9D27D666CD88E42B4
  gpgv: Good signature from "Elasticsearch (Elasticsearch Signing Key)"
  [GNUPG:] VALIDSIG 46095ACC8548582C1A2699A9D27D666CD88E42B4 ...
  rc=0

negative cases, same keyring:
  good tarball               rc=0     (want 0)
  truncated download         rc=1     (want non-zero)
  wrong pinned fingerprint   rc=1     (want non-zero)
  empty keyring              rc=1     (want non-zero)


4. THE WHOLE RECIPE, END TO END

[seki]# (the two big wgets already done by the failed build)
[seki]# wget -qO- .../GPG-KEY-elasticsearch | gpg --dearmor > $T.gpg
[seki]# gpgv --keyring $T.gpg --status-fd 1 $T.asc $T.part | grep -q 'VALIDSIG <fpr> '
[seki]# rm -f $T.asc $T.gpg
[seki]# mv $T.part $T
  recipe completed rc=0
  -rw-r--r--. 1 root root 486769123 logstash-9.5.2-linux-x86_64.tar.gz   <- only the tarball
[seki]# tar tzf $T | head -2
  logstash-9.5.2/NOTICE.TXT
  logstash-9.5.2/CONTRIBUTORS          <- the promoted file is the real thing


5. NOTHING ELSE IN THE RECIPE MOVED

[jail]# make -n over old and new elk.mk, expanded command sequences diffed
  only the verification chain differs:
    -  rm -rf /ARCS/logstash-gnupg && mkdir -p -m 700 /ARCS/logstash-gnupg
    -  wget -qO- ...GPG-KEY-elasticsearch | GNUPGHOME=... gpg --batch --quiet --import
    -  GNUPGHOME=... gpg --batch --status-fd 1 --verify ....asc ....part | grep -q ...
    +  wget -qO- ...GPG-KEY-elasticsearch | gpg --dearmor > ....tar.gz.gpg
    +  gpgv --keyring ....tar.gz.gpg --status-fd 1 ....asc ....part | grep -q ...
    -  rm -rf /ARCS/logstash-gnupg ....asc
    +  rm -f ....asc ....gpg
  every other recipe command byte-identical and in the same order.

[dev]$ grep -rn GNUPGHOME core/ --include='*.mk'
  (none)
```

