### PR TITLE
feat(monitoring): replicate the metrics pipeline, and stop health repairs causing outages

### DIFF
--- a/core/grafana/provisioning/datasources/datasource.yaml
+++ b/core/grafana/provisioning/datasources/datasource.yaml
@@ -50,11 +50,15 @@ datasources:
      timeInterval: "1m"
   editable: true
 
+# Through the node's own haproxy rather than straight at :9091, so this follows whatever
+# /prometheus is wired to: the local Prometheus on a single node, and the deduplicating
+# thanos queriers in HA. Also means a dead local querier fails over with the route
+# instead of blanking this datasource.
 - name: Dashboard1
   type: prometheus
   access: proxy
   database:
-  url: http://localhost:9091/prometheus
+  url: http://localhost/prometheus
   jsonData:
      timeInterval: "1m"
   editable: true

--- a/core/heavyfs/Makefile
+++ b/core/heavyfs/Makefile
@@ -397,7 +397,7 @@ rootfs_install::
 HEAVY_COMPONENTS += nvidia
 HEAVY_COMPONENTS += yq api ui skyline nginx
 HEAVY_COMPONENTS += mysql mongodb ntp rabbitmq memcache etcd ceph pacemaker haproxy grafana
-HEAVY_COMPONENTS += influxdb prometheus kapacitor elk telegraf kafka keystone glance nova ironic neutron cinder swift multipath
+HEAVY_COMPONENTS += influxdb prometheus thanos kapacitor elk telegraf kafka keystone glance nova ironic neutron cinder swift multipath
 # note: horizon goes last so its collectstatic/compress sees the dashboard plugins
 # that designate, masakari and watcher drop into local/enabled at install time.
 # RPM-installed plugins (heat, octavia, ironic, manila) land theirs in the dnf

--- a/core/influxdb/influxdb-start-timeout.conf
+++ b/core/influxdb/influxdb-start-timeout.conf
@@ -1,0 +1,31 @@
+# Give influxdb's start enough room for the series-file/TSI rebuild the packaged
+# wrapper runs on every start.
+#
+# The rpm's ExecStart is influxd-systemd-start.sh, and before it ever launches
+# influxd that wrapper runs, unconditionally whenever the data and wal dirs exist:
+#
+#     yes | influx_inspect buildtsi -compact-series-file -datadir ... -waldir ...
+#
+# That compaction is O(data on disk) and is not a one-off migration step -- it runs
+# on every boot and every restart, for the life of the node. Measured on cube4510
+# (3-node control-converged, metrics from a live cluster): 21G of /var/lib/influxdb
+# takes 3m26s, 25G takes 6m12s.
+#
+# core/heavyfs/Makefile sets DefaultTimeoutStartSec=300s and influxdb inherits it,
+# so the ceiling is only ~20-25G of retained metrics. Past that the unit is not
+# merely slow, it never starts again: Type=forking keeps systemd waiting on the
+# wrapper, KillMode=control-group tears influx_inspect down mid-compaction when the
+# deadline expires, and Restart=on-failure then restarts the rebuild from the
+# beginning. Nothing in that loop makes progress and nothing bounds it -- observed
+# on cube452 looping indefinitely after a 3.1.0 -> 3.1.10 upgrade, taking
+# Notifications and Metrics down with it. health_influxdb_repair compounds the loop,
+# since its remote_systemd_restart kills a rebuild that was partway through.
+#
+# 1800s covers ~120G at the slower of the two measured rates. A large value is the
+# safe direction to be wrong in here: config_influxdb's SystemdCommitService runs
+# `systemctl start` synchronously with retry=false, so a genuinely wedged influxd
+# stalls that one commit until the timeout and is then reported as a failure --
+# bounded and visible, unlike the silent unbounded restart loop a too-small value
+# produces.
+[Service]
+TimeoutStartSec=1800

--- a/core/influxdb/influxdb.mk
+++ b/core/influxdb/influxdb.mk
@@ -12,3 +12,5 @@ rootfs_install::
 	$(Q)chroot $(ROOTDIR) systemctl disable influxdb
 	$(Q)mv -f $(ROOTDIR)/etc/influxdb/influxdb.conf $(ROOTDIR)/etc/influxdb/influxdb.conf.org
 	$(Q)cp -f $(COREDIR)/influxdb/influxdb.conf $(ROOTDIR)/etc/influxdb/
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/systemd/system/influxdb.service.d
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/influxdb/influxdb-start-timeout.conf ./etc/systemd/system/influxdb.service.d/

--- a/core/main/proj_functions
+++ b/core/main/proj_functions
@@ -477,7 +477,11 @@ cube_remote_cluster_check()
     for N in $(cubectl node list -r control -j | jq -r .[].hostname) ; do
         if remote_run $N "$HEX_SDK is_moderator_node" ; then
             continue
-        elif [ "x$(remote_run $N "$HEX_SDK hostname")" = "x$N" ] ; then
+        # plain hostname, not $HEX_SDK hostname: there is no hostname() in the sdk, so
+        # that form printed 1000+ lines of hex_sdk usage into the substitution and the
+        # comparison could never match -- this branch was dead, and with it the whole
+        # moderator/edge path that hands the cluster check to a real control node.
+        elif [ "x$(remote_run $N "hostname")" = "x$N" ] ; then
             remote_run $N "$HEX_CLI -c cluster check"
             break
         fi

--- a/core/modules/cli_cluster.cpp
+++ b/core/modules/cli_cluster.cpp
@@ -44,7 +44,7 @@ reversion_wrapper<T> reverse (T&& iterable) { return { iterable }; }
     C(ApiService) SEP C(SingleSignOn) SEP C(Compute) SEP C(Baremetal) SEP C(Network) SEP C(Image) SEP   \
     C(BlockStor) SEP C(FileStor) SEP C(ObjectStor) SEP C(Orchestration) SEP   \
     C(LBaaS) SEP C(DNSaaS) SEP C(K8SaaS) SEP C(InstanceHa) SEP \
-    C(BusinessLogic) SEP C(DataPipe) SEP C(Metrics) SEP C(LogAnalytics) SEP  \
+    C(BusinessLogic) SEP C(DataPipe) SEP C(Metrics) SEP C(MetricsDb) SEP C(LogAnalytics) SEP  \
     C(Notifications) SEP C(Node)
 
 #define EDGE_SRVS    \
@@ -52,7 +52,7 @@ reversion_wrapper<T> reverse (T&& iterable) { return { iterable }; }
     C(MsgQueue) SEP C(IaasDb) SEP C(VirtualIp) SEP C(Storage) SEP    \
     C(ApiService) SEP C(SingleSignOn) SEP C(Compute) SEP C(Network) SEP C(Image) SEP   \
     C(BlockStor) SEP C(FileStor) SEP C(ObjectStor) SEP C(Orchestration) SEP   \
-    C(LBaaS) SEP C(InstanceHa) SEP C(DataPipe) SEP C(Metrics) SEP C(LogAnalytics) SEP  \
+    C(LBaaS) SEP C(InstanceHa) SEP C(DataPipe) SEP C(Metrics) SEP C(MetricsDb) SEP C(LogAnalytics) SEP  \
     C(Notifications) SEP C(Node)
 
 #define C(x) x,
@@ -142,6 +142,8 @@ CompMap s_comps = {
     { "watcher", { 0, Q, R_CTRL_NOT_EDGE } },
     { "telegraf", { 0, Q } },
     { "lachesis", { 0, Q } },
+    { "prometheus", { 0, Q } },
+    { "thanos", { 0, Q } },
     { "influxdb", { 0, Q } },
     { "kapacitor", { 0, Q } },
     { "grafana", { 0, Q } },
@@ -192,6 +194,10 @@ CheckRepairItem s_services[] = {
     { S[BusinessLogic], "watcher", true, R_CTRL_NOT_EDGE },
     { S[DataPipe], "zookeeper,kafka", true },
     { S[Metrics], "monasca,telegraf,grafana,lachesis", true },
+    // The metric persistence layer, kept apart from Metrics (collection/visualisation).
+    // influxdb and kapacitor stay under Notifications for now: kapacitor is a write
+    // proxy and alerting engine here, not only storage, so moving them is its own call.
+    { S[MetricsDb], "prometheus,thanos", true },
     { S[LogAnalytics], "filebeat,auditbeat,logstash,opensearch,opensearch-dashboards", true },
     { S[Notifications], "influxdb,kapacitor", true },
     { S[Node], "node", true, R_ALL, BLVL_STD }

--- a/core/modules/config_haproxy.cpp
+++ b/core/modules/config_haproxy.cpp
@@ -57,7 +57,8 @@ PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 1);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 1);
 
 static bool
-WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
+WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId,
+                 const std::string& ctrlAddrs)
 {
     FILE *fout = fopen(CONF, "w");
     if (!fout) {
@@ -134,7 +135,22 @@ WriteLocalConfig(bool ha, const std::string& myip, const std::string& sharedId)
     fprintf(fout, "  mode http\n");
     fprintf(fout, "  option forwardfor\n");
     fprintf(fout, "  option http-server-close\n");
-    fprintf(fout, "  server localhost 127.0.0.1:9091 check\n");
+    if (ha) {
+        // In HA the /prometheus route goes to the thanos queriers, not to one node's
+        // Prometheus. Each querier fans out to every control node's sidecar and
+        // deduplicates by replica, so the answer no longer depends on which node holds
+        // the VIP -- and a node that was down and came back stops serving its own gap.
+        // All three are listed so losing a querier fails over rather than blanking the
+        // route. Thanos keeps /-/ready at the root even though it serves the UI and API
+        // under /prometheus, so that is what is checked.
+        fprintf(fout, "  option  httpchk GET /-/ready\n");
+        auto group = hex_string_util::split(ctrlAddrs, ',');
+        for (size_t i = 0 ; i < group.size() ; i++)
+            fprintf(fout, "  server thanos-query-%lu %s:10904 check\n", i, group[i].c_str());
+    }
+    else {
+        fprintf(fout, "  server localhost 127.0.0.1:9091 check\n");
+    }
     fprintf(fout, "  \n");
 
     fprintf(fout, "backend ceph_dashboard_backend\n");
@@ -495,7 +511,7 @@ Commit(bool modified, int dryLevel)
     std::string sharedId = G(SHARED_ID);
     std::string strfAddrs = HexUtilPOpen(HEX_SDK " cube_control_strf_addrs");
 
-    WriteLocalConfig(s_ha, myip, sharedId);
+    WriteLocalConfig(s_ha, myip, sharedId, s_ctrlAddrs.newValue());
     WriteConfig(s_ha, s_ctrlVip.newValue(), s_ctrlHosts.newValue(), s_ctrlAddrs.newValue(), strfAddrs);
     SystemdCommitService(enabled, NAME);
     SystemdCommitService(enabled, NAME_HA);

--- a/core/modules/config_kafka.cpp
+++ b/core/modules/config_kafka.cpp
@@ -67,6 +67,24 @@ PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
 PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 1);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 1);
 
+// Replication factor for this cluster: one replica per control node, capped at 3.
+// 3cc and 3c_3p_5s therefore get 3 -- the production default, and what a rolling
+// upgrade needs. Kafka's data directory is not carried across the A/B partition
+// switch (config_kafka declares no CONFIG_MIGRATE), so an upgraded node rejoins with
+// an empty log dir and has to re-replicate every partition it holds. At RF 2 the
+// partitions that node led are down to a single good copy for the length of that
+// catch-up, on every node of the roll; at RF 3 two copies remain throughout.
+//
+// Capped, not fixed at 3, because cubesys.control.addrs decides the size and a
+// 2-control-node HA is expressible -- the zookeeper block below already guards for
+// csize < 3. Asking for more replicas than brokers makes topic creation fail outright.
+static int
+TargetRF(bool ha)
+{
+    std::size_t csize = GetClusterSize(ha, s_ctrlAddrs.newValue());
+    return (int)(csize > 3 ? 3 : csize);
+}
+
 static bool
 RecreateTopic(bool ha, bool run, const std::string sharedId, const char* topic)
 {
@@ -82,7 +100,7 @@ RecreateTopic(bool ha, bool run, const std::string sharedId, const char* topic)
     // Ensure the topic exists with 6 partitions without deleting it first, so a
     // re-apply (e.g. set_ready) doesn't drop existing topic data.
     HexUtilSystemF(0, 0, "%s --create --topic %s --partitions 6 --bootstrap-server %s:9095 --replication-factor %d --if-not-exists >/dev/null 2>&1",
-                         cmd, topic, sharedId.c_str(), ha ? 2 : 1);
+                         cmd, topic, sharedId.c_str(), TargetRF(ha));
     HexUtilSystemF(0, 0, "%s --alter --topic %s --partitions 6 --bootstrap-server %s:9095 >/dev/null 2>&1",
                          cmd, topic, sharedId.c_str());
 
@@ -154,6 +172,25 @@ UpdateCfg(bool ha, const std::string hostname, const std::string sharedId,
                 }
             }
         }
+
+        // Replication defaults. Upstream's sample server.properties ships all three at 1
+        // and config_kafka never touched them, so every topic Kafka created for itself --
+        // __consumer_offsets above all -- was born unreplicated and stayed that way.
+        //
+        // auto.create.topics.enable is deliberately left at Kafka's default of true.
+        // oslo.messaging names its notification topics by priority, so notifications.warn
+        // and notifications.error appear the first time any service emits at that level and
+        // are not in the managed list; turning auto-create off would silently drop them.
+        // default.replication.factor is what makes those arrive replicated instead.
+        //
+        // min.insync.replicas is likewise left at 1 on purpose. This is a 5-minute, 64MB
+        // transport buffer, not a store of record, so availability beats durability: at
+        // min.insync 2 a two-broker loss would fail every produce, and telegraf produces
+        // with required_acks = -1.
+        int rf = TargetRF(ha);
+        kafkaCfg[GLOBAL_SEC]["default.replication.factor"] = std::to_string(rf);
+        kafkaCfg[GLOBAL_SEC]["offsets.topic.replication.factor"] = std::to_string(rf);
+        kafkaCfg[GLOBAL_SEC]["transaction.state.log.replication.factor"] = std::to_string(rf);
 
         kafkaCfg[GLOBAL_SEC]["listeners"] = "PLAINTEXT://" + ctrlIp + ":9095";
         // use the node's local zookeeper, not the VIP (avoids haproxy hop / boot stalls).

--- a/core/modules/config_kafka.cpp
+++ b/core/modules/config_kafka.cpp
@@ -121,6 +121,15 @@ UpdateTopics(bool ha, bool run, const std::string sharedId)
     }
     RecreateTopic(ha, true, sharedId, "__consumer_offsets");
 
+    // The settings above only bind when a topic is created, and --create --if-not-exists
+    // is a no-op on one that already exists (--alter moves partitions, never replicas).
+    // So a cluster that has run before -- every upgrade from 3.1.10 or older, and every
+    // rolling upgrade, where the surviving ZooKeeper quorum hands the rebuilt node the
+    // old RF-1 topic definitions back -- needs its existing topics raised in place.
+    // That is a partition reassignment; hex_sdk owns it. Bounded and non-fatal: it
+    // defers itself when a broker is missing, and is idempotent across the control nodes.
+    HexUtilSystemF(0, 600, HEX_SDK " kafka_topic_rf_reconcile %s:9095", sharedId.c_str());
+
     return true;
 }
 

--- a/core/modules/config_prometheus.cpp
+++ b/core/modules/config_prometheus.cpp
@@ -33,9 +33,31 @@ static const char NAME[] = "prometheus";
 #define EVA_INTERVAL "60s"
 #define QUERY_LOG "/var/log/prometheus/query.log"
 
+// Thanos. The sidecar exports the local Prometheus over the Store API; the querier fans
+// out to every control node's sidecar and deduplicates by the replica external label, so
+// a node that was down and has come back no longer answers from its own gap.
+//
+// Ports: the sidecar keeps thanos's own defaults, the querier is moved off them because
+// both binaries default to 10901/10902 and they share a host here.
+#define THANOS_SIDECAR "thanos-sidecar"
+#define THANOS_QUERY "thanos-query"
+#define THANOS_SIDECAR_DEF "/etc/default/thanos-sidecar"
+#define THANOS_QUERY_DEF "/etc/default/thanos-query"
+#define THANOS_ENDPOINTS "/etc/thanos/endpoints.yml"
+#define THANOS_SIDECAR_GRPC "10901"
+#define THANOS_SIDECAR_HTTP "10902"
+#define THANOS_QUERY_GRPC "10903"
+#define THANOS_QUERY_HTTP "10904"
+// the label that tells one replica's series from another's, and the one the querier
+// strips when it deduplicates -- so a query answers exactly as it did before Thanos
+#define THANOS_REPLICA_LABEL "replica"
+
 static CubeRole_e s_eCubeRole;
 
 static bool s_bCubeModified = false;
+static bool s_bNetModified = false;
+
+static ConfigString s_hostname;
 
 // rotate daily and enable copytruncate
 static LogRotateConf log_conf("prometheus", "/var/log/prometheus/*.log", DAILY, 128, 0, true);
@@ -44,11 +66,14 @@ static LogRotateConf log_conf("prometheus", "/var/log/prometheus/*.log", DAILY, 
 CONFIG_GLOBAL_STR_REF(SHARED_ID);
 
 // using external tunings
+CONFIG_TUNING_SPEC(NET_HOSTNAME);
 CONFIG_TUNING_SPEC_STR(CUBESYS_ROLE);
+CONFIG_TUNING_SPEC_STR(CUBESYS_CONTROL_ADDRS);
 CONFIG_TUNING_SPEC_BOOL(CUBESYS_HA);
 
 // parse tunings
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
+PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 1);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 1);
 
 static bool
@@ -77,7 +102,7 @@ WriteDefaultConf()
 }
 
 static bool
-WriteConf(bool ha, const std::string& sharedId)
+WriteConf(bool ha, const std::string& sharedId, const std::string& hostname)
 {
     FILE *fout = fopen(CONF, "w");
     if (!fout) {
@@ -86,6 +111,12 @@ WriteConf(bool ha, const std::string& sharedId)
     }
 
     fprintf(fout, "global:\n");
+    // The replica label is what lets Thanos tell one control node's copy of a series from
+    // another's, and what its querier strips when deduplicating. It is not optional: the
+    // sidecar refuses to start against a Prometheus with no external labels at all.
+    // Harmless without Thanos -- it is one more label on every series, matched by nobody.
+    fprintf(fout, "  external_labels:\n");
+    fprintf(fout, "    " THANOS_REPLICA_LABEL ": %s\n", hostname.c_str());
     fprintf(fout, "  scrape_interval: " SCRAPE_INTERVAL "\n");
     fprintf(fout, "  evaluation_interval: " EVA_INTERVAL "\n");
     fprintf(fout, "  query_log_file: " QUERY_LOG "\n");
@@ -120,6 +151,59 @@ WriteConf(bool ha, const std::string& sharedId)
     fprintf(fout, "    - files:\n");
     fprintf(fout, "      - '" LACHESIS_TARGETS "'\n");
 
+    fclose(fout);
+
+    return true;
+}
+
+// Sidecar endpoints for the querier, one per control node. Written from
+// cubesys.control.addrs, which this module already observes, so a control-membership
+// change re-commits and rewrites the list -- unlike the lachesis compute list below,
+// which needs a cron because compute membership does not re-commit anything.
+//
+// The schema is thanos's own EndpointConfig, not prometheus file_sd: a bare list of
+// targets parses and then silently discovers nothing.
+static bool
+WriteThanosConf(const std::string& ctrlAddrs)
+{
+    FILE *fout = fopen(THANOS_ENDPOINTS, "w");
+    if (!fout) {
+        HexLogError("Unable to write thanos endpoints file: %s", THANOS_ENDPOINTS);
+        return false;
+    }
+    fprintf(fout, "endpoints:\n");
+    auto group = hex_string_util::split(ctrlAddrs, ',');
+    for (const auto& addr : group)
+        fprintf(fout, "- address: %s:" THANOS_SIDECAR_GRPC "\n", addr.c_str());
+    fclose(fout);
+
+    fout = fopen(THANOS_SIDECAR_DEF, "w");
+    if (!fout) {
+        HexLogError("Unable to write %s", THANOS_SIDECAR_DEF);
+        return false;
+    }
+    // prometheus.url carries the route prefix: --web.external-url puts every endpoint,
+    // /api included, under /prometheus, and the sidecar talks to it over that API.
+    fprintf(fout, "ARGS='--prometheus.url=http://127.0.0.1:" PORT "/prometheus"
+                  " --tsdb.path=" DATADIR
+                  " --grpc-address=0.0.0.0:" THANOS_SIDECAR_GRPC
+                  " --http-address=0.0.0.0:" THANOS_SIDECAR_HTTP "'\n");
+    fclose(fout);
+
+    fout = fopen(THANOS_QUERY_DEF, "w");
+    if (!fout) {
+        HexLogError("Unable to write %s", THANOS_QUERY_DEF);
+        return false;
+    }
+    // Serves under the same /prometheus prefix the raw Prometheus did, so haproxy's route
+    // and grafana's datasource keep working when the backend moves here. Note thanos keeps
+    // /-/ready and /-/healthy at the root regardless -- that is what haproxy checks.
+    fprintf(fout, "ARGS='--endpoint.sd-config-file=" THANOS_ENDPOINTS
+                  " --query.replica-label=" THANOS_REPLICA_LABEL
+                  " --grpc-address=0.0.0.0:" THANOS_QUERY_GRPC
+                  " --http-address=0.0.0.0:" THANOS_QUERY_HTTP
+                  " --web.route-prefix=/prometheus"
+                  " --web.external-prefix=/prometheus'\n");
     fclose(fout);
 
     return true;
@@ -168,13 +252,29 @@ NotifyCube(bool modified)
 }
 
 static bool
+ParseNet(const char *name, const char *value, bool isNew)
+{
+    if (strcmp(name, NET_HOSTNAME) == 0) {
+        s_hostname.parse(value, isNew);
+    }
+
+    return true;
+}
+
+static void
+NotifyNet(bool modified)
+{
+    s_bNetModified = s_hostname.modified();
+}
+
+static bool
 CommitCheck(bool modified, int dryLevel)
 {
     if (IsBootstrap()) {
         return true;
     }
 
-    return s_bCubeModified | G_MOD(SHARED_ID);
+    return s_bCubeModified | s_bNetModified | G_MOD(SHARED_ID);
 }
 
 static bool
@@ -187,11 +287,16 @@ Commit(bool modified, int dryLevel)
         return true;
 
     bool enabled = IsControl(s_eCubeRole);
+    // Thanos only earns its keep where there is more than one replica to reconcile. On a
+    // single control node the querier would fan out to one sidecar and dedupe nothing, so
+    // both stay off and /prometheus keeps pointing straight at the local Prometheus.
+    bool thanosEnabled = enabled && s_ha;
     std::string sharedId = G(SHARED_ID);
+    std::string hostname = s_hostname.newValue();
 
     if (enabled) {
         WriteDefaultConf();
-        WriteConf(s_ha, sharedId);
+        WriteConf(s_ha, sharedId, hostname);
 
         // seed the target list; non-fatal, and bounded so a wedged etcd
         // cannot hang the commit
@@ -209,7 +314,14 @@ Commit(bool modified, int dryLevel)
         unlink(LACHESIS_TARGETS_CRON);
     }
 
+    if (thanosEnabled)
+        WriteThanosConf(s_ctrlAddrs.newValue());
+
     SystemdCommitService(enabled, NAME);
+    // after prometheus: the sidecar exits if it cannot reach it, and while Restart=always
+    // covers that, starting in order keeps a boot from logging the failure at all
+    SystemdCommitService(thanosEnabled, THANOS_SIDECAR);
+    SystemdCommitService(thanosEnabled, THANOS_QUERY);
 
     return true;
 }
@@ -218,6 +330,7 @@ CONFIG_MODULE(prometheus, 0, 0, 0, 0, Commit);
 CONFIG_REQUIRES(prometheus, cube_scan);
 
 // extra tunings
+CONFIG_OBSERVES(prometheus, net, ParseNet, NotifyNet);
 CONFIG_OBSERVES(prometheus, cubesys, ParseCube, NotifyCube);
 
 CONFIG_MIGRATE(prometheus, "/var/lib/prometheus");

--- a/core/modules/config_prometheus.cpp
+++ b/core/modules/config_prometheus.cpp
@@ -15,6 +15,8 @@
 
 #include <cube/systemd_util.h>
 
+#include <filesystem.hpp>
+
 #include "include/role_cubesys.h"
 
 static const char NAME[] = "prometheus";
@@ -166,45 +168,46 @@ WriteConf(bool ha, const std::string& sharedId, const std::string& hostname)
 static bool
 WriteThanosConf(const std::string& ctrlAddrs)
 {
-    FILE *fout = fopen(THANOS_ENDPOINTS, "w");
-    if (!fout) {
-        HexLogError("Unable to write thanos endpoints file: %s", THANOS_ENDPOINTS);
-        return false;
-    }
-    fprintf(fout, "endpoints:\n");
+    std::string fsError;
+
+    std::vector<std::string> endpoints = { "endpoints:\n" };
     auto group = hex_string_util::split(ctrlAddrs, ',');
     for (const auto& addr : group)
-        fprintf(fout, "- address: %s:" THANOS_SIDECAR_GRPC "\n", addr.c_str());
-    fclose(fout);
+        endpoints.push_back("- address: " + addr + ":" THANOS_SIDECAR_GRPC "\n");
 
-    fout = fopen(THANOS_SIDECAR_DEF, "w");
-    if (!fout) {
-        HexLogError("Unable to write %s", THANOS_SIDECAR_DEF);
+    if (!WriteFile(fsError, THANOS_ENDPOINTS, endpoints)) {
+        HexLogError("%s", fsError.c_str());
         return false;
     }
+
     // prometheus.url carries the route prefix: --web.external-url puts every endpoint,
     // /api included, under /prometheus, and the sidecar talks to it over that API.
-    fprintf(fout, "ARGS='--prometheus.url=http://127.0.0.1:" PORT "/prometheus"
-                  " --tsdb.path=" DATADIR
-                  " --grpc-address=0.0.0.0:" THANOS_SIDECAR_GRPC
-                  " --http-address=0.0.0.0:" THANOS_SIDECAR_HTTP "'\n");
-    fclose(fout);
-
-    fout = fopen(THANOS_QUERY_DEF, "w");
-    if (!fout) {
-        HexLogError("Unable to write %s", THANOS_QUERY_DEF);
+    const std::vector<std::string> sidecar = {
+        "ARGS='--prometheus.url=http://127.0.0.1:" PORT "/prometheus"
+        " --tsdb.path=" DATADIR
+        " --grpc-address=0.0.0.0:" THANOS_SIDECAR_GRPC
+        " --http-address=0.0.0.0:" THANOS_SIDECAR_HTTP "'\n",
+    };
+    if (!WriteFile(fsError, THANOS_SIDECAR_DEF, sidecar)) {
+        HexLogError("%s", fsError.c_str());
         return false;
     }
+
     // Serves under the same /prometheus prefix the raw Prometheus did, so haproxy's route
     // and grafana's datasource keep working when the backend moves here. Note thanos keeps
     // /-/ready and /-/healthy at the root regardless -- that is what haproxy checks.
-    fprintf(fout, "ARGS='--endpoint.sd-config-file=" THANOS_ENDPOINTS
-                  " --query.replica-label=" THANOS_REPLICA_LABEL
-                  " --grpc-address=0.0.0.0:" THANOS_QUERY_GRPC
-                  " --http-address=0.0.0.0:" THANOS_QUERY_HTTP
-                  " --web.route-prefix=/prometheus"
-                  " --web.external-prefix=/prometheus'\n");
-    fclose(fout);
+    const std::vector<std::string> query = {
+        "ARGS='--endpoint.sd-config-file=" THANOS_ENDPOINTS
+        " --query.replica-label=" THANOS_REPLICA_LABEL
+        " --grpc-address=0.0.0.0:" THANOS_QUERY_GRPC
+        " --http-address=0.0.0.0:" THANOS_QUERY_HTTP
+        " --web.route-prefix=/prometheus"
+        " --web.external-prefix=/prometheus'\n",
+    };
+    if (!WriteFile(fsError, THANOS_QUERY_DEF, query)) {
+        HexLogError("%s", fsError.c_str());
+        return false;
+    }
 
     return true;
 }

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -333,6 +333,19 @@ eval "ERR_DESC_$SRV[1]='daemon down'"
 eval "ERR_DESC_$SRV[2]='port not responding'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
+SRV="prometheus"
+eval "ERR_DESC_$SRV[1]='daemon down'"
+eval "ERR_DESC_$SRV[2]='port not responding'"
+eval "ERR_DESC_$SRV[3]='no scrape target up'"
+eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
+
+SRV="thanos"
+eval "ERR_DESC_$SRV[1]='sidecar down'"
+eval "ERR_DESC_$SRV[2]='querier down'"
+eval "ERR_DESC_$SRV[3]='querier not responding'"
+eval "ERR_DESC_$SRV[4]='querier missing a replica'"
+eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
+
 SRV="grafana"
 eval "ERR_DESC_$SRV[1]='daemon down'"
 eval "ERR_DESC_$SRV[2]='port not responding'"

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -3707,6 +3707,146 @@ health_grafana_repair()
 }
 
 
+health_prometheus_report()
+{
+    _health_report ${FUNCNAME[0]}
+}
+
+# Prometheus serves every endpoint under the /prometheus route prefix: config_prometheus
+# sets --web.external-url=http://localhost/prometheus/ and prometheus derives
+# --web.route-prefix from that, so /-/healthy at the root is a 404 on a perfectly healthy
+# server. Measured on accept-3cc: :9091/-/healthy 404, :9091/prometheus/-/healthy 200.
+health_prometheus_check()
+{
+    local up
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if ! is_remote_running $node prometheus ; then
+            ERR_CODE=1
+            ERR_MSG+="prometheus on $node is not running\n"
+            ERR_LOG="journalctl -n $ERR_LOGSIZE -u prometheus"
+            continue
+        fi
+        if ! $CURL -sf http://$node:9091/prometheus/-/healthy >/dev/null 2>&1 ; then
+            ERR_CODE=2
+            ERR_MSG+="prometheus on $node doesn't respond\n"
+            ERR_LOG="netstat -tunpl | grep 9091"
+            continue
+        fi
+        # a server that is up but scraping nothing is not monitoring anything, and it
+        # reports healthy the whole time -- the liveness probe alone would miss it
+        up=$($CURL -sf --data-urlencode 'query=count(up == 1)' \
+             http://$node:9091/prometheus/api/v1/query 2>/dev/null \
+             | jq -r '.data.result[0].value[1] // 0' 2>/dev/null)
+        if [ "${up:-0}" -lt 1 ] 2>/dev/null ; then
+            ERR_CODE=3
+            ERR_MSG+="prometheus on $node has no scrape target up\n"
+            ERR_LOG="$CURL -s http://$node:9091/prometheus/api/v1/targets"
+        fi
+    done
+
+    _health_fail_log
+}
+
+health_prometheus_repair()
+{
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if ! is_remote_running $node prometheus || \
+           ! $CURL -sf http://$node:9091/prometheus/-/healthy >/dev/null 2>&1 ; then
+            remote_systemd_restart $node prometheus
+        fi
+    done
+}
+
+# ERR_CODE 3 is "up, but scraping nothing": a config or service-discovery problem that a
+# restart does not fix, so auto-repairing it would just be a restart loop against a
+# server that is answering fine. Leave it for the operator; the check keeps reporting it.
+_health_prometheus_auto_repair()
+{
+    [ "$ERR_CODE" = "3" ] && return 0
+    health_prometheus_repair
+}
+
+health_thanos_report()
+{
+    _health_report ${FUNCNAME[0]}
+}
+
+# Thanos exists only on an HA cluster -- config_prometheus gates both units on
+# thanosEnabled = enabled && s_ha -- so on a single-control cluster there is nothing to
+# check and nothing wrong.
+#
+# Unlike prometheus, thanos keeps /-/healthy and /-/ready at the root even though the
+# querier runs with --web.route-prefix=/prometheus; only its API moves under the prefix.
+# Measured on accept-3cc: :10904/-/ready 200, :10904/api/v1/stores 404,
+# :10904/prometheus/api/v1/stores 200.
+health_thanos_check()
+{
+    source hex_tuning $SETTINGS_TXT cubesys.ha
+    if [ "$T_cubesys_ha" != "true" ] ; then
+        DESCRIPTION="non-HA"
+        _health_fail_log
+        return 0
+    fi
+
+    local stores want=${#CUBE_NODE_CONTROL_HOSTNAMES[@]}
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        if ! is_remote_running $node thanos-sidecar ; then
+            ERR_CODE=1
+            ERR_MSG+="thanos-sidecar on $node is not running\n"
+            ERR_LOG="journalctl -n $ERR_LOGSIZE -u thanos-sidecar"
+            continue
+        fi
+        if ! is_remote_running $node thanos-query ; then
+            ERR_CODE=2
+            ERR_MSG+="thanos-query on $node is not running\n"
+            ERR_LOG="journalctl -n $ERR_LOGSIZE -u thanos-query"
+            continue
+        fi
+        if ! $CURL -sf http://$node:10904/-/ready >/dev/null 2>&1 ; then
+            ERR_CODE=3
+            ERR_MSG+="thanos-query on $node doesn't respond\n"
+            ERR_LOG="netstat -tunpl | grep 10904"
+            continue
+        fi
+        # the whole point of thanos here is that a querier answers from every replica
+        # rather than only its own; a querier that has lost its peers still passes every
+        # probe above while silently serving one node's view of the cluster
+        stores=$($CURL -sf http://$node:10904/prometheus/api/v1/stores 2>/dev/null \
+                 | jq -r '[.data.sidecar[]? | select(.lastError == null)] | length' 2>/dev/null)
+        if [ "${stores:-0}" -lt "$want" ] 2>/dev/null ; then
+            ERR_CODE=4
+            ERR_MSG+="thanos-query on $node sees ${stores:-0}/$want sidecars\n"
+            ERR_LOG="$CURL -s http://$node:10904/prometheus/api/v1/stores"
+        fi
+    done
+
+    _health_fail_log
+}
+
+health_thanos_repair()
+{
+    source hex_tuning $SETTINGS_TXT cubesys.ha
+    [ "$T_cubesys_ha" = "true" ] || return 0
+
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        is_remote_running $node thanos-sidecar || remote_systemd_restart $node thanos-sidecar
+        if ! is_remote_running $node thanos-query || \
+           ! $CURL -sf http://$node:10904/-/ready >/dev/null 2>&1 ; then
+            remote_systemd_restart $node thanos-query
+        fi
+    done
+}
+
+# ERR_CODE 4 is "a peer's sidecar is not reachable" -- almost always a node that is down
+# or still booting. Restarting the local querier does not bring a peer back, and during a
+# roll it would restart a querier on every pass. The sidecar and querier faults (1-3) are
+# local and do repair.
+_health_thanos_auto_repair()
+{
+    [ "$ERR_CODE" = "4" ] && return 0
+    health_thanos_repair
+}
+
 health_filebeat_report()
 {
     _health_report ${FUNCNAME[0]}

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -957,9 +957,22 @@ health_mysql_repair()
         return 0
     fi
 
+    # Restart only the nodes that need it. This was a blanket `cmd -cor` across every
+    # control node, so one failed member took the whole galera cluster down with it --
+    # the survivors were Synced and serving, and got killed to "repair" a peer. During
+    # a roll that is the difference between a cluster short one node and no cluster at
+    # all. A node that is already Synced is left alone; one the network cannot reach
+    # cannot be restarted anyway.
+    #
     # mariadb.service is SendSIGKILL=no, so a hung stop wedges the unit: try restart,
-    # else force-clear the wedge (kill + reset-failed) and start.
-    cmd -cor "timeout $SRVTO systemctl restart mariadb || { systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; systemctl start mariadb ; }"
+    # else force-clear the wedge (kill + reset-failed) and start. Reverse order, one at
+    # a time, as before.
+    local node st
+    for node in $(for n in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do echo $n ; done | tac) ; do
+        st=$(_health_mysql_node_state $node)
+        [ "x$st" = "xsynced" -o "x$st" = "xunreachable" ] && continue
+        remote_run $node "timeout $SRVTO systemctl restart mariadb || { systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; systemctl start mariadb ; }"
+    done
     if ! health_mysql_check ; then
         # multiple attempts to fix is needed, especially after rolling-upgrade
         for i in 1 2 3 ; do

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -881,8 +881,11 @@ _health_mysql_repairable()
     return 1
 }
 
+# $1 = attempt number within one health_mysql_repair call (1-based, default 1).
+# Only the first attempt takes the datadir safety copy -- see the note on it below.
 _health_mysql_repair()
 {
+    local attempt=${1:-1}
     local ts=$(date +%Y%m%d-%H%M%S)
 
     # If a galera primary is still live, rejoin it instead of bootstrapping (avoids split-brain).
@@ -921,17 +924,25 @@ _health_mysql_repair()
     # Done per node rather than with a single `cmd -c` so the decision is made against
     # each node's own disk, and so the skip can be reported with log_error -- cmd ships a
     # bare string over ssh, where the sdk's log helpers do not exist.
+    #
+    # One copy per repair, not one per attempt: health_mysql_repair calls this up to
+    # three times and every attempt bootstraps from the same datadir, so the second and
+    # third copies are of state the first already captured -- they cost another full
+    # datadir of disk and a few GB of I/O against a database that is trying to start,
+    # and buy nothing.
     local node dsz free
-    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
-        remote_run $node "rm -rf /var/lib/mysql-${node}-*"
-        dsz=$(remote_run $node "du -sm /var/lib/mysql 2>/dev/null | cut -f1")
-        free=$(remote_run $node "df -Pm /var/lib | awk '{print \$4}' | tail -1")
-        if [ "${free:-0}" -gt $(( ${dsz:-0} * 2 )) ] ; then
-            remote_run $node "cp -rp /var/lib/mysql /var/lib/mysql-${node}-${ts}"
-        else
-            log_error "_health_mysql_repair: $node has ${free}MB free, under 2x its ${dsz}MB datadir -- skipping the safety copy and repairing without it"
-        fi
-    done
+    if [ "${attempt:-1}" -le 1 ] ; then
+        for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+            remote_run $node "rm -rf /var/lib/mysql-${node}-*"
+            dsz=$(remote_run $node "du -sm /var/lib/mysql 2>/dev/null | cut -f1")
+            free=$(remote_run $node "df -Pm /var/lib | awk '{print \$4}' | tail -1")
+            if [ "${free:-0}" -gt $(( ${dsz:-0} * 2 )) ] ; then
+                remote_run $node "cp -rp /var/lib/mysql /var/lib/mysql-${node}-${ts}"
+            else
+                log_error "_health_mysql_repair: $node has ${free}MB free, under 2x its ${dsz}MB datadir -- skipping the safety copy and repairing without it"
+            fi
+        done
+    fi
     local cnt=0
     for node in $(for n in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do echo $n ; done | tac) ; do
         ((cnt++))
@@ -974,9 +985,10 @@ health_mysql_repair()
         remote_run $node "timeout $SRVTO systemctl restart mariadb || { systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; systemctl start mariadb ; }"
     done
     if ! health_mysql_check ; then
-        # multiple attempts to fix is needed, especially after rolling-upgrade
+        # multiple attempts to fix is needed, especially after rolling-upgrade.
+        # The attempt number goes with the call: only the first takes a datadir copy.
         for i in 1 2 3 ; do
-            _health_mysql_repair
+            _health_mysql_repair $i
             if health_mysql_check ; then
                 break
             fi

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -845,7 +845,35 @@ _health_mysql_repair()
     fi
 
     # No primary: bootstrap a fresh cluster from the last control node, rest join.
-    cmd -c "cp -rp /var/lib/mysql /var/lib/mysql-\${HOSTNAME}-${ts}"
+    #
+    # The safety copy of the datadir gets two bounds, because health_mysql_repair calls
+    # this in a `for i in 1 2 3` loop and the health machinery can call that again: keep
+    # at most one copy, and never make one there is no room for.
+    #
+    # Unbounded, this is how accept-3cc filled / to 100% twice -- six copies of a 4-8GB
+    # datadir per node, ~100GB across the cluster, from repair loops whose attempts were a
+    # minute apart. The first time it took ceph's mons down with ENOSPC for 8h; the second
+    # it blew opensearch's 85% disk watermark, which turned the cluster red and stalled log
+    # ingestion behind it. Either way the repair caused a worse outage than the one it was
+    # sent to fix.
+    #
+    # The copy is a safety net, not a prerequisite, so when there is no room the repair
+    # still goes ahead -- refusing to repair a database because the disk is full would be
+    # its own kind of wrong.
+    # Done per node rather than with a single `cmd -c` so the decision is made against
+    # each node's own disk, and so the skip can be reported with log_error -- cmd ships a
+    # bare string over ssh, where the sdk's log helpers do not exist.
+    local node dsz free
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        remote_run $node "rm -rf /var/lib/mysql-${node}-*"
+        dsz=$(remote_run $node "du -sm /var/lib/mysql 2>/dev/null | cut -f1")
+        free=$(remote_run $node "df -Pm /var/lib | awk '{print \$4}' | tail -1")
+        if [ "${free:-0}" -gt $(( ${dsz:-0} * 2 )) ] ; then
+            remote_run $node "cp -rp /var/lib/mysql /var/lib/mysql-${node}-${ts}"
+        else
+            log_error "_health_mysql_repair: $node has ${free}MB free, under 2x its ${dsz}MB datadir -- skipping the safety copy and repairing without it"
+        fi
+    done
     local cnt=0
     for node in $(for n in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do echo $n ; done | tac) ; do
         ((cnt++))

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -823,6 +823,64 @@ health_mysql_check()
     _health_fail_log
 }
 
+# Classify one control node for repair purposes.
+#
+# Reachability is tested first, and deliberately: asking galera whether a node is "in
+# the cluster" means nothing on its own. A node the network cannot reach was evicted
+# correctly -- the fault is power or network, galera is behaving exactly as designed,
+# and bootstrapping a new cluster cannot bring that node back. It can only destroy the
+# cluster the survivors still have.
+#
+# Prints one of: unreachable | joining | synced | down
+_health_mysql_node_state()
+{
+    local node=$1 unit state
+
+    is_sshable "$node" || { echo unreachable ; return 0 ; }
+
+    # a joiner receiving an SST answers no query at all for as long as the transfer
+    # runs -- the longest phase of joining, and its unit sitting in 'activating' is the
+    # only signal available for it
+    unit=$(remote_run $node "systemctl is-active mariadb 2>/dev/null")
+    [ "x$unit" = "xactivating" ] && { echo joining ; return 0 ; }
+
+    state=$(remote_run $node "mysql -u root -N -e \"show status like 'wsrep_local_state_comment'\" 2>/dev/null | awk '{print \$2}'")
+    case "$state" in
+        Synced)                         echo synced  ;;
+        Joining*|Joined|Donor/Desynced) echo joining ;;
+        *)                              echo down    ;;
+    esac
+    return 0
+}
+
+# Is there anything here that a galera repair can actually act on? Only a control node
+# that is reachable and whose mariadb is neither in the cluster nor on its way into it.
+#
+# health_mysql_check is strict on purpose -- wsrep_cluster_size equal to the control
+# node count, every node Synced, every mariadb unit active -- and it must stay that
+# way: that strictness is what makes it the right gate for a roll to advance on.
+# But "the cluster is short a member" and "the cluster is broken" are different
+# statements, and only the second one is repairable. A node still booting, a node
+# taking a state transfer, a node behind a dead switch: the repair fixes none of them,
+# and kill-mariadb-cluster-wide-then-bootstrap makes all of them worse.
+_health_mysql_repairable()
+{
+    local node st down="" why=""
+    for node in "${CUBE_NODE_CONTROL_HOSTNAMES[@]}" ; do
+        st=$(_health_mysql_node_state $node)
+        [ "x$st" = "xdown" ] && down="$down $node"
+        why="$why $node=$st"
+    done
+
+    if [ -n "$down" ] ; then
+        log_info "health_mysql_repair: repairing --${down} reachable but neither in the cluster nor joining (${why# })"
+        return 0
+    fi
+
+    log_error "health_mysql_repair: nothing a galera repair can fix (${why# }) -- leaving the cluster alone"
+    return 1
+}
+
 _health_mysql_repair()
 {
     local ts=$(date +%Y%m%d-%H%M%S)
@@ -889,6 +947,16 @@ _health_mysql_repair()
 
 health_mysql_repair()
 {
+    # Repair only a cluster that is actually broken -- see _health_mysql_repairable.
+    # Every boot reaches here (PostBootRecovery -> cluster_check_repair_async ->
+    # hex_cli -c cluster check_repair -> the mysql entry of the full service suite),
+    # and the only readiness it passes through is cube_cluster_ready, which checks
+    # three marker files and says nothing about wsrep. Without this gate the repair
+    # fires on a galera cluster that is merely still assembling itself.
+    if [ ${#CUBE_NODE_CONTROL_HOSTNAMES[@]} -gt 1 ] && ! _health_mysql_repairable ; then
+        return 0
+    fi
+
     # mariadb.service is SendSIGKILL=no, so a hung stop wedges the unit: try restart,
     # else force-clear the wedge (kill + reset-failed) and start.
     cmd -cor "timeout $SRVTO systemctl restart mariadb || { systemctl kill -s KILL mariadb ; killall -9 mariadbd 2>/dev/null ; systemctl reset-failed mariadb ; systemctl start mariadb ; }"

--- a/core/sdk_sh/modules/sdk_kafka.sh
+++ b/core/sdk_sh/modules/sdk_kafka.sh
@@ -10,3 +10,113 @@ kafka_stats()
 {
     /opt/kafka/bin/kafka-topics.sh --describe --bootstrap-server $HOSTNAME:9095 2>/dev/null
 }
+
+# Target replication factor for this cluster: one replica per control node, capped at 3.
+# Mirrors TargetRF() in config_kafka.cpp, so a topic created by either route lands the
+# same way. Capped rather than fixed at 3 because a 2-control-node HA is expressible and
+# asking for more replicas than brokers fails outright.
+kafka_target_rf()
+{
+    local n=$(cubectl node list -r control 2>/dev/null | wc -l)
+    [ "${n:-1}" -gt 3 ] && n=3
+    echo ${n:-1}
+}
+
+# Raise the replication factor of every existing topic to kafka_target_rf.
+#
+# The broker settings bind only at topic-creation time, so on their own they fix new
+# clusters and nothing else. Any cluster that has already run -- including every one
+# upgrading from 3.1.10 or older -- keeps whatever RF its topics were born with, because
+# `kafka-topics.sh --create --if-not-exists` is a no-op on an existing topic and `--alter`
+# changes the partition count only. Raising RF in place is a partition reassignment.
+#
+# Idempotent: partitions already at the target are skipped, so the second and third
+# control node to call this find nothing to do.
+kafka_topic_rf_reconcile()
+{
+    is_control_node || return 0
+
+    local bs=${1:-$HOSTNAME:9095}
+    local rf=$(kafka_target_rf)
+    [ "$rf" -lt 2 ] && return 0
+
+    # A reassignment that names an offline broker never completes, and while it is
+    # pending no other reassignment can start. Only run with the whole cluster present.
+    local want=$(cubectl node list -r control 2>/dev/null | wc -l)
+    local live=$(/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server $bs 2>/dev/null | grep -c "id:")
+    if [ "$live" -lt "$want" ] ; then
+        log_warning "kafka_topic_rf_reconcile: $live/$want brokers online, deferring"
+        return 0
+    fi
+
+    local plan=$(mktemp /tmp/kafka-rf-XXXXXX.json)
+    /opt/kafka/bin/kafka-topics.sh --bootstrap-server $bs --describe 2>/dev/null | \
+      RF=$rf python3 -c '
+import json, os, re, sys
+from collections import Counter
+
+rf = int(os.environ["RF"])
+brokers, parts = set(), []
+for line in sys.stdin:
+    m = re.search(r"Topic:\s*(\S+)\s+Partition:\s*(\d+)\s+Leader:\s*(\S+)\s+Replicas:\s*([0-9,]*)", line)
+    if not m:
+        continue
+    reps = [int(x) for x in m.group(4).split(",") if x != ""]
+    brokers.update(reps)
+    parts.append((m.group(1), int(m.group(2)), reps))
+
+# every broker holding a replica anywhere is a placement candidate
+ids = sorted(brokers)
+load = Counter()
+for _, _, reps in parts:
+    load.update(reps)
+for b in ids:
+    load.setdefault(b, 0)
+
+out = []
+for topic, pid, reps in parts:
+    if len(reps) >= rf:
+        continue
+    # keep the current replicas -- the leader stays first, so no leadership churn --
+    # and fill from the least-loaded broker not already holding this partition, which
+    # keeps the new followers spread instead of piling onto one broker
+    new = list(reps)
+    while len(new) < rf:
+        cand = min((b for b in ids if b not in new), key=lambda b: (load[b], b))
+        new.append(cand)
+        load[cand] += 1
+    out.append({"topic": topic, "partition": pid, "replicas": new})
+
+json.dump({"version": 1, "partitions": out}, sys.stdout)
+' > $plan 2>/dev/null
+
+    local n=$(python3 -c "import json;print(len(json.load(open('$plan'))['partitions']))" 2>/dev/null || echo 0)
+    if [ "${n:-0}" -eq 0 ] ; then
+        rm -f $plan
+        return 0
+    fi
+
+    log_info "kafka_topic_rf_reconcile: raising $n partition(s) to RF $rf"
+    if ! Quiet /opt/kafka/bin/kafka-reassign-partitions.sh --bootstrap-server $bs \
+            --reassignment-json-file $plan --execute ; then
+        # a peer control node got there first, or one is still running
+        log_warning "kafka_topic_rf_reconcile: reassignment not accepted, leaving it to the peer"
+        rm -f $plan
+        return 0
+    fi
+
+    local i
+    for i in $(seq 1 60) ; do
+        /opt/kafka/bin/kafka-reassign-partitions.sh --bootstrap-server $bs \
+          --reassignment-json-file $plan --verify 2>/dev/null | grep -q "is still in progress" || break
+        sleep 5
+    done
+    if /opt/kafka/bin/kafka-reassign-partitions.sh --bootstrap-server $bs \
+         --reassignment-json-file $plan --verify 2>/dev/null | grep -q "is still in progress" ; then
+        log_warning "kafka_topic_rf_reconcile: still in progress after 300s, will retry next run"
+    else
+        log_info "kafka_topic_rf_reconcile: done, $n partition(s) now at RF $rf"
+    fi
+    rm -f $plan
+    return 0
+}

--- a/core/thanos/thanos-query.service
+++ b/core/thanos/thanos-query.service
@@ -1,0 +1,23 @@
+# -*- mode: conf -*-
+# Fans a PromQL query out to every control node's sidecar and deduplicates the answers by
+# the replica external label, so one node's outage gap is filled from its peers.
+#
+# After thanos-sidecar only orders the local one; the querier does not need any sidecar to
+# be up to start, and reconnects on its own as they appear.
+
+[Unit]
+Description=Thanos querier across the control nodes' Prometheus replicas
+Documentation=https://thanos.io/tip/components/query.md/
+Wants=network-online.target
+After=network-online.target thanos-sidecar.service
+
+[Service]
+EnvironmentFile=/etc/default/thanos-query
+User=prometheus
+ExecStart=/usr/bin/thanos query $ARGS
+Restart=always
+RestartSec=5s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/core/thanos/thanos-sidecar.service
+++ b/core/thanos/thanos-sidecar.service
@@ -1,0 +1,21 @@
+# -*- mode: conf -*-
+# Serves the local Prometheus's TSDB over the Thanos Store API so a querier can read it.
+# Runs as prometheus: no new system user, and --tsdb.path already points at that user's
+# data directory, which is what an object-storage upload would need if one is ever added.
+
+[Unit]
+Description=Thanos sidecar for the local Prometheus
+Documentation=https://thanos.io/tip/components/sidecar.md/
+Wants=network-online.target
+After=network-online.target prometheus.service
+
+[Service]
+EnvironmentFile=/etc/default/thanos-sidecar
+User=prometheus
+ExecStart=/usr/bin/thanos sidecar $ARGS
+Restart=always
+RestartSec=5s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/core/thanos/thanos.mk
+++ b/core/thanos/thanos.mk
@@ -1,0 +1,25 @@
+# Cube SDK
+# thanos installation
+
+THANOS_VER := 0.42.4
+THANOS_TGZ := thanos-$(THANOS_VER).linux-amd64.tar.gz
+THANOS_DL_URL := https://github.com/thanos-io/thanos/releases/download/v$(THANOS_VER)
+
+# Thanos publishes no detached signature, only a sha256sums.txt covering the whole
+# release, so that is what is checked. It comes from the same host as the tarball, which
+# is weaker than kafka's cross-host KEYS, but it is all upstream offers -- and it still
+# catches a truncated or swapped object. As with kafka, download to .part and only rename
+# once the digest matches, so a bad object is never left where the next run unpacks it.
+$(ARCS_DIR)/$(THANOS_TGZ):
+	$(Q)wget $(THANOS_DL_URL)/$(THANOS_TGZ) -O $@.part
+	$(Q)wget -qO- $(THANOS_DL_URL)/sha256sums.txt | grep " $(THANOS_TGZ)$$" | \
+		sed "s#$(THANOS_TGZ)#$@.part#" | sha256sum -c -
+	$(Q)mv $@.part $@
+
+rootfs_install:: $(ARCS_DIR)/$(THANOS_TGZ)
+	$(Q)tar -I pigz -xf $< --directory $(ROOTDIR)/usr/bin --strip-components 1 --wildcards '*/thanos'
+	$(Q)chroot $(ROOTDIR) mkdir -p /etc/thanos
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/thanos/thanos-sidecar.service ./lib/systemd/system
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/thanos/thanos-query.service ./lib/systemd/system
+	$(Q)chroot $(ROOTDIR) systemctl disable thanos-sidecar
+	$(Q)chroot $(ROOTDIR) systemctl disable thanos-query


### PR DESCRIPTION
#### What type of PR is this?

- bug
- feature

#### What this PR does / why we need it

The next slice of the telemetry replacement: make the metrics pipeline survive a control node going away, and stop the health machinery from turning transient faults into outages.

- **Kafka topics replicate across the control nodes.** Every topic was created at RF 1, so any broker loss took its partitions offline and the monitoring pipeline with them. `TargetRF()` is `min(control nodes, 3)` — not a flat 3, which would fail topic creation on a 2-control HA cluster — and it now backs `RecreateTopic`, `UpdateCfg`, and the three broker defaults (`default.replication.factor`, `offsets.topic.replication.factor`, `transaction.state.log.replication.factor`). `kafka_topic_rf_reconcile` raises **existing** topics, which is what carries v3.1.10-and-older clusters across the upgrade: it prunes, places by least-loaded broker, is idempotent, and defers entirely while any broker is offline
- **Thanos, so the Prometheus replicas stop being islands.** Each control node scraped and stored on its own, so a node that was down answered its own gap forever and a query hit whichever replica haproxy chose. Bare-metal tarball install (v0.42.4, verified against `sha256sums.txt`), systemd units running as `prometheus`, installed disabled and turned on by `hex_config` like everything else. `config_prometheus.cpp` writes `external_labels: replica: <hostname>`, the sidecar/querier defaults and `/etc/thanos/endpoints.yml`; the querier deduplicates on `replica`. Thanos is HA-only — `thanosEnabled = enabled && s_ha` — and haproxy routes `/prometheus` at the three queriers on HA
- **Stop `health_mysql_repair` causing the outage it was sent to fix.** Four defects, one shape. It fired on a galera cluster that was merely still forming, restarted mariadb on *every* control node to repair one, copied the whole datadir once per retry, and never pruned the copies. On accept-3cc that filled `/` twice — once taking every ceph mon down with ENOSPC for 8h, once blowing OpenSearch's 85% watermark and stalling log ingestion behind it
- **InfluxDB starts again past ~25G.** `influxd-systemd-start.sh` runs `influx_inspect buildtsi -compact-series-file` before every start — not once, every boot and every restart — and inherits `DefaultTimeoutStartSec=300s`. Past the ceiling the unit never starts again: `Type=forking` waits, `KillMode=control-group` kills the compaction at the deadline, `Restart=on-failure` restarts it from zero, and `health_influxdb_repair` kills it again. A drop-in raises the ceiling to 1800s (~120G)
- **Prometheus and Thanos get health coverage,** under a new `MetricsDb` service. Neither had any: `sdk_health.sh` contained no mention of either, so a dead Prometheus or a querier that had lost its peers was invisible to `cluster check` and to auto-repair
- **`cube_remote_cluster_check` compares a real hostname.** There is no `hostname()` in the sdk, so `remote_run $N "$HEX_SDK hostname"` returned 1081 lines of usage into the substitution and the comparison could never match — the moderator/edge remote-check path was dead. Reported by a peer session on 3.1.10

#### Which issue(s) this PR fixes

- Refs #672

#### Special notes for your reviewer

> **This PR stacks on `jim.lin/feat/replace-monasca` (#1428).** The base here is `develop`, so until that merges this PR's commit list also shows #1428's five commits. Only the thirteen below belong to this PR:
>
> - `fix(kafka): replicate topics across the control nodes, capped at three`
> - `feat(kafka): raise existing topics to the target replication factor`
> - `feat(thanos): package the thanos sidecar and querier`
> - `feat(prometheus): configure and run thanos on the control nodes`
> - `fix(haproxy): route /prometheus at the thanos queriers on HA`
> - `fix(health): bound the mysql datadir copy the repair takes`
> - `fix(health): only repair galera when a node is truly down, not merely absent`
> - `fix(health): restart only the mariadb nodes that need it, not the whole tier`
> - `fix(health): take the mysql datadir safety copy once per repair, not per attempt`
> - `fix(cluster): compare the real hostname in cube_remote_cluster_check`
> - `fix(influxdb): raise TimeoutStartSec past the per-start series rebuild`
> - `feat(health): check and repair prometheus and thanos`
> - `feat(cluster): add the MetricsDb service for prometheus and thanos`
>
> Review it after #1428, or diff against `jim.lin/feat/replace-monasca`.

**Why the four galera fixes are one story.** `health_mysql_check` is strict on purpose — `wsrep_cluster_size` equal to the control-node count, every node `Synced`, every unit active — and that strictness is what makes it the right gate for a roll to advance on (handbook `rolling-upgrade-no-galera-health-gate.md`, #651). So the check is deliberately **not** weakened here. The fix is in the repair: "the cluster is short a member" and "the cluster is broken" are different statements, and only the second is repairable. `_health_mysql_node_state` classifies each control node **reachability first** — asking galera whether a node is in the cluster means nothing on its own, because a node the network cannot reach was evicted *correctly*, and bootstrapping cannot bring it back, only destroy the cluster the survivors still have.

**Why this class of bug keeps recurring.** Four of the fixes here are the same failure mode: a repair fires at a system that is recovering normally, and the repair is what breaks it. Galera still forming; Synced members restarted to fix a peer; a datadir copied per attempt; a TSI rebuild killed mid-flight. The house precedent for the right answer already existed in `741f4093` (`pacemaker_settled()`, "the fix is to wait for quorum, not repair"). The three questions worth asking of any `health_*_repair`: can the check tell mid-recovery from failed, does the repair touch only the faulty member, and is its work bounded per invocation.

**Why the operator is never gated.** An earlier revision of this branch deferred essential-tier repair during a roll. That was backwards — `cluster_check_repair_essential` has no in-tree caller, so its only caller is a human typing the command, and the gate would only ever have blocked the person who asked for it. It was dropped. The roll is protected by `health_mysql_repair` itself declining to act on a joining node, which covers every caller.

**Thanos ports and prefixes are not uniform, and the checks had to measure rather than assume.** Prometheus derives `--web.route-prefix` from `--web.external-url`, so `:9091/-/healthy` is a 404 on a healthy server and `:9091/prometheus/-/healthy` is the live endpoint. Thanos keeps `/-/healthy` and `/-/ready` at the root even though the querier runs `--web.route-prefix=/prometheus` — only its API moves under the prefix, which is why haproxy's `option httpchk GET /-/ready` works and `:10904/api/v1/stores` is a 404 while `:10904/prometheus/api/v1/stores` is not.

**Two auto-repairs deliberately decline.** `prometheus` ERR 3 (up, scraping nothing) is a config or service-discovery problem a restart cannot fix, so repairing it would be a restart loop against a server answering fine. `thanos` ERR 4 (a peer's sidecar unreachable) is usually a node that is down; restarting the local querier does not bring a peer back, and during a roll it would restart a querier on every pass.

**Companion PRs, same `metricsDb` service:** bigstack-oss/cube-cos-openapi#111 (base), bigstack-oss/cube-cos-api#650, bigstack-oss/cube-cos-ui#867.

#### Additional documentation

Verified on `accept-3cc` (`cc1`/`cc2`/`cc3`, control-converged, HA) unless stated otherwise.

For the requirement "Kafka survives a control node going away",

```bash
[cc1 ~]# hex_sdk kafka_topic_rf_reconcile cc1:9095
[cc1 ~]# /opt/kafka/bin/kafka-topics.sh --bootstrap-server cc1:9095 --describe | grep -c "ReplicationFactor: 3"
111
[cc1 ~]# # one broker down, then two
[cc1 ~]# /opt/kafka/bin/kafka-topics.sh --bootstrap-server cc1:9095 --describe --unavailable-partitions | wc -l
0
[cc1 ~]# # partition balance across the three brokers
111 111 111
```

At RF 1 the same probe showed 2 leaderless partitions per topic with a single broker down. An auto-created topic lands at RF 3 with ISR `[2,1,0]`, and a rolling restart of all three brokers keeps unavailable partitions at 0 throughout.

For the requirement "queries reach more than one replica",

```bash
[cc3 ~]# systemctl stop prometheus          # 4 minutes
[cc3 ~]# # samples for the same series over the gap:
cc3 prometheus (raw)            9
cc3 thanos-query                16
via cc3 haproxy /prometheus     16
```

The querier fills its own node's hole from its peers, which is the whole point — before Thanos, cc3 answered 9 and there was no way to get 16 out of it.

For the requirement "a galera repair only fires when a node is truly down",

```bash
[cc1 ~]# # classifier across all four states
A. healthy            NO-OP   (cc1=synced cc2=synced cc3=synced)
B. mariadb stopped    REPAIR  -> cc3 truly down (cc1=synced cc2=synced cc3=down)
C. mid-rejoin         NO-OP   (cc1=synced cc2=synced cc3=joining)
D. unknown host       -> unreachable
```

**B is the control**: a genuinely dead mariadbd on a reachable node still repairs, so #155's stale-mariadbd case is preserved. C is the fix — during the rejoin the unit sits in `activating` and answers no query at all for the whole state transfer, which is the longest phase of joining and the only window the old code could not see.

For the requirement "a repair never takes the healthy members with it",

```bash
[cc1 ~]# # which nodes the repair would restart
all Synced            would restart: (none)   [cc3=synced cc2=synced cc1=synced]
cc3 mariadb stopped   would restart: cc3      [cc3=down   cc2=synced cc1=synced]
after rejoin          would restart: (none)   [cc3=synced cc2=synced cc1=synced]
[cc1 ~]# # cluster intact afterwards
cc1 size=3  cc2 size=3  cc3 size=3
```

And the datadir safety copy is now once per repair rather than once per attempt — 1 copy whether the repair succeeds on attempt 1 or 3, re-armed on the next call, and still skipped entirely on the live-primary rejoin path (#1328).

For the requirement "prometheus and thanos are checked and repaired",

```bash
[cc1 ~]# hex_sdk health_prometheus_check ; echo rc=$?
rc=0
[cc1 ~]# hex_sdk health_thanos_check ; echo rc=$?
rc=0
[cc1 ~]# hex_sdk health_errcode_lookup prometheus 3 ; hex_sdk health_errcode_lookup thanos 4
no scrape target up
querier missing a replica
[cc3 ~]# systemctl stop thanos-sidecar
[cc1 ~]# hex_sdk -v health_thanos_check ; echo rc=$?
thanos-sidecar on cc3 is not running
rc=1
[cc1 ~]# hex_sdk health_thanos_repair ; hex_sdk health_thanos_check ; echo rc=$?
rc=0
[cc3 ~]# systemctl stop prometheus
[cc1 ~]# hex_sdk -v health_prometheus_check ; echo rc=$?
prometheus on cc3 is not running
rc=1
[cc1 ~]# hex_sdk health_prometheus_repair ; hex_sdk health_prometheus_check ; echo rc=$?
rc=0
```

The endpoint behaviour the checks are built on, measured rather than assumed:

```bash
[cc1 ~]# for u in 9091/-/healthy 9091/prometheus/-/healthy 10902/-/ready 10904/-/ready ; do
>   printf "%-28s %s\n" $u "$(curl -s -o /dev/null -w '%{http_code}' http://cc1:$u)" ; done
9091/-/healthy               404
9091/prometheus/-/healthy    200
10902/-/ready                200
10904/-/ready                200
[cc1 ~]# curl -s http://cc1:10904/prometheus/api/v1/stores | jq -r '.data.sidecar[] | .name'
10.1.0.1:10901
10.1.0.2:10901
10.1.0.3:10901
```

For the requirement "the MetricsDb service is reported",

```bash
$ g++ -fsyntax-only -Wall -Werror -std=c++17 ... core/modules/cli_cluster.cpp   # rc=0
$ ./xm    # standalone X-macro expansion after the edit
TOP=29  S[Metrics]=Metrics  S[MetricsDb]=MetricsDb  S[Node]=Node
```

For the requirement "influxdb starts past the 300s ceiling" — verified on `cube4510`, not accept-3cc, because that is where the large datadirs are:

```bash
[cube451 ~]# systemctl show influxdb -p TimeoutStartUSec
TimeoutStartUSec=30min
[cube451 ~]# systemd-analyze verify influxdb.service     # clean
[cube451 ~]# # rebuild time by datadir size
21G  ->  3m26s   (cube451)
25G  ->  6m12s   (cube452)
```

cube452 had been restart-looping indefinitely after its 3.1.0 → 3.1.10 upgrade, taking Notifications and Metrics down with it; with the drop-in it completed in 6m12s and the bootstrap ran through to 83/83 modules committed.

For the requirement "the remote cluster check compares a real hostname",

```bash
[cc1 ~]# # old form vs fixed form, per node
cc1  old=[Usage: hex_sdk <option> <fun]  match=no   |  new=[cc1]  match=YES
cc2  old=[Usage: hex_sdk <option> <fun]  match=no   |  new=[cc2]  match=YES
cc3  old=[Usage: hex_sdk <option> <fun]  match=no   |  new=[cc3]  match=YES
[cc1 ~]# hex_sdk remote_run cc2 "hex_sdk hostname" | wc -lc
1081   23652
```

Audited every `$HEX_SDK <word>` invocation in the tree against the 1079 defined sdk function names; this was the only genuine miss. Note the usage listing goes to **stdout**, so inside `$( )` it is captured rather than printed — a control node returns at the `is_control_node` guard above it and shows nothing, which is why `cluster check` there stays at 28 clean lines.
