### PR TITLE
feat(horizon): upgrade horizon from openstack antelope to caracal

### DIFF
--- a/core/barbican/barbican.mk
+++ b/core/barbican/barbican.mk
@@ -32,25 +32,21 @@ rootfs_install::
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
-# python-barbicanclient stays in the *antelope* venv -- TEMPORARY, see below
+# python-barbicanclient
 #
-# It is the only part of barbican that does not follow the service into the caracal venv,
-# because it is the one part the openstack cli loads rather than the one barbican runs.
-# python-barbicanclient contributes an [openstack.cli.extension] entry point plus sixteen
-# [openstack.key_manager.v1] commands (secret store/get/list/delete/update, the container
-# and consumer families, and the order family), and a stevedore entry point is only visible
-# to the interpreter it was installed under. /usr/bin/openstack is the antelope venv's
-# (core/heavyfs/Makefile links it there), so installing the client into the caracal venv
-# would take `openstack secret ...` off the node entirely.
+# It is kept in a block of its own because it was the one part of barbican that could not
+# follow the service into the caracal venv: it is what the openstack cli loads rather than
+# what barbican runs. python-barbicanclient contributes an [openstack.cli.extension] entry
+# point plus sixteen [openstack.key_manager.v1] commands (secret store/get/list/delete/
+# update, the container and consumer families, and the order family), and a stevedore entry
+# point is only visible to the interpreter it was installed under, so it has to sit next to
+# /usr/bin/openstack or `openstack secret ...` leaves the node entirely.
 #
-# This is the first caracal hop to hit that. keystone, glance, cinder and nova escaped it
+# #632 was the first caracal hop to hit that. keystone, glance, cinder and nova escaped it
 # because `openstack image|volume|server ...` are osc built-ins -- python-keystoneclient and
 # python-cinderclient contribute no [openstack.cli.extension] at all -- so their clients
-# could move with the service. The same split is already spelled out for designate in
-# core/designate/designate.mk, from the era when the cli was the system python's.
-#
-# TEMPORARY: this goes away when the cli itself reaches the caracal venv, at which point
-# this install block moves back into the one above.
+# could move with the service. #636 moved the cli, so the split is over; the block stays
+# separate only because the reasoning above is worth keeping next to the install.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/

--- a/core/barbican/barbican.mk
+++ b/core/barbican/barbican.mk
@@ -54,8 +54,8 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) bash -c "source $(OPENSTACK_HOME_DIR)/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-barbicanclient"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/cyborg/cyborg.mk
+++ b/core/cyborg/cyborg.mk
@@ -74,13 +74,13 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-cyborgclient
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-	$(Q)# Link the cli plugin's console script, which is the antelope venv's
-	$(Q)chroot $(ROOTDIR) ln -sf $(OPENSTACK_HOME_DIR)/bin/cyborg /usr/bin/cyborg
+	$(Q)# Link the cli plugin's console script
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/cyborg /usr/bin/cyborg
 
 rootfs_install::
 	$(Q)[ -d $(CYBORG_PATCHDIR) ] && cp -rf $(CYBORG_PATCHDIR)/* $(CYBORG_SRCDIR)/ || /bin/true

--- a/core/cyborg/cyborg.mk
+++ b/core/cyborg/cyborg.mk
@@ -53,24 +53,22 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/cyborg-status /usr/bin/cyborg-status
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/cyborg-wsgi-api /usr/bin/cyborg-wsgi-api
 
-# the osc plugin stays in the antelope venv -- TEMPORARY
+# the osc plugin
 #
 # python-cyborgclient owns the `openstack accelerator ...` commands, and a
 # stevedore entry point is only visible to the interpreter it was installed
-# under. /usr/bin/openstack is the antelope venv's (core/heavyfs/Makefile), so
-# the plugin has to stay next to it or those commands disappear from the cli.
-# Every service whose client owns an osc plugin meets this on its way over.
+# under, so the plugin has to sit next to /usr/bin/openstack or those commands
+# disappear from the cli. That held it in the antelope venv while the cli was
+# there; #636 moved the cli, so it sits with the service again. Every service
+# whose client owns an osc plugin met this on its way over.
 #
 # Nothing in hex_sdk drives this one -- health_cyborg_check() only asks systemd
 # whether the three units are running -- so no health check depends on it. What
 # would go quiet is the operator-facing cli.
 #
 # It is a pip install rather than a git checkout for the same reason the service
-# is, and no version is named: os-antelope-pip-upper-constraints.txt already
-# carries python-cyborgclient (2.1.0), so a version here could only drift from
-# that file.
-#
-# It goes once /usr/bin/openstack is the caracal venv's (#636).
+# is, and no version is named: os-caracal-pip-upper-constraints.txt already
+# carries python-cyborgclient, so a version here could only drift from that file.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/

--- a/core/designate/designate.mk
+++ b/core/designate/designate.mk
@@ -5,14 +5,15 @@ ROOTFS_DNF += bind bind-utils
 
 # python-designateclient owns the "dns" osc plugin entry point, which hex_sdk's
 # health_designate_check() drives as `openstack dns service list`, counting the
-# api/central/worker/producer/mdns rows that report UP. Since #634 it is installed by
-# its own block, the one that keeps it in the antelope venv while the service moves to
-# caracal -- see the note there for why it cannot follow.
+# api/central/worker/producer/mdns rows that report UP. It is installed by its own
+# block further down, which #634 split out to hold it in the antelope venv while the
+# service moved to caracal; #636 took /usr/bin/openstack to caracal too, so the block
+# now installs alongside the service and only the separation remains.
 #
 # It used to be the yoga python3-designateclient rpm under the *system* python 3.9,
 # because /usr/bin/openstack was itself `#!/usr/bin/python3` and a stevedore entry point
 # is only visible to the interpreter it was installed under. core/heavyfs moved the cli
-# into the venv, so the plugin follows it and the rpm is gone.
+# into a venv, so the plugin follows it and the rpm is gone.
 #
 # It is still named explicitly rather than left to designate-dashboard's requirements,
 # for the same reason it had to be named as an rpm: it once arrived only as a side effect
@@ -72,22 +73,20 @@ rootfs_install::
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
-# the osc plugin and the dashboard stay in the antelope venv -- TEMPORARY
+# the osc plugin and the dashboard
 #
 # python-designateclient owns the "dns" osc plugin entry point, and a stevedore entry
-# point is only visible to the interpreter it was installed under. /usr/bin/openstack
-# is the antelope venv's, so the plugin has to stay next to it or
-# health_designate_check()'s `openstack dns service list` cannot run at all -- which is
-# how this was first found, as "DNSaaS NG [ designate(9 api not all up) ]" while every
-# designate unit was active. See the note at the top of this file; #632 has the same
-# constraint for python-barbicanclient.
+# point is only visible to the interpreter it was installed under, so the plugin has
+# to sit next to /usr/bin/openstack or health_designate_check()'s `openstack dns
+# service list` cannot run at all -- which is how this was first found, as
+# "DNSaaS NG [ designate(9 api not all up) ]" while every designate unit was active.
+# That held it in the antelope venv from #634 until #636 moved the cli here; #632 had
+# the same constraint for python-barbicanclient.
 #
 # designate-dashboard is a horizon plugin: core/horizon/horizon.mk copies its enabled
 # panels out of $(HORIZON_VENV_SP), which is the site-packages of whichever venv
 # horizon runs in, so the dashboard goes where horizon goes. #636 took horizon to
 # caracal, so the panel is a caracal-venv install now.
-#
-# The osc plugin goes once /usr/bin/openstack is the caracal venv's (#636).
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/

--- a/core/designate/designate.mk
+++ b/core/designate/designate.mk
@@ -91,8 +91,8 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-designateclient
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \

--- a/core/designate/designate.mk
+++ b/core/designate/designate.mk
@@ -24,9 +24,14 @@ ROOTFS_DNF += bind bind-utils
 NAMED_CONF_FILES := /etc/named*
 NAMED_APP_DIR := /var/named
 
-# https://releases.openstack.org/teams/designate.html
-# Only the dashboard is still built from git; designate itself is a pinned pip install.
-DESIGNATE_DASHBOARD_REPO_URL := https://github.com/openstack/designate-dashboard.git
+# https://releases.openstack.org/caracal/index.html#caracal-designate-dashboard
+# Horizon plugins are not in the upper-constraints (that file only covers libraries),
+# so the pin is explicit. This was a $(OPS_GITHUB_BRANCH_02) clone until #636: the
+# branch name was chosen while the dashboard had to match an antelope horizon, and a
+# branch resolves to whatever its tip is on build day. Now that the panel follows
+# horizon into the caracal venv the version has to change anyway, so it changes to a
+# number.
+DESIGNATE_DASHBOARD_VER := 18.0.0
 
 DESIGNATE_CONF_DIR := /etc/designate
 DESIGNATE_APP_DIR := /var/lib/designate
@@ -36,11 +41,6 @@ DESIGNAT_LOG_DIR := /var/log/designate
 # dashboard and the osc plugin do not follow it there -- see the install blocks.
 DESIGNATE_BINDIR := $(ROOTDIR)$(CARACAL_OPENSTACK_HOME_DIR)/bin
 DESIGNATE_BIN_PATCHDIR := $(COREDIR)/designate/$(CARACAL_OPENSTACK_RELEASE)_bin_patch
-
-# prepare the build directory
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) rm -rf /tmp/designate
-	$(Q)chroot $(ROOTDIR) mkdir -p /tmp/designate
 
 # install designate into the caracal venv
 #
@@ -82,29 +82,23 @@ rootfs_install::
 # designate unit was active. See the note at the top of this file; #632 has the same
 # constraint for python-barbicanclient.
 #
-# designate-dashboard is a horizon plugin, and horizon itself is still the antelope
-# venv's 23.1.1 (core/horizon/horizon.mk -- the caracal 24.0.2 copy next to it is a
-# down payment that nothing serves). $(HORIZON_VENV_SP) is the antelope
-# site-packages, and that is where horizon's collectstatic collects the panels from,
-# so the dashboard cannot move ahead of horizon. It is left on its git checkout at
-# $(OPS_GITHUB_BRANCH_02) deliberately: converting it to pip would change which
-# dashboard version lands, and this story is not the place to do that.
+# designate-dashboard is a horizon plugin: core/horizon/horizon.mk copies its enabled
+# panels out of $(HORIZON_VENV_SP), which is the site-packages of whichever venv
+# horizon runs in, so the dashboard goes where horizon goes. #636 took horizon to
+# caracal, so the panel is a caracal-venv install now.
 #
-# Both go once horizon reaches the caracal venv (#636).
+# The osc plugin goes once /usr/bin/openstack is the caracal venv's (#636).
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-designateclient
-	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(OPS_GITHUB_BRANCH_02) --depth 1 $(DESIGNATE_DASHBOARD_REPO_URL) /tmp/designate/designate-dashboard
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
-		-r /tmp/designate/designate-dashboard/requirements.txt
-	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/designate/designate-dashboard && \
-		$(OPENSTACK_HOME_DIR)/bin/python setup.py install"
+		designate-dashboard==$(DESIGNATE_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 	$(Q)# Link binaries
@@ -155,7 +149,3 @@ rootfs_install::
 
 rootfs_install::
 	$(Q)[ -d $(DESIGNATE_BIN_PATCHDIR) ] && cp -rf $(DESIGNATE_BIN_PATCHDIR)/* $(DESIGNATE_BINDIR)/ || /bin/true
-
-# clean up the build directory
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) rm -rf /tmp/designate

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -46,16 +46,15 @@ HEAT_CONFDIR := $(ROOTDIR)/etc/heat
 # 2024.1 revision, the same rule #1191 used to land on 20.0.1.
 HEAT_VER := 22.0.1
 
-# Deliberately still the 2023.1 pin, and deliberately still in the antelope venv.
-# core/horizon/horizon.mk serves the dashboard out of $(OPENSTACK_HOME_DIR) --
-# openstack-dashboard.service, gunicorn-config.py and the httpd reverse proxy all
-# point at the antelope tree, and every dashboard plugin installs next to it.
-# heat-dashboard follows horizon, not the heat service, so the Orchestration panels
-# stay on 9.0.0 until horizon itself hops; 11.0.1 is the caracal release to move to
-# on that day. It talks to the API over HTTP through heatclient and imports nothing
-# from heat, so the split costs nothing. Horizon plugins are not in the
-# upper-constraints (that file only covers libraries), so the pin has to be explicit.
-HEAT_DASHBOARD_VER := 9.0.0
+# heat-dashboard follows horizon, not the heat service: it installs next to horizon
+# because that is where collectstatic collects panels from. #636 moved horizon into
+# the caracal venv, so this moved with it. 11.0.0 is the caracal release --
+# https://releases.openstack.org/caracal/index.html#caracal-heat-dashboard. There is
+# no 11.0.1: the comment this replaces named one, and it does not exist on PyPI.
+# heat-dashboard talks to the API over HTTP through heatclient and imports nothing
+# from heat, so it never had to move when the service did. Horizon plugins are not in
+# the upper-constraints (that file only covers libraries), so the pin is explicit.
+HEAT_DASHBOARD_VER := 11.0.0
 
 # install heat
 rootfs_install::
@@ -166,17 +165,15 @@ rootfs_install::
 # Registering its panels, settings snippet and policy files is core/horizon's job:
 # every dashboard action lives there, because horizon is built last and is what runs
 # collectstatic and compress. Unlike the other components' panels this one needs no
-# entry in HORIZON_POLICY_NS_*: heat-dashboard ships a pre-generated
+# entry in HORIZON_POLICY_NS: heat-dashboard ships a pre-generated
 # conf/default_policies/heat.yaml, so horizon copies it instead of dumping the
 # `heat` oslo.policy namespace out of a venv.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)# $(OPENSTACK_HOME_DIR), not the caracal venv: this follows horizon, which
-	$(Q)# has not hopped -- see the note by HEAT_DASHBOARD_VER.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
 		heat-dashboard==$(HEAT_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -8,26 +8,21 @@
 # healthy.
 #
 # It used to be the yoga python3-heatclient rpm under the *system* python, because
-# /usr/bin/openstack was `#!/usr/bin/python3` (3.9) and the copy pip put in the 3.10
-# venv was invisible to it -- an entry point is only visible to the interpreter it
-# was installed under. core/heavyfs moved the CLI into the venv, so the plugin
-# followed it.
+# /usr/bin/openstack was `#!/usr/bin/python3` (3.9) and the copy pip put in a venv was
+# invisible to it -- an entry point is only visible to the interpreter it was
+# installed under. #609 moved the CLI into the antelope venv and the plugin followed
+# it; when heat moved to caracal the plugin had to stay behind, because the CLI had
+# not; #636 moved the CLI too, so the plugin sits with the service again.
 #
-# It stays in the *antelope* venv now that heat itself has moved to caracal, for that
-# same entry-point reason: core/heavyfs still links /usr/bin/openstack at
-# $(OPENSTACK_HOME_DIR), so the `orchestration` plugin has to be installed under that
-# interpreter or health_heat_check() breaks again. heat's own requirements.txt names
-# python-heatclient, so the caracal venv gets a 3.5.0 copy of its own; the antelope
-# one is what /usr/bin/openstack sees, and its 3.2.0 talks to a 22.0.1 API, which is
-# the supported direction -- `orchestration service list` is /v1/{tenant}/services
-# and predates 2023.1. Named explicitly rather than left transitive because nothing
-# in the antelope venv would pull it any more.
+# It is named explicitly rather than left transitive. heat's own requirements.txt
+# asks for it today, but designate.mk carries the story of what happens when the only
+# thing asking for a client is some other install: it disappears the day that install
+# moves, and `cluster check` reports the service NG while every unit is active.
 #
-# /usr/bin/heat, the client's own CLI, therefore also stays on the antelope venv: it
-# is python-heatclient's console script, not heat's. Nothing in this tree calls it,
-# but it has always been on the image for operators. /usr/bin/heat-3, the Fedora
-# python3 alias, is not recreated -- no other venv console script here is aliased
-# that way.
+# /usr/bin/heat, the client's own CLI, follows it: it is python-heatclient's console
+# script, not heat's. Nothing in this tree calls it, but it has always been on the
+# image for operators. /usr/bin/heat-3, the Fedora python3 alias, is not recreated --
+# no other venv console script here is aliased that way.
 #
 # Nothing else is needed: the RDO spec's only non-python Requires was
 # shadow-utils, for the heat user and group, and core/heavyfs/account/centos9
@@ -35,9 +30,9 @@
 #
 # openstack-heat-ui, the Horizon dashboard plugin, is replaced by the
 # heat-dashboard wheel installed further down. It was dropped when heat moved to
-# pip because horizon was still on python 3.9; #609 moved horizon into the venv, so
-# the Orchestration panels come back here. That wheel does *not* follow heat to
-# caracal -- see the note above it.
+# pip because horizon was still on python 3.9; #609 moved horizon into the antelope
+# venv and #636 into the caracal one, and the wheel has followed horizon both times
+# -- see the note above it.
 
 HEAT_CONFDIR := $(ROOTDIR)/etc/heat
 

--- a/core/heat/heat.mk
+++ b/core/heat/heat.mk
@@ -60,14 +60,13 @@ HEAT_DASHBOARD_VER := 11.0.0
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# python-heatclient owns the "orchestration" osc plugin and /usr/bin/heat. It
+	$(Q)# is named explicitly: an entry point is only visible to the interpreter
+	$(Q)# /usr/bin/openstack runs under, so a dependency nothing asks for is one that
+	$(Q)# can disappear silently and take `openstack orchestration ...` with it.
 	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
 		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-			openstack-heat==$(HEAT_VER)"
-	$(Q)# and the "orchestration" osc plugin in the antelope venv: that entry point is
-	$(Q)# only visible to the interpreter /usr/bin/openstack runs under, and that is
-	$(Q)# still the antelope one -- see the note at the top of this file.
-	$(Q)chroot $(ROOTDIR) bash -c "source $(OPENSTACK_HOME_DIR)/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			openstack-heat==$(HEAT_VER) \
 			python-heatclient"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
@@ -82,9 +81,8 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-engine /usr/bin/heat-engine
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-manage /usr/bin/heat-manage
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat-status /usr/bin/heat-status
-	$(Q)# the heatclient CLI, which is python-heatclient's console script and so
-	$(Q)# follows the antelope install above, not heat.
-	$(Q)chroot $(ROOTDIR) ln -sf $(OPENSTACK_HOME_DIR)/bin/heat /usr/bin/heat
+	$(Q)# the heatclient CLI, which is python-heatclient's console script.
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/heat /usr/bin/heat
 
 # prepare the build directory
 rootfs_install::

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -325,12 +325,13 @@ rootfs_install::
 #   - below 82 (2026-02-08), which deleted pkg_resources. That is the hard one, and
 #     it is a runtime requirement as much as a build one -- keystonemiddleware above,
 #     plus pbr's egg_info writer on every --no-build-isolation build in this venv.
-#   - below 80 (2025-04-27), which removed `setup.py install`. Nothing in this venv
-#     needs it today: ceph's bindings moved to `pip install` (see core/ceph/ceph.mk)
-#     and skyline's did too. It is kept as headroom for masakari, designate and
-#     watcher, which still install that way in antelope and will bring the command
-#     with them unless they are converted when they hop -- cyborg (#633) was, so it
-#     no longer needs it.
+#   - below 80 (2025-04-27), which removed `setup.py install`. Nothing anywhere in
+#     the tree invokes that command any more: ceph's bindings moved to `pip install`
+#     (see core/ceph/ceph.mk), skyline's did too, and #636 converted the last four --
+#     the designate, masakari, watcher and neutron-vpnaas dashboards -- from a git
+#     clone to a pinned pip install as they followed horizon here. The ceiling is
+#     kept anyway: it costs nothing, and it is what makes a future `setup.py`
+#     install fail on review rather than on build day.
 #
 # Verified in a python 3.11 venv before the bump: horizon 24.0.2's six sdists build
 # under --no-build-isolation, ceph's rados and rbd bindings produce the same flat

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -297,38 +297,6 @@ rootfs_install::
 # from 'xstatic.pkg' (unknown location)". A single pip invocation is fine -- pip
 # builds every sdist before installing any of them.
 
-# install the openstack cli inside the python 3.10 virtual environment
-#
-# /usr/bin/openstack was the python3-openstackclient rpm, so it ran as
-# `#!/usr/bin/python3` (3.9). That shebang is what pinned half a dozen osc plugins
-# to the system python: a plugin is an [openstack.cli.extension] stevedore entry
-# point, and entry points are only visible to the interpreter they were installed
-# under, so the copies pip put in this venv were invisible to the cli and every
-# plugin had to be held in 3.9 as well -- as an rpm (designate, heat, manila,
-# octavia) or as a second pip install (cyborg, watcher, monasca). Each of those
-# carried a comment saying it could go once the cli moved; this is that move, and
-# with it python 3.9 holds no openstack cli at all.
-#
-# Measured on jim-1cc: 977 commands under the 3.9 cli against 1574 here, because
-# the venv resolves plugins 3.9 never had -- `openstack baremetal ...` among them,
-# which used to fall through to osc's did-you-mean list.
-#
-# No version is pinned. python-openstackclient is a client, so
-# os-antelope-pip-upper-constraints.txt already carries it (6.2.1) and naming it
-# again here could only drift from that file.
-#
-# The rpm also owned /usr/bin/openstack-3, the Fedora python3 alias. Nothing in this
-# tree calls it and no other venv console script is aliased that way, so it is not
-# recreated.
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-		python-openstackclient
-	$(Q)# Link the cli. hex_sdk reaches it by absolute path ($$OPENSTACK in
-	$(Q)# core/sdk_sh/modules.pre/sdk_01-var-static.sh is /usr/bin/openstack), so
-	$(Q)# this symlink is what carries every caller over.
-	$(Q)chroot $(ROOTDIR) ln -sf $(OPENSTACK_HOME_DIR)/bin/openstack /usr/bin/openstack
-
 # set up the execution context for openstack caracal
 rootfs_install::
 	$(Q)chroot $(ROOTDIR) mkdir -p $(CARACAL_OPENSTACK_HOME_DIR)
@@ -367,6 +335,44 @@ rootfs_install::
 # Verified in a python 3.11 venv before the bump: horizon 24.0.2's six sdists build
 # under --no-build-isolation, ceph's rados and rbd bindings produce the same flat
 # .so + .dist-info layout as under 65.7.0 and import, and pkg_resources is present.
+
+# install the openstack cli inside the python 3.11 virtual environment
+#
+# /usr/bin/openstack was the python3-openstackclient rpm, so it ran as
+# `#!/usr/bin/python3` (3.9). That shebang is what pinned half a dozen osc plugins
+# to the system python: a plugin is an [openstack.cli.extension] stevedore entry
+# point, and entry points are only visible to the interpreter they were installed
+# under, so the copies pip put in a venv were invisible to the cli and every plugin
+# had to be held in 3.9 as well -- as an rpm (designate, heat, manila, octavia) or as
+# a second pip install (cyborg, watcher, monasca). #609 moved the cli into the
+# antelope venv and every plugin followed it there; #636 moves it again, into the
+# caracal venv, and the plugins follow it a second time.
+#
+# The second move is the same mechanism as the first, so the same rule decides where
+# each plugin goes: next to whichever interpreter runs /usr/bin/openstack. Each
+# component installs its own -- see core/{heat,manila,octavia,designate,masakari,
+# watcher,cyborg,barbican,monasca}. python-ironicclient needs no line of its own:
+# ironic-ui and python-watcher both declare it and both are in this venv.
+#
+# Measured on jim-1cc: 977 commands under the 3.9 cli against 1574 under the antelope
+# one, because a venv resolves plugins 3.9 never had -- `openstack baremetal ...`
+# among them, which used to fall through to osc's did-you-mean list.
+#
+# No version is pinned. python-openstackclient is a client, so
+# os-caracal-pip-upper-constraints.txt already carries it (6.6.1) and naming it again
+# here could only drift from that file.
+#
+# The rpm also owned /usr/bin/openstack-3, the Fedora python3 alias. Nothing in this
+# tree calls it and no other venv console script is aliased that way, so it is not
+# recreated.
+rootfs_install::
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		python-openstackclient
+	$(Q)# Link the cli. hex_sdk reaches it by absolute path ($$OPENSTACK in
+	$(Q)# core/sdk_sh/modules.pre/sdk_01-var-static.sh is /usr/bin/openstack), so
+	$(Q)# this symlink is what carries every caller over.
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/openstack /usr/bin/openstack
 
 # Allow admin to be sudoers
 rootfs_install::

--- a/core/horizon/gunicorn-config.py
+++ b/core/horizon/gunicorn-config.py
@@ -1,6 +1,6 @@
 # gunicorn settings for the horizon dashboard.
 #
-# Horizon moved into the python 3.10 venv at /opt/openstack-antelope, and
+# Horizon runs out of the python 3.11 venv at /opt/openstack-caracal, and
 # mod_wsgi is built against the system python 3.9, so httpd can no longer host
 # the application in-process. It reverse-proxies this socket instead, the same
 # arrangement keystone, barbican and monasca-api already use.

--- a/core/horizon/horizon.mk
+++ b/core/horizon/horizon.mk
@@ -1,17 +1,15 @@
 # Cube SDK
 # horizon installation
 
-# https://releases.openstack.org/antelope/index.html#antelope-horizon
-HORIZON_VER := 23.1.1
+# https://releases.openstack.org/caracal/index.html#caracal-horizon
+#
+# The same version $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) already pins, so the
+# two agree and neither decides the release on its own.
+HORIZON_VER := 24.0.2
 
-# The caracal dashboard, installed alongside it in the caracal venv. Nothing serves
-# this one -- see the note by its install block below -- and the version is the one
-# $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) already pins, so the two agree.
-CARACAL_HORIZON_VER := 24.0.2
-
-# Not in the antelope upper-constraints, so pinned here for reproducibility. This is
-# also a source build (see core/mysql/mysql.mk), which is the other reason not to
-# leave it floating.
+# Not in the caracal upper-constraints either, so pinned here for reproducibility.
+# This is also a source build (see core/mysql/mysql.mk), which is the other reason not
+# to leave it floating.
 MYSQLCLIENT_VER := 2.2.8
 
 # The dashboard layout. These used to live in core/heavyfs/Makefile, from the days
@@ -24,7 +22,7 @@ MYSQLCLIENT_VER := 2.2.8
 # path, so a plain cp from the build host would follow it out to the *host* root
 # instead of into $(ROOTDIR).
 HORIZON_APP_DIR := /usr/share/openstack-dashboard
-HORIZON_VENV_SITE_PACKAGES := $(OPENSTACK_HOME_DIR)/lib/python$(PYTHON_VER)/site-packages
+HORIZON_VENV_SITE_PACKAGES := $(CARACAL_OPENSTACK_HOME_DIR)/lib/python$(CARACAL_PYTHON_VER)/site-packages
 HORIZON_DIR := $(HORIZON_VENV_SITE_PACKAGES)/openstack_dashboard
 HORIZON_ETCDIR := /etc/openstack-dashboard
 HORIZON_POLICY_DIR := $(HORIZON_ETCDIR)/default_policies
@@ -37,31 +35,42 @@ HORIZON_LOG_DIR := /var/log/horizon
 HORIZON_APP_STATE_DIR := /var/lib/openstack-dashboard
 
 # The same site-packages directory as seen from the build host. Every dashboard plugin
-# is pip installed by the component that owns it -- heat-dashboard by heat.mk,
-# ironic-ui by ironic.mk, manila-ui by manila.mk, octavia-dashboard by octavia.mk, and
-# designate/masakari/watcher/neutron-vpnaas from git by theirs -- and all of them land
-# here for the collection step below to pick up.
+# is a pinned pip install done by the component that owns it -- heat-dashboard by
+# heat.mk, ironic-ui by ironic.mk, manila-ui by manila.mk, octavia-dashboard by
+# octavia.mk, and designate/masakari/watcher/neutron-vpnaas by theirs -- and all of
+# them land here for the collection step below to pick up.
 HORIZON_VENV_SP := $(ROOTDIR)$(HORIZON_VENV_SITE_PACKAGES)
 
 CUBE_THEME_SRCS := $(shell find $(CUBE_THEME_SRCDIR) -type f 2>/dev/null)
 
 $(PROJ_HEAVYFS): $(COREDIR)/horizon/local_settings.in $(CUBE_THEME_SRCS)
 
-# install horizon inside the python 3.10 virtual environment
+# install horizon inside the python 3.11 virtual environment
 #
 # The rpms this replaces are openstack-dashboard, openstack-dashboard-theme and
 # python3-django-horizon. Each dashboard plugin is pip installed by the component
 # that owns it; registering the panels and running manage.py is this file's job, and
 # horizon is built last so all of it happens once every plugin is in the venv.
 #
-# Two dependencies that are not horizon requirements and so have to be named:
+# This used to be two installs: the served dashboard in the antelope venv, and a
+# second 24.0.2 copy here whose only job was to give dump_default_policies an
+# interpreter that could see the caracal services' oslo.policy entry points. That
+# copy was a down payment on this move -- same version, so the dependency set landed
+# once -- and this is the move, so there is one install again.
+#
+# Three dependencies that are not horizon requirements and so have to be named:
 #   - mysqlclient replaces the python3-mysqlclient rpm. local_settings.in uses
 #     django.db.backends.mysql for the cached_db session store, and that backend
-#     imports MySQLdb. PyMySQL is already in the venv but django 3.2 rejects it:
-#     it wants MySQLdb >= 1.4.0 and PyMySQL reports 1.0.2.
+#     imports MySQLdb. PyMySQL is already in the venv but django rejects it: 4.2
+#     wants MySQLdb >= 1.4.3 and PyMySQL reports 1.0.2.
 #   - pymemcache backs the PyMemcacheCache cache backend. python-memcached is in
-#     the venv already, but MemcachedCache is removed in django 4.1 and there is
-#     no reason to move onto a dead backend now.
+#     the venv already, but MemcachedCache was removed in django 4.1, and 24.0.2
+#     runs on 4.2.
+#   - gunicorn is what openstack-dashboard.service execs. It was never named while
+#     the dashboard was in the antelope venv, because core/monasca put it there and
+#     monasca is not moving; keystone.mk and barbican.mk put it in this one, but a
+#     dependency nothing asks for is one that disappears silently -- the reason
+#     barbican.mk names it even though keystone.mk already installs it.
 #
 # These are two pip invocations rather than one because the two halves want opposite
 # build environments, and a single command can only have one. See the note by the venv
@@ -71,44 +80,19 @@ rootfs_install::
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)# horizon's sdist-only XStatic dependencies import a pkg_resources-declared
 	$(Q)# namespace from setup.py, so they have to be built against this venv's
-	$(Q)# setuptools 65.7.0 -- a current setuptools has no pkg_resources at all.
-	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-			--no-build-isolation \
-			horizon==$(HORIZON_VER)"
-	$(Q)# mysqlclient is the counter-example: it is also a source build, but its
-	$(Q)# pyproject.toml is newer than setuptools 65.7.0 can parse, so it keeps pip's
-	$(Q)# default build isolation and gets a current setuptools of its own.
-	$(Q)chroot $(ROOTDIR) bash -c "source /opt/openstack-antelope/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-			mysqlclient==$(MYSQLCLIENT_VER) \
-			pymemcache"
-	$(Q)# clean up dns configurations after downloading packages
-	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-
-# the same dashboard again, in the caracal venv
-#
-# Nothing serves this copy. openstack-dashboard.service, gunicorn-config.py and the
-# httpd reverse proxy all point at $(HORIZON_APP_DIR), which is the antelope tree,
-# and every dashboard plugin still installs next to it. This one exists so that
-# dump_default_policies can run under the interpreter that owns the core services'
-# oslo.policy entry points -- see the policy block near the end of this file.
-#
-# It is a down payment rather than scaffolding: 24.0.2 is what horizon's own move to
-# this venv will install, so the dependency set lands once. Verified against a built
-# rootfs: 41 packages, +170MB, and no already-installed caracal package changes
-# version, so keystone/nova/cinder/glance/placement are untouched (pip check clean).
-#
-# --no-build-isolation for the XStatic sdists, exactly as above -- this venv also
-# carries setuptools 65.7.0, so the pkg_resources those setup.py files import is
-# there.
-rootfs_install::
-	$(Q)# enable dns in the rootfs for downloading packages
-	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
+	$(Q)# setuptools 75.6.0 -- a current setuptools has no pkg_resources at all.
 	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
 		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 			--no-build-isolation \
-			horizon==$(CARACAL_HORIZON_VER)"
+			horizon==$(HORIZON_VER)"
+	$(Q)# mysqlclient is the counter-example: it is also a source build, but its
+	$(Q)# pyproject.toml wants a setuptools newer than this venv's, so it keeps pip's
+	$(Q)# default build isolation and gets a current setuptools of its own.
+	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
+		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			mysqlclient==$(MYSQLCLIENT_VER) \
+			pymemcache \
+			gunicorn"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
@@ -218,39 +202,36 @@ rootfs_install::
 # DEFAULT_POLICY_FILES points at came from the openstack-dashboard rpm, and the
 # masakari one from masakari.mk running this same command under python 3.9. Generate
 # them all here instead, from the services that are actually running -- every one of
-# these namespaces is an oslo.policy.policies entry point in one of the two venvs.
+# these namespaces is an oslo.policy.policies entry point in the venv this dashboard
+# now shares with them.
 #
-# Which venv is the whole difficulty. stevedore only sees entry points registered in
-# the interpreter it is running under, so one python cannot dump them all any more:
-# keystone, nova, cinder, glance, neutron, octavia and masakari have all moved to
-# caracal, so the antelope list is empty and its loop below does not run. Each list is
-# dumped by the dashboard that shares its venv. A namespace listed against the venv
-# that does not hold it fails the build with 'The requested namespace "<x>" is not
-# found'; move it to the other list when its service makes the hop.
+# There used to be a second list, dumped by the antelope venv's python, because
+# stevedore only sees entry points registered in the interpreter it is running under
+# and one python could not dump them all. It emptied out as the services hopped, and
+# horizon following them is what removes the split: every namespace below is a caracal
+# package's entry point, and this dashboard runs on caracal. A namespace whose service
+# is still in the antelope venv cannot be dumped from here -- it fails the build with
+# 'The requested namespace "<x>" is not found' -- so nothing may be added to this list
+# ahead of its service.
 #
-# Note the octavia and masakari entries follow the *service*, not the panel:
-# octavia-dashboard and masakaridashboard are both still installed into the antelope
-# venv beside horizon, but the oslo.policy.policies entry points named "octavia" and
-# "masakari" are registered by the octavia and masakari packages, which #640 and #639
-# moved to caracal.
-HORIZON_POLICY_NS_ANTELOPE :=
-HORIZON_POLICY_NS_CARACAL := keystone nova cinder glance neutron octavia masakari
+# Note the octavia and masakari entries follow the *service*, not the panel: the
+# oslo.policy.policies entry points named "octavia" and "masakari" are registered by
+# the octavia and masakari packages, not by their dashboard plugins.
+HORIZON_POLICY_NS := keystone nova cinder glance neutron octavia masakari
 
-# django-admin rather than $(HORIZON_APP_DIR)/manage.py, for both venvs so the two
-# loops stay one shape. manage.py sits in a directory whose horizon and
-# openstack_dashboard entries are symlinks into the *antelope* venv, and a script's
-# own directory leads sys.path -- so running it with the caracal python imports
-# python3.10 packages under python3.11. A console script has no such directory.
+# django-admin rather than $(HORIZON_APP_DIR)/manage.py. Both resolve to this venv now
+# that the symlinks in that directory point here, so the cross-venv import hazard that
+# used to force the console script is gone; it stays because a console script has no
+# directory of its own leading sys.path, and DJANGO_SETTINGS_MODULE is set explicitly
+# below anyway.
 #
-# --skip-checks because django's system checks instantiate every configured cache
-# backend, and horizon defaults CACHES to django's PyMemcacheCache. The antelope venv
-# has pymemcache (installed above, for the running dashboard); the caracal venv has
-# no reason to. The dump reads oslo.policy entry points and touches no cache.
-# "No local_settings file found." on the caracal side is expected and harmless:
-# openstack_dashboard/settings.py warns and carries on, and only the antelope copy is
-# ever configured.
+# --skip-checks because the dump reads oslo.policy entry points and needs nothing
+# else: no cache, no database, no static tree. django's system checks instantiate
+# every configured cache backend, and this runs before collectstatic has built
+# anything, so skipping them keeps the dump independent of what the rest of the build
+# has done so far.
 #
-# Both loops are noisy on stderr -- the USE_L10N notice, a debreach distutils warning,
+# The loop is noisy on stderr -- the USE_L10N notice, a debreach distutils warning,
 # and oslo.policy grumbling about upstream nova/cinder rules that set deprecated_since
 # on the RuleDefault instead of the DeprecatedRule. It is left alone: PYTHONWARNINGS
 # does not reach it (something under settings resets the filters), and stderr has to
@@ -263,13 +244,7 @@ rootfs_install::
 	$(Q)# "No policy rules for service '<x>'" and a denied panel. masakari.mk used to
 	$(Q)# state this guarantee explicitly ("that command exits 1 and the build fails");
 	$(Q)# folding the dump into a loop here is what dropped it.
-	$(Q)for ns in $(HORIZON_POLICY_NS_ANTELOPE) ; do \
-		chroot $(ROOTDIR) env DJANGO_SETTINGS_MODULE=openstack_dashboard.settings \
-			$(OPENSTACK_HOME_DIR)/bin/django-admin dump_default_policies --skip-checks \
-			--namespace $$ns \
-			--output-file $(HORIZON_POLICY_DIR)/$$ns.yaml || exit 1 ; \
-	done
-	$(Q)for ns in $(HORIZON_POLICY_NS_CARACAL) ; do \
+	$(Q)for ns in $(HORIZON_POLICY_NS) ; do \
 		chroot $(ROOTDIR) env DJANGO_SETTINGS_MODULE=openstack_dashboard.settings \
 			$(CARACAL_OPENSTACK_HOME_DIR)/bin/django-admin dump_default_policies --skip-checks \
 			--namespace $$ns \
@@ -285,9 +260,9 @@ rootfs_install::
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/horizon/openstack-dashboard.conf ./etc/httpd/conf.d/
 
 rootfs_install::
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py compilemessages 2>&1 > /dev/null
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py collectstatic --noinput 2>&1 > /dev/null
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py compress --force 2>&1 > /dev/null
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py compilemessages 2>&1 > /dev/null
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py collectstatic --noinput 2>&1 > /dev/null
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/python $(HORIZON_APP_DIR)/manage.py compress --force 2>&1 > /dev/null
 	$(Q)chroot $(ROOTDIR) chmod 755 -R $(HORIZON_APP_DIR)
 	$(Q)chroot $(ROOTDIR) sh -c "chown root:apache -R $(HORIZON_POLICY_DIR)/*"
 	$(Q)chroot $(ROOTDIR) sh -c "chmod 640 -R $(HORIZON_POLICY_DIR)/*"

--- a/core/horizon/local_settings.in
+++ b/core/horizon/local_settings.in
@@ -46,7 +46,7 @@ COMPRESS_OFFLINE = True
 # with the list of host/domain names that the application can serve.
 # For more information see:
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = '*'
+ALLOWED_HOSTS = ['*']
 
 # Set SSL proxy settings:
 # Pass this header from the proxy after terminating the SSL,

--- a/core/horizon/manage.py
+++ b/core/horizon/manage.py
@@ -1,4 +1,4 @@
-#!/opt/openstack-antelope/bin/python
+#!/opt/openstack-caracal/bin/python
 import os
 import sys
 

--- a/core/horizon/openstack-dashboard.conf
+++ b/core/horizon/openstack-dashboard.conf
@@ -1,4 +1,4 @@
-# Horizon moved into the python 3.10 venv at /opt/openstack-antelope and
+# Horizon runs out of the python 3.11 venv at /opt/openstack-caracal and
 # mod_wsgi is built against the system python 3.9, so httpd can only proxy the
 # application, not host it in-process. openstack-dashboard.service runs it under
 # gunicorn on the socket below; this file is what used to be the

--- a/core/horizon/openstack-dashboard.service
+++ b/core/horizon/openstack-dashboard.service
@@ -25,7 +25,7 @@ Environment=SCRIPT_NAME=/horizon
 # /usr/lib/systemd/system/httpd.service.d/openstack-dashboard.conf. They have to
 # move here for two reasons: the rpm (and therefore the drop-in) is gone, and
 # they ran under /usr/bin/python3, which can no longer import the dashboard or
-# its plugins now that both live in the python 3.10 venv.
+# its plugins now that both live in the python 3.11 venv.
 #
 # They are kept rather than left to the build because config_horizon.cpp
 # rewrites local_settings on every Commit() -- WEBROOT and STATIC_URL are
@@ -43,11 +43,11 @@ Environment=SCRIPT_NAME=/horizon
 # openstack-dashboard`. collectstatic overwrites what it collects, so --clear only
 # buys the removal of files a plugin has stopped shipping, which is not worth a
 # window where the dashboard has no assets.
-ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput -v0
-ExecStartPre=+/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compress --force -v0
+ExecStartPre=+/opt/openstack-caracal/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput -v0
+ExecStartPre=+/opt/openstack-caracal/bin/python /usr/share/openstack-dashboard/manage.py compress --force -v0
 TimeoutStartSec=5min
 
-ExecStart=/opt/openstack-antelope/bin/gunicorn \
+ExecStart=/opt/openstack-caracal/bin/gunicorn \
     -c /etc/openstack-dashboard/gunicorn-config.py \
     openstack_dashboard.wsgi:application
 

--- a/core/ironic/ironic.mk
+++ b/core/ironic/ironic.mk
@@ -23,18 +23,14 @@ IRONIC_VER := 24.1.5
 # while "inspector" is still in that list.
 IRONIC_INSP_VER := 12.1.1
 
-# Deliberately still the 2023.1 pin, and deliberately still in the antelope venv.
-# core/horizon/horizon.mk serves the dashboard out of $(OPENSTACK_HOME_DIR) --
-# openstack-dashboard.service, gunicorn-config.py and the httpd reverse proxy all
-# point at the antelope tree, and every dashboard plugin installs next to it.
-# ironic-ui follows horizon, not the ironic service, so the Bare Metal Provisioning
-# panel stays on 6.1.0 until horizon itself hops; 6.3.0 is the caracal release to move
-# to on that day. It reaches the api over HTTP through python-ironicclient and imports
-# nothing from ironic, so the split costs nothing -- the same reasoning
-# octavia-dashboard got in #1373, manila-ui in #1353 and heat-dashboard in #1376.
-# Horizon plugins are not in the caracal upper-constraints either (that file only
-# covers libraries), so the pin has to be explicit.
-IRONIC_UI_VER := 6.1.0
+# ironic-ui follows horizon, not the ironic service: it installs next to horizon
+# because that is where collectstatic collects panels from. #636 moved horizon into
+# the caracal venv, so this moved with it. 6.3.0 is the caracal release --
+# https://releases.openstack.org/caracal/index.html#caracal-ironic-ui. It reaches the
+# api over HTTP through python-ironicclient and imports nothing from ironic, so it
+# never had to move when the service did. Horizon plugins are not in the caracal
+# upper-constraints either (that file only covers libraries), so the pin is explicit.
+IRONIC_UI_VER := 6.3.0
 
 # python-ironicclient owns the `baremetal` osc plugin, and an entry point is only
 # visible to the interpreter it was installed under. core/heavyfs still links
@@ -114,10 +110,8 @@ rootfs_install::
 	$(Q)# --no-build-isolation: ironic-ui pulls horizon, whose sdist-only XStatic
 	$(Q)# dependencies cannot be built against a current setuptools. See the note by
 	$(Q)# the venv bootstrap in core/heavyfs/Makefile.
-	$(Q)# $(OPENSTACK_HOME_DIR), not the caracal venv: this follows horizon, which
-	$(Q)# has not hopped -- see the note by IRONIC_UI_VER.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
 		ironic-ui==$(IRONIC_UI_VER)
 	$(Q)# clean up dns configurations after downloading packages

--- a/core/ironic/ironic.mk
+++ b/core/ironic/ironic.mk
@@ -33,13 +33,13 @@ IRONIC_INSP_VER := 12.1.1
 IRONIC_UI_VER := 6.3.0
 
 # python-ironicclient owns the `baremetal` osc plugin, and an entry point is only
-# visible to the interpreter it was installed under. core/heavyfs still links
-# /usr/bin/openstack at $(OPENSTACK_HOME_DIR), so that plugin has to stay in the
-# antelope venv -- and it does, without a pip line of its own: ironic-ui (installed
-# below) and python-watcher (core/watcher) both declare it, so it is guaranteed there
-# rather than lucky. That is why this hop needs no counterpart to the explicit
-# python-heatclient / python-manilaclient antelope installs #1376 and #1353 had to add.
-# A 5.1.0 client against a 24.1.5 api is the supported direction.
+# visible to the interpreter it was installed under, so it has to sit next to whichever
+# interpreter runs /usr/bin/openstack. #636 made that the caracal venv, where it is
+# already present without a pip line of its own: ironic-ui (installed below) and
+# python-watcher (core/watcher) both declare it and both are in that venv, so it is
+# guaranteed there rather than lucky. Two declarers is what makes it safe to leave
+# implicit here where heat and manila had to be explicit -- see designate.mk for the
+# failure mode a single transitive declarer produces.
 #
 # System requirements formerly pulled in by the openstack-ironic RPMs.
 # ipmitool backs enabled_hardware_types=ipmi / enabled_management_interfaces=ipmitool

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -10,7 +10,7 @@ HEX_DONE=/run/bootstrap_done
 CUBE_DONE=/run/cube_commit_done
 CLUSTER_SYNC=/run/cube_cluster_synced
 CLUSTER_REPAIRING=/run/cube_cluster_repairing
-# Note: openstack_dashboard is a symlink into the python 3.10 venv's site-packages
+# Note: openstack_dashboard is a symlink into the python 3.11 venv's site-packages
 # now, so this path resolves inside the venv. Moving panels aside below therefore
 # edits the installed package rather than a private copy under /usr/share.
 HORIZON_APP_DIR=/usr/share/openstack-dashboard/openstack_dashboard/local/enabled
@@ -230,12 +230,12 @@ cube_edge_cfg()
         remote_run $ctrl mv $HORIZON_APP_DIR/_17*.py $HORIZON_APP_DIR/bak/
         # watcher
         remote_run $ctrl mv $HORIZON_APP_DIR/_310*.py $HORIZON_APP_DIR/bak/
-        # horizon lives in the python 3.10 venv, so /usr/bin/python3 can no longer
+        # horizon lives in the python 3.11 venv, so /usr/bin/python3 can no longer
         # import openstack_dashboard -- use the venv interpreter, the same one
         # config_horizon.cpp and openstack-dashboard.service name.
-        remote_run $ctrl /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compilemessages 2>&1 > /dev/null
-        remote_run $ctrl /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput 2>&1 > /dev/null
-        remote_run $ctrl /opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py compress --force 2>&1 > /dev/null
+        remote_run $ctrl /opt/openstack-caracal/bin/python /usr/share/openstack-dashboard/manage.py compilemessages 2>&1 > /dev/null
+        remote_run $ctrl /opt/openstack-caracal/bin/python /usr/share/openstack-dashboard/manage.py collectstatic --noinput 2>&1 > /dev/null
+        remote_run $ctrl /opt/openstack-caracal/bin/python /usr/share/openstack-dashboard/manage.py compress --force 2>&1 > /dev/null
         # the dashboard is its own unit now; restarting httpd only reloads the proxy
         # in front of it and no longer reruns collectstatic/compress.
         remote_run $ctrl systemctl restart openstack-dashboard

--- a/core/manila/manila.mk
+++ b/core/manila/manila.mk
@@ -69,16 +69,14 @@ MANILA_UI_VER := 11.0.1
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)# python-manilaclient owns /usr/bin/manila, named explicitly -- see the note
-	$(Q)# at the top of this file for why it is installed into both venvs.
+	$(Q)# python-manilaclient owns /usr/bin/manila and the "share" osc plugin, and is
+	$(Q)# named explicitly: an entry point is only visible to the interpreter
+	$(Q)# /usr/bin/openstack runs under, so a dependency nothing asks for is one that
+	$(Q)# can disappear silently. It used to be installed into the antelope venv as
+	$(Q)# well, for the plugin alone; #636 took the cli here, so one copy does both.
 	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
 		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 			manila==$(MANILA_VER) \
-			python-manilaclient"
-	$(Q)# and again in the antelope venv, for the "share" osc plugin alone: that entry
-	$(Q)# point is only visible to the interpreter /usr/bin/openstack runs under.
-	$(Q)chroot $(ROOTDIR) bash -c "source $(OPENSTACK_HOME_DIR)/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 			python-manilaclient"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/manila/manila.mk
+++ b/core/manila/manila.mk
@@ -57,15 +57,13 @@ MANILA_RUN_DIR := /var/run/manila
 MANILA_SRCDIR := $(ROOTDIR)$(CARACAL_OPENSTACK_HOME_DIR)/lib/python$(CARACAL_PYTHON_VER)/site-packages/manila
 MANILA_PATCHDIR := $(COREDIR)/manila/$(CARACAL_OPENSTACK_RELEASE)_patch
 
-# Deliberately still the 2023.1 pin, and deliberately still in the antelope venv.
-# core/horizon/horizon.mk installs the dashboard into both venvs, but nothing serves
-# the caracal copy -- openstack-dashboard.service, gunicorn-config.py and the httpd
-# reverse proxy all point at the antelope tree, and every dashboard plugin installs
-# next to it. manila-ui follows horizon, not the manila service, so the Shares panels
-# stay on 9.0.1 against horizon 23.x until horizon itself hops; 11.0.1 is the caracal
-# release to move to on that day. Horizon plugins are not in the upper-constraints
-# (that file only covers libraries), so the pin has to be explicit.
-MANILA_UI_VER := 9.0.1
+# manila-ui follows horizon, not the manila service: it installs next to horizon
+# because that is where collectstatic collects panels from. #636 moved horizon into
+# the caracal venv, so this moved with it. 11.0.1 is the caracal release --
+# https://releases.openstack.org/caracal/index.html#caracal-manila-ui. Horizon plugins
+# are not in the upper-constraints (that file only covers libraries), so the pin is
+# explicit.
+MANILA_UI_VER := 11.0.1
 
 # install manila inside the caracal python 3.11 virtual environment
 rootfs_install::
@@ -111,8 +109,8 @@ rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
 		manila-ui==$(MANILA_UI_VER)
 	$(Q)# clean up dns configurations after downloading packages

--- a/core/manila/manila.mk
+++ b/core/manila/manila.mk
@@ -5,30 +5,30 @@
 # calls in health_manila_check(), os_manila_init() and migrate_manila_db_post(), and
 # the "share" osc plugin entry point.
 #
-# Those two now want different venvs, so it is installed twice.
+# Those two wanted different venvs between #638 and #636, so it was installed twice.
+# #636 took /usr/bin/openstack to caracal, where the api and the standalone cli already
+# were, so one install serves all three consumers again.
 #
 # The osc plugin has to sit with the interpreter that runs /usr/bin/openstack, because
-# an entry point is only visible to the interpreter it was installed under -- and
-# core/heavyfs still links /usr/bin/openstack at $(OPENSTACK_HOME_DIR), the antelope
-# venv. `openstack share` is reached from sdk_os.sh (os_manila_share_delete and the
-# share-type reconcile), so dropping the antelope copy would break those four call
-# sites. Unlike volume/compute/image, share is not built into python-openstackclient;
-# it is a separate plugin, which is why cinder could take its client to caracal
-# wholesale and manila cannot.
+# an entry point is only visible to the interpreter it was installed under. `openstack
+# share` is reached from sdk_os.sh (os_manila_share_delete and the share-type
+# reconcile), so a copy in the wrong venv breaks those four call sites silently. Unlike
+# volume/compute/image, share is not built into python-openstackclient; it is a
+# separate plugin, which is why cinder could take its client to caracal wholesale and
+# manila had to wait.
 #
 # /usr/bin/manila is the standalone cli hex_sdk drives, and it talks HTTP, so it goes
 # to caracal with the api it queries -- 4.8.1, the client caracal's own
 # upper-constraints names for the 18.3.0 api installed here. That keeps the pairing
 # #1203 established when it retired the yoga-client-against-antelope-api one.
 #
-# The antelope copy has a second consumer besides the osc plugin, so do not drop it on the
-# day horizon hops and the plugin follows: manila-ui declares
-# `Requires-Dist: python-manilaclient (>=2.7.0)` and imports it from 15 modules, including
-# manila_ui/api/manila.py and manila_ui/exceptions.py. Whichever of the two moves last is
-# what keeps 4.4.2 needed there.
+# manila-ui is the third consumer: it declares
+# `Requires-Dist: python-manilaclient (>=2.7.0)` and imports it from 15 modules,
+# including manila_ui/api/manila.py and manila_ui/exceptions.py. It moved to caracal
+# with horizon in #636, which is what emptied the antelope side out.
 #
-# openstack-manila-ui is replaced by the manila-ui wheel installed further down, and
-# that one does *not* move: see the note above it.
+# openstack-manila-ui is replaced by the manila-ui wheel installed further down --
+# see the note above it.
 #
 # openstack-manila and openstack-manila-share are what the pip install below
 # replaces. Non-python Requires of those two that are deliberately not restated:

--- a/core/masakari/caracal_patch/masakaridashboard/dashboard.py.orig
+++ b/core/masakari/caracal_patch/masakaridashboard/dashboard.py.orig
@@ -15,7 +15,7 @@
 
 from oslo_log import log as logging
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import horizon
 
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 class MasakariDashboard(horizon.Dashboard):
     slug = "masakaridashboard"
     name = _("Instance-ha")
-    panels = ('default', 'segments', 'hosts', 'notifications')
+    panels = ('default', 'segments', 'hosts', 'notifications', 'vmoves')
     default_panel = 'default'
     policy_rules = (('instance-ha', 'context_is_admin'),)
 

--- a/core/masakari/caracal_patch/masakaridashboard/dashboard.py.patch
+++ b/core/masakari/caracal_patch/masakaridashboard/dashboard.py.patch
@@ -1,9 +1,9 @@
---- masakaridashboard/dashboard.py	2025-04-10 14:09:56.018108719 +0800
-+++ masakaridashboard/dashboard.py	2025-04-10 14:09:56.018108719 +0800
+--- masakaridashboard/dashboard.py	2026-08-31 15:27:49.000000000 +0000
++++ masakaridashboard/dashboard.py	2026-08-31 15:27:49.000000000 +0000
 @@ -29,7 +29,8 @@
      slug = "masakaridashboard"
      name = _("Instance-ha")
-     panels = ('default', 'segments', 'hosts', 'notifications')
+     panels = ('default', 'segments', 'hosts', 'notifications', 'vmoves')
 -    default_panel = 'default'
 +    #default_panel = 'default'
 +    default_panel = 'segments'

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -80,15 +80,15 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/masakari-introspectiveinstancemonitor /usr/bin/masakari-introspectiveinstancemonitor
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/masakari-processmonitor /usr/bin/masakari-processmonitor
 
-# the osc plugin and the dashboard stay in the antelope venv -- TEMPORARY
+# the osc plugin and the dashboard
 #
 # python-masakariclient owns the "ha" osc plugin entry point ("openstack segment ...",
 # which hex_sdk's os_masakari_maintenance_hosts drives), and a stevedore entry point is
-# only visible to the interpreter it was installed under. /usr/bin/openstack is the
-# antelope venv's, so the plugin has to stay next to it. It owns no console script of
-# its own, so nothing needs relinking. It is now a pinned pip install like the rest --
-# the antelope constraints file decides the version, the way core/designate does it for
-# python-designateclient -- rather than a branch-name clone.
+# only visible to the interpreter it was installed under, so the plugin has to sit next
+# to /usr/bin/openstack. That held it in the antelope venv from #639 until #636 moved
+# the cli here. It owns no console script of its own, so nothing needs relinking. The
+# constraints file decides its version, the way core/designate does it for
+# python-designateclient -- it is not a branch-name clone.
 #
 # masakari-dashboard is a horizon plugin: core/horizon/horizon.mk copies its enabled
 # panels out of $(HORIZON_VENV_SP), which is the site-packages of whichever venv
@@ -101,8 +101,6 @@ rootfs_install::
 #
 # 10.0.0 brings the vmoves panel with it. The API behind it has been there since
 # masakari 17.0.0 (#639); only the panel was missing, and this is what supplies it.
-#
-# The osc plugin goes once /usr/bin/openstack is the caracal venv's (#636).
 MASAKARI_DASHBOARD_VER := 10.0.0
 
 rootfs_install::

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -108,8 +108,8 @@ MASAKARI_DASHBOARD_VER := 10.0.0
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-masakariclient
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \

--- a/core/masakari/masakari.mk
+++ b/core/masakari/masakari.mk
@@ -7,22 +7,19 @@ MASAKARI_APP_DIR := /var/lib/masakari
 MASAKARI_LOG_DIR := /var/log/masakari
 MASAKARI_RUN_DIR := /var/run/masakari
 
-# The patch pairs split across two venvs from #639 on. masakari and
-# masakari-monitors are in the caracal venv; masakaridashboard is not, because it is a
-# horizon plugin and horizon is still antelope's. The dashboard patch matters --
-# upstream sets default_panel = 'default', a panel whose urls.py has no index, so an
-# unpatched masakaridashboard makes the sidebar raise NoReverseMatch and every page
-# 500s. It rejoins the others under caracal_patch/ when horizon hops (#636), and
-# antelope_patch/ goes with it.
-MASAKARI_CARACAL_SRCDIR := $(ROOTDIR)$(CARACAL_OPENSTACK_HOME_DIR)/lib/python$(CARACAL_PYTHON_VER)/site-packages
-MASAKARI_CARACAL_PATCHDIR := $(COREDIR)/masakari/$(CARACAL_OPENSTACK_RELEASE)_patch
-MASAKARI_ANTELOPE_SRCDIR := $(ROOTDIR)$(OPENSTACK_HOME_DIR)/lib/python$(PYTHON_VER)/site-packages
-MASAKARI_ANTELOPE_PATCHDIR := $(COREDIR)/masakari/$(OPENSTACK_RELEASE)_patch
-
-# prepare the build directory
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) rm -rf /tmp/masakari
-	$(Q)chroot $(ROOTDIR) mkdir -p /tmp/masakari
+# The patch pairs were split across two venvs between #639 and #636: masakari and
+# masakari-monitors went to caracal, masakaridashboard could not because it is a
+# horizon plugin and horizon was still antelope's. #636 moved horizon, so the
+# dashboard patch rejoins the others under caracal_patch/ and antelope_patch/ is gone.
+#
+# The dashboard patch matters -- upstream sets default_panel = 'default', a panel whose
+# urls.py has no index, so an unpatched masakaridashboard makes the sidebar raise
+# NoReverseMatch and every page 500s. Upstream has not fixed it at 10.0.0, so the patch
+# was re-derived against that release rather than moved: 10.0.0 adds 'vmoves' to the
+# panels tuple two lines above the change and renames ugettext_lazy to gettext_lazy, so
+# the 8.0.0 hunk's context no longer matches.
+MASAKARI_SRCDIR := $(ROOTDIR)$(CARACAL_OPENSTACK_HOME_DIR)/lib/python$(CARACAL_PYTHON_VER)/site-packages
+MASAKARI_PATCHDIR := $(COREDIR)/masakari/$(CARACAL_OPENSTACK_RELEASE)_patch
 
 # masakari common
 rootfs_install::
@@ -93,17 +90,20 @@ rootfs_install::
 # the antelope constraints file decides the version, the way core/designate does it for
 # python-designateclient -- rather than a branch-name clone.
 #
-# masakari-dashboard is a horizon plugin, and horizon itself is still the antelope
-# venv's (core/horizon/horizon.mk). $(HORIZON_VENV_SP) is that venv's site-packages,
-# and that is where horizon's collectstatic collects the panels from, so the dashboard
-# cannot move ahead of horizon. It is left on its git checkout at
-# $(OPS_GITHUB_BRANCH_02) deliberately: converting it to pip would change which
-# dashboard version lands, and this story is not the place to do that. That is also
-# why the caracal vmoves panel does not appear -- the API is there at 17.0.0, the
-# panel that drives it is not.
+# masakari-dashboard is a horizon plugin: core/horizon/horizon.mk copies its enabled
+# panels out of $(HORIZON_VENV_SP), which is the site-packages of whichever venv
+# horizon runs in, so the dashboard goes where horizon goes. #636 took horizon to
+# caracal, so the panel is a caracal-venv install now. 10.0.0 is the caracal release --
+# https://releases.openstack.org/caracal/index.html#caracal-masakari-dashboard. Horizon
+# plugins are not in the upper-constraints (that file only covers libraries), so the
+# pin is explicit; it replaces a $(OPS_GITHUB_BRANCH_02) clone, whose version was
+# whatever the branch tip was on build day.
 #
-# Both go once horizon reaches the caracal venv (#636).
-MASAKARI_DASHBOARD_REPO_URL := https://github.com/openstack/masakari-dashboard.git
+# 10.0.0 brings the vmoves panel with it. The API behind it has been there since
+# masakari 17.0.0 (#639); only the panel was missing, and this is what supplies it.
+#
+# The osc plugin goes once /usr/bin/openstack is the caracal venv's (#636).
+MASAKARI_DASHBOARD_VER := 10.0.0
 
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
@@ -111,14 +111,11 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-masakariclient
-	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(OPS_GITHUB_BRANCH_02) --depth 1 $(MASAKARI_DASHBOARD_REPO_URL) /tmp/masakari/masakari-dashboard
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
-		-r /tmp/masakari/masakari-dashboard/requirements.txt
-	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/masakari/masakari-dashboard && \
-		$(OPENSTACK_HOME_DIR)/bin/python setup.py install"
+		masakari-dashboard==$(MASAKARI_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 
@@ -162,19 +159,9 @@ rootfs_install::
 # review. --forward makes re-runs idempotent; a failed hunk aborts the build
 # (so upstream drift is caught at build time, not shipped silently).
 rootfs_install::
-	$(Q)set -e; for p in $$(find $(MASAKARI_CARACAL_PATCHDIR) -name '*.py.patch' 2>/dev/null | sort); do \
-		rel=$${p#$(MASAKARI_CARACAL_PATCHDIR)/}; tgt=$(MASAKARI_CARACAL_SRCDIR)/$${rel%.patch}; \
+	$(Q)set -e; for p in $$(find $(MASAKARI_PATCHDIR) -name '*.py.patch' 2>/dev/null | sort); do \
+		rel=$${p#$(MASAKARI_PATCHDIR)/}; tgt=$(MASAKARI_SRCDIR)/$${rel%.patch}; \
 		echo "  PATCH $${rel%.patch}"; \
 		patch --forward --no-backup-if-mismatch -r - "$$tgt" < "$$p" \
 			|| { echo "masakari: failed to apply $$p to $$tgt" >&2; exit 1; }; \
 	done
-	$(Q)set -e; for p in $$(find $(MASAKARI_ANTELOPE_PATCHDIR) -name '*.py.patch' 2>/dev/null | sort); do \
-		rel=$${p#$(MASAKARI_ANTELOPE_PATCHDIR)/}; tgt=$(MASAKARI_ANTELOPE_SRCDIR)/$${rel%.patch}; \
-		echo "  PATCH $${rel%.patch}"; \
-		patch --forward --no-backup-if-mismatch -r - "$$tgt" < "$$p" \
-			|| { echo "masakari: failed to apply $$p to $$tgt" >&2; exit 1; }; \
-	done
-
-# clean up the build directory
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) rm -rf /tmp/masakari

--- a/core/modules/config_horizon.cpp
+++ b/core/modules/config_horizon.cpp
@@ -92,9 +92,9 @@ SetupService()
 
     HexLogInfo("Setting up horizon");
 
-    // horizon lives in the python 3.10 venv now; /usr/bin/python3 (3.9) can no
+    // horizon lives in the python 3.11 venv now; /usr/bin/python3 (3.9) can no
     // longer import openstack_dashboard or any of its plugins.
-    HexUtilSystemF(0, 0, "/opt/openstack-antelope/bin/python /usr/share/openstack-dashboard/manage.py migrate --noinput 2>/dev/null");
+    HexUtilSystemF(0, 0, "/opt/openstack-caracal/bin/python /usr/share/openstack-dashboard/manage.py migrate --noinput 2>/dev/null");
 
     return true;
 }

--- a/core/neutron/neutron.mk
+++ b/core/neutron/neutron.mk
@@ -34,7 +34,11 @@ NEUTRON_CONFDIR := $(ROOTDIR)/etc/neutron
 
 OVN_PATCHDIR := $(COREDIR)/neutron/ovn_patch/$(HEX_DIST)
 
-NEUTRON_VPNAAS_DASHBOARD_REPO_URL := https://github.com/openstack/neutron-vpnaas-dashboard.git
+# https://releases.openstack.org/caracal/index.html#caracal-neutron-vpnaas-dashboard
+# Horizon plugins are not in the upper-constraints (that file only covers libraries),
+# so the pin is explicit. It replaces a $(OPS_GITHUB_BRANCH_02) clone, whose version
+# was whatever the branch tip was on build day.
+NEUTRON_VPNAAS_DASHBOARD_VER := 10.0.0
 
 # neutron runs out of the caracal venv. neutron 24.2.2 is the last 2024.1 release
 # and neutron-vpnaas 24.0.2 its counterpart; resolved against the caracal
@@ -125,22 +129,18 @@ rootfs_install::
 
 # set up the neutron-vpnaas VPN panel
 #
-# The dashboard stays in the antelope venv and on $(OPS_GITHUB_BRANCH_02) even though
-# the service it drives has moved: it is a horizon plugin, horizon is still
-# horizon 23.1.1 in /opt/openstack-antelope, and 10.0.0 -- the 2024.1 dashboard --
-# wants a caracal horizon. It talks to neutron over the API, so the two ends are free
-# to sit a release apart. It moves when horizon does.
+# The dashboard is a horizon plugin, so it lives where horizon lives: #636 moved
+# horizon into the caracal venv, and 10.0.0 -- the 2024.1 dashboard -- is what wants a
+# caracal horizon. It talks to neutron over the API, which is why it was free to sit a
+# release behind the service until now.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(OPS_GITHUB_BRANCH_02) --depth 1 $(NEUTRON_VPNAAS_DASHBOARD_REPO_URL) /tmp/neutron/neutron-vpnaas-dashboard
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)chroot $(ROOTDIR) /opt/openstack-antelope/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
-		-r /tmp/neutron/neutron-vpnaas-dashboard/requirements.txt \
-		--no-build-isolation
-	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/neutron/neutron-vpnaas-dashboard && \
-		/opt/openstack-antelope/bin/python setup.py install"
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+		--no-build-isolation \
+		neutron-vpnaas-dashboard==$(NEUTRON_VPNAAS_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -54,16 +54,14 @@ OCTAVIA_PATCHDIR := $(COREDIR)/octavia/$(CARACAL_OPENSTACK_RELEASE)_patch/octavi
 # controllers outside it stay one release.
 OCTAVIA_VER := 14.0.2
 
-# Deliberately still the 2023.1 pin, and deliberately still in the antelope venv.
-# core/horizon/horizon.mk serves the dashboard out of $(OPENSTACK_HOME_DIR) --
-# openstack-dashboard.service, gunicorn-config.py and the httpd reverse proxy all
-# point at the antelope tree, and every dashboard plugin installs next to it.
-# octavia-dashboard follows horizon, not the octavia service, so the Load Balancer
-# panel stays on 11.0.1 until horizon itself hops; 13.0.1 is the caracal release to
-# move to on that day. It talks to the API over HTTP and imports nothing from
-# octavia, so the split costs nothing. Horizon plugins are not in the
-# upper-constraints (that file only covers libraries), so the pin has to be explicit.
-OCTAVIA_DASHBOARD_VER := 11.0.1
+# octavia-dashboard follows horizon, not the octavia service: it installs next to
+# horizon because that is where collectstatic collects panels from. #636 moved horizon
+# into the caracal venv, so this moved with it. 13.0.1 is the caracal release --
+# https://releases.openstack.org/caracal/index.html#caracal-octavia-dashboard. It talks
+# to the API over HTTP and imports nothing from octavia, so it never had to move when
+# the service did. Horizon plugins are not in the upper-constraints (that file only
+# covers libraries), so the pin is explicit.
+OCTAVIA_DASHBOARD_VER := 13.0.1
 
 # install octavia
 rootfs_install::
@@ -156,10 +154,8 @@ rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)# $(OPENSTACK_HOME_DIR), not the caracal venv: this follows horizon, which
-	$(Q)# has not hopped -- see the note by OCTAVIA_DASHBOARD_VER.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
 		octavia-dashboard==$(OCTAVIA_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -9,21 +9,17 @@
 #
 # It used to be the yoga python3-octaviaclient rpm under the *system* python 3.9,
 # because /usr/bin/openstack was `#!/usr/bin/python3` and an entry point is only
-# visible to the interpreter it was installed under. #1206 moved it into the 3.10
+# visible to the interpreter it was installed under. #1206 moved it into the antelope
 # venv alongside the CLI. This rpm was also the only hard Requires on
 # python3-openstackclient anywhere in the tree, so dropping it there is what let
 # core/heavyfs stop installing the yoga CLI.
 #
-# It stays in the *antelope* venv now that octavia itself has moved to caracal, for
-# the same entry-point reason: core/heavyfs still links /usr/bin/openstack at
-# $(OPENSTACK_HOME_DIR), so the `loadbalancer` plugin has to be installed under that
-# interpreter or the call sites above stop resolving. Unlike manila, there is no
-# second consumer -- octavia ships no standalone CLI and nothing in hex_sdk runs one
-# -- so the client is installed once, and only there. That leaves the antelope
-# constraint's python-octaviaclient 3.4.0 talking to a caracal 14.0.2 API, which is
-# the supported direction: octaviaclient negotiates the API version per request and
-# every call sdk_os.sh makes (loadbalancer list, the flavorprofile/flavor pairs,
-# delete --cascade) predates 2023.1.
+# It had to stay in the antelope venv when octavia moved to caracal, for that same
+# entry-point reason -- the `loadbalancer` plugin has to be installed under whichever
+# interpreter runs /usr/bin/openstack or the call sites above stop resolving. #636
+# moved the CLI, so it is installed with the service now. Unlike manila, there is no
+# second consumer: octavia ships no standalone CLI and nothing in hex_sdk runs one, so
+# the client is installed once.
 #
 # NOTE: unlike heat, health_octavia_check() is *not* what depends on this.
 # It checks systemd units, the monasca http_status metric and the octavia-hm0
@@ -33,10 +29,9 @@
 # openstack-octavia-ui, the Horizon dashboard plugin, is replaced by the
 # octavia-dashboard wheel installed further down. It was dropped when octavia moved
 # to pip because Horizon still ran on the system python 3.9 and could not import a
-# package from the 3.10 venv; #609 moved Horizon into the venv, so the Load Balancer
-# panel comes back. Registering it is core/horizon's job, where every dashboard
-# action lives. That wheel does *not* follow octavia to caracal -- see the note
-# above it.
+# package from a venv; #609 moved Horizon into the antelope venv, so the Load Balancer
+# panel came back, and #636 moved both to caracal. Registering it is core/horizon's
+# job, where every dashboard action lives.
 #
 # The octavia user and group are carried statically by
 # core/heavyfs/account/centos9 (uid/gid 138), so the RDO spec's shadow-utils

--- a/core/octavia/octavia.mk
+++ b/core/octavia/octavia.mk
@@ -83,16 +83,17 @@ rootfs_install::
 	$(Q)# named 'kazoo' until this line existed. Named here rather than as
 	$(Q)# taskflow[zookeeper] to match octavia-lib above, and because the constraint
 	$(Q)# file already pins it (2.10.0).
+	$(Q)#
+	$(Q)# python-octaviaclient owns the "loadbalancer" osc plugin. It is named for the
+	$(Q)# same reason as the two above: an entry point is only visible to the
+	$(Q)# interpreter /usr/bin/openstack runs under, so a dependency nothing asks for
+	$(Q)# is one that can disappear silently. It was in the antelope venv until #636
+	$(Q)# took the cli here.
 	$(Q)chroot $(ROOTDIR) bash -c "source $(CARACAL_OPENSTACK_HOME_DIR)/bin/activate && \
 		pip install -c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 			octavia==$(OCTAVIA_VER) \
 			octavia-lib \
-			kazoo"
-	$(Q)# and the "loadbalancer" osc plugin in the antelope venv, alone: that entry
-	$(Q)# point is only visible to the interpreter /usr/bin/openstack runs under, and
-	$(Q)# that is still the antelope one -- see the note at the top of this file.
-	$(Q)chroot $(ROOTDIR) bash -c "source $(OPENSTACK_HOME_DIR)/bin/activate && \
-		pip install -c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+			kazoo \
 			python-octaviaclient"
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf

--- a/core/swift/swift.mk
+++ b/core/swift/swift.mk
@@ -9,13 +9,13 @@
 # #642 moves the client from the antelope venv to the caracal one. There is no server
 # to move, so the client and the /usr/bin/swift symlink below are the whole of it.
 #
-# The install is a re-declaration rather than a first install. horizon 24.0.2's down
-# payment into this venv (core/horizon/horizon.mk, the second rootfs_install::) runs
-# without --no-deps, and horizon 24.0.2 declares python-swiftclient >=3.2.0, so the
-# ===4.5.0 pinned in os-caracal-pip-upper-constraints.txt:103 is already installed by
-# the time this file runs. Naming it here keeps the object-store client an explicit
-# part of the object-store story rather than an accident of horizon's dependency set
-# -- the same reason it was named while it lived in the antelope venv.
+# The install is a re-declaration rather than a first install. horizon (installed
+# into this venv by core/horizon/horizon.mk) runs without --no-deps and declares
+# python-swiftclient >=3.2.0, so the ===4.5.0 pinned in
+# os-caracal-pip-upper-constraints.txt:103 is already installed by the time this file
+# runs. Naming it here keeps the object-store client an explicit part of the
+# object-store story rather than an accident of horizon's dependency set -- the same
+# reason it was named while it lived in the antelope venv.
 #
 # Two library consumers keep it from being a convenience CLI only, and both live in
 # the caracal venv as of #629: the `cube-swift` cinder backup type

--- a/core/watcher/watcher.mk
+++ b/core/watcher/watcher.mk
@@ -66,39 +66,33 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/watcher-status /usr/bin/watcher-status
 	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/watcher-sync /usr/bin/watcher-sync
 
-# the osc plugin and the web ui plugin stay in the antelope venv -- TEMPORARY
+# the osc plugin and the web ui plugin
 #
 # python-watcherclient owns the "optimize" osc plugin entry point, which hex_sdk's
 # health_watcher_check() drives as `openstack optimize service list`. A stevedore entry
 # point is only visible to the interpreter it was installed under, and /usr/bin/openstack
-# is the antelope venv's (core/heavyfs/Makefile), so the plugin has to stay next to it or
-# the health check cannot run its query at all. #632, #633 and #634 hit the same
-# constraint for python-barbicanclient, python-cyborgclient and python-designateclient.
-#
-# The client can stay a release behind because watcher's REST API did not move: not one
-# file under watcher/api/ differs between 10.0.0 and unmaintained/2024.1, so the 4.1.0
-# the antelope constraint resolves still speaks to 12.1.0.
+# is the caracal venv's since #636, so the plugin lives here or the health check cannot
+# run its query at all. It had to stay in antelope while the cli did, which is the
+# constraint #632, #633 and #634 also hit for python-barbicanclient,
+# python-cyborgclient and python-designateclient.
 #
 # It is named explicitly rather than left to watcher-dashboard's requirements.txt, which
 # also asks for it. designate.mk carries the story: a client that arrives only as a side
 # effect of some other install disappears silently the day that install moves, and the
 # symptom is `cluster check` reporting the service NG while every unit is active. No
-# version is named, the same way cyborg.mk does not name one: the antelope constraints
-# file already carries python-watcherclient (4.1.0), so a version here could only drift
-# from it.
+# version is named, the same way cyborg.mk does not name one: the caracal constraints
+# file already carries python-watcherclient, so a version here could only drift from it.
 #
 # watcher-dashboard is a horizon plugin: core/horizon/horizon.mk copies its enabled
 # panels out of $(HORIZON_VENV_SP), which is the site-packages of whichever venv
 # horizon runs in, so the dashboard goes where horizon goes. #636 took horizon to
 # caracal, so the panel is a caracal-venv install now.
 #
-# The osc plugin goes once /usr/bin/openstack is the caracal venv's (#636).
-#
 # /usr/bin/watcher is the client's own cli. It used to come from the system python 3.9
 # install as /usr/local/bin/watcher -- /usr/bin held only the watcher-* service scripts
 # linked above -- and since /usr/local/bin precedes /usr/bin in the PATH hex_sdk sets,
 # the replacement is this symlink, the same shape core/monasca uses. It points at the
-# antelope venv because that is where the client is, not where the service is.
+# client, which is now the same venv as the service.
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/

--- a/core/watcher/watcher.mk
+++ b/core/watcher/watcher.mk
@@ -17,18 +17,14 @@ WATCHER_RUN_DIR := /var/run/watcher
 WATCHER_SRCDIR := $(ROOTDIR)$(CARACAL_OPENSTACK_HOME_DIR)/lib/python$(CARACAL_PYTHON_VER)/site-packages
 WATCHER_PATCHDIR := $(COREDIR)/watcher/$(CARACAL_OPENSTACK_RELEASE)_patch
 
+# https://releases.openstack.org/caracal/index.html#caracal-watcher-dashboard
+# Horizon plugins are not in the upper-constraints (that file only covers libraries),
+# so the pin is explicit. This used to be a git clone of the 2023.1-eol *tag*, because
 # watcher-dashboard publishes neither stable/2023.1 nor unmaintained/2023.1 -- both
-# branches were deleted at EOL -- so pin the tag instead. 2023.1-eol is 9.0.0 plus
-# two commits that touch only .gitreview and tox.ini, exactly the relationship
-# yoga-eol has to 7.0.0, and yoga-eol is what installpip's branch fallback chain
-# resolves to today.
-WATCHER_DASHBOARD_REPO_URL := https://github.com/openstack/watcher-dashboard.git
-WATCHER_DASHBOARD_TAG := 2023.1-eol
-
-# prepare the build directory
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) rm -rf /tmp/watcher
-	$(Q)chroot $(ROOTDIR) mkdir -p /tmp/watcher
+# branches were deleted at EOL, so there was no branch for installpip's fallback chain
+# to resolve. #636 moved the panel to the caracal release, which is on PyPI as a wheel,
+# and the tag hack goes with it.
+WATCHER_DASHBOARD_VER := 11.0.0
 
 # install watcher inside the python 3.11 caracal virtual environment
 #
@@ -91,13 +87,12 @@ rootfs_install::
 # file already carries python-watcherclient (4.1.0), so a version here could only drift
 # from it.
 #
-# watcher-dashboard is a horizon plugin, and horizon itself is still the antelope venv's
-# 23.1.1 -- core/horizon/horizon.mk copies watcher_dashboard's enabled panels out of
-# $(HORIZON_VENV_SP), which is that venv's site-packages, so the dashboard cannot move
-# ahead of horizon. It is left on its git checkout deliberately: converting it to pip
-# would change which dashboard version lands, and this story is not the place for that.
+# watcher-dashboard is a horizon plugin: core/horizon/horizon.mk copies its enabled
+# panels out of $(HORIZON_VENV_SP), which is the site-packages of whichever venv
+# horizon runs in, so the dashboard goes where horizon goes. #636 took horizon to
+# caracal, so the panel is a caracal-venv install now.
 #
-# Both go once horizon reaches the caracal venv (#636).
+# The osc plugin goes once /usr/bin/openstack is the caracal venv's (#636).
 #
 # /usr/bin/watcher is the client's own cli. It used to come from the system python 3.9
 # install as /usr/local/bin/watcher -- /usr/bin held only the watcher-* service scripts
@@ -110,14 +105,11 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
 		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-watcherclient
-	$(Q)chroot $(ROOTDIR) timeout 120 git clone -b $(WATCHER_DASHBOARD_TAG) --depth 1 $(WATCHER_DASHBOARD_REPO_URL) /tmp/watcher/watcher-dashboard
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		--no-build-isolation \
-		-r /tmp/watcher/watcher-dashboard/requirements.txt
-	$(Q)chroot $(ROOTDIR) bash -c "cd /tmp/watcher/watcher-dashboard && \
-		$(OPENSTACK_HOME_DIR)/bin/python setup.py install"
+		watcher-dashboard==$(WATCHER_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
 	$(Q)chroot $(ROOTDIR) ln -sf $(OPENSTACK_HOME_DIR)/bin/watcher /usr/bin/watcher
@@ -176,7 +168,3 @@ rootfs_install::
 		[ -f "$$ep" ] || { echo "watcher: $$ep not found, cannot register allocation_balance" >&2; exit 1; }; \
 		grep -q '^allocation_balance =' "$$ep" || \
 			sed -i '/^\[watcher_strategies\]/a allocation_balance = watcher.decision_engine.strategy.strategies.allocation_balance:AllocationBalance' "$$ep"
-
-# clean up the build directory
-rootfs_install::
-	$(Q)chroot $(ROOTDIR) rm -rf /tmp/watcher

--- a/core/watcher/watcher.mk
+++ b/core/watcher/watcher.mk
@@ -102,8 +102,8 @@ rootfs_install::
 rootfs_install::
 	$(Q)# enable dns in the rootfs for downloading packages
 	$(Q)cp -f /etc/resolv.conf $(ROOTDIR)/etc/
-	$(Q)chroot $(ROOTDIR) $(OPENSTACK_HOME_DIR)/bin/pip install \
-		-c $(OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
+	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
+		-c $(CARACAL_OPENSTACK_INSTALLED_PIP_CONSTRAINT) \
 		python-watcherclient
 	$(Q)# --no-build-isolation because this pulls horizon; see core/heavyfs/Makefile.
 	$(Q)chroot $(ROOTDIR) $(CARACAL_OPENSTACK_HOME_DIR)/bin/pip install \
@@ -112,7 +112,7 @@ rootfs_install::
 		watcher-dashboard==$(WATCHER_DASHBOARD_VER)
 	$(Q)# clean up dns configurations after downloading packages
 	$(Q)rm -f $(ROOTDIR)/etc/resolv.conf
-	$(Q)chroot $(ROOTDIR) ln -sf $(OPENSTACK_HOME_DIR)/bin/watcher /usr/bin/watcher
+	$(Q)chroot $(ROOTDIR) ln -sf $(CARACAL_OPENSTACK_HOME_DIR)/bin/watcher /usr/bin/watcher
 
 # install system directories and files
 #

--- a/project.mk
+++ b/project.mk
@@ -71,18 +71,30 @@ NEXT_OPENSTACK_INSTALLED_PIP_CONSTRAINT :=
 # manila (18.3.0) the seventh (#638), octavia (14.0.2) the eighth (#640),
 # barbican (18.0.0) the ninth (#632), cyborg (12.0.0) the tenth (#633),
 # designate (18.0.0) the eleventh (#634), heat (22.0.1) the twelfth (#635),
-# ironic with ironic-inspector (24.1.5 / 12.1.1) the thirteenth (#637) and
-# watcher (12.1.0) the fourteenth (#643).
+# ironic with ironic-inspector (24.1.5 / 12.1.1) the thirteenth (#637),
+# masakari with masakari-monitors (17.0.0 / 17.0.1) the fourteenth (#639),
+# watcher (12.1.0) the fifteenth (#643) and horizon (24.0.2) the sixteenth (#636),
+# which took the eight dashboard plugins and the openstack cli with it.
 # The services move one at a time and OPENSTACK_RELEASE is promoted once they all have.
 # (#642 moved python-swiftclient rather than a service, so it takes no place in that
 # count.) The ordinals are merge order into develop. #633 and #634 moved their services
 # without coming back to this comment and #635 and #637 then took the numbers they had
 # left free, so cyborg through ironic are renumbered here.
 #
-# barbican leaves a piece behind, the same way octavia does: python-barbicanclient owns
-# the `openstack secret ...` commands and has to stay in the antelope venv for as long as
-# /usr/bin/openstack does. See core/barbican/barbican.mk. designate and watcher each
-# leave two: their osc plugin and their horizon dashboard plugin, both blocked on #636.
+# Several hops had to leave a piece behind: an osc plugin is a stevedore entry point,
+# visible only to the interpreter that runs /usr/bin/openstack, so barbican, designate,
+# masakari, octavia, watcher, cyborg, heat and manila each left their client in the
+# antelope venv, and designate, masakari, watcher and neutron-vpnaas left their horizon
+# dashboard plugin there too. #636 collected all of it: horizon, the eight dashboard
+# plugins, /usr/bin/openstack and the eight clients moved together.
+#
+# What is left in the antelope venv is no longer a service: monasca (core/monasca),
+# ospurge (core/appfw) and ceph's rados/rbd bindings (core/ceph, which builds a copy
+# into each venv). OPENSTACK_RELEASE is promoted when those are dealt with.
+#
+# $(OPS_GITHUB_BRANCH_02) has no reader left after #636 -- the four dashboard clones
+# were the last -- but $(OPS_GITHUB_BRANCH_01) is still what core/heavyfs passes to
+# PROJ_INSTALL_PIP, so the pair is left intact.
 CARACAL_OPENSTACK_RELEASE := caracal
 CARACAL_OPENSTACK_HOME_DIR := /opt/openstack-$(CARACAL_OPENSTACK_RELEASE)
 CARACAL_OPS_GITHUB_BRANCH_01 := stable/2024.1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

horizon was the last thing serving out of `/opt/openstack-antelope` that a user sees, and `/usr/bin/openstack` was the last thing holding other services to that venv after they had already moved away from it. Both hop here, and they have to hop together: the dashboard stays where its plugins are, and every osc plugin client was pinned to whichever venv the cli ran in.

**horizon 23.1.1 → 24.0.2, which is django 3.2 → 4.2.** The caracal venv already held a 24.0.2 copy — a down payment taken in #643 so that `dump_default_policies` could run under the interpreter that owns the caracal services' `oslo.policy` entry points. Same version, so the dependency set landed then and this install replaces the antelope one rather than adding to it. The two policy-namespace lists collapse back into one for the same reason: the antelope list has been empty since octavia and masakari hopped, and its loop was a no-op.

The eight dashboard plugins, all pinned to their 2024.1 releases:

| Plugin | From | To |
| -- | -- | -- |
| heat-dashboard | 9.0.0 | 11.0.0 |
| manila-ui | 9.0.1 | 11.0.1 |
| octavia-dashboard | 11.0.1 | 13.0.1 |
| ironic-ui | 6.1.0 | 6.3.0 |
| designate-dashboard | git clone | 18.0.0 |
| masakari-dashboard | git clone | 10.0.0 |
| watcher-dashboard | git clone | 11.0.0 |
| neutron-vpnaas-dashboard | git clone | 10.0.0 |

`heat.mk` named 11.0.1 as the version to move to. **There is no 11.0.1** — heat-dashboard's caracal series is 11.0.0 alone and PyPI has no such release — so the pin is 11.0.0 and the comment is corrected with it.

**The four clones had to become pins anyway.** Their version was whatever `unmaintained/2023.1` pointed at on build day, and watcher-dashboard's was worse still: a `2023.1-eol` *tag*, because that project deleted both of its 2023.1 branches. Nothing reads `$(OPS_GITHUB_BRANCH_02)` for a dashboard now, and the build directories the clones needed go with them.

**The 18 `cp -f` lines that register panels, settings snippets and policy files are untouched.** Every filename they name was checked against the caracal wheel of all eight plugins: the `enabled/`, `local_settings.d/` and `conf/` file sets are identical across the hop, so none of the globs miss.

**masakari-dashboard's carried patch is re-derived rather than moved.** `default_panel = 'default'` names a panel whose `urls.py` has no index, so the sidebar raises `NoReverseMatch` and every page 500s; upstream has not fixed it at 10.0.0. But 10.0.0 adds `'vmoves'` to the panels tuple two lines above the change and renames `ugettext_lazy` to `gettext_lazy`, so the 8.0.0 hunk's context no longer applies. `antelope_patch/` is gone and masakari's patch pairs are one set again. 10.0.0 also brings the vmoves panel itself — the API behind it arrived with masakari 17.0.0 in #639, only the panel was missing.

**python-openstackclient 6.2.1 → 6.6.1**, and with it the eight clients that were sitting in antelope for no reason other than the cli's location, each already carrying a comment saying it could go once the cli moved:

| Client | osc plugin | Also installs |
| -- | -- | -- |
| python-heatclient | `orchestration` | `/usr/bin/heat` |
| python-manilaclient | `share` | (the antelope duplicate is deleted) |
| python-octaviaclient | `loadbalancer` | |
| python-designateclient | `dns` | |
| python-masakariclient | `ha` | |
| python-watcherclient | `optimize` | `/usr/bin/watcher` |
| python-cyborgclient | `accelerator` | `/usr/bin/cyborg` |
| python-barbicanclient | `secret` | |

Every one is **named explicitly** on the caracal side rather than left to whatever pulls it in transitively. `designate.mk` carries the story of losing the `dns` plugin exactly that way, which is what `cluster check` reported as `DNSaaS NG [ designate(9 api not all up) ]` while every designate unit was up.

`python-monascaclient` gets **no** caracal line. It registers no `openstack.cli.extension` at all, only the standalone `monasca` console script (`metric` comes from aodhclient and gnocchiclient), so the cli move leaves nothing behind: `/usr/bin/monasca` stays pointed at the antelope venv alongside the monasca service that is not moving, and `hex_sdk`'s only caller — `sdk_os.sh`'s `monasca metric-name-list` — keeps working unchanged. Monasca is being removed outright in #672 anyway. `python-ironicclient` needs no line either: ironic-ui and python-watcher both declare it and both are now in the caracal venv, the same two-declarer guarantee `ironic.mk` relied on in antelope.

**Three things run `manage.py` and all three follow the interpreter:** `openstack-dashboard.service`, `config_horizon.cpp`'s migrate, and `cube_edge_cfg()` in `core/main/proj_functions`, which reruns collectstatic and compress after it moves the designate and watcher panels aside on an edge deployment. gunicorn is now named explicitly too — the copy the dashboard had been using came from `core/monasca`, which is not moving.

**One ordering fix:** the heavyfs install block moves below the caracal venv bootstrap. Double-colon rules run in file order, and it used to sit above it — installing into `$(CARACAL_OPENSTACK_HOME_DIR)` before anything had created it.

**`ALLOWED_HOSTS` had to become a list.** Django added it to the `tuple_settings` check in 4.0, so the bare string `local_settings.in` has always carried now raises `ImproperlyConfigured: The ALLOWED_HOSTS setting must be a list or a tuple` on every settings load under django 4.2. Under 3.2 nothing checked the type, and `validate_host()` iterating a one-character string yields the same `'*'` pattern a one-element list does — so it worked by accident, and the comment two lines above already said "list". This fails the *build*, not just the dashboard: the `dump_default_policies` loop loads `openstack_dashboard.settings`, and a settings module that will not load leaves django's command registry holding only the core commands, so the loop dies as `KeyError: 'dump_default_policies'` before it reaches a namespace.

**Nine `.mk` files carried notes** saying their dashboard plugin or osc client was parked in antelope until horizon and the cli moved. They have, so the notes are rewritten in the past tense — the constraint that put each piece there is worth keeping, the claim that it is still in force is not. The load-bearing ones: `heavyfs/Makefile`'s setuptools ceiling (converting the four dashboards to pinned pip removed the last `setup.py install` caller in the tree; the ceiling is kept so a new one fails on review), `ironic.mk`'s two-declarer argument (pointed at the wrong venv), `manila.mk`'s second-consumer claim (manila-ui hopped too), and `project.mk`'s occupant list — whose "leaves a piece behind" paragraph is replaced with what is actually left in antelope: **monasca, ospurge and ceph's bindings. No service**, so `OPENSTACK_RELEASE` is now blocked on those three rather than on a hop. `project.mk` also gains masakari, which #639 moved without adding itself to that list.

**On "ignore the new features".** The one behavioural addition taken deliberately is masakari-dashboard's vmoves panel, and only because its API already shipped in #639 — the panel was the missing half, not a new feature. Nothing else in the eight plugins' 2024.1 releases is enabled beyond what the existing `cp -f` registration already covered.

#### Verification

ISO `CUBE_3.1.20_20260901-0822_c0bd078` — build **#58**, `distclean iso test`, `RC_BASE=v3.1.20`, `E2ETST=1cc`. Green end to end, 3h27m: `build` 10631s, `hex` (sys/iso) 692s, `e2e` 1093s, `publish` all `SUCCESS`.

> That ISO was built from `c0bd078f`, which is this branch plus one commit since dropped — a change to the source-side prerequisites of the `$(HEAVYFS)` rule in `core/heavyfs/Makefile`. It belongs to a separate build-performance story and is parked on its own branch. It cannot affect this ISO: `distclean` builds from an empty tree, so make's up-to-date judgement never runs and the prerequisite list is not consulted. The only file differing between `c0bd078f` and `df172fcb` is that Makefile's prereq expression.

On the 1cc that ISO installed (`cc1`, 10.1.0.1):

| AC / risk | Command | Result |
| -- | -- | -- |
| **Migrate configs** — the setting that gated the build | `grep ALLOWED_HOSTS /etc/openstack-dashboard/local_settings` | `ALLOWED_HOSTS = ['*']`. This is the file `config_horizon.cpp` regenerates from `.in` on every `Commit()`, so it is the value that actually reaches django |
| **Migrate configs** — policy files | `dump_default_policies` over all seven namespaces | keystone / nova / cinder / glance / neutron / octavia / masakari, each a non-empty yaml |
| **The service runs at all** | `systemctl is-active openstack-dashboard` | `active`, gunicorn master + 4 workers under `/usr/local/bin/python3.11`. **This is itself the runtime proof of the ALLOWED_HOSTS fix** — django 4.2 refuses to start on the old value |
| Version actually shipped | `pip show horizon` in the caracal venv | `24.0.2`, in `python3.11/site-packages` |
| **Log in** | POST `/horizon/auth/login/` with `auth_type=credentials` | HTTP 302, session established, `/project/` returns 200 |
| **Volume / network / VM panels** | GET each panel authenticated | `/project/volumes/`, `/project/networks/`, `/project/routers/`, `/project/instances/`, `/admin/volumes/`, `/admin/networks/`, `/admin/instances/`, `/admin/hypervisors/` — **all 200** |
| **Other panels** | 23 authenticated paths swept | **all 200, zero 500** — stacks, shares, load_balancer, dnszones, reverse_dns, vpn, ironic, goals, audits, action_plans, identity, settings |
| **masakari's carried patch** | `grep default_panel .../masakaridashboard/dashboard.py` | `default_panel = 'segments'`, and `panels` contains `'vmoves'`. `/masakaridashboard/` 200, `hosts` / `notifications` / `vmoves` 200. The sidebar renders Project / Admin / Identity / Instance-ha — **`NoReverseMatch` does not occur**, which is the failure this patch exists to prevent and it takes down every page, not one panel |
| **Static assets** (new: httpd serves them directly) | `curl` a collected css + httpd access log | HTTP 200; **404 count 0**. `ProxyPass /horizon/static !` sits at line 31 against `ProxyPass /horizon` at line 41, so the ordering ProxyPass requires holds |
| **Offline compression** | asset URLs on the login page | `output.b597bc3299cf.css` — hashed names, so `COMPRESS_OFFLINE`'s manifest is in use |
| **SCRIPT_NAME** (new: gunicorn, not `WSGIScriptAlias`) | `curl -I /horizon/` | 302 → `/horizon/auth/login/?next=/horizon/` — prefix preserved through the proxy. `IndexError` count in horizon.log: **0**, which is what a stripped prefix would produce on every request |
| osc cli moved | `readlink -f /usr/bin/openstack`; `openstack --version` | `/opt/openstack-caracal/bin/openstack`, **6.6.1** |
| **All nine osc plugins resolve** | `importlib.metadata` over `openstack.cli.extension` | `accelerator`, `baremetal`, `dns`, `ha`, `infra_optim`, `key_manager`, `load_balancer`, `orchestration`, `share` all registered. `openstack segment list` answers `Missing value auth-url` — i.e. resolved, just uncredentialed |
| Antelope venv emptied of services | `pip list` in the antelope venv | zero openstack services, zero dashboard packages |
| **Restart survives** (new: collectstatic/compress moved to `ExecStartPre`) | `systemctl restart openstack-dashboard` | ExecStartPre completes in **8s** against `TimeoutStartSec=5min`; login back to 200 within ~10s; a full login → `/project/` → `/masakaridashboard/` round trip still 302/200/200 |
| Regression: whole-cluster health | 1cc e2e through `test_30` | green (build #58) |

**Still to check by hand, and not covered above:** performing an actual create/delete of a volume, network and instance *through the dashboard* (the sweep proves the panels load, not that operations succeed); logging in through **Cube Account** (Keycloak SAML), which is the form's default `auth_type` where the sweep used `credentials`; and `cube_edge_cfg()`, which only runs on an edge deployment.

#### Which issue(s) this PR fixes

Close #636

#### Special notes for your reviewer

`ALLOWED_HOSTS = '*'` had been wrong since it was written; django 3.2 simply never checked. It is worth a look at whether anything else in `local_settings.in` is in `tuple_settings` — `INSTALLED_APPS`, `TEMPLATE_DIRS`, `LOCALE_PATHS`, `SECRET_KEY_FALLBACKS` — for the same class of latent type error.

The systemd unit is `openstack-dashboard`, not `horizon`.

