### PR TITLE
feat(nova): let an image-backed instance grow its root disk live

### DIFF
--- a/core/nova/caracal_patch/compute/api.py.patch
+++ b/core/nova/caracal_patch/compute/api.py.patch
@@ -1,6 +1,6 @@
 --- compute/api.py
 +++ compute/api.py
-@@ -49,6 +49,7 @@ from nova.compute import utils as comput
+@@ -49,6 +49,7 @@
  from nova.compute.utils import wrap_instance_event
  from nova.compute import vm_states
  from nova import conductor
@@ -8,7 +8,7 @@
  import nova.conf
  from nova import context as nova_context
  from nova import crypto
-@@ -761,7 +762,8 @@ class API:
+@@ -761,7 +762,8 @@
  
          # Target disk is a volume. Don't check flavor disk size because it
          # doesn't make sense, and check min_disk against the volume size.
@@ -18,7 +18,7 @@
              # There are 2 possibilities here:
              #
              # 1. The target volume already exists but bdm.volume_size is not
-@@ -4160,9 +4162,55 @@ class API:
+@@ -4160,9 +4162,59 @@
  
      # TODO(stephenfin): This logic would be so much easier to grok if we
      # finally split resize and cold migration into separate code paths
@@ -35,8 +35,12 @@
 +                    "name": f.name, "spec": b})
 +        if new.vcpus < old.vcpus or new.memory_mb < old.memory_mb:
 +            _bad(_("live resize is grow-only"))
-+        if new.root_gb != old.root_gb and not is_bfv:
-+            _bad(_("root disk size must not change"))
++        # root_gb is grow-only. An image-backed root is grown in place by the
++        # driver, which refuses in check_live_resize when its image backend
++        # cannot -- the same clean pre-hotplug failure the vCPU/memory ceilings
++        # already use. A boot-from-volume root is cinder's.
++        if new.root_gb < old.root_gb:
++            _bad(_("root disk size cannot shrink"))
 +        if new.ephemeral_gb != old.ephemeral_gb:
 +            _bad(_("ephemeral disk size must not change"))
 +        # ceiling the running domain was booted with (config default or

--- a/core/nova/caracal_patch/compute/api.py.patch
+++ b/core/nova/caracal_patch/compute/api.py.patch
@@ -39,7 +39,7 @@
 +        # driver, which refuses in check_live_resize when its image backend
 +        # cannot -- the same clean pre-hotplug failure the vCPU/memory ceilings
 +        # already use. A boot-from-volume root is cinder's.
-+        if new.root_gb < old.root_gb:
++        if new.root_gb < old.root_gb and not is_bfv:
 +            _bad(_("root disk size cannot shrink"))
 +        if new.ephemeral_gb != old.ephemeral_gb:
 +            _bad(_("ephemeral disk size must not change"))

--- a/core/nova/caracal_patch/compute/api.py.patch
+++ b/core/nova/caracal_patch/compute/api.py.patch
@@ -18,7 +18,7 @@
              # There are 2 possibilities here:
              #
              # 1. The target volume already exists but bdm.volume_size is not
-@@ -4160,9 +4162,59 @@
+@@ -4160,9 +4162,57 @@
  
      # TODO(stephenfin): This logic would be so much easier to grok if we
      # finally split resize and cold migration into separate code paths
@@ -35,10 +35,8 @@
 +                    "name": f.name, "spec": b})
 +        if new.vcpus < old.vcpus or new.memory_mb < old.memory_mb:
 +            _bad(_("live resize is grow-only"))
-+        # root_gb is grow-only. An image-backed root is grown in place by the
-+        # driver, which refuses in check_live_resize when its image backend
-+        # cannot -- the same clean pre-hotplug failure the vCPU/memory ceilings
-+        # already use. A boot-from-volume root is cinder's.
++        # an image-backed root can grow but not shrink; nova ignores
++        # root_gb for a volume-backed root
 +        if new.root_gb < old.root_gb and not is_bfv:
 +            _bad(_("root disk size cannot shrink"))
 +        if new.ephemeral_gb != old.ephemeral_gb:

--- a/core/nova/caracal_patch/compute/manager.py.patch
+++ b/core/nova/caracal_patch/compute/manager.py.patch
@@ -1,6 +1,6 @@
 --- compute/manager.py
 +++ compute/manager.py
-@@ -69,6 +69,7 @@ from nova.compute import utils as comput
+@@ -69,6 +69,7 @@
  from nova.compute.utils import wrap_instance_event
  from nova.compute import vm_states
  from nova import conductor
@@ -8,7 +8,7 @@
  import nova.conf
  import nova.context
  from nova import exception
-@@ -1299,6 +1300,17 @@ class ComputeManager(manager.Manager):
+@@ -1299,6 +1300,17 @@
              # host. Abort ongoing migration if still running and reset state.
              self._reset_live_migration(context, instance)
  
@@ -26,14 +26,18 @@
          db_state = instance.power_state
          drv_state = self._get_power_state(instance)
          expect_running = (db_state == power_state.RUNNING and
-@@ -9058,6 +9070,73 @@ class ComputeManager(manager.Manager):
+@@ -9058,6 +9070,77 @@
                  self._set_instance_obj_error_state(instance,
                                                     clean_task_state=True)
  
 +    def _lr_revert_allocations(self, context, instance):
 +        try:
++            # DISK_GB comes back too when we claimed it. The disk grow runs
++            # last, so a revert means it never happened.
++            root_gb = instance.flavor.root_gb if instance.image_ref else None
 +            clr.set_allocations(self.reportclient, context,
-+                                instance.uuid, instance.flavor)
++                                instance.uuid, instance.flavor,
++                                root_gb=root_gb)
 +        except Exception:
 +            LOG.exception("live-resize: failed to revert allocations",
 +                          instance=instance)

--- a/core/nova/caracal_patch/conductor/manager.py.patch
+++ b/core/nova/caracal_patch/conductor/manager.py.patch
@@ -1,6 +1,6 @@
 --- conductor/manager.py
 +++ conductor/manager.py
-@@ -20,6 +20,7 @@ import copy
+@@ -20,6 +20,7 @@
  import eventlet
  import functools
  import sys
@@ -8,7 +8,7 @@
  import typing as ty
  
  from keystoneauth1 import exceptions as ks_exc
-@@ -45,6 +46,7 @@ from nova.conductor.tasks import cross_c
+@@ -45,6 +46,7 @@
  from nova.conductor.tasks import live_migrate
  from nova.conductor.tasks import migrate
  from nova import context as nova_context
@@ -16,7 +16,7 @@
  from nova import exception
  from nova.i18n import _
  from nova.image import glance
-@@ -467,6 +469,87 @@ class ComputeTaskManager:
+@@ -467,6 +469,90 @@
          self._live_migrate(context, instance, scheduler_hint,
                             block_migration, disk_over_commit, request_spec)
  
@@ -40,8 +40,11 @@
 +            instance.save()
 +
 +    def _live_resize_instance(self, context, instance, flavor):
++        # An image-backed root is grown on the compute, so its DISK_GB moves
++        # with the flavor. A boot-from-volume root is cinder's -- leave it.
++        root_gb = flavor.root_gb if instance.image_ref else None
 +        if clr.set_allocations(self.report_client, context,
-+                               instance.uuid, flavor):
++                               instance.uuid, flavor, root_gb=root_gb):
 +            self.compute_rpcapi.live_resize_instance(context, instance,
 +                                                     flavor)
 +            return

--- a/core/nova/caracal_patch/cube_live_resize.py
+++ b/core/nova/caracal_patch/cube_live_resize.py
@@ -84,11 +84,15 @@ def recorded_headroom(instance):
 
 
 def set_allocations(reportclient, context, consumer_uuid, flavor,
-                    vcpus=None, memory_mb=None):
+                    vcpus=None, memory_mb=None, root_gb=None):
     """PUT the consumer's allocations resized to flavor.
 
     vcpus/memory_mb override the flavor values (used to claim only the
     CPU half on the source before an auto-migrate).
+
+    root_gb claims host disk, and is passed ONLY for an image-backed root the
+    driver is about to grow. A boot-from-volume root is cinder's, not the
+    compute's, so its DISK_GB must not move with the flavor.
     Returns False when placement rejects the new size (no capacity).
     """
     allocs = reportclient.get_allocs_for_consumer(context, consumer_uuid)
@@ -101,4 +105,6 @@ def set_allocations(reportclient, context, consumer_uuid, flavor,
         if "MEMORY_MB" in res:
             res["MEMORY_MB"] = (memory_mb if memory_mb is not None
                                 else flavor.memory_mb)
+        if root_gb is not None and "DISK_GB" in res:
+            res["DISK_GB"] = root_gb
     return reportclient.put_allocations(context, consumer_uuid, allocs)

--- a/core/nova/caracal_patch/virt/libvirt/driver.py.patch
+++ b/core/nova/caracal_patch/virt/libvirt/driver.py.patch
@@ -43,7 +43,7 @@
          return guest
  
      def _get_ordered_vpmems(self, instance, flavor):
-@@ -7430,6 +7436,147 @@
+@@ -7430,6 +7436,167 @@
              for resource in vpmem_resources]
          return vpmems
  
@@ -128,8 +128,28 @@
 +        except Exception as ex:
 +            raise exception.LiveResizeError(reason=_(
 +                "could not grow the root image: %s") % ex)
++        # libvirt identifies the disk by its target dev, not by Image.path --
++        # which for rbd is a connection string ("rbd:pool/name:conf=...") that
++        # blockResize rejects. Match the domain's disk the same way the image
++        # backend built it: Rbd.libvirt_info sets source_name to pool/rbd_name,
++        # file backends set source_path to Image.path.
++        names = {image.path}
++        rbd_name = getattr(image, "rbd_name", None)
++        if rbd_name:
++            names.add("%s/%s" % (image.driver.pool, rbd_name))
++        dev = None
++        for disk in guest.get_all_disks():
++            if disk.source_path in names or disk.source_name in names:
++                dev = disk.target_dev
++                break
++        if dev is None:
++            LOG.warning("live-resize: root grown to %dG but its disk was not "
++                        "found in the domain config; the guest keeps the old "
++                        "size until it reboots", new_flavor.root_gb,
++                        instance=instance)
++            return
 +        try:
-+            guest.get_block_device(image.path).resize(size)
++            guest.get_block_device(dev).resize(size)
 +        except libvirt.libvirtError as ex:
 +            # The image is bigger; the guest just has not been told. A hard
 +            # reboot picks the new size up, so the flavor change still stands.
@@ -191,7 +211,7 @@
      def _guest_add_vpmems(self, guest, vpmems):
          guest.max_memory_size = guest.memory
          guest.max_memory_slots = 0
-@@ -7598,7 +7745,7 @@
+@@ -7598,7 +7765,7 @@
              dev.domain, dev.bus, dev.slot, dev.function = (
                  pci_addr['domain'], pci_addr['bus'],
                  pci_addr['device'], pci_addr['function'])

--- a/core/nova/caracal_patch/virt/libvirt/driver.py.patch
+++ b/core/nova/caracal_patch/virt/libvirt/driver.py.patch
@@ -43,7 +43,7 @@
          return guest
  
      def _get_ordered_vpmems(self, instance, flavor):
-@@ -7430,6 +7436,103 @@
+@@ -7430,6 +7436,147 @@
              for resource in vpmem_resources]
          return vpmems
  
@@ -102,6 +102,43 @@
 +                raise exception.LiveResizeError(reason=_(
 +                    "domain memory ceiling missing or too small "
 +                    "(instance must be rebooted to gain headroom)"))
++        # A boot-from-volume instance has no image_ref and no 'disk' image --
++        # its root is cinder's. Same test nova uses where context is absent.
++        if new_flavor.root_gb > old.root_gb and instance.image_ref:
++            # Image.resize_image is a no-op on the base class, so a backend
++            # that never overrode it would silently leave the guest short.
++            image = self.image_backend.by_name(instance, "disk")
++            if type(image).resize_image is imagebackend.Image.resize_image:
++                raise exception.LiveResizeError(reason=_(
++                    "image backend %(be)s cannot grow a root disk in place") %
++                    {"be": type(image).__name__})
++
++    def _live_grow_root(self, guest, instance, new_flavor):
++        """Grow the root image, then tell the running guest.
++
++        Same two steps nova uses for an attached volume in extend_volume().
++        This grows the block device only -- growpart/resizefs are cloud-init
++        boot-time modules, so the guest's partition and filesystem stay at the
++        old size until it reboots or grows them itself.
++        """
++        size = new_flavor.root_gb * units.Gi
++        image = self.image_backend.by_name(instance, "disk")
++        try:
++            image.resize_image(size)
++        except Exception as ex:
++            raise exception.LiveResizeError(reason=_(
++                "could not grow the root image: %s") % ex)
++        try:
++            guest.get_block_device(image.path).resize(size)
++        except libvirt.libvirtError as ex:
++            # The image is bigger; the guest just has not been told. A hard
++            # reboot picks the new size up, so the flavor change still stands.
++            LOG.warning("live-resize: root grown to %(gb)dG but the guest was "
++                        "not notified: %(err)s",
++                        {"gb": new_flavor.root_gb, "err": ex},
++                        instance=instance)
++        LOG.info("live-resize: root disk grown to %dG", new_flavor.root_gb,
++                 instance=instance)
 +
 +    def live_resize(self, context, instance, new_flavor, cpus=True,
 +                    memory=True):
@@ -136,6 +173,13 @@
 +                                  instance=instance)
 +                    raise exception.LiveResizePartial(reason=str(ex))
 +                raise exception.LiveResizeError(reason=str(ex))
++        # Disk last: growing is irreversible while the hotplugs roll back, and
++        # _lr_revert_allocations restores the old flavor wholesale. Growing
++        # first would leave a disk bigger than DISK_GB claims after a refused
++        # hotplug -- the common failure. check_live_resize has already refused
++        # up front when the backend cannot grow at all.
++        if new_flavor.root_gb > old.root_gb and instance.image_ref:
++            self._live_grow_root(guest, instance, new_flavor)
 +        LOG.info("live-resize applied: %(ov)d->%(nv)d vCPU, "
 +                 "%(om)d->%(nm)d MB",
 +                 {"ov": old.vcpus,
@@ -147,7 +191,7 @@
      def _guest_add_vpmems(self, guest, vpmems):
          guest.max_memory_size = guest.memory
          guest.max_memory_slots = 0
-@@ -7598,7 +7701,7 @@
+@@ -7598,7 +7745,7 @@
              dev.domain, dev.bus, dev.slot, dev.function = (
                  pci_addr['domain'], pci_addr['bus'],
                  pci_addr['device'], pci_addr['function'])

--- a/core/nova/caracal_patch/virt/libvirt/driver.py.patch
+++ b/core/nova/caracal_patch/virt/libvirt/driver.py.patch
@@ -43,7 +43,7 @@
          return guest
  
      def _get_ordered_vpmems(self, instance, flavor):
-@@ -7430,6 +7436,167 @@
+@@ -7430,6 +7436,161 @@
              for resource in vpmem_resources]
          return vpmems
  
@@ -128,11 +128,8 @@
 +        except Exception as ex:
 +            raise exception.LiveResizeError(reason=_(
 +                "could not grow the root image: %s") % ex)
-+        # libvirt identifies the disk by its target dev, not by Image.path --
-+        # which for rbd is a connection string ("rbd:pool/name:conf=...") that
-+        # blockResize rejects. Match the domain's disk the same way the image
-+        # backend built it: Rbd.libvirt_info sets source_name to pool/rbd_name,
-+        # file backends set source_path to Image.path.
++        # blockResize wants the target dev. Image.path is an rbd connection
++        # string it rejects, so match the disk the way the backend built it.
 +        names = {image.path}
 +        rbd_name = getattr(image, "rbd_name", None)
 +        if rbd_name:
@@ -193,11 +190,8 @@
 +                                  instance=instance)
 +                    raise exception.LiveResizePartial(reason=str(ex))
 +                raise exception.LiveResizeError(reason=str(ex))
-+        # Disk last: growing is irreversible while the hotplugs roll back, and
-+        # _lr_revert_allocations restores the old flavor wholesale. Growing
-+        # first would leave a disk bigger than DISK_GB claims after a refused
-+        # hotplug -- the common failure. check_live_resize has already refused
-+        # up front when the backend cannot grow at all.
++        # Last: growing is irreversible while the hotplugs roll back, and the
++        # allocation revert restores the old flavor wholesale. See PR #1429.
 +        if new_flavor.root_gb > old.root_gb and instance.image_ref:
 +            self._live_grow_root(guest, instance, new_flavor)
 +        LOG.info("live-resize applied: %(ov)d->%(nv)d vCPU, "
@@ -211,7 +205,7 @@
      def _guest_add_vpmems(self, guest, vpmems):
          guest.max_memory_size = guest.memory
          guest.max_memory_slots = 0
-@@ -7598,7 +7765,7 @@
+@@ -7598,7 +7759,7 @@
              dev.domain, dev.bus, dev.slot, dev.function = (
                  pci_addr['domain'], pci_addr['bus'],
                  pci_addr['device'], pci_addr['function'])

--- a/core/nova/tests/test_cube_live_resize.py
+++ b/core/nova/tests/test_cube_live_resize.py
@@ -144,3 +144,54 @@ class TestRecordedHeadroom(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class FakeAlloc(object):
+    """Minimal report client: records what was PUT back to placement."""
+
+    def __init__(self, resources):
+        self.allocs = {"allocations": {"rp": {"resources": dict(resources)}}}
+        self.put = None
+
+    def get_allocs_for_consumer(self, context, uuid):
+        return self.allocs
+
+    def put_allocations(self, context, uuid, allocs):
+        self.put = allocs["allocations"]["rp"]["resources"]
+        return True
+
+
+class TestSetAllocationsDisk(unittest.TestCase):
+    """DISK_GB moves only when a caller asks, because only an image-backed
+    root is grown by the compute. A boot-from-volume root is cinder's, and
+    claiming host disk for it would double-count."""
+
+    def _run(self, resources, **kwargs):
+        rc = FakeAlloc(resources)
+        clr.set_allocations(rc, None, "uuid",
+                            FakeFlavor(vcpus=4, memory_mb=8192), **kwargs)
+        return rc.put
+
+    def test_disk_untouched_when_root_gb_not_passed(self):
+        put = self._run({"VCPU": 2, "MEMORY_MB": 4096, "DISK_GB": 20})
+        self.assertEqual(20, put["DISK_GB"])
+        self.assertEqual(4, put["VCPU"])
+        self.assertEqual(8192, put["MEMORY_MB"])
+
+    def test_disk_claimed_when_root_gb_passed(self):
+        put = self._run({"VCPU": 2, "MEMORY_MB": 4096, "DISK_GB": 20},
+                        root_gb=40)
+        self.assertEqual(40, put["DISK_GB"])
+
+    def test_disk_absent_from_allocation_is_not_invented(self):
+        # a boot-from-volume consumer has no DISK_GB on the compute's provider
+        put = self._run({"VCPU": 2, "MEMORY_MB": 4096}, root_gb=40)
+        self.assertNotIn("DISK_GB", put)
+
+    def test_cpu_only_claim_still_leaves_disk_alone(self):
+        # the source-side vCPU grow before an auto-migrate
+        put = self._run({"VCPU": 2, "MEMORY_MB": 4096, "DISK_GB": 20},
+                        memory_mb=4096)
+        self.assertEqual(4, put["VCPU"])
+        self.assertEqual(4096, put["MEMORY_MB"])
+        self.assertEqual(20, put["DISK_GB"])


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

`root_gb` was blocked outright for image-backed instances, so every flavor in a ladder that grows disk — which is every stock ladder — resolved to COLD for them. Only boot-from-volume roots could grow live, and only because cinder was doing the growing.

The libvirt image backends already know how to resize in place: `resize_image()` is implemented by `Flat`, `Qcow2`, `Lvm`, `Rbd` and `Ploop`, and nova already pairs it with a guest block-resize in `extend_volume()`. This reuses both, so it works on whatever `images_type` a deployment runs rather than only the ceph pool CubeCOS happens to set.

- `root_gb` is now **grow-only** rather than fixed, and only for image-backed — a volume-backed root's `root_gb` is ignored by nova entirely, so it stays unconstrained.
- `check_live_resize` refuses up front when the backend never overrode `resize_image`, joining the vCPU and memory ceilings as a clean pre-hotplug failure.
- The grow runs **after** the hotplugs. Growing is irreversible while a DIMM attach or `setVcpusFlags` rolls back, and `_lr_revert_allocations` restores the old flavor wholesale — growing first would leave a disk bigger than `DISK_GB` claims after a refused hotplug, which is the common failure.
- `set_allocations` takes an optional `root_gb`, so `DISK_GB` moves only for an image-backed root the compute is about to grow. A boot-from-volume root is cinder's; claiming host disk for it would double-count. The revert passes it too, or a failed resize leaks the larger claim.

## Behaviour matrix

`images_type = rbd` is set unconditionally under a role check (`config_nova.cpp`), so an **image-backed root is always ceph** — the cinder default volume type cannot reach it. The storage axis only affects boot-from-volume.

| | **BFV** (root = cinder volume) | **Image-backed** (root = ceph rbd) |
| :-- | :-- | :-- |
| **CoS / Skyline** | | |
| any cinder backend | LIVE · CPU+mem · *disk unchanged* | LIVE · CPU+mem+**disk** |
| **CMP** | | |
| ceph (CubeStorage) | LIVE · CPU+mem+**disk** | not reachable from the instances UI |
| non-ceph, online-extend | LIVE · CPU+mem+**disk** | not reachable |
| non-ceph, no online-extend | LIVE · CPU+mem · *disk unchanged* (degraded) | not reachable |

- nova never grows a BFV root — it ignores the flavor's `root_gb` for volume-backed instances. cubecmp's worker is what extends the volume, which is why the same instance resized from Skyline keeps its disk.
- CMP's k8s nodes **are** image-backed (Rancher's OpenStack driver, no `--boot-from-volume`), but they never enter CMP's `instances` collection, so its resize path cannot reach them. Skyline can, and after this change a live resize there grows a node's ephemeral root without replacing the node.
- Every cell that grows disk grows the **block device only**. `growpart`/`resizefs` are cloud-init boot-time modules, so the guest keeps its partition table and filesystem until it reboots or runs `growpart /dev/vda N && xfs_growfs /`.

## Which issue(s) this PR fixes

Refs #1369. Builds on #1371.

## Special notes for your reviewer

Verified on the sky 3cc lab, image-backed guest `lr.small` → `t2.xlarge` with a shell open on it:

```
BEFORE  boot=2026-09-05 04:29:35  cpus=2  mem=3G   vda=20G
AFTER   boot=2026-09-05 04:29:35  cpus=4  mem=15G  vda=160G
        vda: detected capacity change from 41943040 to 335544320
```

Same boot timestamp, session never dropped. The same resize returned `400 root disk size must not change` before the change.

`core/nova/tests/test_cube_live_resize.py`: 25/25 against the node's caracal venv, including four covering `DISK_GB` — untouched unless asked for, claimed when asked, never invented when the consumer has no `DISK_GB` allocation, and left alone on the CPU-only claim that precedes an auto-migrate.

Two defects were caught by writing the matrix rather than re-reading the code, and are fixed in the second commit: an unconditional shrink guard that would have blocked a legitimate BFV resize, and a disk lookup that used `Image.path` (an rbd connection string `blockResize` rejects) so the guest was never told its disk had grown.
