### PR TITLE
fix(k3s): resolve the ceph-csi tag check's inputs from the source tree

### DIFF
--- a/core/k3s/ceph-csi/Makefile
+++ b/core/k3s/ceph-csi/Makefile
@@ -57,14 +57,14 @@ $(CSI_NODE_DRIVER_REGISTER_IMG_TAR):
 	$(call RUN_CMD_TIMED,docker pull $(CSI_NODE_DRIVER_REGISTER_IMG):$(CSI_NODE_DRIVER_REGISTER_IMG_TAG),"  PULL    $(CSI_NODE_DRIVER_REGISTER_IMG):$(CSI_NODE_DRIVER_REGISTER_IMG_TAG)")
 	$(call RUN_CMD_TIMED,docker save $(CSI_NODE_DRIVER_REGISTER_IMG):$(CSI_NODE_DRIVER_REGISTER_IMG_TAG) -o $(CSI_NODE_DRIVER_REGISTER_IMG_TAR),"  SAVE    $(CSI_NODE_DRIVER_REGISTER_IMG_TAR)")
 
-CSI_DRIVERS_GO := ../../cubectl/app/util/ceph/csi-drivers.go
+CSI_DRIVERS_GO := $(COREDIR)/cubectl/app/util/ceph/csi-drivers.go
 
 # The charts decide what kubelet pulls; these tags decide what the offline
 # bundle holds. Checked against each other so a chart bump cannot ship a
 # bundle the cluster cannot use.
 .PHONY: verify-image-tags
 verify-image-tags: $(CEPH_CSI_RBD_CHART) $(CEPH_CSI_FS_CHART)
-	$(call RUN_CMD_TIMED,sh verify-image-tags.sh $(CSI_DRIVERS_GO) $(CEPH_CSI_RBD_CHART) $(CEPH_CSI_FS_CHART) -- \
+	$(call RUN_CMD_TIMED,sh $(SRCDIR)/verify-image-tags.sh $(CSI_DRIVERS_GO) $(CEPH_CSI_RBD_CHART) $(CEPH_CSI_FS_CHART) -- \
 	    $(CEPH_CSI_IMG):$(CEPH_CSI_IMG_TAG) \
 	    $(CSI_PROVISIONER_IMG):$(CSI_PROVISIONER_IMG_TAG) \
 	    $(CSI_RESIZER_IMG):$(CSI_RESIZER_IMG_TAG) \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`42400a5f` added a tag check to the ceph-csi rule, but both of its source inputs are named by bare relative paths. `make` runs in `BLDDIR`, while `verify-image-tags.sh` and `csi-drivers.go` live in the source tree, so neither resolves and the rule fails before it can check anything.

`centos9_cubecos_seki_200.13` [#53](https://10.32.200.10/job/centos9_cubecos_seki_200.13/53/) died there:

```
  CHECK   ceph-csi image tags
sh: verify-image-tags.sh: No such file or directory
make[6]: *** [Makefile:67: verify-image-tags] Error 1
```

Verified in that jail, after the failure:

```
BLDDIR .../build/core/k3s/ceph-csi/verify-image-tags.sh    -> No such file
SRCDIR .../cubecos/core/k3s/ceph-csi/verify-image-tags.sh  -> exists
BLDDIR holds only: Makefile, ceph-csi-cephfs-3.13.1.tgz, ceph-csi-rbd-3.13.1.tgz
```

The two charts on the same command line resolve only because they had just been pulled into `BLDDIR` — which is why the failure points at the script alone.

**`CSI_DRIVERS_GO` has the same defect and would have been the next failure.** Same jail:

```
BLDDIR .../build/core/k3s/ceph-csi/../../cubectl/app/util/ceph/csi-drivers.go  -> No such file
SRCDIR .../cubecos/core/k3s/ceph-csi/../../cubectl/app/util/ceph/csi-drivers.go -> exists
```

So both are prefixed here, with the variables the rest of the tree already uses — `$(SRCDIR)` for the module's own script, `$(COREDIR)` for the file under `core/cubectl`. Expanded in that build directory:

```
SRCDIR  = .../cubecos/core/k3s/ceph-csi
COREDIR = .../cubecos/core
```

`Makefile:67` was the only bare source-relative reference in this file; its own parent `core/k3s/Makefile:78,88` already spells both out (`$(SRCDIR)/registries.yaml`, `$(COREDIR)/docker/copy-images.sh`).

Nothing about what the check does changes — same script, same arguments, same failure behaviour.

#### Which issue(s) this PR fixes

Fixes #

Follow-up to `42400a5f`; no closing keyword on purpose.

#### Special notes for your reviewer

> Note

**Why this had not been seen before.** `42400a5f` landed on develop on 2026-08-29. A build whose base predates it never reaches the rule — my earlier #52 is one. The first build I ran with it in the base failed immediately.

#### Additional documentation

```docs
Verified in centos9_cubecos_seki_200.13, the jail that failed.


1. WHAT FAILED (build #53, before this change)

  CHECK   ceph-csi image tags
sh: verify-image-tags.sh: No such file or directory
make[6]: *** [Makefile:67: verify-image-tags] Error 1

  note the label prints either way -- it is RUN_CMD_TIMED's banner, not a result.
  A successful run appends the elapsed time; this one has none.


2. WHY, IN THAT JAIL

[seki]# ls .../build/core/k3s/ceph-csi/verify-image-tags.sh
  No such file or directory
[seki]# ls .../cubecos/core/k3s/ceph-csi/verify-image-tags.sh
  exists
[seki]# ls .../build/core/k3s/ceph-csi/
  Makefile  ceph-csi-cephfs-3.13.1.tgz  ceph-csi-rbd-3.13.1.tgz
                                        ^ the two charts had just been pulled here,
                                          which is why only the script failed to resolve

same defect, not yet reached, on the other input:
[seki]# ls .../build/core/k3s/ceph-csi/../../cubectl/app/util/ceph/csi-drivers.go
  No such file or directory
[seki]# ls .../cubecos/core/k3s/ceph-csi/../../cubectl/app/util/ceph/csi-drivers.go
  exists


3. THE VARIABLES, EXPANDED IN THAT BUILD DIRECTORY

[seki]# make probe-vars   (in .../build/core/k3s/ceph-csi)
  SRCDIR  = .../cubecos/core/k3s/ceph-csi
  COREDIR = .../cubecos/core
  BLDDIR  = .../build/core/k3s/ceph-csi


4. AFTER THIS CHANGE (build #54, same jail, distclean iso)

[jenkins] centos9_cubecos_seki_200.13 #54
  CHECK   ceph-csi image tags (0s)          <- elapsed time present: the check ran
  PULL    quay.io/cephcsi/cephcsi:v3.13.1 (98s)
  SAVE    ceph-csi.tar (12s)
  PULL    registry.k8s.io/sig-storage/csi-provisioner:v5.0.1 (2s)
  SAVE    ceph-csi-provisioner.tar (1s)
  ...

  grep -c "No such file or directory" over the whole console: 0
```
