### PR TITLE
chore(rabbitmq): cap the broker start timeout so a wedged start can't stall bootstrap

### DIFF
--- a/core/rabbitmq/rabbitmq-server-overrides.conf
+++ b/core/rabbitmq/rabbitmq-server-overrides.conf
@@ -18,9 +18,9 @@ Wants=epmd@0.0.0.0.socket
 # broker restarts, and a systemd restart loop hides a node that wants repairing
 Restart=no
 
-# rejoining a cluster and syncing mirrored queues can take far longer than the
-# 600s the rpm allows
-TimeoutStartSec=3600
+# a wedged start blocks the whole bootstrap commit; 300s is rabbit's own ceiling
+# for waiting on peer tables (mnesia retry_timeout 30s x retry_limit 10)
+TimeoutStartSec=300
 
 # the rpm ships 32768 and its own comment names a drop-in as the way to raise it
 LimitNOFILE=65536


### PR DESCRIPTION
#### What type of PR is this?

/kind chore

#### What this PR does / why we need it

- Pull fix of PR #1403 from branch release_3.1.10

#### Which issue(s) this PR fixes

- Part of #1402

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
