### PR TITLE
fix(rabbitmq): cap the broker start timeout so a wedged start can't stall bootstrap

### DIFF
--- a/core/rabbitmq/rabbitmq-server.service
+++ b/core/rabbitmq/rabbitmq-server.service
@@ -10,7 +10,9 @@ User=rabbitmq
 Group=rabbitmq
 UMask=0027
 NotifyAccess=all
-TimeoutStartSec=3600
+# a wedged start blocks the whole bootstrap commit; 300s is rabbit's own ceiling
+# for waiting on peer tables (mnesia retry_timeout 30s x retry_limit 10)
+TimeoutStartSec=300
 LimitNOFILE=65536
 
 # Note:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

A full-cluster `cluster powercycle` stalled the whole cluster for ~1 hour: the master sat in
`bootstrapping` and every other node in `powering_up`, long after their OS and SSH were up.

The master's bootstrap commit was blocked inside one `systemctl start rabbitmq-server`:

```
16:12:25 Starting RabbitMQ broker...
17:12:26 rabbitmq-server.service: Failed with result 'timeout'.
17:12:26 Starting RabbitMQ broker...        <- immediate retry
17:12:32 Started RabbitMQ broker.           <- 6 seconds
```

The broker never signalled readiness (its `rabbit_disk_monitor` kept erroring on the node data dir),
and the unit allows `TimeoutStartSec=3600`, so that single call consumed the full hour. The commit
runs modules serially, so the whole bootstrap froze behind it, and the peers — which wait for the
master's `/run/cube_commit_done` marker — sat in `powering_up` for the same hour.

Capping the start timeout at 300s lets a wedged start fall into the retry that already exists. 300s is
rabbit's own ceiling for waiting on peer tables (`mnesia_table_loading_retry_timeout` 30s x
`mnesia_table_loading_retry_limit` 10, confirmed via `rabbitmqctl environment` on a live broker), so
systemd now gives up at the point the broker itself would.

Note on the value: 300s sits exactly at that ceiling, so a rejoin that consumes the *entire* mnesia
window is cut off at the boundary rather than succeeding by a hair. That window is only exhausted when
the peer tables never arrive -- in which case the start fails anyway -- but it is the trade-off being
made, and the penalty for a false timeout is the `rm -rf /var/lib/rabbitmq/mnesia/*` fallback in
`CommitRabbitMQ`. Anything below 300s would fire inside normal rejoins and is not safe.

#### Which issue(s) this PR fixes

Fixes #1402

#### Special notes for your reviewer

> Note

- Based on `release_3.1.10` — RC-found bug, per our release-branch policy.
- **Deliberately minimal.** Two things from earlier revisions were dropped after checking them:
  - *Recreating `mnesia/rabbit@<node>` after the wipe* — unnecessary. Verified on the sky lab:
    stop → `rm -rf /var/lib/rabbitmq/mnesia/*` → start booted in **6 s** with peers up and **10 s**
    with both peers stopped; rabbit recreated the directory itself both times, zero disk-monitor
    errors. The wipe-and-restart logic has been correct for years.
  - *Bounding the peers' wait for the master marker* — would have made things worse. That loop
    already reports itself every minute (`Waiting for master control to finish bootstrapping [N min]`
    plus `BSP00010I`), and on the affected cluster the peers waited ~67 min and then proceeded
    correctly the moment the marker appeared. Aborting on a bound would turn a cluster that recovers
    on its own into nodes that have permanently given up.
- Caveat on the sky verification: sky runs rabbitmq **3.11.28**, the affected cluster **3.10.25**, so
  why that broker still lacked its data dir 52 s into boot is not fully explained. What is certain is
  that it never became ready, and the hour-long timeout is what turned that into a cluster-wide
  stall. Worth a follow-up on a 3.1.10 environment.
- The issue originally blamed etcd quorum; ruled out in the rewritten description — etcd's health
  wait is bounded and had already failed and moved on at 16:12:25.
- **Forward-port note:** `develop` no longer ships this unit file. 6d57cb32 replaced it with
  `/etc/systemd/system/rabbitmq-server.service.d/rabbitmq-server-overrides.conf`, which also sets
  `TimeoutStartSec=3600` — so the same change on develop must edit that drop-in, and if that
  refactor is ever merged down into this branch it would silently revert this fix.

#### Additional documentation

```docs

```
