### PR TITLE
fix(ceph): 840 correct five defects in the ssd-tier and cache-size paths

### DIFF
--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -1404,7 +1404,11 @@ ceph_osd_get_cache_size()
     local rf=$($CEPH osd pool get $cachepool size | awk '{print $2}')
     local result=0
     # add each size into result (e.g.: 8.31,TiB 865,GiB)
-    for sz in $($CEPH osd df $cachepool | grep " ssd " | awk '{print $5","$6}') ; do
+    # 'osd df <pool>' already lists exactly the OSDs the pool's CRUSH rule can
+    # select, so the device class must not be filtered again here: a cache on
+    # nvme -- or on any other class -- would otherwise sum to zero. $1 is the
+    # OSD id, which keeps the header, TOTAL and MIN/MAX rows out.
+    for sz in $($CEPH osd df $cachepool | awk '$1 ~ /^[0-9]+$/ {print $5","$6}') ; do
         local N=$(echo $sz | awk -F',' '{print $1}')
         local U=$(echo $sz | awk -F',' '{print $2}')
         case "$U" in

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3323,9 +3323,13 @@ ceph_remove_group_ssdpool()
     if [ "$group" = "default" ] ; then
         local pool=${BUILTIN_BACKPOOL}-ssd
         local vtype=CubeStorage-ssd
+        # rule-ssd is shared with the cache tiering path, so it is never removed
+        # here -- see the note at the end of ceph_osd_disable_cache.
+        local rule=
     else
         local pool=${group}-ssd
         local vtype=${group}-ssd
+        local rule=${group}-ssd
     fi
 
     Quiet -n $OPENSTACK volume type delete $vtype
@@ -3338,6 +3342,27 @@ ceph_remove_group_ssdpool()
     else
         if ($CEPH osd pool ls | grep -q "^$pool$") ; then
             Quiet -n $CEPH osd pool delete $pool $pool --yes-i-really-really-mean-it
+        fi
+        # the per-group rule goes with the pool it was made for, but it is not
+        # this pool's alone: ceph_osd_create_cache builds the very same
+        # <group>-ssd rule and binds <group>-cache to it, so it only goes once
+        # no pool is left using it. After the pool delete, because CRUSH
+        # refuses to remove a rule that is still in use.
+        if [ -n "$rule" ] && ($CEPH osd crush rule ls | grep -q "^$rule$") ; then
+            local pools_json=$($CEPH osd pool ls detail -f json 2>/dev/null)
+            # 'numbers' keeps rule_id 0 (a valid id) and drops a null
+            local rule_id=$($CEPH osd crush rule dump $rule -f json 2>/dev/null | jq -r '.rule_id | numbers')
+            if [ -z "$rule_id" ] || ! (echo "$pools_json" | jq -e 'length > 0' >/dev/null 2>&1) ; then
+                # keep it rather than act on an answer we did not get
+                echo "Warning: cannot tell whether crush rule $rule is still in use, leaving it in place"
+            else
+                local rule_users=$(echo "$pools_json" | jq -r --argjson rid "$rule_id" '[ .[] | select(.crush_rule == $rid) | .pool_name ] | join(" ")')
+                if [ -n "$rule_users" ] ; then
+                    echo "Keeping crush rule $rule: still used by $rule_users"
+                else
+                    Quiet -n $CEPH osd crush rule rm $rule
+                fi
+            fi
         fi
         cmd -c "hex_config reconfig_cinder"
         cmd -c "hex_config restart_cinder"

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3284,12 +3284,12 @@ ceph_create_group_ssdpool()
 
     if [ "$group" = "default" ] ; then
         local pool=${BUILTIN_BACKPOOL}-ssd
-        local cpool=$BUILTIN_CACHEPOOL
+        local bpool=$BUILTIN_BACKPOOL
         local rule=rule-ssd
         local vtype=CubeStorage-ssd
     else
         local pool=${group}-ssd
-        local cpool=${group}-cache
+        local bpool=${group}-pool
         local rule=${group}-ssd
         local vtype=${group}-ssd
     fi
@@ -3300,8 +3300,12 @@ ceph_create_group_ssdpool()
 
     Quiet -n ceph_create_pool $pool rbd
 
-    local c_size=$($CEPH osd pool get $cpool size | awk '{print $2}' | tr -d '\n')
-    Quiet -n ceph_adjust_pool_size "$pool" $c_size
+    # RF comes from the base pool this tier was carved from. A cache pool is
+    # sized one replica below its base pool (ceph_create_node_group), so taking
+    # the RF from there left the tiered pool a replica short of the volumes it
+    # serves.
+    local b_size=$($CEPH osd pool get $bpool size | awk '{print $2}' | tr -d '\n')
+    Quiet -n ceph_adjust_pool_size "$pool" $b_size
     $CEPH osd pool set $pool crush_rule $rule
     Quiet -n $HEX_SDK os_volume_type_create $vtype $pool
 

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -800,7 +800,10 @@ ceph_adjust_pgs()
             $BUILTIN_CACHEPOOL|*-cache)
                 ceph_adjust_pool_pg $p 100
                 ;;
-            $BUILTIN_BACKPOOL|*-pool)
+            # a tiered pool (<group>-ssd) holds user volumes just like the base
+            # pool it was carved from, so it gets the base pool's share and not
+            # the 1-per-mille the catch-all hands to unknown pools.
+            $BUILTIN_BACKPOOL|*-pool|*-ssd)
                 ceph_adjust_pool_pg $p 400
                 ;;
             # others 35%: 350

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -726,6 +726,12 @@ ceph_pool_replicate_set()
             $BUILTIN_CACHEPOOL|$BUILTIN_EPHEMERAL|*-cache)
                 ceph_adjust_pool_size $P $cachesize
                 ;;
+            # a tiered pool (<group>-ssd) is a peer of its base pool, not of a
+            # cache pool: it carries user volumes, so it takes the same RF as
+            # the base pool that ceph_create_group_ssdpool sized it from.
+            *-ssd)
+                ceph_adjust_pool_size $P $size
+                ;;
             *)
                 ceph_adjust_pool_size $P $size
                 ;;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Five independent defects in `core/sdk_sh/modules/sdk_ceph.sh`, found while working #840.
They are unrelated to each other and to the rest of that story, so they land first and on
their own — one commit each, every commit `bash -n` clean, no build needed.

Each commit message carries its own "why this never blew up" and the 1cc measurement; this
is the map.

**A tiered pool is a peer of its base pool, not of a cache pool** (`ceph_create_group_ssdpool`)

`ceph_create_group_ssdpool` read the replica count out of the *cache* pool.
`ceph_create_node_group` deliberately sizes a cache pool one replica below its base pool,
so on a three-node cluster where the base pool is 3/2 the cache pool is 2/1 — and the
tiered pool inherited 2/1. It serves ordinary Cinder volumes, the same volumes from the
same tenants as the base pool, so one fewer replica is a durability difference nobody asked
for and nobody is told about. It now takes the base pool's RF.

Invisible in a lab: on a single-node cluster every pool is size 1, so the two sources agree.
It only separates once the cache pool is genuinely a replica below the base pool, which is
the normal 3cc shape.

`ceph_pool_replicate_set` gets a matching `*-ssd` arm. That arm is deliberately identical
to the catch-all — the RF a rebalance lands on was already right — but it sits one line
under `*-cache`, which hands out `$cachesize`, and that is the line the next reader will
fold `-ssd` into.

**A tiered pool is not an unknown pool** (`ceph_adjust_pgs`)

`<group>-ssd` was missing from that case statement too, and here the catch-all is not
harmless: it hands out a `data_pct` of 1 where the base pool gets 400. `data_pct` is per
mille, not per cent — `ceph_adjust_pool_pg` divides by `size * 1000` — so a tiered pool
holding a share of the cluster's Cinder volumes was budgeted one part in a thousand of the
cluster's data. It gets the base pool's share, because it holds the same kind of data for
the same reason.

**A per-group CRUSH rule outlived the pool it was made for** (`ceph_remove_group_ssdpool`)

`ceph_create_group_ssdpool` creates a `<group>-ssd` rule for every non-default group;
removal deleted the volume type and the pool and left the rule in the CRUSH map. An orphan
rule selects nothing, which is why it has sat here — what it costs is the *next*
`add_ssdpool` for the same group name: `crush rule create-replicated` on an existing name
is a silent no-op that returns 0 even when the arguments differ, so the new pool binds to a
rule built from the group's membership at some earlier point in time.

The removal is gated on nothing else still using the rule, rather than on the rule's name.
`ceph_osd_create_cache` derives `rule_ssd=${bucket}-ssd` for a non-default group too and
binds `<group>-cache` to it, and nothing disables the cache before `remove_ssdpool` runs —
`cache switch g1-pool on` followed by `remove_ssdpool g1` is reachable from the CLI. So
`rule-ssd` survives the default group by the same test that keeps `g1-ssd` alive while
`g1-cache` uses it, which is the reason `ceph_osd_disable_cache` already gives for leaving
it behind. Either half of the in-use query coming back empty leaves the rule in place: a
rule kept is recoverable, a rule removed from under a live cache pool is not.

**The cache size must not be filtered by device class again** (`ceph_osd_get_cache_size`)

`ceph osd df <pool>` already lists exactly the OSDs that pool's CRUSH rule can select, so
the `grep " ssd "` on top of it added nothing when the cache was on ssd and zeroed the whole
sum when it was not. That zero does not fall through to a skip:
`ceph_adjust_cache_flush_bytes` guards on `[ -n "$cache_sz" ]` and `"0"` is a non-empty
string, so a cache on any other class ended up with `target_max_bytes` set to 0 rather than
left alone. The grep was also serving as a row filter; matching `$1` — the OSD id — against
a number does that deterministically and does not care what the class is called, so `nvme`,
or a freely named tier, works the same as `ssd`.

#### Which issue(s) this PR fixes

Part of #840

Not a `Fixes`: these are pre-existing defects surfaced by that story, not the story itself.
The centralised tier CLI, the registry, the cache mutual-exclusion guard and the hardware
verification are still to come on the same issue.

#### Special notes for your reviewer

> **One fix cannot be measured end to end, and #1434 is why.** The `ceph_adjust_pgs`
> change is real dispatch — `cinder-volumes-ssd` and `g1-ssd` move from `data_pct` 1 to 400
> and every other pool's value is byte-identical to `develop` — but everything downstream of
> it sits behind `[ "$mode" != "on" ]`, and `pg_autoscale_mode` is `on` for all 25 pools on a
> stock 1cc. Turn the autoscaler off and the undeclared `$PG` two lines further down makes
> `bc` fail silently, so `pg_num` is never set either way. That is filed separately as
> **#1434** and deliberately untouched here. So the evidence for this one commit is the case
> dispatch with the mutating callee stubbed, not a `pg_num` on a live pool — by design, and
> the number is right for when #1434 lands.

> **Two nearby defects are deliberately not fixed.** `ceph_create_group_ssdpool`'s
> existence guard tests an undefined `$rule_ssd` (it expands to `grep -q "^$"`, so
> `create-replicated` always runs and is a no-op when the rule exists) — outside the scope
> agreed on #840, and harmless while that no-op holds. `ceph_adjust_pool_size`'s bucket
> inference does not recognise `-ssd`, but the `host_num` it computes only feeds the `ec`
> branch and no caller passes `ec` for a tiered pool, so there is no reachable failure.

> **Three follow-ups this PR does not take on.** (1) A tiered pool's RF now comes from a
> pool whose rule is class-unrestricted, while the tier's own rule is `$group host ssd`;
> the base pool's RF is clamped to the group's *host* count, not to the number of hosts
> carrying that class, so a 3-node cluster with ssd on only 2 nodes gets a permanently
> undersized tier where the old cache-pool sourcing happened to fit. `pool set size` fails
> `|| true`, so nothing reports it. Worth clamping by the hosts the tier's own rule can
> select. (2) The `data_pct` arms already total ~988 per mille; a tier at 400 takes the
> default group alone to ~1388, and base pool and tier each claim the full share for
> volumes they split — the `FIXME: what to do with variable no. of user-defined pools?`
> above that case statement is the same problem. (3) With the class filter gone, a row whose
> CLASS column is empty would shift `$5`/`$6`, and the `?) return 2` meant to catch an
> unrecognised unit only matches a single character, so it would contribute 0 silently.

> **Measured on a 1cc** (Ceph 18.2.8 reef, 1 host / 2 OSD, all hdd), against the unpatched
> module each time, with the module restored and the cluster reconciled to its baseline
> afterwards — 25 pools, `rules=replicated_rule`, `classes=["hdd"]`, HEALTH_OK,
> `cinder.conf` byte-identical:
> ```
> create_group_ssdpool   base 2 / cache 1 staged by hand -> new asks size 2, old asks 1
> remove_group_ssdpool   g1-ssd rule kept while g1-cache uses it ("Keeping crush rule ...")
>                        rule removed once it is the tier's alone; rule-ssd survives default
> pool_replicate_set     cinder-volumes-ssd stays at 3, matching cinder-volumes not cachepool
> adjust_pgs             *-ssd 1 -> 400, every other pool byte-identical to develop
> get_cache_size         hdd cache  0 -> 48318382080   (2 x 25 GiB x 0.9 / rf 1)
>                        nvme cache 0 -> 24159191040   (1 x 25 GiB x 0.9 / rf 1)
> ```
> The nvme case also confirms the pool filter is still doing the selecting: it sums one OSD,
> not two. `add_ssdpool` / `remove_ssdpool` / `rebalance` all returned 0 throughout.

> **Not verified here.** The shapes that need a real multi-node cluster: a cache pool
> genuinely one replica below its base pool, and a group whose host count is below the
> cluster's. Both were staged by hand on the 1cc rather than observed on a 3cc.

#### Additional documentation

```docs

```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
