### PR TITLE
fix(health): bound the boot-path waits and drop the blocking cluster check

### DIFF
--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -100,11 +100,8 @@ PostBootRecovery()
         bootstrap_status "Cluster checking and repairing"
         hex_log_event -e BSP00005I "interface=system,host=$HOSTNAME,service=bootstrap"
         hex_sdk cmd "rm -f /tmp/health_*error.count"
-        # normal boots only: 'cluster check' kicks auto_repair, which on a roll
-        # boot would restart a settling MDS; the gate below covers the roll
-        if [ "$rolling" != "1" ] ; then
-            hex_cli -c cluster check
-        fi
+        # no blocking 'cluster check' here: cluster_check_repair_async below runs
+        # the same checks (auto_repair included) plus the repairs, off the critical path
         # Roll boots: restore VMs this node suspended for its reboot. Only a
         # restart ever suspends (an upgrade refuses and pauses instead), so this
         # is a no-op on an upgrade -- the record is empty.

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -908,16 +908,18 @@ wait_for_http_endpoint()
         /usr/sbin/arp -d $endpoint
     fi
 
-    local i=0
-    while [ $i -lt $timeout ] ; do
-        if $CURL -sf http://$endpoint:$port > /dev/null ; then
+    # $timeout is seconds: bound the loop by the clock, not by attempt count -- each
+    # probe can cost curl's own timeout (SRVTO, up to 60s) on top of the sleep
+    local deadline=$(( $(date +%s) + timeout ))
+    local rc=1
+    while [ $(date +%s) -lt $deadline ] ; do
+        if $CURL --connect-timeout 2 -m 5 -sf http://$endpoint:$port > /dev/null ; then
+            rc=0
             break
-        else
-            sleep 1
         fi
-        i=$(expr $i + 1)
+        sleep 1
     done
-    [ $i -lt $timeout ]
+    return $rc
 }
 
 check_service_memory_and_run()

--- a/core/modules/config_apache2.cpp
+++ b/core/modules/config_apache2.cpp
@@ -272,9 +272,10 @@ Commit(bool modified, int dryLevel)
     bool enabled = s_enabled && IsControl(s_eCubeRole);
     SystemdCommitService(enabled, NAME);
 
-    // waiting for keystone endpoint service back to work
+    // waiting for keystone endpoint service back to work; 600 is now real
+    // seconds, not attempts (~377s measured on a cold boot)
     std::string sharedId = G(SHARED_ID);
-    if (enabled && HexUtilSystemF(0, 0, HEX_SDK " wait_for_http_endpoint %s 5000 60", sharedId.c_str()) != 0) {
+    if (enabled && HexUtilSystemF(0, 0, HEX_SDK " wait_for_http_endpoint %s 5000 600", sharedId.c_str()) != 0) {
         return false;
     }
 

--- a/core/modules/config_keystone.cpp
+++ b/core/modules/config_keystone.cpp
@@ -513,11 +513,12 @@ Commit(bool modified, int dryLevel)
     }
 
     // 4. keystone relies on httpd proxy and gunicorn, reached via the VIP; on a cold boot
-    // the VIP+haproxy+keystone chain can take >1 min, so wait up to 180s
+    // the VIP+haproxy+keystone chain can take >1 min (#1130). 600 is now real seconds,
+    // not attempts (~361s measured)
     SystemdCommitService(IsControl(s_eCubeRole), "openstack-keystone");
     WriteLogRotateConf(log_conf);
     SystemdCommitService(IsControl(s_eCubeRole), "httpd");
-    if (HexUtilSystemF(0, 0, HEX_SDK " wait_for_http_endpoint %s 5000 180", sharedId.c_str()) != 0) {
+    if (HexUtilSystemF(0, 0, HEX_SDK " wait_for_http_endpoint %s 5000 600", sharedId.c_str()) != 0) {
         return false;
     }
 

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -262,7 +262,9 @@ health_dns_report()
 health_dns_check()
 {
     for node in "${CUBE_NODE_LIST_HOSTNAMES[@]}" ; do
-        local real=$(timeout $SRVSTO ssh root@$node time arp -a 2>&1 | grep real | awk '{print $2}') || ERR_CODE=1
+        # redirect on the remote side: a client reusing a mux master hands its
+        # stderr to that master, so the local pipe outlives the killed client
+        local real=$(timeout $SRVSTO ssh root@$node '{ time arp -a ; } 2>&1' | grep real | awk '{print $2}') || ERR_CODE=1
         if [ "x$ERR_CODE" = "x0" ] ; then
             ERR_MSG+="$node DNS lookup took $real sec\n"
         else


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Two changes from the same `cluster powercycle` post-mortem, both on the boot critical path.

**1. `health_dns_check`'s timeout was inert.** The probe is wrapped in `timeout $SRVSTO` (10s), but merges the remote stderr into the local pipe. CubeCOS runs SSH with connection reuse (`config_cubesys.cpp:119-124`: `ControlMaster auto`, `ControlPersist 120s`), and a client reusing an existing master hands its stdio to that master — so killing the client closes nothing and the pipeline lasts as long as the *remote* command. Caught live on the affected cluster, the hung pipe had two holders:

```
pid=2328096 fd=0  grep real                             <- reader
pid=245042  fd=8  ssh: /run/cube-ssh-f998cf...[mux]     <- master holds the write end
```

Because the probe times `arp -a` and DNS was still broken during boot, the remote command ran ~31 minutes under a 10s cap. Merging stderr on the remote side leaves the local pipe as stdout only — which the client owns — so the cap works again. Measured: `0s` for a fast command (output `0m0.030s` unchanged), `5s` and empty output for a 40s command, i.e. `ERR_CODE=1` as intended.

**2. The blocking `cluster check` in `PostBootRecovery` is removed.** That is where the 31-minute hang landed: 32m20s of the master's 65m26s `finalizing` (BSP00005I 17:52:43 -> BSP00006I 18:25:03). It ran on **every** node, and each pass is cluster-wide, so a 5-node cluster did five of them. `cluster_check_repair_async`, three lines later, runs the same health checks — `check` and `check_repair` are the same `ClusterCheckRepairMain` path, so auto_repair fires either way — plus the explicit repairs, detached via setsid. On this cluster it completed in **88 seconds**.

**3. `wait_for_http_endpoint` counted attempts, not seconds.** The loop ran `$timeout` iterations, each costing curl's own timeout (`SRVTO=60`) plus a `sleep 1`, so the argument spanned anywhere from N seconds to ~N minutes. `config_keystone.cpp:515` asks for `180` and its own comment says *"wait up to 180s"* — on c2 it took **361 s**; `config_apache2.cpp:277` asks for `60` and took **377 s**. Together that is ~12 min on each control node. Now bounded by a wall-clock deadline, with each probe capped (`--connect-timeout 2 -m 5`). `wait_for_service` shares the loop shape but probes with `netstat`, which returns instantly, so it was already honest and is left alone.

**Both caller values are raised to real seconds (600).** This matters: #1130 raised keystone's argument from 60 to 180 precisely because the cold-boot VIP -> haproxy -> keystone chain is slow, and on c2 that wait genuinely *succeeded* at 361 s. Bounding the loop at the same number would have cut it off at 180 s and returned failure — turning a slow-but-successful commit into a failed one. 600 s is comfortably above both measurements (361 s, 377 s) while still bounded, against a current worst case of ~3 hours.

#### Which issue(s) this PR fixes

Fixes #1405

#### Special notes for your reviewer

> Note

- Targets `develop`. The branch was rebased with `--onto origin/develop origin/release_3.1.10`, so it carries only this commit; `release_3.1.10` has diverged and a plain rebase would have replayed its unique commits.
- `ssh -n` does **not** fix the timeout defeat; `-o ControlPath=none` does but throws away connection reuse. The remote-side redirect keeps reuse and is the pattern `sdk_remote.sh:14` already uses.
- `sdk_health.sh:265` is the only site in the tree with this shape today.
- The scoped `hex_cli -c cluster check Storage` probe later in the same function is kept — it gates the ceph backup and is not the blocking full-cluster pass.
- **Behaviour change worth weighing:** repairs now happen in the detached pass rather than before `power_bootup_mark done`, and that pass waits on `cube_wait_all_committed` (up to 1500s) so it fires once on a settled cluster. If anything downstream treats `done` as "already repaired", that assumption moves. It is also master-only, but each pass is cluster-wide, so peers stay covered.
- Two things I chased and did **not** change, recorded so they are not re-investigated:
  - *Did keystone's wait exhaust rather than succeed?* No. `migrate_keystone` (`config_keystone.cpp:526`)
    sits after the wait and c2 logged it at 17:27:14, so execution passed the `return false` at line 516 —
    the endpoint did come up, the wait just took 361 s to see it.
  - *Does apache2 restart httpd right after keystone started it?* No. `SystemdCommitService(enabled, NAME)`
    on an already-running unit is a no-op (`systemctl start httpd` → `httpd is running`, instantly). apache2's
    377 s is the VIP endpoint going unhealthy again after keystone's wait returned, which the wall-clock
    bound caps regardless.
- Not addressed here: the master's `finalizing` also spent 33m05s in `cube_cluster_start` (BSP00002I 17:19:37 -> BSP00005I 17:52:43). That window is almost entirely the *peers*: the master's marker released c2/c3 (own commits 17:19:40-17:34:46), whose markers released p4/p5 (17:35:18-17:42:20, then finalize to 17:49:36); the master's own tail was the last ~3 min. Bring-up is strictly tiered, so the phases add rather than overlap. `bootstrap_run_logged` also writes its output without timestamps, which is why this needed log archaeology — worth fixing separately.

#### Additional documentation

```docs

```
