### PR TITLE
fix(rolling): scope the API-ready gate to control nodes (develop)

### DIFF
--- a/core/sdk_sh/modules/sdk_power.sh
+++ b/core/sdk_sh/modules/sdk_power.sh
@@ -185,12 +185,13 @@ _power_roll_api_ready()
     # until their workers are up, while haproxy re-enables the rejoined backend
     # after two passing checks. A live-migration pre-check balanced onto one of
     # those marks the instance ERROR (no retry in nova's pre-check path), so
-    # gate the next drain on a real response from every node.
+    # gate the next drain on a real response. Control-only: compute nodes
+    # never serve 9696/8774.
     local deadline=$(( $(date +%s) + ${ROLLING_API_READY_TIMEOUT:-600} ))
     local bad
     while : ; do
         bad=""
-        for n in $(cubectl node list -j | jq -r '.[].ip.management') ; do
+        for n in $(cubectl node list -j -r control | jq -r '.[].ip.management') ; do
             for p in 9696 8774 ; do
                 Quiet timeout 5 curl -s -o /dev/null http://$n:$p/ || bad="$bad $n:$p"
             done


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`develop` carries the same defect as `release_3.1.10`: `_power_roll_api_ready()` probes 9696/8774 on **every** node's own management IP, but only control nodes run nova-api/neutron-server (`config_nova.cpp` `NovaService()` gates both on `IsControl`). A compute node can never answer, so the pre-drain gate fails deterministically, burns its 600s timeout and pauses the job — before every node transition, since it runs from `_power_roll_kick()`. On any compute-bearing topology `rolling_update` has no unattended path.

Fix is `cubectl node list -j -r control`. The role bitmask (`util/role.go`) still matches `control-converged` / `control-network` / `edge-core` / `moderator`, so converged topologies keep the full gate.

#### Which issue(s) this PR fixes

Refs #1391

#### Special notes for your reviewer

> Note

- **Companion to #1392**, which carries the identical one-liner on `release_3.1.10`. `release_3.1.10` is not an ancestor of `develop` — the branches exchange fixes by cherry-pick (`41841ff4` here vs `b2eca68f` there) — so merging #1392 alone would leave 3.2.0 shipping the bug. Diff is byte-identical to #1392's current tip, including the shortened comment applied there on 2026-09-01.
- `Refs` rather than `Fixes` deliberately: #1392 holds the closing reference, so whichever merges second doesn't find the issue already closed out from under it.
- The adjacent unfiltered loop in `_power_roll_kick()` is **intentionally left alone** — that one is the `is_sshable` reachability check and does want every node.
- Validation as on #1392: `-r control` returns all three `control-converged` nodes on the sky 3cc lab, and the patched loop passes there with 9696/8774 → HTTP 200 on each node's own IP. Still **not** validated by an unattended roll on a compute-bearing topology (no compute-only node in the lab) — that is issue #1391's QA step 1 and remains owed.

#### Additional documentation

```docs
bigstack-handbook: kb/cubecos/known-issues/rolling-api-ready-gate-probes-compute-nodes.md (+ .scenario.yaml) — landed in bigstack-handbook#452
```

