### PR TITLE
feat(keycloak): 649 upgrade keycloak from 18.0.2 to 22.0.5

### DIFF
--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -6,9 +6,14 @@ include ../../build.mk
 # keycloakx is codecentric's chart for the Quarkus distribution. Their plain "keycloak"
 # chart is the WildFly one -- its 18.x versions are chart versions, and every one of them
 # still ships appVersion 17.0.1-legacy -- so moving to Quarkus means changing chart, not
-# just bumping a version. Chart 1.6.0 is the newest one whose appVersion is 18.x.
+# just bumping a version.
+#
+# 2.3.0 is the only keycloakx version that tracks a 22.x server: 2.2.2 before it is 21.1.1
+# and 2.4.1 after it jumps straight to 25.0.0. appVersion only supplies the default image
+# tag, which chart-values.yaml overrides with the bundled cube-cos-login image, so what it
+# actually buys is templates written against the server we ship.
 CHART_NAME := keycloakx
-CHART_VERSION := 1.6.0
+CHART_VERSION := 2.3.0
 CHART := $(CHART_NAME)-$(CHART_VERSION).tgz
 
 $(CHART):

--- a/core/keycloak/Makefile
+++ b/core/keycloak/Makefile
@@ -35,10 +35,13 @@ ifneq ($(RC),)
 # pushes a tag nothing loaded. It drifted before: IMG_BUILD said 17.1.0 while the pinned
 # rpm was 17.2.0.
 #
-# 3.1.10 is also where this stops being a WildFly image: KEYCLOAK_VERSION is 18.0.2, the
-# spec builds on quay.io/keycloak/keycloak:18.0.2 and runs kc.sh build, so it is the
-# Quarkus distribution CHART_NAME/CHART_VERSION (keycloakx 1.6.0) needs -- the chart could
-# never drive the old 17.0.1-legacy image.
+# This pin is currently BEHIND the chart above. It is a Keycloak 18.0.2 image, while
+# CHART_NAME/CHART_VERSION now ship 22 and chart-values.yaml asks for the tag the matching
+# cube-cos-login carries. Until cube-cos-ui cuts a 22.x release for this to point at, RC
+# builds fail the bundled-registry check in keycloak.mk -- .push-img pushes the tag named
+# here and chart-values.yaml names a different one. Non-RC builds are unaffected: they
+# build the rpm from the cube-cos-ui default branch and take the tag from its package.json.
+# Move both this URL and the IMG_BUILD literal to that release when it exists.
 $(LOGIN_RPM):
 	$(call RUN_CMD_TIMED, \
 		wget -O login.rpm $(GITHUB_URL)/releases/download/$(PKG_NAME)-v3.1.10-rc1/$(PKG_NAME)-18.0.0-1.54a03f5.x86_64.rpm, \

--- a/core/keycloak/chart-values.yaml
+++ b/core/keycloak/chart-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: localhost:5080/bigstack/keycloak
-  tag: 18.0.0
+  tag: 22.0.0
 
 replicas: 1
 

--- a/core/modules/config_keycloak.cpp
+++ b/core/modules/config_keycloak.cpp
@@ -23,6 +23,11 @@ static const std::string KEYCLOAK_ADMIN_PASSWORD_K8S_SECRET = "admin-password";
 static const std::string KEYCLOAK_ADMIN_PASSWORD_TERRAFORM_VARIABLE_FILE
     = "/etc/cube/cos/terraform/values/keycloak-admin-password.tfvars";
 static const int SAML_METADATA_STUCK_NOTIFY_SECS = 600;
+// how long to give the old keycloak pods to go before a cross-version upgrade. The chart
+// asks for a 60s termination grace period per pod and takes them one at a time, so three
+// control nodes can legitimately need three minutes.
+static const int KEYCLOAK_DOWN_ATTEMPTS = 60;
+static const int KEYCLOAK_DOWN_INTERVAL_SECS = 5;
 // operator escape hatch: touching this releases the saml metadata gate below
 // (one-shot; consumed when honored). /run is tmpfs so it cannot outlive a boot.
 static const char SAML_METADATA_GATE_RELEASE[] = "/run/cube_keycloak_saml_gate_release";
@@ -456,6 +461,154 @@ retireLegacyKeycloak()
 }
 
 /**
+ * Strip trailing whitespace from a captured command output.
+ */
+static const std::string
+trimOutput(const std::string& output)
+{
+    const size_t end = output.find_last_not_of(" \t\r\n");
+    return (end == std::string::npos) ? "" : output.substr(0, end + 1);
+}
+
+/**
+ * The image tag chart-values.yaml asks for.
+ *
+ * Read the same way core/keycloak/keycloak.mk reads it when it checks the bundled
+ * registry at build time, so the tag this module compares against and the tag the build
+ * was gated on cannot come apart.
+ *
+ * @return the tag, or an empty string if it could not be read.
+ */
+static const std::string
+readWantedKeycloakImageTag()
+{
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        false,
+        {},
+        std::string("awk '/^  tag:/ {print $2; exit}' ") + KEYCLOAK_CHART_VALUES);
+    if (r.exitCode != 0) {
+        return "";
+    }
+
+    return trimOutput(r.stdoutOutput);
+}
+
+/**
+ * Take the running Keycloak down before an upgrade that changes its version.
+ *
+ * Keycloak migrates its schema when the first pod of a new version starts, and upstream
+ * is explicit that the database is not compatible with the old server afterwards. The
+ * chart rolls pods one at a time and replicas tracks the node count, so on an HA cluster
+ * a plain helm upgrade leaves the pods that have not been rolled yet running against a
+ * schema the first new one has already migrated. retireLegacyKeycloak() above does not
+ * cover this: it retires the statefulset the WildFly chart created, a different object,
+ * whereas a version change within the Quarkus chart rolls inside this one.
+ *
+ * So scale to zero and wait for the pods to actually be gone, which leaves exactly one
+ * version looking at the schema. K3sDeleteAllPods() is not a substitute -- it force
+ * deletes pods and the statefulset recreates them from the same old spec at once.
+ *
+ * Failure is fail-closed: return false and let the commit report it. The schema may
+ * already have been touched by then, and putting the old version back on top of a
+ * migrated schema is the combination upstream says does not work. Recovery is a restore
+ * from backup, not an automatic rollback.
+ *
+ * @return true when helm may proceed.
+ */
+static bool
+takeKeycloakDownForVersionChange()
+{
+    const std::string wanted = readWantedKeycloakImageTag();
+    if (wanted.empty()) {
+        HexLogError(
+            "cannot tell whether this keycloak upgrade changes version: no image tag in %s",
+            KEYCLOAK_CHART_VALUES);
+        return false;
+    }
+
+    // --ignore-not-found so a missing statefulset is an empty success rather than an exit
+    // status shared with "the api server did not answer" -- the two need opposite
+    // responses, and only one of them is safe to carry on from
+    const ExecSyncResult r = ExecBashSync(
+        0,
+        true,
+        false,
+        {},
+        "/usr/local/bin/k3s kubectl get " + APP + " -n " + APP_NAMESPACE
+            + " --ignore-not-found "
+            + "-o jsonpath='{.spec.template.spec.containers[?(@.name==\"keycloak\")].image}'");
+    if (r.exitCode != 0) {
+        HexLogError("failed to read the image the running keycloak statefulset deploys");
+        return false;
+    }
+
+    const std::string running = trimOutput(r.stdoutOutput);
+    if (running.empty()) {
+        // nothing is deployed yet, so there is no schema anybody could be holding
+        return true;
+    }
+
+    // the tag is what follows the last colon, and only when that colon comes after the
+    // last slash -- otherwise it is the registry port in localhost:5080. An image pinned
+    // by digest has no tag at all; the chart only emits that shape when image.digest is
+    // set, which chart-values.yaml does not do, and an unreadable version is treated as a
+    // changed one because taking the pods down is the harmless direction to be wrong in.
+    const size_t at = running.find('@');
+    const size_t colon = running.find_last_of(':');
+    const size_t slash = running.find_last_of('/');
+    const bool tagged = (at == std::string::npos)
+        && (colon != std::string::npos)
+        && (slash == std::string::npos || colon > slash);
+    if (tagged && running.substr(colon + 1) == wanted) {
+        // same version: let helm roll the pods the way it does on every other commit
+        return true;
+    }
+
+    HexLogInfo(
+        "keycloak is moving from %s to tag %s; taking the statefulset down so that only "
+        "one version sees the schema",
+        running.c_str(),
+        wanted.c_str());
+
+    const ExecSyncResult scaled = ExecBashSync(
+        0,
+        false,
+        false,
+        {},
+        "/usr/local/bin/k3s kubectl scale " + APP + " -n " + APP_NAMESPACE
+            + " --replicas=0");
+    if (scaled.exitCode != 0) {
+        HexLogError("failed to scale the keycloak statefulset down");
+        return false;
+    }
+
+    // wait on the pods the controller still has, not on the replica count that was just
+    // asked for: a pod that is terminating is still connected to the database
+    for (int attempt = 0; attempt < KEYCLOAK_DOWN_ATTEMPTS; attempt++) {
+        const ExecSyncResult left = ExecBashSync(
+            0,
+            true,
+            false,
+            {},
+            "/usr/local/bin/k3s kubectl get " + APP + " -n " + APP_NAMESPACE
+                + " -o jsonpath='{.status.replicas}'");
+        if (left.exitCode == 0 && trimOutput(left.stdoutOutput) == "0") {
+            HexLogInfo("the keycloak statefulset is down; upgrading it now");
+            return true;
+        }
+        sleep(KEYCLOAK_DOWN_INTERVAL_SECS);
+    }
+
+    HexLogError(
+        "keycloak pods were still up %d seconds after scaling the statefulset down; "
+        "refusing to upgrade onto a schema the old version can still reach",
+        KEYCLOAK_DOWN_ATTEMPTS * KEYCLOAK_DOWN_INTERVAL_SECS);
+    return false;
+}
+
+/**
  * Deploy Keycloak using Helm.
  */
 static bool
@@ -464,6 +617,10 @@ updateKeycloak()
     HexLogInfo("update keycloak helm chart and roll out pods");
 
     retireLegacyKeycloak();
+
+    if (!takeKeycloakDownForVersionChange()) {
+        return false;
+    }
 
     int nodeCount = K3sGetNodeCounts();
     if (nodeCount < 0) {

--- a/core/terraform/Makefile
+++ b/core/terraform/Makefile
@@ -8,11 +8,20 @@ RANCHER_PROV_VER      := v7.0.0
 RANCHER_PROV_DIR      := terraform-provider-rancher2
 RANCHER_UPSTREAM_BIN  := $(RANCHER_PROV_DIR)/bin/terraform-provider-rancher2
 KEYCLOAK_PROV_REPO    := https://github.com/mrparkers/terraform-provider-keycloak.git
-# 4.x is the first line that understands the Quarkus distribution. Its releases up to
-# 4.2.0 are validated against Keycloak 19, the closest supported neighbour of the 18.x we
-# deploy; 4.3.0 onwards moved to Keycloak 21. Keep the required_providers pins in
-# src/keycloak/**/main.tf in step with this.
-KEYCLOAK_PROV_VER     := v4.2.0
+# 4.x is the first line that understands the Quarkus distribution. No release of it is
+# validated against the Keycloak 22 we deploy -- 4.2.0 tested against 19, and 4.3.0
+# through 4.5.0 all stop at 21, the closest supported neighbour, while 5.x starts at 26 --
+# so take the newest 4.x neighbour instead of reaching across that gap.
+#
+# That newest one is 4.4.0, not 4.5.0. The provider moved to the Keycloak organization in
+# 4.5.0 and republished under the keycloak/keycloak registry namespace; mrparkers/keycloak
+# ends at 4.4.0. The `terraform init` in this Makefile resolves the source below from the
+# public registry before the locally built binary is copied over it, so a 4.5.0 pin under
+# the old namespace does not resolve. Nothing is lost by staying: 4.5.0 carries only the
+# org move, the Apache 2.0 relicence, dependency bumps and go 1.22 -- no resource changes.
+#
+# Keep the required_providers pins in src/keycloak/**/main.tf in step with this.
+KEYCLOAK_PROV_VER     := v4.4.0
 KEYCLOAK_PROV_SEMVER  := $(patsubst v%,%,$(KEYCLOAK_PROV_VER))
 KEYCLOAK_PROV_DIR     := terraform-provider-keycloak
 KEYCLOAK_UPSTREAM_BIN := $(KEYCLOAK_PROV_DIR)/terraform-provider-keycloak

--- a/core/terraform/src/keycloak/api_client/main.tf
+++ b/core/terraform/src/keycloak/api_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 4.2.0"
+      version = "= 4.4.0"
     }
   }
 }

--- a/core/terraform/src/keycloak/ceph_dashboard_client/main.tf
+++ b/core/terraform/src/keycloak/ceph_dashboard_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 4.2.0"
+      version = "= 4.4.0"
     }
   }
 }

--- a/core/terraform/src/keycloak/keystone_client/main.tf
+++ b/core/terraform/src/keycloak/keystone_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 4.2.0"
+      version = "= 4.4.0"
     }
   }
 }

--- a/core/terraform/src/keycloak/lmi_client/main.tf
+++ b/core/terraform/src/keycloak/lmi_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 4.2.0"
+      version = "= 4.4.0"
     }
   }
 }

--- a/core/terraform/src/keycloak/main.tf
+++ b/core/terraform/src/keycloak/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 4.2.0"
+      version = "= 4.4.0"
     }
   }
 }

--- a/core/terraform/src/keycloak/rancher_client/main.tf
+++ b/core/terraform/src/keycloak/rancher_client/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "= 4.2.0"
+      version = "= 4.4.0"
     }
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

The `cubecos` half of moving Keycloak off `18.0.2` — June 2022, and the reason the story
was filed — onto `22.0.5`. bigstack-oss/cube-cos-ui#866 changes what the login image *is*;
this changes the chart that deploys it, the terraform provider that configures it, and what
`hex_config commit keycloak` does when it finds a different major already running.

**The chart — `keycloakx` 1.6.0 → 2.3.0** (`core/keycloak/Makefile`)

`2.3.0` is the only `keycloakx` release that tracks a 22.x server: `2.2.2` before it is
21.1.1, and `2.4.1` after it jumps straight to 25.0.0. `appVersion` only supplies a default
image tag, which `chart-values.yaml` overrides with the bundled image, so what the bump
actually buys is templates written against the server we ship.

Note this is `keycloakx`, not codecentric's `keycloak` chart. The latter is the WildFly
one — its 18.x releases are *chart* versions and every one of them still ships
`appVersion 17.0.1-legacy`.

**The image tag — `18.0.0` → `22.0.0`** (`core/keycloak/chart-values.yaml`)

The tag is the `cube-cos-login` `package.json` version, **not** the Keycloak version.
`cube-cos-login.spec` builds `FROM quay.io/keycloak/keycloak:%{keycloak_version}` and
commits the result as `localhost:5080/bigstack/keycloak:%{version}`. Both numbers have
read 18.x so far, which makes them easy to conflate; they are separate, and this PR is
pinned against the second one.

**The terraform provider — `v4.2.0` → `v4.4.0`** (`core/terraform/Makefile` + six `main.tf`)

4.2.0 was validated against Keycloak 19; everything from 4.3.0 to 4.5.0 stops at 21, the
closest supported neighbour of the 22 we now deploy. 4.4.0 is the newest of those — see
**Special notes** for why not 4.5.0.

**The deployment — a stop before a cross-major upgrade** (`core/modules/config_keycloak.cpp`)

This is the half of AC 2 that is not a version bump: *ensure upgrading CubeCOS could bring
in new images for containers on K3S*. Upstream does not support 18 and 22 pods serving the
same migrated schema concurrently, and the chart rolls pods one at a time, so on an HA
cluster a plain `helm upgrade` puts both majors on one database. The commit now compares
the tag `chart-values.yaml` asks for against the tag the running statefulset deploys, and
when they differ it scales the statefulset to zero and waits for `.status.replicas` to
reach 0 before letting helm proceed. Same-tag commits — every ordinary one — are untouched
and never take SSO down.

#### Which issue(s) this PR fixes

Part of #649

Not a `Fixes`: the story still needs the in-place upgrade verified on a 3cc and a
`bigstack-handbook` note.

#### Special notes for your reviewer

> **Please hold the `done` label on both this and bigstack-oss/cube-cos-ui#866, and land
> them minutes apart with #866 first.** Approve freely — it is only the merge that is
> paired. `core/keycloak/Makefile` builds the login RPM from a `git clone` of cube-cos-ui's
> **default branch** and reads the image tag out of its `package.json`, so neither repo can
> merge alone: #866 first leaves `develop` here asking for `18.0.0` while the registry gets
> `22.0.0`, and this one first leaves the gate asking for `22.0.0` while the registry gets
> `18.0.0`. Either way `core/keycloak/keycloak.mk` fails every clean build until the gap
> closes. Two `done` labels means two bots racing, and the order stops being ours.
>
> For context: #1256 and cube-cos-ui#847 (the 17 → 18 pair) merged 28 hours apart, and
> `e35f03d8` — the gate — was written two days after that, its comment describing the
> fresh-install `ImagePullBackOff` those 28 hours produced.

> **Why provider 4.4.0 and not 4.5.0.** The provider moved to the Keycloak organization in
> 4.5.0 and republished under the `keycloak/keycloak` registry namespace; `mrparkers/keycloak`
> ends at 4.4.0. `core/terraform/Makefile` runs `terraform init` *before* copying the
> locally built binary over it, and that init resolves `source` against the public registry
> — so a 4.5.0 pin under the old namespace fails there, and switching namespace is a change
> this PR deliberately does not make (Keycloak 25 onwards, provider 5.x defaults SAML
> clients to carry `saml_organization`, and an unspecified one deletes that scope — it
> touches all six SAML clients and belongs with the 26 hop). 4.5.0 over 4.4.0 costs nothing
> anyway: its changelog is the org move, an Apache 2.0 relicence, dependency bumps and go
> 1.22, with no resource changes.

> **The RC pin is deliberately left at 18.** `core/keycloak/Makefile`'s RC branch names a
> published release, and cube-cos-ui has not cut a 22.x one yet, so it and the `IMG_BUILD`
> literal stay where they are with a note saying they move together when that release
> exists — the same way the 17 pin was carried through the move to 18. Until then, RC builds
> fail the registry gate. Non-RC builds are unaffected: they build the RPM from source and
> read the tag from `package.json`.

> **Why the stop is written the way it is.** `K3sDeleteAllPods()` cannot be the mechanism —
> the statefulset recreates the pods immediately — and `k3s.hpp` has no scale helper, hence
> the explicit `kubectl scale --replicas=0`. The wait reads `.status.replicas` rather than
> `K3sGetReadyReplicas()`, because that helper reads `{{.status.readyReplicas}}`, a field
> that is absent at zero and renders as `<no value>`, whose `stoi` throws and returns -1 —
> indistinguishable from a failed query. Failure anywhere in the sequence is fail-closed:
> the commit reports the error and does not roll back, because the schema may already be
> partly migrated and quietly restoring the old pods is the worse outcome. Concurrency needs
> no handling: the existing `isUpdateKeycloakPossible()` gate already means only the last
> control node to be upgraded runs this.

> **Verified — build and artifacts.** Personal ISO build #61 (`distclean iso test`, RC base
> v3.1.20, 1cc e2e) came out green end to end, with the login clone pointed at
> cube-cos-ui's branch so the pair could be built before either merged:
>
> ```
> CLONE   https://github.com/bigstack-oss/cube-cos-ui#feat/649-keycloak-22 (1s)
> BUILD   cube-cos-login-22.0.0-1.el9.3e69dea.x86_64.rpm (163s)
> CLONE   keycloak-provider (1s) / BUILD keycloak-provider (13s) / INIT terraform (8s)
> GEN     CUBE_3.1.20_20260902-0626_64c6253.iso (24s)
> ```
>
> `INIT terraform` passing is what confirms the 4.4.0 reasoning above, since that is the
> step a 4.5.0 pin would fail. The artifacts were then read on the build node rather than
> inferred from a green build:
>
> ```
> build/core/keycloak/version              22.0.0
> build/core/keycloak/keycloak_version     22.0.5
> heavy_rootfs/opt/keycloak/               keycloakx-2.3.0.tgz, chart-values.yaml (tag: 22.0.0)
> registry .../bigstack/keycloak/_manifests/tags/    22.0.0        (only tag present)
> image config blob    LABEL org.opencontainers.image.version = 22.0.5
> ```
>
> So the tag in the registry is the package version, the image behind it is a 22.0.5 base,
> the chart that reaches the rootfs is 2.3.0, and no 18.0.0 tag survives. The 1cc fresh
> install then completed first-time setup, which runs `hex_config commit keycloak` end to
> end — a keycloak commit failure aborts bootstrap and leaves every service behind it
> unstarted, so that path was genuinely walked.

> **Not verified here.** The in-place 18 → 22 upgrade on a 3cc: the pipeline's e2e is a
> fresh install and never triggers the stop sequence this PR adds. Nor is the `cos-ui`
> theme's rendering under 22 — the image deploys, but nobody has loaded the page out of it
> yet. Both are tracked on #649 and are why this is `Part of` rather than `Fixes`.

#### Additional documentation

```docs

```
