### PR TITLE
fix(advisor): fold the cluster id the way the Advisor stores it

### DIFF
--- a/core/sdk_sh/modules/sdk_advisor.sh
+++ b/core/sdk_sh/modules/sdk_advisor.sh
@@ -147,8 +147,11 @@ advisor_cluster_id()
 {
     local id=""
 
-    if [ -r /etc/cube/phone-home-agent.env ] ; then
-        id=$(sed -n 's/^CUBE_CLUSTER_ID=//p' /etc/cube/phone-home-agent.env | head -1)
+    # CLUSTER_ENV is overridable so the unit test can supply a file; nothing
+    # in production sets it.
+    local env_file=${CLUSTER_ENV:-/etc/cube/phone-home-agent.env}
+    if [ -r "$env_file" ] ; then
+        id=$(sed -n 's/^CUBE_CLUSTER_ID=//p' "$env_file" | head -1)
     fi
     if [ -z "$id" ] ; then
         id=$(source /usr/sbin/hex_tuning /etc/settings.txt 2>/dev/null ; echo "$T_cubesys_controller")
@@ -158,11 +161,22 @@ advisor_cluster_id()
         return 1
     fi
 
-    # It becomes a certificate CN and a URL path segment, and nothing on the
-    # Advisor side validates either -- so refuse the shapes that would break
-    # them here, where the message can still be useful.
+    # The Advisor folds this to lowercase and stores the folded form, so case
+    # is not an error here either -- cubesys.controller is declared with
+    # ValidateRegex/DFT_REGEX_STR ("^.*$"), which constrains nothing, and a
+    # cluster whose controller is named Controller01 is perfectly legal. Fold
+    # to match what will be stored, then refuse only the shapes that genuinely
+    # break a certificate CN, a URL path segment or /etc/hosts. The Advisor
+    # enforces the same set with a CHECK constraint; refusing here first means
+    # the operator sees the rule before a round trip, not a remote error after.
+    id=$(echo "$id" | tr '[:upper:]' '[:lower:]')
     case $id in
-        */*|*\ *) echo "Error: cluster id contains a character that cannot appear in a URL path: $id" >&2 ; return 1 ;;
+        *[!a-z0-9._-]*)
+            echo "Error: cluster id may contain only letters, digits, '.', '-' and '_': $id" >&2
+            return 1 ;;
+        [!a-z0-9]*|*[!a-z0-9])
+            echo "Error: cluster id must start and end with a letter or digit: $id" >&2
+            return 1 ;;
     esac
     if [ ${#id} -gt 64 ] ; then
         echo "Error: cluster id is longer than 64 characters, which strict X.509 tooling rejects: $id" >&2

--- a/core/sdk_sh/tests/test_sdk_advisor_verify.sh
+++ b/core/sdk_sh/tests/test_sdk_advisor_verify.sh
@@ -20,7 +20,7 @@ set -u
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC="$DIR/../modules/sdk_advisor.sh"
 
-for f in advisor_verify_release advisor_release_version advisor_install_release advisor_agent_arch advisor_enroll ; do
+for f in advisor_verify_release advisor_release_version advisor_install_release advisor_agent_arch advisor_enroll advisor_cluster_id ; do
     fn="$(awk -v want="^$f\\\\(\\\\)" '$0 ~ want {f=1} f{print} f&&/^}/{exit}' "$SRC")"
     [ -n "$fn" ] || { echo "FAIL: $f not found in $SRC"; exit 1; }
     eval "$fn"
@@ -148,6 +148,41 @@ if advisor_enroll https://example "$WORK/no-such-token" 0.2.0 >/dev/null 2>&1 ; 
 else
     ok
 fi
+
+
+# --- the cluster id matches what the Advisor will store ----------------------
+#
+# cubesys.controller is declared with ValidateRegex/DFT_REGEX_STR ("^.*$"), so
+# CubeCOS constrains it not at all -- the Advisor must accept what CubeCOS
+# produces. It folds to lowercase and stores the folded form; these cases pin
+# that the local check folds the same way and refuses only what genuinely
+# breaks a CN, a path segment or /etc/hosts.
+idcheck() {
+    local want="$1" id="$2" env="$WORK/phone-home-agent.env"
+    printf 'CUBE_CLUSTER_ID=%s\n' "$id" > "$env"
+    local got
+    if got=$(CLUSTER_ENV="$env" advisor_cluster_id 2>/dev/null) ; then
+        check "cluster id '$id'" "accept:$got" "$want"
+    else
+        check "cluster id '$id'" "reject" "$want"
+    fi
+}
+idcheck "accept:ky3haclust01" ky3haclust01
+idcheck "accept:sky-140"      sky-140
+idcheck "accept:cube.lab.01"  cube.lab.01
+idcheck "accept:foo_bar"      foo_bar
+# Folded, not refused: the Advisor stores the lowercase form, so a controller
+# named in caps must enrol -- as the id the Advisor will actually hold.
+idcheck "accept:controller01" Controller01
+idcheck "accept:acme-prod-01" ACME-PROD-01
+# Refused: each of these breaks a CN, a path segment, or /etc/hosts.
+idcheck "reject" "a/b"
+idcheck "reject" "has space"
+idcheck "reject" _leading
+idcheck "reject" trailing_
+idcheck "reject" -leading
+idcheck "reject" .dot
+idcheck "reject" "$(printf 'x%.0s' $(seq 1 65))"
 
 echo "----"
 echo "pass=$pass fail=$fail"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`cubesys.controller` is declared with `ValidateRegex` and `DFT_REGEX_STR` (`^.*$`), so CubeCOS constrains it **not at all** — its only de-facto shape comes from `UpdateHosts` writing it into `/etc/hosts`. A cluster whose controller is named `Controller01` is perfectly legal, and anything downstream that refuses it is imposing a rule on a value it does not own.

The Advisor now folds the id to lowercase and stores the folded form (bigstack-oss/cube-ai-advisor#129), accepting lowercase letters, digits, `.`, `-` and `_`, with alphanumeric ends and a 64-character limit. This folds the same way here, so **the id this node reports is the id the Advisor will hold**, and refuses only shapes that genuinely break a certificate CN, a URL path segment or `/etc/hosts` — refused locally, where the message can name the rule, instead of arriving as a remote error after a round trip.

Accepts `ky3haclust01` (the driver's UUID-derived id), `sky-140`, `cube.lab.01`, `foo_bar`, and folds `Controller01` → `controller01`, `ACME-PROD-01` → `acme-prod-01`. Refuses `a/b`, `has space`, `_leading`, `trailing_`, `-leading`, `.dot`, and anything over 64 characters.

#### Which issue(s) this PR fixes

None — follow-on to bigstack-oss/cube-ai-advisor#108 and #129, whose rule this mirrors.

#### Special notes for your reviewer

- **This PR reversed direction.** Its first revision narrowed the local check to the Advisor's *pre-#129* rule, which would have locked out exactly the clusters it now admits. Travis caught the premise: the SaaS should honour what CubeCOS produces, not the other way round. The Advisor widened; this now mirrors the wider rule.
- Tests cover **both** failure directions — dropping the fold fails two cases (`Controller01`, `ACME-PROD-01`), and restoring the narrower charset fails another (`foo_bar`). Both were run before being restored, so the cases pin the behaviour rather than describing it.
- `CLUSTER_ENV` is a testability seam with a production default; nothing sets it outside the unit test.
- `bash test_sdk_advisor_verify.sh` → pass=27 fail=0.

#### Additional documentation

None; the reasoning is in the function's comment.