### PR TITLE
fix(advisor): rate-limit the agent unit's journal output

### DIFF
--- a/core/advisor/cube-advisor-agent.service
+++ b/core/advisor/cube-advisor-agent.service
@@ -19,5 +19,10 @@ ExecStart=/usr/local/bin/cube-advisor-agent run
 Restart=on-failure
 RestartSec=5s
 
+# Cap what one runaway loop can write: journald's global limit is shared, so
+# bound this unit's own rate too.
+LogRateLimitIntervalSec=30s
+LogRateLimitBurst=1000
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Caps `cube-advisor-agent.service` at 1000 journal messages per 30s.

A misclassified transport error spun the agent's accept loop and wrote 147 GB to a lab
node's root filesystem, taking it to 100% — ceph-mon fell out of quorum and k3s/keycloak,
rancher and zookeeper lost pods. The agent-side fix is
bigstack-oss/cube-advisor-agent#27, and that is the real fix.

This is the supervisor-side bound. journald's rate limit is global, so one chatty unit can
still crowd it; a per-unit cap keeps a future runaway loop from costing a node regardless
of what the application does.

#### Which issue(s) this PR fixes

Relates to bigstack-oss/cube-advisor-agent#26

#### Special notes for your reviewer

> The unit was **not present on the affected image** (3.1.20) — the agent there ran
> unsupervised, writing to a plain file with no rotation, which is why the flood was
> unbounded. `.service` files live in the cached `hex_full_rootfs.cgz` layer, so this
> only reaches nodes on a base image rebuild, not an incremental `pxedeploy`.
>
> Config-only change; no build impact.

#### Additional documentation

```docs
Handbook known-issue note + scenario sidecar to follow.
```