### PR TITLE
fix(health): make wait_for_http_endpoint say why it is still waiting

### DIFF
--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -911,14 +911,24 @@ wait_for_http_endpoint()
     # $timeout is seconds: bound the loop by the clock, not by attempt count -- each
     # probe can cost curl's own timeout (SRVTO, up to 60s) on top of the sleep
     local deadline=$(( $(date +%s) + timeout ))
-    local rc=1
+    local rc=1 tries=0 crc=0 code=
     while [ $(date +%s) -lt $deadline ] ; do
-        if $CURL --connect-timeout 2 -m 5 -sf http://$endpoint:$port > /dev/null ; then
+        code=$($CURL --connect-timeout 2 -m 5 -s -o /dev/null -w '%{http_code}' http://$endpoint:$port 2>/dev/null)
+        crc=$?
+        if [ $crc -eq 0 ] && [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 400 ] ; then
             rc=0
             break
         fi
+        tries=$(( tries + 1 ))
+        # say why it is still waiting: a silent retry loop leaves nothing to
+        # diagnose afterwards, and "waited 6 minutes" does not distinguish a
+        # refused connect from a 503 served by haproxy
+        if [ $tries -eq 1 -o $(( tries % 30 )) -eq 0 ] ; then
+            log_warning "wait_for_http_endpoint $endpoint:$port not ready after $tries tries (curl rc=$crc http=${code:-none})"
+        fi
         sleep 1
     done
+    [ $rc -eq 0 ] || log_warning "wait_for_http_endpoint $endpoint:$port gave up after ${timeout}s (curl rc=$crc http=${code:-none})"
     return $rc
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Follow-up to #1406 (merged). That PR bounded `wait_for_http_endpoint` by the clock; this one makes it say *why* it is waiting.

Today the wait throws away everything it learns — `$CURL -sf http://$endpoint:$port > /dev/null` keeps neither the exit code nor the HTTP status. During the `cluster powercycle` post-mortem, keystone's wait ran **361 s** and apache2's **377 s** on each control node, and nothing on the waiting node recorded whether the endpoint had refused the connection, timed out, or answered 503. Answering that required going to *another* node's keystone access log — which showed keystone healthy and serving **288 requests**, including 26 `POST /v3/auth/tokens`, for the whole window. The endpoint was never down; the probes were not reaching it.

That distinction matters, and it is the difference between this being a slow-endpoint problem and a reachability one (#1390). Six minutes of silent retries should not need cross-node log archaeology to classify.

Now: the reason is logged on the first failure, every 30th after that, and once on give-up:

```
WARN: wait_for_http_endpoint 127.0.0.1:18099 not ready after 1 tries (curl rc=7 http=000)
WARN: wait_for_http_endpoint 127.0.0.1:18099 gave up after 4s (curl rc=7 http=000)
```

`curl rc=7` is connection refused — the line that would have pointed straight at reachability rather than the endpoint.

#### Which issue(s) this PR fixes

Context for #1390 — it does not fix the `balance source` behaviour there, it makes the next occurrence self-diagnosing. #1405 was closed by #1406.

#### Special notes for your reviewer

> Note

- Behaviour change: the probe now uses `-s -o /dev/null -w '%{http_code}'` and treats 2xx/3xx as success, rather than relying on `-f`. Verified both ways: a live endpoint returns `rc=0` immediately, and a refused one returns `rc=1` at exactly its budget with the reason logged.
- Rate-limited deliberately — one line at the start, then every 30th attempt — so a genuinely slow cold boot does not flood the console the way an unbounded writer would (see the console-stall note in the handbook).
- `log_warning` is the sdk's own helper (`sdk_log.sh`), already used across `sdk_ceph.sh`, `sdk_git.sh`, `sdk_ovn.sh`.

#### Additional documentation

```docs

```
