### PR TITLE
fix(rolling): scope the API-ready gate to control nodes

### DIFF
--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -185,12 +185,13 @@ _power_roll_api_ready()
     # until their workers are up, while haproxy re-enables the rejoined backend
     # after two passing checks. A live-migration pre-check balanced onto one of
     # those marks the instance ERROR (no retry in nova's pre-check path), so
-    # gate the next drain on a real response from every node.
+    # gate the next drain on a real response. Control-only: compute nodes
+    # never serve 9696/8774.
     local deadline=$(( $(date +%s) + ${ROLLING_API_READY_TIMEOUT:-600} ))
     local bad
     while : ; do
         bad=""
-        for n in $(cubectl node list -j | jq -r '.[].ip.management') ; do
+        for n in $(cubectl node list -j -r control | jq -r '.[].ip.management') ; do
             for p in 9696 8774 ; do
                 Quiet timeout 5 curl -s -o /dev/null http://$n:$p/ || bad="$bad $n:$p"
             done


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`_power_roll_api_ready()` probes 9696/8774 on **every** node's own management IP. Only control nodes run nova-api/neutron-server (`config_nova.cpp` `NovaService()` gates both on `IsControl`), so a compute node can never answer — the gate fails deterministically, times out (600s), and pauses the job. It runs from `_power_roll_kick()` before every node transition, so on any compute-bearing topology `rolling_update` has no unattended path at all.

One-line fix: `cubectl node list -j -r control`. The role bitmask (`util/role.go`) still matches `control-converged` / `control-network` / `edge-core` / `moderator`, so converged topologies keep the full gate; only pure compute/storage/network nodes drop out — which is why 1cc/3cc runs never surfaced this.

#### Which issue(s) this PR fixes

Fixes #1391

#### Special notes for your reviewer

> Note

- The adjacent unfiltered loop in `_power_roll_kick()` (the `is_sshable` reachability check) is **intentionally left unfiltered** — that one does want every node before taking another down.
- Comment updated to state why the gate is control-only, so the next reader doesn't "fix" it back.
- Validated on the sky 3cc lab (`27df138`, = the RC2 pkg the issue reproduced against): `cubectl node list -j -r control` returns all 3 `control-converged` nodes, and the patched loop passes with 9696/8774 → HTTP 200 on each node's own IP. `bash -n` clean.
- **Not** re-validated on a compute-bearing topology — the lab has no compute-only node. Issue #1391's QA step 1 (unattended roll on 3c2p) is still owed and is the real acceptance test; the reporter's run only got through with fake listeners, so the gate's intended protective behaviour on control nodes was never exercised there either.

#### Additional documentation

```docs
bigstack-handbook: kb/cubecos/known-issues/rolling-api-ready-gate-probes-compute-nodes.md (+ .scenario.yaml)
```

