### PR TITLE
fix(k3s): bind the engine socket at /run, which crun can resolve

### DIFF
--- a/core/k3s/build/Dockerfile.dapper
+++ b/core/k3s/build/Dockerfile.dapper
@@ -41,12 +41,19 @@ RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
 ARG SELINUX=true
 ENV SELINUX $SELINUX
 
-ENV DAPPER_RUN_ARGS --privileged -v k3s-cache:/go/src/github.com/k3s-io/k3s/.cache -v trivy-cache:/root/.cache/trivy
+# DAPPER_DOCKER_SOCKET binds the engine socket at /var/run/docker.sock, and the
+# crun the jail now carries (1.29.1, from CentOS Stream 9 baseos) cannot resolve a
+# mount destination that walks this image's /var/run -> ../run symlink: every run
+# dies with "cannot resolve `var/run/docker.sock' under rootfs: Too many levels of
+# symbolic links". Any destination under /var/run does it, in any image; the same
+# path under /run resolves. So bind the socket at /run/docker.sock ourselves and
+# point the client there.
+ENV DAPPER_RUN_ARGS --privileged -v /run/docker.sock:/run/docker.sock -v k3s-cache:/go/src/github.com/k3s-io/k3s/.cache -v trivy-cache:/root/.cache/trivy
 ENV DAPPER_ENV REPO TAG DRONE_TAG IMAGE_NAME SKIP_VALIDATE SKIP_AIRGAP AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID GITHUB_TOKEN GOLANG DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/k3s-io/k3s/
 ENV DAPPER_OUTPUT ./bin ./dist ./build/out ./build/static ./pkg/static ./pkg/deploy
 
-ENV DAPPER_DOCKER_SOCKET true
+ENV DOCKER_HOST unix:///run/docker.sock
 ENV HOME ${DAPPER_SOURCE}
 ENV CROSS true
 ENV STATIC_BUILD true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The accept pipeline on `develop` cannot get past the k3s build. #717 and #719 (2026-09-01/02) both die in the same place, seconds after the dapper image is committed:

```
STEP 19/25: ENV DAPPER_DOCKER_SOCKET true
...
Successfully tagged localhost/k3s-source:HEAD
Error: OCI runtime error: crun: cannot resolve `var/run/docker.sock` under rootfs: Too many levels of symbolic links
time="2026-09-02T11:06:05+08:00" level=fatal msg="exit status 126"
make[5]: *** [Makefile:13: download] Error 1
```

(#718, in between, failed on something unrelated — a baseos `repomd.xml` checksum mismatch. The string appears in no build back to #700, so this is new.)

**The fault is the mount destination, and nothing else.** Reproduced minimally inside the accept jail:

| mount | result |
|---|---|
| `-v /var/run/docker.sock:/var/run/docker.sock` on `localhost/k3s-source:HEAD` | ELOOP |
| the same, on plain `docker.io/library/alpine:latest` | ELOOP |
| `-v /run/podman/podman.sock:/var/run/docker.sock` (the real socket as source) | ELOOP |
| `-v /var/run/dbus:/var/run/dbus` | ELOOP |
| **`-v /var/run/docker.sock:/run/docker.sock`** | **works** |

So it is not the source path, not the socket, not the image, and not anything we build — `crun` cannot resolve a mount target that walks the image's `/var/run -> ../run` symlink. The jail now carries **crun 1.29.1-1.el9**, which has moved into CentOS Stream 9 **baseos**; appstream still offers only 1.23/1.24/1.26/1.27/1.28, so the unpinned `dnf install -y crun` + `dnf -y update` in `jail/jail.ubi9.dockerfile:117` silently takes the baseos build. The accept builder is CentOS Linux 8 on kernel `4.18.0-348.7.1.el8_5`, podman 5.8.5.

**Why k3s is the only casualty.** dapper v0.6.0's built-in socket bind is hardwired to `/var/run/docker.sock:/var/run/docker.sock` — confirmed with `strings` on the downloaded `.dapper`, which carries that path and no other — and `core/k3s/build/Dockerfile.dapper` turned it on with `ENV DAPPER_DOCKER_SOCKET true`. It is also the only podman bind in the whole cubecos build with a `/var/run` destination; every other `/var/run` reference in the tree is a `chroot install -d` into the appliance rootfs, not a mount.

**The change.** Drop `DAPPER_DOCKER_SOCKET`, bind the socket at its canonical `/run` path through `DAPPER_RUN_ARGS` (which dapper appends to `docker run` verbatim, and which already carries the two cache volumes), and point the client at it explicitly:

```dockerfile
ENV DAPPER_RUN_ARGS --privileged -v /run/docker.sock:/run/docker.sock -v k3s-cache:... -v trivy-cache:...
ENV DOCKER_HOST unix:///run/docker.sock
```

`/run/docker.sock` is the right source on either engine: under podman it is the `podman-docker` tmpfiles symlink to `/run/podman/podman.sock`, and under real docker it is the socket itself (with `/var/run` a symlink to `/run`).

#### Which issue(s) this PR fixes

No issue filed — this is a CI-blocking regression found while running accept against `develop`.

#### Special notes for your reviewer

> Note

- **Scope of the verification, stated honestly.** In `centos9_cubecos_accept`, against the exact `localhost/k3s-source:HEAD` image that failed: the `/run` bind mounts cleanly where `/var/run` gives ELOOP; the socket is then live inside the container at **both** `/run/docker.sock` and `/var/run/docker.sock` (via the image's own `/var/run -> ../run`), so nothing that hardcodes the conventional path regresses; and the alpine `docker` client reaches the engine — `docker version --format {{.Server.Version}}` returns `5.8.5`, with and without `DOCKER_HOST`. What is **not** proven is dapper assembling these `DAPPER_RUN_ARGS` into a completed `make download`. That step is mechanical, but the first accept run on this branch is the real proof.
- `DOCKER_HOST` is belt-and-braces. The bind alone already surfaces at `/var/run/docker.sock` inside the container because of the base image's symlink, so the client would find it unaided; the explicit variable just stops that from being load-bearing.
- `core/k3s/Makefile:30` copies this file over `k3s-source/Dockerfile.dapper` on every build, so the change takes effect with no other edit.
- **crun is deliberately left unpinned.** Pinning it in `jail/jail.ubi9.dockerfile` would fix the whole class rather than this one mount, and 1.23-1.28 are all still installable. I did not do it because the file already carries a comment that `crun-1.21-1` broke a *different* way ("OCI runtime attempted to invoke a command"), and `2bdd69c` had to unlock `crun-1.20-2.el9` when it vanished upstream — version-chasing there is a known trap. Worth a separate decision. If a new `/var/run` bind destination ever appears in the build, it will hit this same wall.
- The `--privileged` and both cache volumes in `DAPPER_RUN_ARGS` are unchanged; only the socket bind is added.

#### Additional documentation

```docs

```
