### PR TITLE
feat(metrics): bound influxdb and prometheus retention, and keep the history in ceph s3

### DIFF
--- a/core/api/cube-cos-api.yaml.in
+++ b/core/api/cube-cos-api.yaml.in
@@ -45,6 +45,12 @@ spec:
         enableAutoRenew: true
     aws:
       region: auto
+      # accessKey is a keystone USERNAME, not an S3 key: cube-cos-api resolves the
+      # user by this name and mints an EC2 credential for it whose access key is the
+      # name itself. It used to default to "admin", which is why the API and hex_sdk
+      # fought over one credential. Its own user keeps them apart.
+      accessKey: @S3_ACCESS_KEY@
+      secretKey: @S3_SECRET_KEY@
       enableStaticCreds: true
       enableCustomURL: true
       insecureSkipVerify: true

--- a/core/main/bootstrap_cube_config
+++ b/core/main/bootstrap_cube_config
@@ -10,8 +10,6 @@ else
     export MASTER_CONTROL=$(echo $T_cubesys_control_hosts | cut -d"," -f1)
 fi
 
-systemctl mask openvswitch # openvswitch shouldn't be brought up by pacemaker commit
-
 # from the kernel: ssh-localhost returned empty whenever sshd wasn't up yet
 export HOSTNAME=$(hostname)
 # 79 cols fits an 80-col console row, so the status rewrites in place

--- a/core/main/cube.mk
+++ b/core/main/cube.mk
@@ -63,6 +63,7 @@ hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_snapshot.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_stats.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_storage.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_support.sh
+hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_thanos.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_toggle.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_update.sh
 hex_shell_MODULES += $(PROJ_SHMODDIR)/modules/sdk_util.sh

--- a/core/modules/config_api.cpp
+++ b/core/modules/config_api.cpp
@@ -19,6 +19,14 @@ static const char API_NAME[] = "cube-cos-api";
 static const char API_CONF_IN[] = "/etc/cube/api/cube-cos-api.yaml.in";
 static const char API_CONF[] = "/etc/cube/api/cube-cos-api.yaml";
 
+// cube-cos-api's own keystone identity for S3. Its "accessKey" setting is a keystone
+// user name, and it defaulted to admin -- so the API minted an EC2 credential for the
+// admin user while sdk_health and cube_cluster_start_cluster listed, cached and
+// recreated admin's credentials for the health log upload. Each side could delete the
+// other's key. Issue #703.
+static const char API_S3USER[] = "cube-cos-api";
+static const char API_S3PASS[] = "Zt7QaXwNsL2mEyKd";
+
 static bool s_bCubeModified = false;
 static bool s_bMongodbModified = false;
 
@@ -30,11 +38,17 @@ CONFIG_TUNING_SPEC_STR(CUBESYS_SEED);
 CONFIG_TUNING_SPEC_BOOL(CUBESYS_SALTKEY);
 CONFIG_TUNING_SPEC_STR(MONGODB_DBPASS);
 
+// own tunings
+// The secret half of that EC2 credential. Salted like the mongodb password so it is not
+// the same on every cluster; the API creates the credential itself from this value.
+CONFIG_TUNING_STR(API_S3_SECRET, "api.s3.secret", TUNING_UNPUB, "Set cube-cos-api s3 credential secret.", API_S3PASS, ValidateRegex, DFT_REGEX_STR);
+
 // parse tunings
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
 PARSE_TUNING_X_STR(s_seed, CUBESYS_SEED, 1);
 PARSE_TUNING_X_BOOL(s_saltkey, CUBESYS_SALTKEY, 1);
 PARSE_TUNING_X_STR(s_dbPass, MONGODB_DBPASS, 2);
+PARSE_TUNING_STR(s_s3Secret, API_S3_SECRET);
 
 // external global variables
 // we still need to listen to changes on MGMT_ADDR to restart cube-cos-api
@@ -72,9 +86,13 @@ NotifyMongodb(bool modified)
 }
 
 static bool
-WriteApiConf(std::string mongodbPass)
+WriteApiConf(const std::string& mongodbPass, const std::string& s3Secret)
 {
-    if (HexSystemF(0, "sed -e \"s/@MONGODB_ADMIN_ACCESS@/%s/\" %s > %s", mongodbPass.c_str(), API_CONF_IN, API_CONF) != 0) {
+    if (HexSystemF(0, "sed -e \"s/@MONGODB_ADMIN_ACCESS@/%s/\""
+                      " -e \"s/@S3_ACCESS_KEY@/%s/\""
+                      " -e \"s/@S3_SECRET_KEY@/%s/\" %s > %s",
+                      mongodbPass.c_str(), API_S3USER, s3Secret.c_str(),
+                      API_CONF_IN, API_CONF) != 0) {
         HexLogError("failed to update %s", API_CONF);
         return false;
     }
@@ -109,7 +127,15 @@ Commit(bool modified, int dryLevel)
     }
 
     std::string dbPass = GetSaltKey(s_saltkey, s_dbPass.newValue(), s_seed.newValue());
-    if (!WriteApiConf(dbPass.c_str())) {
+    std::string s3Secret = GetSaltKey(s_saltkey, s_s3Secret.newValue(), s_seed.newValue());
+
+    // The keystone user and EC2 credential the API signs its S3 requests with. Control
+    // nodes only: that is where keystone is reachable, and the sdk drives the openstack
+    // CLI. Passing the secret keeps keystone and the config file in agreement -- the API
+    // would otherwise create the credential itself and ignore the 409 on a rotation.
+    if (IsControl(s_eCubeRole))
+        HexUtilSystemF(0, 0, HEX_SDK " api_s3_user_setup %s %s", API_S3USER, s3Secret.c_str());
+    if (!WriteApiConf(dbPass, s3Secret)) {
         return false;
     }
 
@@ -120,6 +146,9 @@ Commit(bool modified, int dryLevel)
 
 CONFIG_MODULE(api, 0, 0, 0, 0, Commit);
 CONFIG_REQUIRES(api, cube_scan);
+// api_s3_user_setup drives the openstack CLI, so keystone must already be serving.
+// api already sorted after it through apache2; this states the reason.
+CONFIG_REQUIRES(api, keystone);
 CONFIG_REQUIRES(api, mongodb);
 CONFIG_REQUIRES(api, keycloak);
 CONFIG_REQUIRES(api, influxdb);

--- a/core/modules/config_influxdb.cpp
+++ b/core/modules/config_influxdb.cpp
@@ -24,12 +24,8 @@ static const char CURATOR[] = "/etc/cron.d/influx-curator";
 #define CONF    "/etc/influxdb/influxdb.conf"
 #define MAKRER  "/etc/appliance/state/ceph_mgr_influx_enabled"
 #define INFLUX_INTERVAL 60
-#define TSDB_RP "def"     // default rp
-#define RP_DURATION "52w" // 1 years
-#define SGP_DURATION "5w" // 1 month
-#define HC_TSDB_RP "hc"      // high cardinality rp
-#define HC_RP_DURATION "2w"  // 2 weeks
-#define HC_SGP_DURATION "1w" // 1 week
+#define TSDB_RP "def"        // default rp, low-cardinality metrics
+#define HC_TSDB_RP "hc"      // high cardinality rp -- sflow and vrouter.top
 
 static CubeRole_e s_eCubeRole;
 
@@ -43,12 +39,32 @@ CONFIG_GLOBAL_STR_REF(SHARED_ID);
 
 // public tunings
 CONFIG_TUNING_INT(INFLUXDB_CURATOR_RP, "influxdb.curator.rp", TUNING_PUB, "influxdb curator retention policy in days.", 7, 0, 365);
+// Retention is two policies per database, split by cardinality: 'def' carries the
+// low-cardinality series whose count scales with node count (host cpu/mem/disk,
+// ceph_*), 'hc' carries sflow and vrouter.top, whose series count scales with
+// traffic -- one per flow tuple -- and would otherwise dominate the TSDB index.
+//
+// Duration and shard duration are tuned together on purpose. InfluxDB never deletes
+// individual points; it drops whole shard groups, and only once the entire group is
+// older than the duration. So a point written at the start of a shard group survives
+// duration + shard duration, and disk is freed in shard-sized steps. A long duration
+// with a coarse shard therefore both overshoots and frees space in cliffs -- the
+// previous 364d/35d pair kept data for up to 399 days and reclaimed it five weeks at
+// a time, on the same partition as the OS.
+CONFIG_TUNING_INT(INFLUXDB_RP_DAYS, "influxdb.def.rp.duration", TUNING_PUB, "influxdb default retention policy duration in days.", 14, 1, 3650);
+CONFIG_TUNING_INT(INFLUXDB_SGP_DAYS, "influxdb.def.rp.shard", TUNING_PUB, "influxdb default retention policy shard group duration in days.", 7, 1, 365);
+CONFIG_TUNING_INT(INFLUXDB_HC_RP_DAYS, "influxdb.hc.rp.duration", TUNING_PUB, "influxdb high-cardinality retention policy duration in days.", 7, 1, 3650);
+CONFIG_TUNING_INT(INFLUXDB_HC_SGP_DAYS, "influxdb.hc.rp.shard", TUNING_PUB, "influxdb high-cardinality retention policy shard group duration in days.", 2, 1, 365);
 
 // using external tunings
 CONFIG_TUNING_SPEC_STR(CUBESYS_ROLE);
 
 // parse tunings
 PARSE_TUNING_INT(s_curatorRp, INFLUXDB_CURATOR_RP);
+PARSE_TUNING_INT(s_rpDays, INFLUXDB_RP_DAYS);
+PARSE_TUNING_INT(s_sgpDays, INFLUXDB_SGP_DAYS);
+PARSE_TUNING_INT(s_hcRpDays, INFLUXDB_HC_RP_DAYS);
+PARSE_TUNING_INT(s_hcSgpDays, INFLUXDB_HC_SGP_DAYS);
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
 
 static bool
@@ -120,35 +136,51 @@ EnableCephInfluxPlugin(bool update, const std::string sharedId)
 }
 
 static bool
-CreateDBs()
+CreateDBs(int rpDays, int sgpDays, int hcRpDays, int hcSgpDays)
 {
     // Re-creation is allowed
     HexUtilSystemF(0, 0, HEX_SDK " wait_for_service :: 8086 90");
-    HexLogInfo("updating influxdb polices");
+
+    // A shard group wider than the policy it lives in is rejected by InfluxDB, and
+    // would mean the policy could never drop anything. Clamp rather than fail the
+    // commit, and say so.
+    if (sgpDays > rpDays) {
+        HexLogWarning("influxdb: def shard duration %dd exceeds retention %dd, clamping to %dd",
+                      sgpDays, rpDays, rpDays);
+        sgpDays = rpDays;
+    }
+    if (hcSgpDays > hcRpDays) {
+        HexLogWarning("influxdb: hc shard duration %dd exceeds retention %dd, clamping to %dd",
+                      hcSgpDays, hcRpDays, hcRpDays);
+        hcSgpDays = hcRpDays;
+    }
+
+    HexLogInfo("updating influxdb policies: def %dd/shard %dd, hc %dd/shard %dd",
+               rpDays, sgpDays, hcRpDays, hcSgpDays);
 
     std::string dbs[] = {"telegraf", "ceph", "monasca", "events"};
 
     for (const std::string &db : dbs) {
-        HexSystemF(0, "influx -execute 'CREATE DATABASE %s WITH DURATION %s SHARD DURATION %s NAME %s'",
-                      db.c_str(), RP_DURATION, SGP_DURATION, TSDB_RP);
+        HexSystemF(0, "influx -execute 'CREATE DATABASE %s WITH DURATION %dd SHARD DURATION %dd NAME %s'",
+                      db.c_str(), rpDays, sgpDays, TSDB_RP);
 
-        HexSystemF(0, "influx -execute 'CREATE RETENTION POLICY %s ON %s DURATION %s "
-                      "REPLICATION 1 SHARD DURATION %s'",
-                      TSDB_RP, db.c_str(), RP_DURATION, SGP_DURATION);
-        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s DURATION %s DEFAULT'",
-                      TSDB_RP, db.c_str(), RP_DURATION);
+        HexSystemF(0, "influx -execute 'CREATE RETENTION POLICY %s ON %s DURATION %dd "
+                      "REPLICATION 1 SHARD DURATION %dd'",
+                      TSDB_RP, db.c_str(), rpDays, sgpDays);
+        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s DURATION %dd DEFAULT'",
+                      TSDB_RP, db.c_str(), rpDays);
         HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s DEFAULT'",
                       TSDB_RP, db.c_str());
-        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s SHARD DURATION %s DEFAULT'",
-                      TSDB_RP, db.c_str(), SGP_DURATION);
+        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s SHARD DURATION %dd DEFAULT'",
+                      TSDB_RP, db.c_str(), sgpDays);
 
-        HexSystemF(0, "influx -execute 'CREATE RETENTION POLICY %s ON %s DURATION %s "
-                      "REPLICATION 1 SHARD DURATION %s'",
-                      HC_TSDB_RP, db.c_str(), HC_RP_DURATION, HC_SGP_DURATION);
-        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s DURATION %s'",
-                      HC_TSDB_RP, db.c_str(), HC_RP_DURATION);
-        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s SHARD DURATION %s'",
-                      HC_TSDB_RP, db.c_str(), HC_SGP_DURATION);
+        HexSystemF(0, "influx -execute 'CREATE RETENTION POLICY %s ON %s DURATION %dd "
+                      "REPLICATION 1 SHARD DURATION %dd'",
+                      HC_TSDB_RP, db.c_str(), hcRpDays, hcSgpDays);
+        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s DURATION %dd'",
+                      HC_TSDB_RP, db.c_str(), hcRpDays);
+        HexSystemF(0, "influx -execute 'ALTER RETENTION POLICY %s ON %s SHARD DURATION %dd'",
+                      HC_TSDB_RP, db.c_str(), hcSgpDays);
     }
 
     return true;
@@ -211,7 +243,8 @@ Commit(bool modified, int dryLevel)
     if (enabled) {
         EnableCephInfluxPlugin(true, sharedId);
         WriteLogRotateConf(log_conf);
-        CreateDBs();
+        CreateDBs(s_rpDays.newValue(), s_sgpDays.newValue(),
+                  s_hcRpDays.newValue(), s_hcSgpDays.newValue());
     }
 
     CuratorCronJob(s_curatorRp.newValue());

--- a/core/modules/config_pacemaker.cpp
+++ b/core/modules/config_pacemaker.cpp
@@ -213,19 +213,36 @@ Commit(bool modified, int dryLevel)
 
     // Mask the units pacemaker must not bring up before their own module has
     // configured them. Both are unmasked later in the same commit pass, by the
-    // module that owns them: openvswitch by config_neutron (L13), thanos-compact
-    // by config_prometheus (L12). SetupCluster, which creates the pcs resources,
-    // runs from CommitLast at L18 -- after both -- so by the time pacemaker is
-    // told about thanos-compact the unit exists, is configured and is unmasked.
+    // module that owns them: openvswitch by config_neutron's OvnService (L13),
+    // thanos-compact by config_prometheus (L12). SetupCluster, which creates the
+    // pcs resources, runs from CommitLast at L18 -- after both -- so by the time
+    // pacemaker is told about thanos-compact the unit exists, is configured and is
+    // unmasked.
     //
-    // This mask used to live at the top of bootstrap_cube_config, where it ran on
-    // every boot whether or not a commit followed. Here it is scoped to the path
-    // that actually needs it: pacemaker is brought up a few lines below, and the
-    // window this closes is exactly between that and the owning module's commit.
-    // Commit() has already returned for any role other than control or compute,
-    // which is the same set config_neutron's OvnService unmasks openvswitch for.
-    HexUtilSystemF(0, 0, "systemctl mask %s", OVS_NAME);
-    HexUtilSystemF(0, 0, "systemctl mask %s", THANOS_COMPACT);
+    // Bootstrap only, and that qualifier is the whole safety of the handshake: the
+    // unmasks are in other modules, and their CommitCheck predicates are not this
+    // one's. This module commits on its own `modified` and on G_MOD(MGMT_IF), which
+    // neutron has neither of, and prometheus has neither of plus no
+    // G_MOD(IS_MASTER). So a settings commit that changes only a pacemaker tunable
+    // -- or the management interface, or the master flag -- would mask here and
+    // never reach an unmask. A mask does not stop a running daemon, so nothing
+    // breaks immediately; what breaks is every later `systemctl restart
+    // openvswitch`, the repair paths included, until the next full commit, and on
+    // compute nodes too because this sits above the `if (enabled)` block. For
+    // thanos-compact the cost is a compactor pacemaker can no longer restart.
+    //
+    // Every CommitCheck in the pass short-circuits to true under IsBootstrap(), so
+    // that is exactly the set of commits where both unmasks are guaranteed to
+    // follow. It is also the only path where the window exists at all: on any later
+    // commit both units are already configured, so there is nothing to protect them
+    // from. This is the same scope the mask had at the top of bootstrap_cube_config,
+    // a PROJ_BOOTSTRAP script, before it moved here -- except that Commit() has
+    // already returned for any role other than control or compute, which is the
+    // same set OvnService unmasks openvswitch for.
+    if (IsBootstrap()) {
+        HexUtilSystemF(0, 0, "systemctl mask %s", OVS_NAME);
+        HexUtilSystemF(0, 0, "systemctl mask %s", THANOS_COMPACT);
+    }
 
     if (enabled) {
         if (isMaster) {

--- a/core/modules/config_pacemaker.cpp
+++ b/core/modules/config_pacemaker.cpp
@@ -22,6 +22,10 @@
 
 const static char NAME[] = "pacemaker";
 const static char PCSD[] = "pcsd";
+// Units pacemaker manages or must not start early. Named here rather than
+// included from their own modules: this is the only place that masks them.
+static const char OVS_NAME[] = "openvswitch";
+static const char THANOS_COMPACT[] = "thanos-compact";
 const static char FORCE_NEW_MARK[] = "/etc/appliance/state/pacemaker_new_setup";
 static const char CONFIGURED_FILE[] = "/etc/appliance/state/configured";
 
@@ -88,6 +92,18 @@ SetupCluster(const bool enabled, const bool ha, std::string sharedId, const std:
         HexUtilSystemF(0, 0, "pcs constraint order vip then haproxy");
         HexUtilSystemF(0, 0, "pcs resource create cinder-volume systemd:openstack-cinder-volume");
 
+        // Exactly one compactor cluster-wide: two of them against one thanos bucket
+        // corrupt it. Same shape as cinder-volume -- a plain systemd resource with no
+        // colocation, so pacemaker places it wherever it can run.
+        //
+        // failure-timeout matters here specifically. This resource is masked when
+        // pacemaker first comes up and only unmasked once config_prometheus has written
+        // its config, so pacemaker will see it fail a few times on the way through a
+        // bootstrap; without the timeout those failures never age out and the resource
+        // stays stopped. vaw carries the same meta for the same reason.
+        HexUtilSystemF(0, 0, "pcs resource create thanos-compact systemd:thanos-compact "
+                       "meta failure-timeout=\"60s\"");
+
         HexUtilSystemF(0, 0, "pcs resource create ovndb_servers ocf:ovn:ovndb-servers "
                        "manage_northd=yes master_ip=%s listen_on_master_ip_only=no promotable", sharedId.c_str());
         HexUtilSystemF(0, 0, "pcs resource meta ovndb_servers-clone notify=true clone-max=%lu", hosts.size());
@@ -99,6 +115,7 @@ SetupCluster(const bool enabled, const bool ha, std::string sharedId, const std:
             HexUtilSystemF(0, 0, "pcs constraint location vaw prefers %s --force", host.c_str());
             HexUtilSystemF(0, 0, "pcs constraint location haproxy prefers %s --force", host.c_str());
             HexUtilSystemF(0, 0, "pcs constraint location cinder-volume prefers %s --force", host.c_str());
+            HexUtilSystemF(0, 0, "pcs constraint location thanos-compact prefers %s --force", host.c_str());
             HexUtilSystemF(0, 0, "pcs constraint location ovndb_servers-clone prefers %s --force", host.c_str());
         }
 
@@ -193,6 +210,22 @@ Commit(bool modified, int dryLevel)
     }
 
     isMaster = isMaster & !isMasterRejoin;
+
+    // Mask the units pacemaker must not bring up before their own module has
+    // configured them. Both are unmasked later in the same commit pass, by the
+    // module that owns them: openvswitch by config_neutron (L13), thanos-compact
+    // by config_prometheus (L12). SetupCluster, which creates the pcs resources,
+    // runs from CommitLast at L18 -- after both -- so by the time pacemaker is
+    // told about thanos-compact the unit exists, is configured and is unmasked.
+    //
+    // This mask used to live at the top of bootstrap_cube_config, where it ran on
+    // every boot whether or not a commit followed. Here it is scoped to the path
+    // that actually needs it: pacemaker is brought up a few lines below, and the
+    // window this closes is exactly between that and the owning module's commit.
+    // Commit() has already returned for any role other than control or compute,
+    // which is the same set config_neutron's OvnService unmasks openvswitch for.
+    HexUtilSystemF(0, 0, "systemctl mask %s", OVS_NAME);
+    HexUtilSystemF(0, 0, "systemctl mask %s", THANOS_COMPACT);
 
     if (enabled) {
         if (isMaster) {

--- a/core/modules/config_prometheus.cpp
+++ b/core/modules/config_prometheus.cpp
@@ -24,7 +24,6 @@ static const char NAME[] = "prometheus";
 #define DEFCONF "/etc/default/prometheus"
 #define DATADIR  "/var/lib/prometheus/data"
 #define PORT "9091"
-#define TSDB_RP "90d"
 
 #define CONF "/etc/prometheus/prometheus.yml"
 #define LACHESIS_TARGETS "/etc/prometheus/targets/lachesis.json"
@@ -67,6 +66,21 @@ static LogRotateConf log_conf("prometheus", "/var/log/prometheus/*.log", DAILY, 
 // external global variables
 CONFIG_GLOBAL_STR_REF(SHARED_ID);
 
+// Retention, tunable so a cluster can be sized without a rebuild.
+//
+// Both limits apply and whichever is reached first wins, which is the point: time
+// alone does not bound disk if cardinality grows, and 90d with no size cap was the
+// same unbounded shape as influxdb's 364d -- on the same system partition as the OS,
+// ceph and the influx TSDB.
+//
+// Size 0 disables the size limit (prometheus's own semantics), and the flag is then
+// omitted entirely rather than written as 0.
+//
+// Note prometheus counts in powers of two: its "GB" is 1024^3, so 5GB here is 5 GiB
+// and prometheus echoes it back as "5GiB".
+CONFIG_TUNING_INT(PROMETHEUS_RP_DAYS, "prometheus.rp.duration", TUNING_PUB, "prometheus retention duration in days.", 30, 1, 3650);
+CONFIG_TUNING_INT(PROMETHEUS_RP_SIZE, "prometheus.rp.size", TUNING_PUB, "prometheus retention size cap in GiB, 0 to disable.", 5, 0, 10240);
+
 // using external tunings
 CONFIG_TUNING_SPEC(NET_HOSTNAME);
 CONFIG_TUNING_SPEC_STR(CUBESYS_ROLE);
@@ -74,6 +88,8 @@ CONFIG_TUNING_SPEC_STR(CUBESYS_CONTROL_ADDRS);
 CONFIG_TUNING_SPEC_BOOL(CUBESYS_HA);
 
 // parse tunings
+PARSE_TUNING_INT(s_rpDays, PROMETHEUS_RP_DAYS);
+PARSE_TUNING_INT(s_rpSize, PROMETHEUS_RP_SIZE);
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
 PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 1);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 1);
@@ -90,12 +106,14 @@ WriteDefaultConf()
     // ARGS, not PROMETHEUS_OPTS: EPEL's prometheus unit is ExecStart=/usr/bin/prometheus $ARGS.
     // (packagecloud's retired prometheus2 unit used $PROMETHEUS_OPTS.)
     //
-    // retention.time, not retention: the bare --storage.tsdb.retention has been deprecated
-    // since 2.x and 3.13's own --help still marks it [DEPRECATED]. It is accepted today, but
-    // there is no reason to keep feeding a flag upstream has been telling us to stop using.
+    // Retention is not passed here. Both --storage.tsdb.retention.time and .size
+    // are marked [DEPRECATED] in 3.13, which points at the config file's
+    // storage.tsdb.retention block instead, and a flag set here would take
+    // precedence over that block -- silently pinning the value and making the
+    // tunings look ineffective. WriteConf emits the block; this file only carries
+    // the flags that have no config-file equivalent.
     fprintf(fout, "ARGS='--config.file=" CONF
                   " --storage.tsdb.path=" DATADIR
-                  " --storage.tsdb.retention.time=" TSDB_RP
                   " --web.external-url=http://localhost/prometheus/"
                   " --web.listen-address=:" PORT "'\n");
     fclose(fout);
@@ -104,13 +122,29 @@ WriteDefaultConf()
 }
 
 static bool
-WriteConf(bool ha, const std::string& sharedId, const std::string& hostname)
+WriteConf(bool ha, const std::string& sharedId, const std::string& hostname, int rpDays, int rpSizeGib)
 {
     FILE *fout = fopen(CONF, "w");
     if (!fout) {
         HexLogError("Unable to write %s conf file: %s", NAME, CONF);
         return false;
     }
+
+    // storage.tsdb.retention rather than the command-line flags: 3.13 marks both
+    // --storage.tsdb.retention.time and .size [DEPRECATED] and names this block as
+    // the replacement. Time and size are both enforced, whichever is reached first
+    // -- time alone does not bound disk if cardinality grows.
+    //
+    // This block requires prometheus 3.x; a 2.x prometheus refuses to parse the file
+    // rather than ignoring the unknown field ("field retention not found in type
+    // config.plain"), so it must not be emitted for a 2.x install. This branch ships
+    // 3.13 from EPEL, so that case cannot arise here.
+    fprintf(fout, "storage:\n");
+    fprintf(fout, "  tsdb:\n");
+    fprintf(fout, "    retention:\n");
+    fprintf(fout, "      time: %dd\n", rpDays);
+    if (rpSizeGib > 0)
+        fprintf(fout, "      size: %dGB\n", rpSizeGib);   // prometheus GB is 1024^3
 
     fprintf(fout, "global:\n");
     // The replica label is what lets Thanos tell one control node's copy of a series from
@@ -299,7 +333,7 @@ Commit(bool modified, int dryLevel)
 
     if (enabled) {
         WriteDefaultConf();
-        WriteConf(s_ha, sharedId, hostname);
+        WriteConf(s_ha, sharedId, hostname, s_rpDays.newValue(), s_rpSize.newValue());
 
         // seed the target list; non-fatal, and bounded so a wedged etcd
         // cannot hang the commit

--- a/core/modules/config_prometheus.cpp
+++ b/core/modules/config_prometheus.cpp
@@ -52,6 +52,29 @@ static const char NAME[] = "prometheus";
 // the label that tells one replica's series from another's, and the one the querier
 // strips when it deduplicates -- so a query answers exactly as it did before Thanos
 #define THANOS_REPLICA_LABEL "replica"
+// Object storage. The sidecar ships each finished block to ceph RGW, the store gateway
+// serves those blocks back to the querier, and the compactor downsamples and enforces
+// retention there. Without the store gateway the querier would only ever see what each
+// prometheus still holds locally, so anything past local retention would be unreachable
+// even though it is safely in the bucket.
+#define THANOS_STORE "thanos-store"
+#define THANOS_COMPACT "thanos-compact"
+#define THANOS_STORE_DEF "/etc/default/thanos-store"
+#define THANOS_COMPACT_DEF "/etc/default/thanos-compact"
+#define THANOS_OBJSTORE "/etc/thanos/objstore.yml"
+#define THANOS_BUCKET "thanos"
+// rgw's beast frontend, and haproxy's radosgw_proxy in front of it (config_ceph,
+// config_haproxy). Same port config_swift publishes as the object-store endpoint.
+#define RGW_PORT "8888"
+#define THANOS_STORE_GRPC "10905"
+#define THANOS_STORE_HTTP "10906"
+#define THANOS_COMPACT_HTTP "10907"
+// Scratch for downsampling. On the root filesystem, not /store -- /store is the
+// cross-version upgrade share, not a working directory. thanos has no flag that caps
+// this directory, so what bounds it is the concurrency defaults (all 1, one compaction
+// group at a time); /var/lib is already covered by the cube_disk_stats telegraf input.
+#define THANOS_STORE_DATADIR   "/var/lib/thanos/store"
+#define THANOS_COMPACT_DATADIR "/var/lib/thanos/compact"
 
 static CubeRole_e s_eCubeRole;
 
@@ -65,6 +88,10 @@ static LogRotateConf log_conf("prometheus", "/var/log/prometheus/*.log", DAILY, 
 
 // external global variables
 CONFIG_GLOBAL_STR_REF(SHARED_ID);
+// the node's own management address: the store gateway's http port binds to it so
+// health_thanos_check can reach it from any control node, without offering it on every
+// interface the way 0.0.0.0 would
+CONFIG_GLOBAL_STR_REF(MGMT_ADDR);
 
 // Retention, tunable so a cluster can be sized without a rebuild.
 //
@@ -80,6 +107,11 @@ CONFIG_GLOBAL_STR_REF(SHARED_ID);
 // and prometheus echoes it back as "5GiB".
 CONFIG_TUNING_INT(PROMETHEUS_RP_DAYS, "prometheus.rp.duration", TUNING_PUB, "prometheus retention duration in days.", 30, 1, 3650);
 CONFIG_TUNING_INT(PROMETHEUS_RP_SIZE, "prometheus.rp.size", TUNING_PUB, "prometheus retention size cap in GiB, 0 to disable.", 5, 0, 10240);
+// Retention in object storage, enforced by the compactor rather than by any RGW
+// lifecycle rule: expiry that thanos does not know about leaves dangling block
+// metadata behind. Applied to all three resolutions, so 90d means 90d of history
+// whatever its resolution.
+CONFIG_TUNING_INT(THANOS_RP_DAYS, "prometheus.thanos.rp.duration", TUNING_PUB, "thanos object storage retention in days.", 90, 1, 3650);
 
 // using external tunings
 CONFIG_TUNING_SPEC(NET_HOSTNAME);
@@ -90,12 +122,13 @@ CONFIG_TUNING_SPEC_BOOL(CUBESYS_HA);
 // parse tunings
 PARSE_TUNING_INT(s_rpDays, PROMETHEUS_RP_DAYS);
 PARSE_TUNING_INT(s_rpSize, PROMETHEUS_RP_SIZE);
+PARSE_TUNING_INT(s_thanosRpDays, THANOS_RP_DAYS);
 PARSE_TUNING_X_STR(s_cubeRole, CUBESYS_ROLE, 1);
 PARSE_TUNING_X_STR(s_ctrlAddrs, CUBESYS_CONTROL_ADDRS, 1);
 PARSE_TUNING_X_BOOL(s_ha, CUBESYS_HA, 1);
 
 static bool
-WriteDefaultConf()
+WriteDefaultConf(const std::string& myIp)
 {
     FILE *fout = fopen(DEFCONF, "w");
     if (!fout) {
@@ -112,10 +145,23 @@ WriteDefaultConf()
     // precedence over that block -- silently pinning the value and making the
     // tunings look ineffective. WriteConf emits the block; this file only carries
     // the flags that have no config-file equivalent.
+    // max-block-duration = min-block-duration disables prometheus's own compaction,
+    // which the thanos sidecar REQUIRES before it will upload anything. It validates
+    // this itself and refuses loudly rather than shipping bad blocks -- observed:
+    // "found that TSDB Max time is 3d and Min time is 2h. Compaction needs to be
+    // disabled". Prometheus derives max as 10% of retention when unset, so this is not
+    // a constant that can be left alone: cutting retention to 30d moved it to 3d.
     fprintf(fout, "ARGS='--config.file=" CONF
                   " --storage.tsdb.path=" DATADIR
-                  " --web.external-url=http://localhost/prometheus/"
-                  " --web.listen-address=:" PORT "'\n");
+                  " --storage.tsdb.max-block-duration=2h"
+                  " --storage.tsdb.min-block-duration=2h"
+                  " --web.external-url=http://localhost/prometheus/");
+    // Prometheus is the one listener that needs both. Loopback is what the thanos
+    // sidecar, the self-scrape job and the non-HA haproxy backend all use; the
+    // management address is what health_prometheus_check probes from another control
+    // node. The flag is documented "Can be repeated" and 3.13 binds both.
+    fprintf(fout, " --web.listen-address=127.0.0.1:" PORT
+                  " --web.listen-address=%s:" PORT "'\n", myIp.c_str());
     fclose(fout);
 
     return true;
@@ -200,14 +246,32 @@ WriteConf(bool ha, const std::string& sharedId, const std::string& hostname, int
 // The schema is thanos's own EndpointConfig, not prometheus file_sd: a bare list of
 // targets parses and then silently discovers nothing.
 static bool
-WriteThanosConf(const std::string& ctrlAddrs)
+WriteThanosConf(const std::string& ctrlAddrs, const std::string& sharedId, int thanosRpDays)
 {
     std::string fsError;
+    // Every listener below binds either this or loopback -- never 0.0.0.0. A thanos port
+    // is reachable off-box only where something off-box actually calls it.
+    const std::string myIp = G(MGMT_ADDR);
 
+    // The bucket, its native rgw user and the credentials file thanos reads. Done in the
+    // sdk because it needs radosgw-admin and s3cmd; idempotent, so it runs every commit.
+    //
+    // The endpoint is passed rather than discovered. os_endpoint.snapshot is the obvious
+    // source but is not written until cube_last, six levels after this module, and on a
+    // master's first bootstrap keystone skips writing it too -- so at L12 it is routinely
+    // absent and thanos would come up with no objstore config at all. <shared_id>:8888 is
+    // the same internal endpoint config_swift registers, and it only needs rgw (ceph, L11)
+    // and haproxy's radosgw_proxy (L10), both of which this module already sorts after.
+    HexUtilSystemF(0, 120, HEX_SDK " thanos_objstore_setup %s:%s %s",
+                   sharedId.c_str(), RGW_PORT, THANOS_BUCKET);
+
+    // Every sidecar, plus this node's store gateway. Without the store gateway entry the
+    // querier sees only what the prometheis still hold locally.
     std::vector<std::string> endpoints = { "endpoints:\n" };
     auto group = hex_string_util::split(ctrlAddrs, ',');
     for (const auto& addr : group)
         endpoints.push_back("- address: " + addr + ":" THANOS_SIDECAR_GRPC "\n");
+    endpoints.push_back("- address: 127.0.0.1:" THANOS_STORE_GRPC "\n");
 
     if (!WriteFile(fsError, THANOS_ENDPOINTS, endpoints)) {
         HexLogError("%s", fsError.c_str());
@@ -216,11 +280,17 @@ WriteThanosConf(const std::string& ctrlAddrs)
 
     // prometheus.url carries the route prefix: --web.external-url puts every endpoint,
     // /api included, under /prometheus, and the sidecar talks to it over that API.
+    //
+    // gRPC binds the management address: every control node's querier dials this node's
+    // sidecar, which is the endpoints.yml list written above. The HTTP port carries only
+    // readiness and metrics and nothing reads it -- the health check establishes sidecar
+    // liveness through systemd, not over HTTP -- so it stays on loopback.
     const std::vector<std::string> sidecar = {
         "ARGS='--prometheus.url=http://127.0.0.1:" PORT "/prometheus"
         " --tsdb.path=" DATADIR
-        " --grpc-address=0.0.0.0:" THANOS_SIDECAR_GRPC
-        " --http-address=0.0.0.0:" THANOS_SIDECAR_HTTP "'\n",
+        " --objstore.config-file=" THANOS_OBJSTORE
+        " --grpc-address=" + myIp + ":" THANOS_SIDECAR_GRPC
+        " --http-address=127.0.0.1:" THANOS_SIDECAR_HTTP "'\n",
     };
     if (!WriteFile(fsError, THANOS_SIDECAR_DEF, sidecar)) {
         HexLogError("%s", fsError.c_str());
@@ -230,15 +300,63 @@ WriteThanosConf(const std::string& ctrlAddrs)
     // Serves under the same /prometheus prefix the raw Prometheus did, so haproxy's route
     // and grafana's datasource keep working when the backend moves here. Note thanos keeps
     // /-/ready and /-/healthy at the root regardless -- that is what haproxy checks.
+    //
+    // HTTP binds the management address: haproxy lists every control node as a backend
+    // for this port and health_thanos_check probes it across nodes. The gRPC port would
+    // matter if a querier fanned out to another querier, or if thanos-rule existed here;
+    // neither does, so nothing dials it and it stays on loopback.
     const std::vector<std::string> query = {
         "ARGS='--endpoint.sd-config-file=" THANOS_ENDPOINTS
         " --query.replica-label=" THANOS_REPLICA_LABEL
-        " --grpc-address=0.0.0.0:" THANOS_QUERY_GRPC
-        " --http-address=0.0.0.0:" THANOS_QUERY_HTTP
+        " --grpc-address=127.0.0.1:" THANOS_QUERY_GRPC
+        " --http-address=" + myIp + ":" THANOS_QUERY_HTTP
         " --web.route-prefix=/prometheus"
         " --web.external-prefix=/prometheus'\n",
     };
     if (!WriteFile(fsError, THANOS_QUERY_DEF, query)) {
+        HexLogError("%s", fsError.c_str());
+        return false;
+    }
+
+    // Neither port is offered on every interface. The store gateway is only ever
+    // consulted by the querier on its own node -- that is the 127.0.0.1 entry written
+    // above -- so gRPC binds loopback. Its HTTP port serves only readiness and metrics,
+    // but health_thanos_check probes it from whichever control node runs the check, so
+    // it binds the management address rather than 0.0.0.0. Contrast the sidecar, whose
+    // gRPC port every node's querier dials, and the querier, which sits behind haproxy.
+    const std::vector<std::string> store = {
+        "ARGS='--objstore.config-file=" THANOS_OBJSTORE
+        " --data-dir=" THANOS_STORE_DATADIR
+        " --grpc-address=127.0.0.1:" THANOS_STORE_GRPC
+        " --http-address=" + myIp + ":" THANOS_STORE_HTTP "'\n",
+    };
+    if (!WriteFile(fsError, THANOS_STORE_DEF, store)) {
+        HexLogError("%s", fsError.c_str());
+        return false;
+    }
+
+    // --wait keeps the compactor running as a service instead of doing one pass and
+    // exiting. Retention is applied to all three resolutions, so the tuning means
+    // "keep this much history" regardless of how coarse it has been downsampled to.
+    // Concurrency is left at thanos's defaults (all 1): there is no flag that caps
+    // --data-dir, and one compaction group at a time is what keeps it bounded.
+    //
+    // Loopback, and unlike the store gateway not even the management address: nothing
+    // reads this port. The compactor exposes no gRPC at all -- no querier talks to it --
+    // and health_thanos_check establishes the singleton by asking every node whether the
+    // unit is active, which is what pacemaker actually places, rather than by probing an
+    // address it would first have to discover.
+    const std::string rp = std::to_string(thanosRpDays) + "d";
+    const std::vector<std::string> compact = {
+        "ARGS='--objstore.config-file=" THANOS_OBJSTORE
+        " --data-dir=" THANOS_COMPACT_DATADIR
+        " --wait"
+        " --retention.resolution-raw=" + rp +
+        " --retention.resolution-5m=" + rp +
+        " --retention.resolution-1h=" + rp +
+        " --http-address=127.0.0.1:" THANOS_COMPACT_HTTP "'\n",
+    };
+    if (!WriteFile(fsError, THANOS_COMPACT_DEF, compact)) {
         HexLogError("%s", fsError.c_str());
         return false;
     }
@@ -311,7 +429,7 @@ CommitCheck(bool modified, int dryLevel)
         return true;
     }
 
-    return s_bCubeModified | s_bNetModified | G_MOD(SHARED_ID);
+    return s_bCubeModified | s_bNetModified | G_MOD(SHARED_ID) | G_MOD(MGMT_ADDR);
 }
 
 static bool
@@ -332,7 +450,7 @@ Commit(bool modified, int dryLevel)
     std::string hostname = s_hostname.newValue();
 
     if (enabled) {
-        WriteDefaultConf();
+        WriteDefaultConf(G(MGMT_ADDR));
         WriteConf(s_ha, sharedId, hostname, s_rpDays.newValue(), s_rpSize.newValue());
 
         // seed the target list; non-fatal, and bounded so a wedged etcd
@@ -352,19 +470,31 @@ Commit(bool modified, int dryLevel)
     }
 
     if (thanosEnabled)
-        WriteThanosConf(s_ctrlAddrs.newValue());
+        WriteThanosConf(s_ctrlAddrs.newValue(), sharedId, s_thanosRpDays.newValue());
 
     SystemdCommitService(enabled, NAME);
     // after prometheus: the sidecar exits if it cannot reach it, and while Restart=always
     // covers that, starting in order keeps a boot from logging the failure at all
     SystemdCommitService(thanosEnabled, THANOS_SIDECAR);
     SystemdCommitService(thanosEnabled, THANOS_QUERY);
+    SystemdCommitService(thanosEnabled, THANOS_STORE);
+
+    // thanos-compact is pacemaker's to place -- two of them on one bucket corrupt it --
+    // so it is never enabled here. config_pacemaker masks it before pacemaker comes up;
+    // unmasking once its config exists is this module's half of that handshake, and
+    // pacemaker creates the resource later still, from CommitLast.
+    if (thanosEnabled)
+        HexUtilSystemF(0, 0, "systemctl unmask " THANOS_COMPACT);
 
     return true;
 }
 
 CONFIG_MODULE(prometheus, 0, 0, 0, 0, Commit);
 CONFIG_REQUIRES(prometheus, cube_scan);
+// thanos_objstore_setup needs a working RGW to create its user and bucket, and ceph is
+// what brings radosgw up. Without this prometheus commits at L8, three levels ahead of
+// ceph at L11, and the bootstrap would run against an object store that does not exist.
+CONFIG_REQUIRES(prometheus, ceph);
 
 // extra tunings
 CONFIG_OBSERVES(prometheus, net, ParseNet, NotifyNet);

--- a/core/sdk_sh/modules/errcodes
+++ b/core/sdk_sh/modules/errcodes
@@ -344,6 +344,9 @@ eval "ERR_DESC_$SRV[1]='sidecar down'"
 eval "ERR_DESC_$SRV[2]='querier down'"
 eval "ERR_DESC_$SRV[3]='querier not responding'"
 eval "ERR_DESC_$SRV[4]='querier missing a replica'"
+eval "ERR_DESC_$SRV[5]='store gateway down'"
+eval "ERR_DESC_$SRV[6]='store gateway not responding'"
+eval "ERR_DESC_$SRV[7]='compactor not a single instance'"
 eval for idx in \"\${!ERR_DESC_${SRV}[@]}\" \; do ERR_CODE[${SRV},\$idx]=\"\${ERR_DESC_${SRV}[\$idx]}\" \; done
 
 SRV="grafana"

--- a/core/sdk_sh/modules/sdk_api.sh
+++ b/core/sdk_sh/modules/sdk_api.sh
@@ -34,3 +34,91 @@ api_get_images_materials()
 {
     _api ${FUNCNAME[0]}
 }
+
+# cube-cos-api's own keystone user and EC2 credential, so it stops sharing admin's.
+#
+# This lives with the API rather than under os_ because the credential shape is the
+# API's, not a general one: cube-cos-api treats its "accessKey" setting as a keystone
+# user NAME and signs with an access key equal to that name, so the credential written
+# here must use the user name as its access key. A generic S3-user helper would take an
+# access key and a secret independently.
+#
+# The shared credential is genuinely contested. cube-cos-api mints one whose access key
+# is literally the username -- its accessKey setting is a keystone user name, defaulting
+# to "admin" -- while sdk_health and cube_cluster_start_cluster list admin's credentials,
+# cache the first in /run/ec2.key and delete/recreate on an empty read. So
+# `ec2 credentials delete admin` removes precisely the credential the API created, and
+# whichever side runs next silently adopts or destroys the other's key. Issue #703.
+#
+# Access to the shared "log" bucket survives the split because rgw runs with
+# `rgw keystone implicit tenants = false`: the S3 owner is the keystone PROJECT, not the
+# user, and "log" is owned by the admin project. Any user holding an rgw-accepted role
+# on that project therefore authenticates as that same S3 owner, so no bucket policy or
+# ACL is needed -- verified by `radosgw-admin bucket stats --bucket=log`, whose owner is
+# the admin project id.
+#
+# Idempotent: safe to run on every commit.
+api_s3_user_setup()
+{
+    local user=$1
+    local secret=$2
+    local domain=${3:-default}
+    local project=${4:-admin}
+
+    if [ "x$user" = "x" -o "x$secret" = "x" ] ; then
+        log_error "api_s3_user_setup: usage: api_s3_user_setup <user> <secret> [domain] [project]"
+        return 1
+    fi
+
+    if ! $OPENSTACK user show $user >/dev/null 2>&1 ; then
+        log_info "api_s3_user_setup: creating keystone user $user"
+        # No password: the EC2 credential is the only way this identity is ever used,
+        # so there is nothing to gain from it being able to log in.
+        $OPENSTACK user create --domain $domain $user >/dev/null 2>&1
+    fi
+    if ! $OPENSTACK user show $user >/dev/null 2>&1 ; then
+        log_error "api_s3_user_setup: keystone user $user missing after create"
+        return 1
+    fi
+
+    # "member" rather than "admin": rgw keystone accepted roles includes it, and it is
+    # the project mapping above -- not the role -- that grants the bucket access.
+    $OPENSTACK role add --project $project --user $user member >/dev/null 2>&1
+    if ! $OPENSTACK role assignment list --user $user --project $project --names -f value -c Role 2>/dev/null | grep -q . ; then
+        log_error "api_s3_user_setup: $user has no role on project $project"
+        return 1
+    fi
+
+    # Own the EC2 credential here rather than leaving it to cube-cos-api. The API does
+    # create it on startup, but treats an HTTP 409 as success -- so the first time the
+    # configured secret changes (a new seed, or the api.s3.secret tuning) keystone keeps
+    # the old secret while the API signs with the new one, and every S3 request is denied
+    # with nothing in either log saying why. Reconciling here makes the API's own create
+    # a harmless no-op and the pair self-healing.
+    #
+    # The access key is the user name, which is what cube-cos-api derives from its
+    # accessKey setting -- the two must agree or the API signs with a key keystone has
+    # never heard of.
+    local id cur
+    read -r id cur <<< "$($OPENSTACK credential list --user $user --type ec2 -f json 2>/dev/null \
+        | jq -r --arg a "$user" '.[] | select((.Data|fromjson).access == $a)
+                                     | "\(.ID) \((.Data|fromjson).secret)"' | head -1)"
+    if [ "x$id" != "x" -a "x$cur" = "x$secret" ] ; then
+        return 0
+    fi
+    if [ "x$id" != "x" ] ; then
+        log_info "api_s3_user_setup: rotating stale ec2 credential for $user"
+        $OPENSTACK credential delete $id >/dev/null 2>&1
+    fi
+    log_info "api_s3_user_setup: creating ec2 credential for $user"
+    $OPENSTACK credential create --type ec2 --project $project $user \
+        "{\"access\": \"$user\", \"secret\": \"$secret\"}" >/dev/null 2>&1
+    if ! $OPENSTACK credential list --user $user --type ec2 -f json 2>/dev/null \
+        | jq -e --arg a "$user" --arg s "$secret" \
+            'any(.[]; (.Data|fromjson).access == $a and (.Data|fromjson).secret == $s)' >/dev/null 2>&1 ; then
+        log_error "api_s3_user_setup: ec2 credential for $user is not in place"
+        return 1
+    fi
+
+    return 0
+}

--- a/core/sdk_sh/modules/sdk_health.sh
+++ b/core/sdk_sh/modules/sdk_health.sh
@@ -3808,6 +3808,20 @@ health_thanos_check()
             ERR_LOG="netstat -tunpl | grep 10904"
             continue
         fi
+        # the store gateway is what makes anything past local prometheus retention
+        # readable at all: without it the querier can only see what is still on disk
+        if ! is_remote_running $node thanos-store ; then
+            ERR_CODE=5
+            ERR_MSG+="thanos-store on $node is not running\n"
+            ERR_LOG="journalctl -n $ERR_LOGSIZE -u thanos-store"
+            continue
+        fi
+        if ! $CURL -sf http://$node:10906/-/ready >/dev/null 2>&1 ; then
+            ERR_CODE=6
+            ERR_MSG+="thanos-store on $node doesn't respond\n"
+            ERR_LOG="netstat -tunpl | grep 10906"
+            continue
+        fi
         # the whole point of thanos here is that a querier answers from every replica
         # rather than only its own; a querier that has lost its peers still passes every
         # probe above while silently serving one node's view of the cluster
@@ -3819,6 +3833,16 @@ health_thanos_check()
             ERR_LOG="$CURL -s http://$node:10904/prometheus/api/v1/stores"
         fi
     done
+
+    # The compactor is a pacemaker singleton, so it is checked cluster-wide rather than
+    # per node: exactly one instance must be running, anywhere. Two would corrupt the
+    # bucket, none means retention and downsampling have silently stopped.
+    local running=$(cmd -c -v "systemctl is-active thanos-compact" 2>/dev/null | grep -c "|0|active$")
+    if [ "${running:-0}" -ne 1 ] ; then
+        ERR_CODE=7
+        ERR_MSG+="thanos-compact instances running: ${running:-0}, expected exactly 1\n"
+        ERR_LOG="pcs status | grep -A2 thanos-compact"
+    fi
 
     _health_fail_log
 }
@@ -3834,7 +3858,21 @@ health_thanos_repair()
            ! $CURL -sf http://$node:10904/-/ready >/dev/null 2>&1 ; then
             remote_systemd_restart $node thanos-query
         fi
+        if ! is_remote_running $node thanos-store || \
+           ! $CURL -sf http://$node:10906/-/ready >/dev/null 2>&1 ; then
+            remote_systemd_restart $node thanos-store
+        fi
     done
+
+    # thanos-compact is pacemaker's, not ours. Restarting the unit directly would
+    # either fight pacemaker or, worse, start a second compactor against the bucket
+    # while pacemaker still believes its own instance is running. Ask pacemaker to
+    # replace it instead, and only from one node.
+    local running=$(cmd -c -v "systemctl is-active thanos-compact" 2>/dev/null | grep -c "|0|active$")
+    if [ "${running:-0}" -ne 1 ] && [ "x$HOSTNAME" = "x${CUBE_NODE_CONTROL_HOSTNAMES[0]}" ] ; then
+        log_error "health_thanos_repair: ${running:-0} thanos-compact instances, expected 1, asking pacemaker to replace it"
+        Quiet -n pcs resource cleanup thanos-compact
+    fi
 }
 
 # ERR_CODE 4 is "a peer's sidecar is not reachable" -- almost always a node that is down

--- a/core/sdk_sh/modules/sdk_thanos.sh
+++ b/core/sdk_sh/modules/sdk_thanos.sh
@@ -1,0 +1,74 @@
+# CUBE SDK
+# thanos object storage
+
+# Object storage for thanos: a native RGW user, its bucket, and the objstore config
+# thanos reads.
+#
+# Deliberately a NATIVE radosgw user rather than a keystone EC2 credential. The
+# admin EC2 credential is contested: sdk_health's log-upload path runs
+# `ec2 credentials delete admin` and recreates it, while cube-cos-api recreates a
+# deterministic one of its own -- so each rotates the other out, and anything caching
+# the pair breaks. A native user is invisible to both and cannot be rotated out from
+# under thanos. os_s3_bucket_quota already drives radosgw-admin directly, so native
+# users alongside keystone-mapped ones are an established arrangement here.
+#
+# The endpoint is supplied by the caller rather than discovered here.
+# os_endpoint.snapshot is the obvious source and the wrong one twice over: it is not
+# written until cube_last, six commit levels after prometheus, and a master's first
+# bootstrap skips it entirely, so at commit time it is routinely absent. Its "public"
+# row also resolves to EXTERNAL, the wrong side of the appliance for a control-plane
+# upload. config_prometheus already holds the control vip, so it passes <vip>:8888 --
+# the same internal endpoint config_swift publishes -- and this stays a single source
+# of truth instead of re-deriving it from a tuning.
+#
+# Idempotent: safe to run on every commit.
+thanos_objstore_setup()
+{
+    local ep=$1
+    local bucket=${2:-thanos}
+    local uid=thanos
+    local conf=/etc/thanos/objstore.yml
+    local ak sk host
+
+    if [ "x$ep" = "x" ] ; then
+        log_error "thanos_objstore_setup: usage: thanos_objstore_setup <host:port> [bucket]"
+        return 1
+    fi
+
+    if ! radosgw-admin user info --uid=$uid >/dev/null 2>&1 ; then
+        log_info "thanos_objstore_setup: creating native rgw user $uid"
+        radosgw-admin user create --uid=$uid --display-name="Thanos object storage" >/dev/null 2>&1
+    fi
+    ak=$(radosgw-admin user info --uid=$uid 2>/dev/null | jq -r '.keys[0].access_key')
+    sk=$(radosgw-admin user info --uid=$uid 2>/dev/null | jq -r '.keys[0].secret_key')
+    if [ "x$ak" = "x" -o "x$ak" = "xnull" ] ; then
+        log_error "thanos_objstore_setup: no access key for rgw user $uid"
+        return 1
+    fi
+
+    host=$(echo $ep | cut -d':' -f1)
+
+    if ! /usr/bin/s3cmd --no-ssl --host=$ep --host-bucket=$host \
+            --access_key=$ak --secret_key=$sk ls "s3://$bucket" >/dev/null 2>&1 ; then
+        log_info "thanos_objstore_setup: creating bucket $bucket"
+        /usr/bin/s3cmd --no-ssl --host=$ep --host-bucket=$host \
+            --access_key=$ak --secret_key=$sk mb "s3://$bucket" >/dev/null 2>&1
+    fi
+
+    mkdir -p /etc/thanos
+    # written whole then moved, so a reader never sees a half-written credential file
+    cat > $conf.tmp <<EOF
+type: S3
+config:
+  bucket: $bucket
+  endpoint: $ep
+  access_key: $ak
+  secret_key: $sk
+  insecure: true
+  signature_version2: false
+EOF
+    chown prometheus:prometheus $conf.tmp
+    chmod 0640 $conf.tmp
+    mv -f $conf.tmp $conf
+    return 0
+}

--- a/core/thanos/thanos-compact.service
+++ b/core/thanos/thanos-compact.service
@@ -1,0 +1,28 @@
+# -*- mode: conf -*-
+# Downsamples blocks in object storage and enforces retention there.
+#
+# This unit is NOT enabled. Two compactors running against one bucket corrupt it, so
+# placement belongs to pacemaker, which runs exactly one instance cluster-wide -- the
+# same arrangement as cinder-volume. systemd must never start it on its own, or every
+# control node would run one.
+#
+# config_pacemaker masks it before pacemaker comes up and config_prometheus unmasks it
+# once the configuration exists, so pacemaker cannot start it against a half-written
+# config during the same commit pass.
+
+[Unit]
+Description=Thanos compactor for the metrics object store
+Documentation=https://thanos.io/tip/components/compact.md/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=/etc/default/thanos-compact
+User=prometheus
+ExecStart=/usr/bin/thanos compact $ARGS
+Restart=always
+RestartSec=5s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/core/thanos/thanos-store.service
+++ b/core/thanos/thanos-store.service
@@ -1,0 +1,25 @@
+# -*- mode: conf -*-
+# Serves blocks that the sidecar has uploaded to object storage back to the querier.
+# Without it the querier can only see what each Prometheus still holds locally, so
+# anything past the local retention window would be unreachable even though it is
+# safely in S3.
+#
+# Runs as prometheus for the same reason the sidecar does: no new system user, and it
+# needs to read the same objstore credentials file.
+
+[Unit]
+Description=Thanos store gateway over the metrics object store
+Documentation=https://thanos.io/tip/components/store.md/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=/etc/default/thanos-store
+User=prometheus
+ExecStart=/usr/bin/thanos store $ARGS
+Restart=always
+RestartSec=5s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/core/thanos/thanos.mk
+++ b/core/thanos/thanos.mk
@@ -21,5 +21,13 @@ rootfs_install:: $(ARCS_DIR)/$(THANOS_TGZ)
 	$(Q)chroot $(ROOTDIR) mkdir -p /etc/thanos
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/thanos/thanos-sidecar.service ./lib/systemd/system
 	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/thanos/thanos-query.service ./lib/systemd/system
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/thanos/thanos-store.service ./lib/systemd/system
+	$(Q)$(INSTALL_DATA) $(ROOTDIR) $(COREDIR)/thanos/thanos-compact.service ./lib/systemd/system
+	$(Q)chroot $(ROOTDIR) mkdir -p /var/lib/thanos/store /var/lib/thanos/compact
+	$(Q)chroot $(ROOTDIR) chown -R prometheus:prometheus /var/lib/thanos
 	$(Q)chroot $(ROOTDIR) systemctl disable thanos-sidecar
 	$(Q)chroot $(ROOTDIR) systemctl disable thanos-query
+	$(Q)chroot $(ROOTDIR) systemctl disable thanos-store
+	# thanos-compact is pacemaker-managed and must never be enabled in systemd:
+	# two compactors on one bucket corrupt it. See thanos-compact.service.
+	$(Q)chroot $(ROOTDIR) systemctl disable thanos-compact


### PR DESCRIPTION
#### What type of PR is this?

- feature
- bug

#### What this PR does / why we need it

A metrics database should not be able to fill the system partition, and it should not lose history when it is capped. This PR does both halves of that, and fixes the credential collision that surfaced while wiring the second half up.

- **Bound both time-series stores.** InfluxDB kept **364d + 35d** on the `def` retention policy — worst case an InfluxDB 1.x shard survives `duration + shardGroupDuration`, because whole shard groups are dropped and a group only expires once its *end* time plus the duration has passed. Prometheus kept 90d with no size cap at all. Both are now tunable in `hex_config` rather than compiled-in: `def` drops to 14d/7d, `hc` to 7d/2d, prometheus to 30d with a 5 GiB cap
- **Stop throwing the capped history away.** A 30d cap only makes sense if what falls off the end still exists somewhere, so the thanos sidecar now ships finished blocks to a ceph RGW bucket, a store gateway serves them back to the querier, and a compactor downsamples and enforces 90d retention *in the bucket*. Retention is thanos's, not an RGW lifecycle rule: expiry that thanos does not know about leaves dangling block metadata behind
- **Give cube-cos-api its own RGW identity.** The API's `accessKey` setting is a keystone *user name*, not an S3 key, and it defaulted to `admin` — so it minted an EC2 credential whose access key is literally `"admin"`, while `sdk_health` and `cube_cluster_start_cluster` list admin's credentials, cache the first in `/run/ec2.key` and delete/recreate on an empty read. `ec2 credentials delete admin` removes exactly the credential the API created. This is the residue of #703

#### Which issue(s) this PR fixes

- Refs #672 — items 1, 2, 5 and 6 of the retention comment
- Refs #703 — the admin EC2 credential is no longer shared

#### Special notes for your reviewer

**Why the two InfluxDB numbers add up.** They are not two windows, they are duration and shard-group duration. InfluxDB 1.x never deletes points, only whole shard groups, and a group's `expiry_time` is its *end* time plus the retention duration — so the oldest point still on disk can be `duration + shardGroupDuration` old. 364d/35d was a worst case of 399d. The new pairs keep that arithmetic visible: 14d/7d and 7d/2d.

**Why prometheus retention moved into the config file.** 3.13 marks both `--storage.tsdb.retention.time` and `.size` `[DEPRECATED]` and points at the `storage.tsdb.retention` block, and a flag set on the command line takes precedence over that block — which would silently pin the value and make the tunings look inert. This is 3.x-only: 2.55 does not know the field and *refuses to parse* rather than ignoring it, which took all three `accept-3cc` nodes to `activating` when it was tried there before the upgrade.

**The sidecar will not upload unless prometheus stops compacting.** `--storage.tsdb.max-block-duration` must equal `--min-block-duration`. Prometheus derives max as 10% of retention when unset, so this is not a constant that could be left alone — cutting retention to 30d moved it to 3d and would have silently stopped every upload. The sidecar validates this itself and refuses loudly (`"found that TSDB Max time is 3d and Min time is 2h. Compaction needs to be disabled"`) rather than shipping bad blocks.

**Why the compactor is a pacemaker resource and not a systemd unit.** Two compactors against one bucket corrupt it, so exactly one must run cluster-wide — the same shape as `cinder-volume`. That leaves a bootstrap window where pacemaker exists but the compactor has no config, so `config_pacemaker` masks it before bringing pacemaker up and `config_prometheus` unmasks it once the config is written. The `openvswitch` mask moves out of `bootstrap_cube_config` into the same place.

**The mask is gated on `IsBootstrap()`, and that qualifier is the whole safety of the handshake.** The mask lives in `config_pacemaker` while both unmasks live in the modules that own the units — `openvswitch` in `config_neutron`'s `OvnService`, `thanos-compact` in `config_prometheus` — and those modules' `CommitCheck` predicates are not this one's:

```
commits pacemaker but NOT neutron     pacemaker.modified | G_MOD(MGMT_IF)
commits pacemaker but NOT prometheus  pacemaker.modified | G_MOD(MGMT_IF) | G_MOD(IS_MASTER)
```

Without the gate, a settings commit carrying any of those masks both units and nothing ever unmasks them. **A tuning change is applied cluster-wide, and it lands on exactly this path:** cube-cos-ui to cube-cos-api, whose `ApplyTuning()` runs `hex_config apply <dir>` on each node, which translates the policy and then spawns `hex_config commit <settings>` — a settings commit, so `IsBootstrap()` is false. One tuning change therefore masks `openvswitch` on every control and compute node at once, compute included because the mask sits above the `if (enabled)` block. A mask does not stop a running daemon, so nothing looks wrong at the time; what it does is arm every later restart to fail, the repair paths and the next boot included. Every `CommitCheck` in the pass short-circuits to true under `IsBootstrap()`, so that is exactly the set of commits where both unmasks are guaranteed to follow — and it is the only path where the window exists at all, since on any later commit both units are already configured. Caught in review by @SekiXu; see the verification below.

**Why the endpoint is passed to the sdk rather than discovered.** `os_endpoint.snapshot` is the obvious source and unusable at commit time — its only commit-path writers are `cube_last` (six levels after prometheus) and keystone, which skips it on a master's first bootstrap. Measured on `accept-3cc`, the file's mtime is 42 minutes after boot. Its `public` row also resolves to `EXTERNAL`, the wrong side of the appliance for a control-plane upload.

**Why a separate keystone user is enough for the shared `log` bucket.** rgw runs with `rgw keystone implicit tenants = false`, so the S3 owner is the keystone **project**, not the user — and `radosgw-admin bucket stats --bucket=log` reports its owner as the admin project id on both clusters. A user with an rgw-accepted role on that project authenticates as the same S3 owner, so no bucket policy or ACL is involved. `member` suffices; the role is not what grants the access.

**Why hex_config owns that credential.** cube-cos-api creates it on startup but treats an HTTP 409 as success. Without reconciliation, the first time the configured secret changes — a new seed, or the `api.s3.secret` tuning — keystone would keep the old secret while the API signed with the new one, and every request would be denied with nothing in either log saying why.

#### Additional documentation

Verified on `accept-3cc` (3-node HA) and `jim-1cc` (single control) unless stated otherwise.

For the requirement "InfluxDB is bounded", applied live after the tunings landed:

```
jim-1cc     125M -> 58M
accept-3cc  cc1 279M -> 122M    cc2 316M -> 147M    cc3 265M -> 124M
```

For the requirement "prometheus honours both caps", from prometheus's own startup log rather than the flags:

```
level=INFO msg="Time-based retention policy" duration=30d
level=INFO msg="Size-based retention policy" size=5GiB
```

`accept-3cc` was upgraded 2.55.1 -> 3.13.1 first, since the config-file form does not exist in 2.x.

For the requirement "blocks reach S3 and are readable back", on all three control nodes:

```bash
[cc1 ~]# systemctl is-active prometheus thanos-sidecar thanos-store thanos-query
active active active active
[cc1 ~]# curl -s http://10.1.0.1:10904/prometheus/api/v1/stores | jq -r ...
  sidecar  10.1.0.1:10901   err=None
  sidecar  10.1.0.2:10901   err=None
  sidecar  10.1.0.3:10901   err=None
  store    127.0.0.1:10905  err=None
[cc1 ~]# curl -s http://10.1.0.1:10906/metrics | grep 'blocks_meta_synced{state="loaded"}'
thanos_blocks_meta_synced{state="loaded"} 12
```

Zero `"Compaction needs to be disabled"` messages and `thanos_shipper_upload_failures_total 0` on every node.

For the requirement "the compactor is a singleton and does real work":

```bash
[cc1 ~]# pcs status resources | grep thanos-compact
  * thanos-compact   (systemd:thanos-compact):  Started cc1
[cc1 ~]# hex_sdk cmd -c -v "systemctl is-active thanos-compact"
cc1|0|active
cc2|3|inactive
cc3|3|inactive
```

A full cycle in its log — initial sync, garbage collection, compaction, both downsampling passes, retention apply — and the bucket shows the result: three level-2 blocks each spanning 6h with 1,344,240 samples, exactly 3 x 448,080, i.e. three consecutive 2h level-1 blocks merged. 18 blocks, 10,740,568 samples, continuous coverage with no gap.

For the requirement "nothing is offered on an interface that does not need it", every listener this module writes was audited; none is left on `0.0.0.0`:

```
9091  prometheus   127.0.0.1 + mgmt   sidecar/self-scrape/non-HA haproxy are local; health check is cross-node
10901 sidecar grpc mgmt               every node's querier dials it
10902 sidecar http loopback           nothing reads it
10903 query grpc   loopback           no querier fan-out, no thanos-rule
10904 query http   mgmt               haproxy backend, and the health check
10905 store grpc   loopback           only that node's own querier
10906 store http   mgmt               the health check probes across nodes
10907 compact http loopback           nothing reads it; the singleton is established through systemd
```

Confirmed on all three nodes: the four cross-node paths answer, the four loopback-only ports are refused off-box, the self-scrape is `up`, and grafana's route through the VIP (`https://<vip>/prometheus/graph`) returns 200.

For the requirement "commit order is correct", from `hex_config -d` on the built binary:

```
L9   pacemaker    <- masks openvswitch and thanos-compact, then starts pacemaker
L11  ceph         <- radosgw up
L12  prometheus   <- ceph cube_scan first        (was L8 without CONFIG_REQUIRES(prometheus, ceph))
L13  neutron      <- unmasks openvswitch
L16  api          <- apache2 cube_scan cyborg first influxdb keycloak keystone mongodb
L18  pacemaker_last <- creates the pcs resources
```

For the requirement "a settings commit cannot leave openvswitch masked" — an A/B of two binaries built from the same source, one with the `IsBootstrap()` gate and one without, each running the identical non-bootstrap, pacemaker-only commit on `jim-1cc`. `WriteLogRotateConf` is `Commit()`'s last statement, so `/etc/logrotate.d/pacemaker` witnesses that the module ran rather than returning at its `CommitCheck`:

```bash
[cc1 ~]# hex_config commit <settings with one added pacemaker.enabled line> pacemaker
without the gate   witness written   openvswitch/thanos-compact -> masked/masked
with the gate      witness written   openvswitch/thanos-compact -> unchanged
```

The delta has to be recreated from a pristine settings copy before each run: a commit writes its settings back, so a second run finds nothing modified, returns at `CommitCheck` and proves nothing — the first attempt at this measured exactly that false pass.

What the leaked mask costs, measured with both units masked:

```bash
[cc1 ~]# systemctl restart openvswitch
Failed to restart openvswitch.service: Unit openvswitch.service is masked.
[cc1 ~]# systemctl start thanos-compact
Failed to start thanos-compact.service: Unit thanos-compact.service is masked.
[cc1 ~]# systemctl is-active ovs-vswitchd
active                    # <- still up, which is why this would go unnoticed
```

For the requirement "health notices when either new component fails":

```bash
[cc1 ~]# hex_sdk health_thanos_check ; echo $?
0
[cc1 ~]# ssh cc3 systemctl stop thanos-store ; hex_sdk health_thanos_check ; echo $?
5
[cc1 ~]# hex_sdk health_thanos_repair ; hex_sdk health_thanos_check ; echo $?
0
[cc1 ~]# pcs resource disable thanos-compact ; hex_sdk health_thanos_check ; echo $?
7
```

For the requirement "cube-cos-api no longer shares admin's credential" — `jim-1cc`, converge from no user at all, then idempotence, then rotation:

```bash
[cc1 ~]# openstack user delete cube-cos-api
[cc1 ~]# hex_sdk api_s3_user_setup cube-cos-api SECRET_ONE ; echo $?
0
    access=cube-cos-api secret=SECRET_ONE     role on admin project: member
[cc1 ~]# hex_sdk api_s3_user_setup cube-cos-api SECRET_ONE     # credential id unchanged
[cc1 ~]# hex_sdk api_s3_user_setup cube-cos-api SECRET_TWO     # rotation
    old secret rejected: yes    new secret works: ok    credentials: 1
```

And the isolation that #703 was about — the delete that used to break the API:

```bash
[cc1 ~]# openstack ec2 credentials delete admin
[cc1 ~]# openstack credential list --user cube-cos-api --type ec2 -f value -c ID | wc -l
1
[cc1 ~]# systemctl is-active cube-cos-api
active
```

On `accept-3cc`, run concurrently from all three control nodes it still converges to exactly one credential, all three reach `s3://log`, all three API instances come up `active`, and `health_api_check` returns 0. Reaching that state needed keycloak repaired first: its realm was half-migrated behind the XA abort described in `92e9520a`, which is a pre-existing fault on that cluster and not something this PR touches. Two details worth recording — a StatefulSet `RollingUpdate` will not replace a `pod-0` that never becomes Ready, so the XA env var sat in the statefulset while the pod ran without it until the pod was deleted; and once `MIGRATION_MODEL` is empty while the master realm already holds its default client scopes, no amount of restarting recovers it.
