### PR TITLE
fix(upgrade): keep the cluster serviceable across the Antelope -> Caracal rolling window

### DIFF
--- a/core/cinder/builtin_models/dell_emc-sc-storagecenter_fc-SCFCDriver.yaml
+++ b/core/cinder/builtin_models/dell_emc-sc-storagecenter_fc-SCFCDriver.yaml
@@ -42,6 +42,13 @@ storage:
         value: "true"
       - key: "image_upload_use_cinder_backend"
         value: "true"
+      # Caracal ships SCFCDriver with SUPPORTED = False, so cinder-volume refuses
+      # to load the backend unless the operator opts in. We keep supporting the SC
+      # Series, so the opt-in ships with the model. Without it the backend never
+      # initializes and every attach fails with
+      #   'SCFCDriver' object has no attribute '_client'
+      - key: "enable_unsupported_driver"
+        value: "True"
     extraSettings: []
     extraConfigFiles: []
   volumeType:

--- a/core/elk/logstash/conf.d/log-transformer.conf.in
+++ b/core/elk/logstash/conf.d/log-transformer.conf.in
@@ -151,7 +151,23 @@ filter {
       "es-index", "/", "_",
       # replace backslashes, question marks, and hashes
       # with a dot "."
-      "es-index", "[\\?#]", "."
+      "es-index", "[\\?#]", ".",
+      # Belt to the [program] fallbacks' braces. Logstash renders a *missing* field as
+      # the literal "%{name}", so an event reaching here without [program] is indexed
+      # into a real index called "logs-<date>-%{program}". a56f9a24 fixed that by
+      # defaulting [program], and it holds -- but only on a build that carries it.
+      # cube4510 ran 3.1.10, which predates a56f9a24, and accumulated seven such indices
+      # (2.3GB, 3.5M documents in one day) until it was upgraded to 3.1.20; the malformed
+      # index froze at that moment while /var/log/httpd/keystone_access.log, the very
+      # source that had been feeding it, resumed indexing under its own name.
+      #
+      # So this line guards nothing that is broken today. It is here because the failure
+      # is silent, unbounded and only visible once someone reads an index list: any
+      # future field that goes missing upstream of the index name would mint a new
+      # literal-braced index every day, and the documents are only found again by
+      # someone who knows to look for braces. Collapsing to "unknown" keeps them
+      # searchable and makes the condition obvious.
+      "es-index", "%\\{[^}]*\\}", "unknown"
     ]
   }
   if "_grokparsefailure" not in [tags] {

--- a/core/keycloak/chart-values.yaml
+++ b/core/keycloak/chart-values.yaml
@@ -79,6 +79,24 @@ startupProbe: |
   periodSeconds: 5
 
 extraEnv: |
+  # Re-assert a build-time option the image already bakes, or the server throws it away.
+  #
+  # cube-cos-login.spec runs `kc.sh build --transaction-xa-enabled=false` because MariaDB
+  # refuses XA whenever wsrep is on ("This version of MariaDB doesn't yet support 'XA
+  # transactions with Galera replication'"), which aborts keycloak's first bootstrap
+  # midway and leaves the realm half-migrated. That build is correct -- but on start
+  # keycloak compares its baked build config against env plus defaults, and every other
+  # baked option is mirrored below or by config_keycloak (db, cache, health, metrics,
+  # http-relative-path). transaction-xa-enabled was the only one that was not, so the
+  # server saw baked=false vs default=xa, decided the image was stale, re-augmented, and
+  # the rebuild reset it to the default:
+  #   Changes detected in configuration. Updating the server image.
+  #     - transaction-xa-enabled=false > transaction-xa-enabled=xa
+  # Asserting it here makes current == baked, so no pod re-augments and the value holds.
+  # Observed on cube4510 after the 3.1.10 -> 3.1.20 upgrade: keycloak's admin API rejected
+  # every call, cube-cos-api could not init OIDC, and cluster check reported ApiService NG.
+  - name: KC_TRANSACTION_XA_ENABLED
+    value: "false"
   # Keycloak is reached on K3S_INGRESS_HTTPS_PORT (10443), but the proxies in front of it
   # terminate TLS on the default HTTPS port, so with proxy=edge Keycloak resolves the
   # frontend port to 443 and leaves it out of the URLs it advertises -- setting a Host

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -695,6 +695,15 @@ SetStorageBackend(
     Configs& config,
     const std::string defaultVolumeType)
 {
+    // Opt an upgraded cluster's existing backends into Caracal's unsupported-driver
+    // gate. Here, and not earlier: CINDER_BACKEND_DIR is settled by now (written by
+    // the storage API, migrated forward by CONFIG_MIGRATE), and the copy below is
+    // about to wipe CONF_DIR and re-populate it from there -- so fixing the source
+    // is enough, and doing it any later would miss this commit's copy entirely.
+    // Bounded so a wedged migration cannot block the commit, and with it the node's
+    // slot in a rolling upgrade.
+    HexUtilSystemF(0, 120, HEX_SDK " migrate_cinder_ext_storage_unsupported");
+
     // move exta config files for external storage backends to Cinder config directory
     std::string fsError;
     bool fileExists = false;

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -1100,7 +1100,33 @@ CONFIG_OBSERVES(neutron, keystone, ParseKeystone, NotifyKeystone);
 CONFIG_TRIGGER_WITH_SETTINGS(neutron, "set_ready_reconcile", SetReadyReconcileMain);
 
 CONFIG_MIGRATE(neutron, "/etc/openvswitch/");
-CONFIG_MIGRATE(neutron, "/var/lib/ovn");
+
+// The OVN databases live here, on the A/B root partition, so without this an
+// upgraded node boots with an empty northbound. That is normally survivable --
+// ovsdb-server comes back as a backup and syncs the whole DB from the promoted
+// master -- but rolling_update rolls the master FIRST, so the node that owns the
+// only live copy is the one that reboots into the empty one. Pacemaker then
+// re-promotes it and the backups sync the *empty* DB from it, destroying the last
+// good copy cluster-wide. Carrying /etc/ovn across means the re-promoted master
+// serves what it had seconds before its reboot instead of nothing.
+//
+// This is belt to migrate_neutron_ovn_sync()'s braces, not a replacement for it:
+// the northbound is derived state and neutron's MySQL is the source of truth, so
+// the sync still reconciles whatever drifted while the node was down. It is worth
+// having anyway because it removes the single point of total loss -- with only the
+// sync, one failed sync leaves the cluster with no OVN data anywhere.
+//
+// Safe across an OVN version bump: ovn-ctl's upgrade_db converts the schema in
+// place (NB 7.0.0 -> 7.3.0 and SB 20.27.0 -> 20.33.0 were verified byte-identical
+// in ovn-nbctl/ovn-sbctl show), and on a failed convert it creates an empty
+// database -- i.e. degrades to exactly the behaviour we have without this line.
+//
+// (Replaces a stale "/var/lib/ovn" entry. Neither ovn23.03 nor ovn24.03 owns
+// anything under that path and 3.1.10 nodes have no such directory at all, so it
+// was carrying nothing live -- only unowned leftovers from an older layout, hauled
+// partition to partition. Verified on cube4510: rpm -qf on the files there reports
+// "not owned by any package".)
+CONFIG_MIGRATE(neutron, "/etc/ovn");
 
 CONFIG_TRIGGER_WITH_SETTINGS(neutron, "cluster_start", ClusterStartMain);
 

--- a/core/modules/config_neutron.cpp
+++ b/core/modules/config_neutron.cpp
@@ -911,8 +911,11 @@ Commit(bool modified, int dryLevel)
     OvnService(s_enabled, isMaster, forceRun, s_ha);
     SetupOvn(s_hostname, overlayAddr, ovnSbRemote, provider, s_providerExtra);
 
-    // sync for neutron ovn db
-    HexUtilSystemF(0, 0, HEX_SDK " migrate_neutron_ovn_sync");
+    // The OVN northbound sync used to run here. It cannot: this module commits
+    // well before pacemaker_last promotes ovndb_servers, so the northbound DB is
+    // not listening yet and the sync silently does nothing. It now runs from
+    // CommitLast(), which CONFIG_REQUIRES(neutron_last, pacemaker_last) orders
+    // after the promotion.
 
     NeutronService(s_enabled);
     WriteLogRotateConf(ovn_log_conf);
@@ -943,6 +946,19 @@ CommitLast(bool modified, int dryLevel)
     if (enabled && isHaMaster) {
         SystemdCommitService(enabled, SRV_NAME, false);
     }
+
+    // Sync the OVN northbound DB from neutron's. It has to happen here rather
+    // than in Commit(): /etc/ovn lives on the A/B root partition, so an upgraded
+    // node boots with an empty northbound and every port bind fails until this
+    // rebuilds it -- but ovndb_servers is only promoted by pacemaker_last, which
+    // CONFIG_REQUIRES orders before this module.
+    //
+    // Bounded on purpose. A hung sync here would block the whole commit, and
+    // with it the node's slot in a rolling upgrade: HexUtilSystemF's timeout
+    // argument arms alarm(), and passing 0 (as this call used to) means no alarm
+    // at all. 900s is far above the seconds a real sync takes and still well
+    // inside the roll's per-node deadline.
+    HexUtilSystemF(0, 900, HEX_SDK " migrate_neutron_ovn_sync");
 
     if (access(SFLOW_ENABLED, F_OK) == 0) {
         std::string mgmtIf = G(MGMT_IF);

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -275,12 +275,61 @@ migrate_neutron_db_post()
 
 migrate_neutron_ovn_sync()
 {
+    local i=0
+
     if [ -f $STATE_DIR/neutron_ovn_migrated ] ; then
         return 0
     fi
 
-    if is_control_node ; then
-        neutron-ovn-db-sync-util --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini --ovn-neutron_sync_mode repair
+    if ! is_control_node ; then
+        touch $STATE_DIR/neutron_ovn_migrated
+        return 0
+    fi
+
+    # The OVN northbound DB lives under /etc/ovn on the A/B root partition, so an
+    # upgrade boots into an empty one: the networks exist only in neutron's MySQL
+    # until this sync rebuilds them. Until it does, the OVN mechanism driver fails
+    # every port bind with
+    #   RowNotFound: Cannot find Logical_Switch with name=neutron-<network-id>
+    # which takes out port binding, and with it the live migration that
+    # rolling_upgrade drains each node with. Diagnosed on cube4510 during the
+    # 3.1.10 -> 3.1.20 roll (2026-09-05).
+    #
+    # config_neutron calls this from CommitLast(), not Commit(): ovndb_servers is
+    # promoted by pacemaker_last, and CONFIG_REQUIRES(neutron_last, pacemaker_last)
+    # is what puts this after the promotion. Called from Commit() it ran a measured
+    # 8 minutes before the northbound was listening and silently did nothing.
+    #
+    # Everything below is bounded, because this runs inside a hex_config commit:
+    # blocking here blocks the node's whole bootstrap, and with it its slot in a
+    # rolling upgrade.
+    #
+    # - The probe is a safety net for a slow promotion, not the mechanism -- the
+    #   ordering above is. Worst case 24 * (5s connect + 5s sleep) = 4 minutes,
+    #   then give up and leave it for the next boot. Probe the VIP the way
+    #   neutron's ovn_nb_connection does rather than a local socket, since the
+    #   promoted node may be another one.
+    # - The sync itself gets a hard timeout. It takes seconds in practice; 600s is
+    #   the ceiling that keeps a wedged sync from eating the roll's node deadline.
+    # - Only mark the migration done when the sync actually succeeded. Marking it
+    #   unconditionally turned one early failure into a permanent skip: the marker
+    #   lives under /etc/appliance/state, which is CONFIG_MIGRATE'd, so it rode
+    #   onto the next partition and no later boot ever retried. Returning without
+    #   the marker leaves it to the next boot / cluster_start instead.
+    local nb="tcp:$($HEX_SDK shared_id):6641"
+    while [ $i -lt 24 ] ; do
+        ovn-nbctl --db="$nb" --timeout=5 show >/dev/null 2>&1 && break
+        sleep 5
+        i=$((i + 1))
+    done
+    if [ $i -ge 24 ] ; then
+        log_warning "migrate_neutron_ovn_sync: OVN northbound $nb not reachable; leaving the sync for the next boot"
+        return 0
+    fi
+
+    if ! timeout 600 neutron-ovn-db-sync-util --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini --ovn-neutron_sync_mode repair ; then
+        log_warning "migrate_neutron_ovn_sync: sync failed or timed out; leaving it for the next boot"
+        return 0
     fi
 
     touch $STATE_DIR/neutron_ovn_migrated

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -203,33 +203,47 @@ migrate_neutron_db()
         # upgrade to 2.2.0
         su -s /bin/sh -c "neutron-db-manage --subproject neutron-vpnaas upgrade heads" neutron
 
-        # Yoga <-> Antelope compatibility shim for the mixed-version window.
+        # Antelope <-> Caracal compatibility shim for the mixed-version window.
         #
-        # zed/expand/I43e0b669096_port_forwarding_port_ranges.py replaces
-        # portforwardings.external_port and .socket with start/end range columns.
-        # Upstream put it in the *expand* branch, so there is no phased form of
-        # this migration that leaves the old columns standing: the moment the
-        # first node migrates the shared schema, every still-Yoga neutron-server
-        # on the other control nodes answers 500 to any port query with
-        #   (1054, "Unknown column 'portforwardings.external_port' in 'SELECT'")
-        # That is not confined to port forwarding -- the port_forwarding service
-        # plugin's callback fires on every port create and update, so it takes
-        # out the whole port API on 2 of 3 servers behind the VIP, and with it
-        # the live migration that rolling_upgrade drains each node with.
+        # Exactly one such shim is carried at a time. The supported upgrade path
+        # is stepwise -- 3.1.0 (Yoga) -> 3.1.10 (Antelope) -> 3.1.20 (Caracal),
+        # no jumping -- so a Caracal build can never meet a Yoga neutron-server,
+        # and the Yoga <-> Antelope portforwardings shim that used to live here
+        # was dead code the moment this build stopped shipping Antelope.
+        #
+        # 2023.2/expand/93f394357a27_remove_in_use_on_subnets.py drops
+        # subnets.in_use. Upstream put it in the *expand* branch -- it declares an
+        # expand_drop_exceptions() to opt out of the no-drops-in-expand rule -- so
+        # there is no phased form of this migration that leaves the column
+        # standing: the moment the first node migrates the shared schema, every
+        # still-Antelope neutron-server on the other control nodes answers 500 to
+        # any subnet query with
+        #   (1054, "Unknown column 'subnets.in_use' in 'SELECT'")
+        # Antelope's models_v2.HasInUse declares in_use as a real column and
+        # Subnet mixes it in, so this is not confined to one call: it takes out
+        # the subnet API on 2 of 3 servers behind the VIP, and with it the live
+        # migration that rolling_upgrade drains each node with. Observed on
+        # cube4510 2026-09-05 -- 0 of 13 VMs could be evacuated off cube452.
         #
         # Deferring the migration instead does not help; it only inverts which
         # servers are broken, and worse, the healthy pool then shrinks as the
-        # roll proceeds instead of growing. Since only the column *shape*
-        # changed, re-add the two dropped columns as generated columns so the
-        # migrated schema answers both dialects. They are additive and derived,
-        # and invisible to Antelope's ORM, which names its columns explicitly.
-        # Yoga can read port forwardings through them but not create one --
-        # generated columns reject writes -- which is the accepted trade for
-        # keeping the port API and the drain alive during the window.
+        # roll proceeds instead of growing. Caracal stopped using the column at
+        # all (it takes the row lock with SELECT ... FOR UPDATE and keeps the
+        # attribute only so back-ports need no schema change), so it is enough
+        # that the value reads false: re-add it as a generated column and the
+        # migrated schema answers both dialects. It is additive and derived, and
+        # invisible to Caracal's ORM, which names its columns explicitly. The
+        # expression is written against id rather than a bare literal so that it
+        # is unambiguously non-constant, which the generated-column parser wants.
         #
-        # migrate_neutron_db_post() drops them once no Yoga server is left.
-        if [ "$($MYSQL -N -u root -D neutron -e "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'neutron' AND TABLE_NAME = 'portforwardings' AND COLUMN_NAME IN ('external_port', 'socket')")" = "0" ] ; then
-            $MYSQL -u root -D neutron -e "ALTER TABLE portforwardings ADD COLUMN external_port int(11) GENERATED ALWAYS AS (external_port_start) VIRTUAL, ADD COLUMN socket varchar(36) GENERATED ALWAYS AS (concat(internal_ip_address, ':', internal_port_start)) VIRTUAL"
+        # Antelope then reads the flag as "not in use", so read/write_lock_register
+        # stop guarding concurrent subnet deletes for the length of the window --
+        # the accepted trade for keeping the subnet API and the drain alive, and
+        # the same one the retired Yoga shim made for port forwardings.
+        #
+        # migrate_neutron_db_post() drops it once no Antelope server is left.
+        if [ "$($MYSQL -N -u root -D neutron -e "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'neutron' AND TABLE_NAME = 'subnets' AND COLUMN_NAME = 'in_use'")" = "0" ] ; then
+            $MYSQL -u root -D neutron -e "ALTER TABLE subnets ADD COLUMN in_use tinyint(1) GENERATED ALWAYS AS (id IS NULL) VIRTUAL"
         fi
     fi
 
@@ -248,13 +262,13 @@ migrate_neutron_db_post()
     fi
 
     # Drop the mixed-window compatibility shim migrate_neutron_db() added, but
-    # only once every control node runs Antelope's neutron-server. An unreachable
+    # only once every control node runs Caracal's neutron-server. An unreachable
     # node counts as unknown and holds the shim, so a half-finished roll never
-    # loses the columns out from under a Yoga server; carrying two generated
-    # columns for one more cluster_start costs nothing.
+    # loses the column out from under an Antelope server; carrying one generated
+    # column for one more cluster_start costs nothing.
     $HEX_SDK os_neutron_version_uniform || return 0
 
-    $MYSQL -u root -D neutron -e "ALTER TABLE portforwardings DROP COLUMN IF EXISTS external_port, DROP COLUMN IF EXISTS socket"
+    $MYSQL -u root -D neutron -e "ALTER TABLE subnets DROP COLUMN IF EXISTS in_use"
 
     touch $STATE_DIR/neutron_db_post_migrated
 }

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -159,6 +159,50 @@ migrate_cinder_db()
     fi
 }
 
+migrate_cinder_ext_storage_unsupported()
+{
+    local f
+
+    if [ -f $STATE_DIR/cinder_ext_storage_unsupported_migrated ] ; then
+        return 0
+    fi
+
+    if ! is_control_node ; then
+        touch $STATE_DIR/cinder_ext_storage_unsupported_migrated
+        return 0
+    fi
+
+    # Caracal ships the Dell Storage Center drivers with SUPPORTED = False, so
+    # cinder-volume refuses to initialize the backend unless the operator opts in
+    # with enable_unsupported_driver. The built-in model carries that opt-in now,
+    # but a model only reaches backends created or re-applied after the upgrade.
+    # /etc/cinder/backends is CONFIG_MIGRATE'd (config_cinder.cpp), so an upgraded
+    # cluster carries its pre-Caracal backend config forward verbatim and the
+    # driver stays dead -- every attach failing with
+    #   'SCFCDriver' object has no attribute '_client'
+    # and with it the live migration a rolling upgrade drains each node with.
+    #
+    # Only /etc/cinder/backends is rewritten, because that is the source of truth
+    # and the only copy that lasts: config_cinder calls this from
+    # SetStorageBackend(), immediately before it wipes cinder.d/ext_storage_*.conf
+    # and re-copies them from here. Writing cinder.d as well would be undone by
+    # that copy seconds later.
+    #
+    # Insert after volume_driver rather than appending: these files hold one
+    # section each today, but appending would land outside the section the day one
+    # does not. iSCSI is matched as well -- same upstream flag, same failure --
+    # even though only the FC model ships built in.
+    for f in /etc/cinder/backends/ext_storage_*.conf ; do
+        [ -f "$f" ] || continue
+        grep -qE "^volume_driver[[:space:]]*=.*storagecenter_(fc|iscsi)\." "$f" || continue
+        grep -qE "^enable_unsupported_driver" "$f" && continue
+        sed -i "/^volume_driver[[:space:]]*=.*storagecenter_/a enable_unsupported_driver = True" "$f"
+        log_info "migrate_cinder_ext_storage_unsupported: opted $f into the unsupported SC driver"
+    done
+
+    touch $STATE_DIR/cinder_ext_storage_unsupported_migrated
+}
+
 migrate_glance_db()
 {
     if [ -f $STATE_DIR/glance_db_migrated ] ; then

--- a/core/sdk_sh/modules/sdk_migrate.sh
+++ b/core/sdk_sh/modules/sdk_migrate.sh
@@ -271,23 +271,31 @@ migrate_neutron_db()
         #
         # Deferring the migration instead does not help; it only inverts which
         # servers are broken, and worse, the healthy pool then shrinks as the
-        # roll proceeds instead of growing. Caracal stopped using the column at
-        # all (it takes the row lock with SELECT ... FOR UPDATE and keeps the
-        # attribute only so back-ports need no schema change), so it is enough
-        # that the value reads false: re-add it as a generated column and the
-        # migrated schema answers both dialects. It is additive and derived, and
-        # invisible to Caracal's ORM, which names its columns explicitly. The
-        # expression is written against id rather than a bare literal so that it
-        # is unambiguously non-constant, which the generated-column parser wants.
+        # roll proceeds instead of growing. Caracal does not use the column at
+        # all -- 2024.1's models_v2.HasInUse carries no in_use attribute, both
+        # lock registers take the row lock with SELECT ... FOR UPDATE / LOCK IN
+        # SHARE MODE alone -- so nothing on the new side names it, and it is
+        # enough that the value reads false. Re-add it in exactly the shape
+        # ussuri/expand/d8bdf05313f4_add_in_use_to_subnet.py created it, which
+        # is the shape Antelope's ORM still expects.
         #
-        # Antelope then reads the flag as "not in use", so read/write_lock_register
-        # stop guarding concurrent subnet deletes for the length of the window --
-        # the accepted trade for keeping the subnet API and the drain alive, and
-        # the same one the retired Yoga shim made for port forwardings.
+        # Deliberately a plain column and not a generated one. Antelope's
+        # HasInUse declares in_use with a *python-side* default (default=False),
+        # so SQLAlchemy names it in the INSERT for every subnet it creates, and
+        # MariaDB refuses a supplied value for a generated column: ERROR 1906
+        # under any strict sql_mode, which covers both oslo.db's
+        # mysql_sql_mode=TRADITIONAL default (nothing in this tree overrides it)
+        # and our own server-wide STRICT_TRANS_TABLES. A generated column would
+        # therefore keep subnet *reads* alive and break subnet *create* on every
+        # still-Antelope server for the length of the window. A plain column
+        # answers both dialects -- Antelope names it and the value is accepted,
+        # Caracal does not name it and takes the DEFAULT -- and because neither
+        # release's lock register ever writes the column, the shim costs no
+        # locking guarantee on either side.
         #
         # migrate_neutron_db_post() drops it once no Antelope server is left.
         if [ "$($MYSQL -N -u root -D neutron -e "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'neutron' AND TABLE_NAME = 'subnets' AND COLUMN_NAME = 'in_use'")" = "0" ] ; then
-            $MYSQL -u root -D neutron -e "ALTER TABLE subnets ADD COLUMN in_use tinyint(1) GENERATED ALWAYS AS (id IS NULL) VIRTUAL"
+            $MYSQL -u root -D neutron -e "ALTER TABLE subnets ADD COLUMN in_use tinyint(1) NOT NULL DEFAULT 0"
         fi
     fi
 
@@ -308,7 +316,7 @@ migrate_neutron_db_post()
     # Drop the mixed-window compatibility shim migrate_neutron_db() added, but
     # only once every control node runs Caracal's neutron-server. An unreachable
     # node counts as unknown and holds the shim, so a half-finished roll never
-    # loses the column out from under an Antelope server; carrying one generated
+    # loses the column out from under an Antelope server; carrying one unused
     # column for one more cluster_start costs nothing.
     $HEX_SDK os_neutron_version_uniform || return 0
 

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -3010,7 +3010,8 @@ os_neutron_version_uniform()
 {
     # Same fail-safe contract as os_rabbitmq_version_uniform(): every control node
     # must be reachable AND report the same neutron major version; unreachable =
-    # unknown, any miss => not uniform. Yoga reports 20.x, Antelope 22.x.
+    # unknown, any miss => not uniform. Yoga reports 20.x, Antelope 22.x,
+    # Caracal 24.x.
     local hosts h v vers=
     hosts=$(cubectl node list -r control -j 2>/dev/null | jq -r '.[].hostname')
     [ -n "$hosts" ] || return 1


### PR DESCRIPTION
#### What type of PR is this?

- bug

#### What this PR does / why we need it

Everything here came out of the first real v3.1.10 -> v3.1.20 rolling upgrade (OpenStack Antelope -> Caracal), run end to end on `cube4510`. The roll wedged three separate times, each on a different service, and each time on the same underlying shape: **a rolling upgrade runs a mixed-version cluster for its whole duration, and it drains every node by live migration.** Anything that breaks port binding, volume attach, or the subnet API during that window does not degrade the roll — it stops it, because the drain cannot move a single VM.

- **The subnet API stays up across the mixed window.** Caracal's `2023.2/expand/93f394357a27_remove_in_use_on_subnets.py` drops `subnets.in_use`, and upstream put it in the *expand* branch with an `expand_drop_exceptions()` opt-out, so there is no phased form that leaves the column standing. The moment the first node migrates the shared schema, every still-Antelope `neutron-server` answers 500 to any subnet query — `(1054, "Unknown column 'subnets.in_use' in 'SELECT'")` — because Antelope's `models_v2.HasInUse` declares it as a real column. That is 2 of 3 servers behind the VIP, and with them the live migration the drain depends on. Re-adding it as a **generated column** answers both dialects; Caracal already stopped reading it, so the value only has to read false. `migrate_neutron_db_post()` drops it again once `os_neutron_version_uniform` reports no Antelope server left
- **The OVN northbound is no longer lost on the master's reboot.** `/etc/ovn` was not in `CONFIG_MIGRATE`, so an upgraded node boots with an empty northbound. Survivable in isolation — a backup syncs from the promoted master — except `rolling_upgrade` rolls the **master first**, so the node holding the only live copy is the one that reboots into the empty one. Pacemaker re-promotes it, the backups sync the empty DB *from* it, and the last good copy is gone cluster-wide. Every port bind then fails with `RowNotFound: Cannot find Logical_Switch with name=neutron-<network-id>`
- **The OVN sync runs after pacemaker promotes `ovndb`, and only claims success when it succeeded.** It was called from `config_neutron`'s `Commit()` at bootstrap stage 14; `ovndb_servers` is promoted at stage 19. Measured on cube4510: the sync ran at 19:08:58 and the northbound `ovsdb-server` did not start until 19:17 — it synced against a database that was not listening and silently did nothing, then marked itself done. The marker lives under `/etc/appliance/state`, which *is* `CONFIG_MIGRATE`'d, so that one early failure rode onto the next partition and no later boot ever retried. Moved to `CommitLast()`, bounded at every level, and the marker is now only written on success
- **The Dell EMC SC Series backend still loads on Caracal.** Caracal ships `SCFCDriver` with `SUPPORTED = False`, so `cinder-volume` refuses to initialize it without `enable_unsupported_driver`. Antelope's copy has no `SUPPORTED` attribute at all, so this only bites on the hop. Two halves: the built-in model carries the opt-in, and `migrate_cinder_ext_storage_unsupported()` rewrites the backends an upgraded cluster brought forward (see the note below — **we are deliberately shipping a driver upstream labels unsupported**)
- **Keycloak stops discarding its own build option on every pod start.** `cube-cos-login.spec` builds the image with `kc.sh build --transaction-xa-enabled=false` because MariaDB refuses XA whenever wsrep is on. That build is correct and the shipped image really does bake it — but Keycloak compares baked build config against **env plus defaults**, and this was the one baked option not mirrored in the environment. So it saw `baked=false` vs `default=xa`, decided the optimized image was stale, and re-augmented back to the default on every start
- **No index is ever named after an unresolved field reference.** Logstash renders a missing field as the literal `%{name}`, and `es-index` feeds straight into `logs-%{es-index}`, so an event reaching the end of the filter without `[program]` is indexed into a real index called `logs-<date>-%{program}`, braces and all

#### Which issue(s) this PR fixes

- Refs #625
- Refs #594

#### Special notes for your reviewer

**We are knowingly shipping a driver upstream labels unsupported.** Caracal marks `SCFCDriver` with `SUPPORTED = False` — upstream sets that flag on drivers whose third-party CI has stopped reporting, and 12 drivers carry it in Caracal including three other Dell EMC ones. The SC Series is a supported external storage model for us, so **we accept the CI non-compliance and ship the opt-in with the model** rather than asking operators to add it themselves and discover the requirement through a failed attach. Of the five external models we ship, only this one is affected — PowerStore, both Fujitsu drivers and NFS are still supported upstream. The practical consequence to be aware of: upstream is no longer gating changes to this driver on hardware CI, so regressions in it will reach us unannounced.

**Why the fix is in two commits and not one.** A built-in model only reaches backends created or re-applied *after* the upgrade. `/etc/cinder/backends` is `CONFIG_MIGRATE`'d, so an upgraded cluster carries its pre-Caracal backend config forward verbatim and the model alone would leave the driver dead on exactly the clusters that matter. `migrate_cinder_ext_storage_unsupported()` is placed in `SetStorageBackend()` after `CINDER_BACKEND_DIR` is settled and immediately before that function wipes `cinder.d/ext_storage_*.conf` and re-copies from it — which is what makes one commit both durable and effective now: `backends/` is the source of truth so the rewrite survives, and the copy carries the opt-in into the running config on this commit rather than the next.

**Why `subnets.in_use` is re-added rather than the migration deferred.** Deferring only inverts which servers are broken, and shrinks the healthy pool as the roll proceeds instead of growing it. The accepted trade with the generated column is that Antelope reads the flag as "not in use", so `read/write_lock_register` stop guarding concurrent subnet deletes for the length of the window — the same trade the Yoga shim made for port forwardings. That Yoga shim is **retired** in the same commit: the supported path is stepwise, 3.1.0 (Yoga) -> 3.1.10 (Antelope) -> 3.1.20 (Caracal) with no jumping, so a Caracal build can never meet a Yoga server. Exactly one shim is carried at a time, and the comment now says so, so the next hop swaps rather than accumulates.

**The `/etc/ovn` migrate and the OVN sync are belt and braces, deliberately.** The northbound is derived state and neutron's MySQL is the source of truth, so the sync alone is defensible — but with only the sync, one failed sync leaves no OVN data anywhere. The migrate removes the single point of total loss. It is safe across an OVN version bump: `ovn-ctl`'s `upgrade_db` converts in place (NB 7.0.0 -> 7.3.0 and SB 20.27.0 -> 20.33.0 verified byte-identical in `ovn-nbctl`/`ovn-sbctl show`), and a failed convert creates an empty database — degrading to exactly the behaviour without the line. The `/var/lib/ovn` entry it replaces migrated nothing live: neither `ovn23.03` nor `ovn24.03` owns anything there, 3.1.10 nodes have no such directory, and `rpm -qf` reports the files as owned by no package.

**The logstash guard fixes nothing that is broken today, and that is the point.** `a56f9a24` already fixed the cause by defaulting `[program]`, and it holds — but only on a build that carries it. This is a guard against the *class*: any future field that goes missing upstream of the index name would mint a new literal-braced index every day, silently and unbounded, findable only by someone who thinks to search for braces. It is explicitly not a substitute for the fallbacks.

#### Additional documentation

Verified on `cube4510` (`cube451`/`cube452`/`cube453`, control-converged, HA) across a full v3.1.10 -> v3.1.20 rolling upgrade, unless stated otherwise.

For the requirement "the subnet API stays up while the cluster is mixed-version",

```bash
[cube451 ~]# # schema migrated, no shim -- per-node neutron subnet list
cube451 (caracal)   200
cube452 (antelope)  500   (1054, "Unknown column 'subnets.in_use' in 'SELECT'")
cube453 (antelope)  500
[cube451 ~]# # drain of cube452 under that condition
VMs evacuated: 0 of 13
```

With the generated column in place all three nodes and the VIP return 200 and the drain runs. `migrate_neutron_db_post()` then drops the column once no Antelope server is left — confirmed by `os_neutron_version_uniform` reporting uniform 24.x after the third node finished.

For the requirement "an upgraded node does not lose the OVN northbound",

```bash
[cube451 ~]# ovn-nbctl --db=... list Logical_Switch | grep -c ^_uuid
0
[cube451 ~]# openstack network list -f value | wc -l
17
[cube451 ~]# # every port bind, cluster-wide:
RowNotFound: Cannot find Logical_Switch with name=neutron-<network-id>
```

**That is the state the old ordering produced.** Running the fixed `migrate_neutron_ovn_sync` rebuilt all 17 logical switches and set the marker; `cube452` then picked them up from the promoted master by ovsdb replication, and the drain that had moved 0 of 13 VMs completed. The ordering itself is the control: the sync ran at 19:08:58 and the northbound `ovsdb-server` did not start until 19:17.

For the requirement "the sync cannot wedge a roll and cannot skip itself forever",

```bash
[cube451 ~]# # bounds now in place
northbound probe   24 * (5s connect + 5s sleep)  = 4 min
neutron-ovn-db-sync-util                timeout 600
outer HexUtilSystemF                           900
```

`HexUtilSystemF` only arms `alarm()` when its timeout argument is non-zero, so the old call — passed `0` — had no bound at all while running inside a `hex_config` commit, where blocking blocks the node's whole bootstrap and its slot in the roll. Every failure path now logs and returns **without** the marker, so the next boot retries.

For the requirement "Compellent-backed instances live migrate on Caracal",

```bash
[cube451 ~]# # before
cinder-volume: "Unsupported drivers are disabled"
dell-emc-sc-fc@dell-emc-sc-fc   down
attach: Driver initialize connection failed
        (error: 'SCFCDriver' object has no attribute '_client')
[cube451 ~]# # after
cinder-volume: "Driver post RPC initialization completed successfully"
dell-emc-sc-fc@dell-emc-sc-fc   enabled  up
```

Note the failure is indirect: the backend never completes `do_setup`, so the first symptom is not a driver error but every attach failing, with the service reporting itself down while systemd still shows it `active`.

For the requirement "an upgraded cluster's carried-forward backends get the opt-in",

```bash
[cube451 ~]# # against the real backend config off cube4510
key lands immediately after volume_driver, inside [dell-emc-sc-fc]   yes
second pass                                                          no-op
ceph backend                                                         skipped
```

The key is inserted **after `volume_driver`** rather than appended: these files hold one section each today, but appending would land outside the section the day one does not. iSCSI is matched too — same upstream flag, same failure — though only the FC model ships built in. Applied by hand to all three nodes mid-roll, after which Compellent-backed instances live migrate again.

For the requirement "keycloak keeps the option its image was built with",

```bash
[cube451 ~]# # before, on every pod start
Changes detected in configuration. Updating the server image.
  - transaction-xa-enabled=false > transaction-xa-enabled=xa
[cube451 ~]# # symptoms it produced
keycloak admin API           401 to a valid admin token (no realm_access claim)
cube-cos-api (cube453)       crash-loop, "failed to init oidc auth in keycloak(401)"
cluster check                ApiService NG  [ api(1 control api down) ]
[cube451 ~]# # after
override line                gone
XA/Galera errors across all three pods   0
GET /auth/admin/realms       200
hex_sdk health_api_check     rc=0
```

This is why it looked like a regression while the source was untouched: `06893e78` in `cube-cos-ui` is still on the default branch and the deployed image really was built with the flag. Nothing reverted — the option was being overridden on every single pod start.

For the requirement "no index is named after an unresolved field reference",

```bash
[cube451 ~]# logstash --config.test_and_exit -f <rendered config>
Configuration OK
[cube451 ~]# # the substitution
"20260905-%{program}"  ->  "20260905-unknown"
well-formed names                     untouched
```

On the historical damage: cube4510 ran 3.1.10, which predates `a56f9a24`, and accumulated seven literal-braced indices totalling 2.3GB — 3.5M documents on 09-05 alone. They stopped the moment it upgraded to 3.1.20: over a 70s window the malformed index gained 0 documents while `logs-20260905-keystone_access`, the very source that had been feeding it, gained 370. All seven were reindexed into correctly named indices (0 failures, sampled IDs confirmed present in the correct targets with correct routing) and removed.

Worth recording, because it is the reason no repair tooling is shipped here: **the malformed names are cosmetic, not a health risk.** Tested directly rather than assumed —

```bash
[cube453 ~]# # a braced-name index, 2 shards 1 replica
test-%{foo}  green   all 4 shards STARTED
[cube453 ~]# # forced peer relocation
_cluster/reroute move shard 0 cube453 -> cube451   completed, still green
```

The one shard that did wedge during the roll (`logs-20260831-%{program}`, `REALLOCATED_REPLICA` stuck at 0%) was a rolling-reboot recovery casualty that happened to land on that index, not a consequence of its name. So an upgraded cluster does not need a cleanup pipeline to stay healthy, and none is added.

End state after the full roll:

```bash
[cube451 ~]# hex_cli -v -c cluster check
27 services ok, 0 NG
[cube451 ~]# # all three nodes
CUBE_3.1.20_20260904-0153_51fd955
[cube451 ~]# # VMs, post-rebalance
cube451 7    cube452 7    cube453 6
```
