### PR TITLE
fix(install,airgap): terraform tree rebuild, ingress bundling, OSD symlink, disk eligibility

### DIFF
--- a/core/k3s/images.txt
+++ b/core/k3s/images.txt
@@ -3,3 +3,4 @@ docker.io/rancher/mirrored-coredns-coredns:1.10.1
 docker.io/rancher/mirrored-library-busybox:1.34.1
 docker.io/rancher/mirrored-metrics-server:v0.6.3
 docker.io/rancher/mirrored-pause:3.6
+registry.k8s.io/ingress-nginx/controller:v1.8.1

--- a/core/k3s/ingress-nginx/chart-values.yaml
+++ b/core/k3s/ingress-nginx/chart-values.yaml
@@ -1,5 +1,12 @@
 controller:
   kind: DaemonSet
+  # copy-images.sh bundles a single-arch copy, whose manifest digest differs
+  # from upstream's multi-arch index. Clear the chart's digest pins so the pull
+  # resolves by tag through the registries.yaml mirror instead of by a digest
+  # the local registry will never hold.
+  image:
+    digest: ""
+    digestChroot: ""
   hostPort:
     enabled: true
     ports:

--- a/core/main/cube-journald.conf
+++ b/core/main/cube-journald.conf
@@ -1,0 +1,15 @@
+# Persistent journal.
+#
+# systemd's default Storage=auto keeps the journal in /run unless
+# /var/log/journal exists, so every reboot discards it. Failures that occur
+# during boot -- storage activation, udev, ceph OSD bring-up -- therefore leave
+# no evidence behind by the time anyone looks. Storage=persistent creates
+# /var/log/journal itself.
+#
+# Bounded so the journal can never crowd the root filesystem.
+[Journal]
+Storage=persistent
+SystemMaxUse=2G
+SystemMaxFileSize=128M
+SystemKeepFree=5G
+MaxRetentionSec=1month

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -265,6 +265,11 @@ rootfs_install::
 	$(Q)mkdir -p $(ROOTDIR)/etc/systemd/system.conf.d
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-watchdog.conf ./etc/systemd/system.conf.d
 
+# persistent journal so boot-time failures survive the reboot they happen on
+rootfs_install::
+	$(Q)mkdir -p $(ROOTDIR)/etc/systemd/journald.conf.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/cube-journald.conf ./etc/systemd/journald.conf.d
+
 # roll stall watchdog -- installed disabled; the roll arms/disarms it
 rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/main/hex-roll-watchdog.service ./lib/systemd/system

--- a/core/modules/config_ceph.cpp
+++ b/core/modules/config_ceph.cpp
@@ -380,16 +380,16 @@ prepareOsdDirectories()
         snprintf(osddir, sizeof(osddir), OSDDIR_FMT, osdId);
         s_osdIds.push_back(osdId);
 
-        bool isOldOsd = stat(osddir, &ds) == 0 && S_ISDIR(ds.st_mode);
-        if (!isOldOsd) {
+        if (stat(osddir, &ds) != 0 || !S_ISDIR(ds.st_mode)) {
             if (HexMakeDir(osddir, USER, GROUP, 0755) != 0) {
                 HexLogError("failed to create ceph osd directory %s", osddir);
                 return false;
             }
-
-            s_osdNewIds.push_back(osdId);
         }
 
+        // Mount before deciding. The directory alone says nothing about whether
+        // an OSD exists -- it is just a mountpoint, and the metadata only shows
+        // up once the metapart is mounted.
         const ExecSyncResult mr = ExecBashSync(
             0,
             false,
@@ -400,11 +400,34 @@ prepareOsdDirectories()
             HexUtilSystemF(0, 0, "mount %s %s", d.c_str(), osddir);
         }
 
+        // An OSD already lives here if its metadata is on the mounted metapart,
+        // or its data partition still carries a bluestore label. Deciding this
+        // from the directory's existence wipes a healthy OSD whose directory was
+        // removed while it was unmounted (cubecos#1284).
+        struct stat ts;
+        std::string typePath = std::string(osddir) + "/type";
+        bool isOldOsd = stat(typePath.c_str(), &ts) == 0;
+        if (!isOldOsd && dataPartUuid.length() > 0) {
+            const ExecSyncResult lr = ExecBashSync(
+                0,
+                false,
+                false,
+                {},
+                HEX_SDK " ceph_osd_datapart_has_osd " + dataPartUuid);
+            isOldOsd = (lr.exitCode == 0);
+            if (isOldOsd)
+                HexLogWarning("osd %lu has no metadata at %s but its data partition %s carries a "
+                              "bluestore label; not re-creating it", osdId, osddir, dataPartUuid.c_str());
+        }
+
         if (!isOldOsd) {
+            s_osdNewIds.push_back(osdId);
+            HexLogInfo("creating a new osd %lu on %s", osdId, d.c_str());
             HexSystemF(0, "rm -rf %s/*", osddir);
             HexSystemF(0, "echo bluestore > %s/type", osddir);
             HexSystemF(0, "ln -sf /dev/disk/by-partuuid/%s %s/block", dataPartUuid.c_str(), osddir);
-            HexUtilSystemF(0, 0, "ceph-osd -i %lu --mkfs --osd-uuid %s >/dev/null 2>&1", osdId, uuid.c_str());
+            if (HexUtilSystemF(0, 0, "ceph-osd -i %lu --mkfs --osd-uuid %s", osdId, uuid.c_str()) != 0)
+                HexLogError("failed to mkfs osd %lu on %s", osdId, d.c_str());
             HexSystemF(0, "chown -R %s:%s %s", USER, GROUP, osddir);
         }
     }

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -932,13 +932,24 @@ Commit(bool modified, int dryLevel)
             HexLogError("failed to set the login theme of the master realm");
         }
 
-        // create default cube groups
+        // Create the default cube groups and the SAML/OIDC clients. Failing here
+        // is not cosmetic: cube-cos-api requires the api_client SAML client at
+        // startup and crash-loops without it, so a run that only logged the
+        // failure reported a successful FTS on a cluster whose API cannot start.
+        // Report it on the console the way the SAML metadata gate does, so the
+        // operator sees it at install time rather than in `cluster check`.
         if (!ExecTerraform(
                 "apply",
                 "keycloak",
                 { "cube_controller=" + sharedId },
                 { KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE })) {
-            HexLogError("failed to create default cube groups via terraform");
+            HexLogError("failed to create the keycloak clients and default cube groups via terraform");
+            HexSystemF(0,
+                "echo 'CUBE: keycloak client provisioning failed."
+                " Single sign-on and the control API (cube-cos-api) will not work:"
+                " cube-cos-api requires the api_client SAML client at startup."
+                " Check the terraform provider mirror, then re-run"
+                " hex_config install_keycloak.' > /dev/console");
         }
     }
 

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2625,6 +2625,24 @@ ceph_osd_create_map()
         done
         cat $osdmap_new | sort -k1 > ${osdmap_new}.sorted
         unlink $osdmap_new
+
+        # this scan can miss an OSD whose udev links are momentarily gone; keep
+        # its existing entry when the data partition is still valid, otherwise
+        # ceph_osd_remount leaves a healthy OSD unmounted (cubecos#1284)
+        if [ -s $CEPH_OSD_MAP ] ; then
+            while read -r dev id metauuid datauuid ; do
+                [ -n "${id:-}" ] || continue
+                awk -v i="$id" '$2==i{f=1} END{exit !f}' ${osdmap_new}.sorted && continue
+                if ceph_osd_datapart_resolve "$datauuid" >/dev/null 2>&1 ; then
+                    log_warning "ceph_osd_create_map: osd $id missing from this scan but $datauuid still resolves to a device; keeping its entry"
+                    echo "$dev $id $metauuid $datauuid" >> ${osdmap_new}.sorted
+                else
+                    log_warning "ceph_osd_create_map: osd $id removed from $CEPH_OSD_MAP"
+                fi
+            done < $CEPH_OSD_MAP
+            sort -k1 -o ${osdmap_new}.sorted ${osdmap_new}.sorted
+        fi
+
         if cmp -s ${osdmap_new}.sorted $CEPH_OSD_MAP ; then
             rm -f ${osdmap_new}.sorted
         else
@@ -2633,12 +2651,36 @@ ceph_osd_create_map()
     fi
 
     # clean up broken ceph osd folders
-    for osddir in $(ls -1d ${osdpth}/ceph-*) ; do
-        if ! readlink -e ${osddir}/block ; then
-            rm -f ${osddir}/block
-            rmdir ${osddir}
+    for osddir in $(ls -1d ${osdpth}/ceph-* 2>/dev/null) ; do
+        [ -L ${osddir}/block ] || continue
+        readlink -e ${osddir}/block >/dev/null 2>&1 && continue
+        # the link dangles; only remove it when the data device is really gone,
+        # not when udev merely lost the symlink (cubecos#1284)
+        datauuid=$(basename "$(readlink ${osddir}/block 2>/dev/null)")
+        if ceph_osd_datapart_resolve "$datauuid" >/dev/null 2>&1 ; then
+            log_warning "ceph_osd_create_map: ${osddir}/block dangles but $datauuid still resolves to a device; keeping it"
+            continue
         fi
+        rm -f ${osddir}/block
+        rmdir ${osddir} 2>/dev/null
     done
+}
+
+# resolve a dev_osd.map data uuid to its device without going through
+# /dev/disk: a GPT PARTUUID for raw OSDs, an LVM lv_uuid for encrypted/mpath
+# ones. Fails only when the device is genuinely absent, so callers can treat
+# failure as proof the OSD is gone.
+ceph_osd_datapart_resolve()
+{
+    local uuid=$1
+    [ -n "$uuid" ] || return 1
+
+    # blkid reads the GPT off the disk, so it resolves without the udev symlink
+    local dev=$(blkid -o device --match-token PARTUUID=$uuid 2>/dev/null | head -1)
+    [ -n "$dev" ] || dev=$(lvs --noheadings -o lv_path -S lv_uuid=$uuid 2>/dev/null | head -1 | tr -d ' ')
+    [ -n "$dev" ] || return 1
+
+    echo -n "$dev"
 }
 
 ceph_wait_for_services()

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -2666,6 +2666,16 @@ ceph_osd_create_map()
     done
 }
 
+# true if data uuid $1 resolves to a device that already carries a bluestore
+# label, i.e. an OSD lives there and must not be re-created
+ceph_osd_datapart_has_osd()
+{
+    local dev=$(ceph_osd_datapart_resolve "$1") || return 1
+    [ -n "$dev" ] || return 1
+
+    ceph-bluestore-tool show-label --dev "$dev" >/dev/null 2>&1
+}
+
 # resolve a dev_osd.map data uuid to its device without going through
 # /dev/disk: a GPT PARTUUID for raw OSDs, an LVM lv_uuid for encrypted/mpath
 # ones. Fails only when the device is genuinely absent, so callers can treat

--- a/core/terraform/Makefile
+++ b/core/terraform/Makefile
@@ -77,7 +77,15 @@ $(TF_CORE_BIN): $(TF_CORE_DIR)
 		-o terraform-core ., \
 		"  BUILD   tf-core")
 
-terraform: $(TF_CORE_BIN) $(RANCHER_UPSTREAM_BIN) $(KEYCLOAK_UPSTREAM_BIN)
+# The .tf sources are a prerequisite: without them make keeps a tree built
+# before the last source change, and terraform.mk ships that stale tree next to
+# an override.tfrc taken fresh from source -- a pair that can disagree about
+# which providers are needed. Rebuild from scratch too, since cp -rfT merges
+# and would leave a module that source has since deleted.
+TF_SRCS := $(shell find $(SRCDIR)/src -type f 2>/dev/null)
+
+terraform: $(TF_CORE_BIN) $(RANCHER_UPSTREAM_BIN) $(KEYCLOAK_UPSTREAM_BIN) $(TF_SRCS)
+	$(Q)rm -rf ./$@
 	$(Q)cp -rfT $(SRCDIR)/src/ ./$@
 	$(Q)make clean-etcd
 	$(call RUN_CMD_TIMED,make run-etcd,"  RUN     etcd@jail")

--- a/project.mk
+++ b/project.mk
@@ -17,9 +17,6 @@ PROJ_MODDIR := $(TOP_BLDDIR)/core/modules
 # Node config namespace: the installer (hex) drops the phone-home agent's env
 # file here (overrides hex's default).
 HEX_AGENT_ENV_DIR := /etc/cube
-# Installer disk auto-detect: skip our OSD/data disks (cube_ partition labels).
-# SAN LUNs (Compellent, etc.) are excluded by hex's default transport filter.
-HEX_INSTALL_DATA_LABEL_PREFIX := cube_
 
 # policy source tree
 CORE_POLICYDIR := $(COREDIR)/policies


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Five install/air-gap fixes found across the recent lab rounds, plus the hex bump that carries the
disk-eligibility rewrite.

- **terraform stale tree** (#1396) — the `terraform` target's prerequisites were the three provider
  binaries, never the `.tf` sources it copies, so a stale tree shipped beside a fresh
  `override.tfrc`. They disagreed about which providers exist, `terraform init` failed, and the
  keycloak apply that creates the `api_client` SAML client never ran — `cube-cos-api` crash-loops
  and `cluster check` reports `ApiService NG`, while the install still declares success. Rebuild
  from scratch when sources change, and announce the failed apply on the console.
- **ingress-nginx bundling** (#1397) — image added to `images.txt` and the chart's digest pins
  cleared (the bundled copy is single-arch, so its digest cannot match the upstream multi-arch
  index). Without it an air-gapped FTS hangs on the keycloak SAML-metadata gate forever.
- **ceph `create_map`** (#1398) — it trusted `/dev/disk` to decide whether an OSD still exists, in
  two places: the cleanup loop deleted `ceph-N/block` on a failed `readlink -e` (and since the
  metapart is already mounted by then, that `rm` lands on the OSD's own XFS and is permanent), and
  the map rebuild dropped any OSD the scan missed, after which `ceph_osd_remount` — which first
  stops and unmounts every OSD on the host — never remounts it. Resolve the data uuid off the disk
  instead (`blkid` PARTUUID for raw, `lvs` lv_uuid for encrypted/mpath) and only discard when it
  resolves nowhere; carry a lost entry forward and log either way. Plus a journald
  `Storage=persistent` drop-in so boot-time failures leave evidence.
- **ceph `prepareOsdDirectories`** — it decided whether an OSD was new by `stat()`ing
  `/var/lib/ceph/osd/ceph-N`, but a directory is only a mountpoint, and the metapart is mounted onto
  it *after* that decision. An existing OSD whose directory had been removed while unmounted took the
  "new" branch against freshly mounted live metadata: `rm -rf` of its own files, then
  `ceph-osd --mkfs` over the top. Reachable from the same transient as #1284 — an OSD with a
  momentarily blank PARTLABEL is skipped by `ceph_osd_list_meta_partitions` and never mounted,
  `create_map`'s cleanup then succeeds in `rmdir`ing the empty directory, and the next boot treats it
  as new. Now: mount first, then decide from the disk (metadata on the mounted metapart, or a
  bluestore label on the data partition). Also stops discarding `--mkfs`'s exit status.
- **installer disk auto-detect** — retire `HEX_INSTALL_DATA_LABEL_PREFIX`; eligibility now comes
  from hex's shared `hex_install_disks` rule. Bumps hex to `d500f45`.

#### Which issue(s) this PR fixes

Fixes #1396
Fixes #1397
Fixes #1398

Submodule bump for bigstack-oss/hex#161 (PR bigstack-oss/hex#162).

#### Special notes for your reviewer

**Merge order: hex#162 first** — this PR's submodule pointer is that commit, so merging this first
would point develop at a sha not yet on hex's develop.

Field evidence: the terraform failure was reproduced end-to-end on the lab R630 on 2026-08-31
(`cluster check_repair` → `FAIL [ api(2) ]`, `cube-cos-api` restart counter 29,
`master saml client not found`). The ingress-nginx fix was verified on the same box by side-loading
the image and watching the gate release on its own.

**ceph fix — validated on the sky 3-node lab (sky143), 2026-09-01.** The failure was first
reproduced end to end from a single transient: `dev_osd.map` 6→5 entries, `ceph-N/block` deleted,
the directory left empty and unmounted, `missing 'type' file and unable to infer osd type`, unit
stuck `activating`. With the fix, holding the same transient across `create_map` + `ceph_osd_remount`
and then releasing it: map stays at 6, `block` preserved, OSD remounts and reaches `active` with no
manual repair. Regression suite on the same node: a healthy run is a no-op, the function is
idempotent, a genuinely dead OSD (synthetic id, partuuid resolving nowhere) is still cleaned up and
logged, an empty map rebuilds correctly, and all 18 real OSDs stayed up throughout. Cluster returned
to `HEALTH_OK` 18/18 after every round.

**`prepareOsdDirectories` fix — validated on sky143, 2026-09-01**, with `hex_config` built from this
branch and installed on the node. A healthy OSD's directory was removed while unmounted (the state
`create_map`'s `rmdir` leaves behind), then `hex_config refresh_ceph_osd` was run. The OSD's `fsid`
was byte-identical afterwards — `--mkfs` necessarily rewrites it, so the destructive branch was not
taken — along with `whoami`, all 17 metadata files, and no `creating a new osd 8` in the log. The OSD
restarted cleanly and the cluster returned to HEALTH_OK 18/18. Under the previous code the same
scenario mounts the live metapart and then `rm -rf`s it.

That run exercised the `type`-file predicate. The bluestore-label fallback
(`ceph_osd_datapart_has_osd`) is only reached when the metapart has no `type`; it was tested directly
against all six real OSDs (true) and bogus/empty uuids (false), but not end-to-end through the C++
path.

Not covered on this hardware: LVM-backed (encrypted/mpath) OSDs — the sky cluster has none, so the
`lvs` resolution path is written but untested.

The 1cc re-verify that proves the terraform fix end to end (a clean `cluster check`) still needs an
image built from this branch — not yet run.

#### Additional documentation

```docs
kb/cubecos/known-issues/stale-terraform-tree-breaks-provider-init.md
kb/cubecos/known-issues/ingress-nginx-not-bundled-blocks-airgap-fts.md
kb/cubecos/known-issues/create-map-deletes-healthy-osd-block-symlink.md
kb/cubecos/known-issues/install-disk-eligibility-differs-per-path.md
```



