### PR TITLE
feat(cinder): 840 add the device tier registry and generate its storage backend

### DIFF
--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -900,7 +900,7 @@ StartCinderService(const bool enabled, const bool isHa, const bool isBootstrap, 
  * Create volume types.
  */
 static void
-CreateVolumeTypes(const TuningStringArray& storageBackends)
+CreateVolumeTypes(const TuningStringArray& storageBackends, const TuningStringArray& storageTiers)
 {
     std::stringstream typesLine;
     typesLine << BUILTIN_VOLUME_TYPE;
@@ -918,6 +918,21 @@ CreateVolumeTypes(const TuningStringArray& storageBackends)
 
         typesLine << "," << storageBackendName;
         HexUtilSystemF(0, 0, HEX_SDK " os_volume_type_create %s %s", storageBackendName.c_str(), storageBackendName.c_str());
+    }
+
+    /**
+     * A device tier follows the same convention, so it is created the same way --
+     * and it has to be named on typesLine for a second reason: os_volume_type_clear
+     * deletes every volume type that is not on it.
+     */
+    for (std::vector<ConfigString>::const_iterator it = storageTiers.begin(); it != storageTiers.end(); it++) {
+        const std::string storageTierName = it->newValue();
+        if (storageTierName.length() == 0) {
+            continue;
+        }
+
+        typesLine << "," << storageTierName;
+        HexUtilSystemF(0, 0, HEX_SDK " os_volume_type_create %s %s", storageTierName.c_str(), storageTierName.c_str());
     }
 
     HexUtilSystemF(0, 0, HEX_SDK " os_volume_type_clear %s", typesLine.str().c_str());
@@ -1063,7 +1078,7 @@ Commit(bool modified, int dryLevel)
 
     // create the volume type
     if (s_bStorageBackendChanged)
-        CreateVolumeTypes(s_storageBackends);
+        CreateVolumeTypes(s_storageBackends, s_storageTiers);
 
     return true;
 }

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -96,6 +96,7 @@ CONFIG_TUNING_BOOL(CINDER_ENABLED, "cinder.enabled", TUNING_UNPUB, "Set to true 
 CONFIG_TUNING_STR(CINDER_USERPASS, "cinder.user.password", TUNING_UNPUB, "Set cinder user password.", USERPASS, ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(CINDER_DBPASS, "cinder.db.password", TUNING_UNPUB, "Set cinder database password.", DBPASS, ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(CINDER_STORAGE_BACKEND, "cinder.storage.backend.%d.name", TUNING_UNPUB, "Set additional storage backends.", "", ValidateRegex, DFT_REGEX_STR);
+CONFIG_TUNING_STR(CINDER_STORAGE_TIER, "cinder.storage.tier.%d.name", TUNING_UNPUB, "Set the Ceph device tiers that are backed by their own storage backend.", "", ValidateRegex, DFT_REGEX_STR);
 CONFIG_TUNING_STR(CINDER_VOLUME_TYPE_DEFAULT, "cinder.storage.volumeType.default", TUNING_UNPUB, "Set the default cinder volume type.", BUILTIN_VOLUME_TYPE, ValidateRegex, DFT_REGEX_STR);
 
 // public tunigns
@@ -124,6 +125,7 @@ PARSE_TUNING_BOOL(s_debug, CINDER_DEBUG);
 PARSE_TUNING_STR(s_cinderPass, CINDER_USERPASS);
 PARSE_TUNING_STR(s_dbPass, CINDER_DBPASS);
 PARSE_TUNING_STR_ARRAY(s_storageBackends, CINDER_STORAGE_BACKEND);
+PARSE_TUNING_STR_ARRAY(s_storageTiers, CINDER_STORAGE_TIER);
 PARSE_TUNING_STR(s_volumeTypeDefault, CINDER_VOLUME_TYPE_DEFAULT);
 PARSE_TUNING_BOOL(s_backupOverride, CINDER_BACKUP_OVERRIDE);
 PARSE_TUNING_STR(s_backupType, CINDER_BACKUP_TYPE);
@@ -313,6 +315,7 @@ CommitCheck(bool modified, int dryLevel)
         || s_bCubeModified;
 
     s_bStorageBackendChanged = s_storageBackends.modified()
+        || s_storageTiers.modified()
         || s_volumeTypeDefault.modified()
         || isStorageBackendModified();
 

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -712,6 +712,7 @@ AddCephPoolAsStorageBackend(
     config[pool]["rados_connect_timeout"] = "-1";
     config[pool]["rbd_store_chunk_size"] = "4";
     config[pool]["rbd_max_clone_depth"] = "5";
+    config[pool]["enable_deferred_deletion"] = "true";
     config[pool]["rbd_flatten_volume_from_snapshot"] = "false";
     config[pool]["image_upload_use_cinder_backend"] = "true";
 }

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -20,6 +20,8 @@
 #include <hex/process_util.h>
 #include <mysql_util.h>
 
+#include <algorithm>
+
 static LogRotateConf log_conf("cinder", "/var/log/cinder/*.log", DAILY, 128, 0, true);
 
 static const char USER[] = "cinder";
@@ -691,6 +693,96 @@ SetBackup(
 }
 
 /**
+ * Collect the device tiers that this module can safely act on.
+ *
+ * The tuning framework does not validate a string tuning at all: TuningStringArray
+ * takes a ValidateType and drops it (hex/include/hex/config_tuning.h), and the regex
+ * this one is declared with is DFT_REGEX_STR, "^.*$", so it would accept anything
+ * even if it were applied. Whatever reaches the registry reaches a cinder.conf
+ * section name and, through HexUtilSystemF, a /bin/bash -c line.
+ *
+ * The CLI checks all of this before it writes, but the CLI is not the only writer --
+ * the policy file this array is translated from is itself an entry point, and a
+ * commit can be handed a settings file directly. So the checks that need nothing but
+ * this file are made here as well, on the consuming side, where no writer can go
+ * around them.
+ *
+ * A rejected entry is skipped rather than failing the commit: one bad name in the
+ * registry should cost that tier, not every other thing this module configures.
+ *
+ * What is deliberately NOT checked here, because it needs Ceph or the Cinder catalog:
+ * whether the name collides with an existing CRUSH rule, pool, device class or volume
+ * type, and whether the OSDs behind it are eligible. Those stay with the CLI.
+ */
+static std::vector<std::string>
+CollectStorageTiers(
+    const TuningStringArray& storageTiers,
+    const TuningStringArray& storageBackends)
+{
+    static const char TIER_NAME_CHARS[] =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+
+    std::vector<std::string> tiers;
+
+    for (std::vector<ConfigString>::const_iterator it = storageTiers.begin(); it != storageTiers.end(); it++) {
+        const std::string tier = it->newValue();
+
+        // an empty entry is how the policy file encodes an empty list, not an error
+        if (tier.length() == 0) {
+            continue;
+        }
+
+        if (tier.find_first_not_of(TIER_NAME_CHARS) != std::string::npos) {
+            HexLogError("device tier \"%s\" is not [A-Za-z0-9_-]+, ignoring it", tier.c_str());
+            continue;
+        }
+
+        /**
+         * The scan in ReconfigMain matches "-pool" and "-ssd" as substrings, not as
+         * suffixes, so a tier carrying either would be claimed as a node group pool
+         * as well and end up configured twice.
+         */
+        if (tier.find("-pool") != std::string::npos || tier.find("-ssd") != std::string::npos) {
+            HexLogError("device tier \"%s\" contains -pool or -ssd, which the node group scan claims, ignoring it", tier.c_str());
+            continue;
+        }
+
+        /**
+         * A tier named after the built-in backend would take the [ceph] section with
+         * it -- AddCephPoolAsStorageBackend would repoint rbd_pool away from
+         * cinder-volumes -- and one named after the built-in volume type would leave
+         * that type pointing at the built-in backend while a section by the same name
+         * waits on a pool nobody created.
+         */
+        if (tier == BUILTIN_STORAGE_BACKEND || tier == BUILTIN_VOLUME_TYPE) {
+            HexLogError("device tier \"%s\" is a reserved name, ignoring it", tier.c_str());
+            continue;
+        }
+
+        bool taken = false;
+        for (std::vector<ConfigString>::const_iterator bit = storageBackends.begin(); bit != storageBackends.end(); bit++) {
+            if (bit->newValue().length() > 0 && bit->newValue() == tier) {
+                HexLogError("device tier \"%s\" is already an external storage backend, ignoring it", tier.c_str());
+                taken = true;
+                break;
+            }
+        }
+        if (taken) {
+            continue;
+        }
+
+        if (std::find(tiers.begin(), tiers.end(), tier) != tiers.end()) {
+            HexLogError("device tier \"%s\" is listed more than once, ignoring the repeat", tier.c_str());
+            continue;
+        }
+
+        tiers.push_back(tier);
+    }
+
+    return tiers;
+}
+
+/**
  * Add a Ceph pool as a storage backend.
  */
 static void
@@ -723,7 +815,8 @@ AddCephPoolAsStorageBackend(
 static void
 SetStorageBackend(
     Configs& config,
-    const std::string defaultVolumeType)
+    const std::string defaultVolumeType,
+    const std::vector<std::string>& storageTiers)
 {
     // Opt an upgraded cluster's existing backends into Caracal's unsupported-driver
     // gate. Here, and not earlier: CINDER_BACKEND_DIR is settled by now (written by
@@ -770,14 +863,9 @@ SetStorageBackend(
      * generated here from the registry, the same way ReconfigMain generates one for
      * a node group pool.
      */
-    for (std::vector<ConfigString>::const_iterator it = s_storageTiers.begin(); it != s_storageTiers.end(); it++) {
-        const std::string tier = it->newValue();
-        if (tier.length() == 0) {
-            continue;
-        }
-
-        AddCephPoolAsStorageBackend(config, tier);
-        enabledBackendLine << "," << tier;
+    for (std::vector<std::string>::const_iterator it = storageTiers.begin(); it != storageTiers.end(); it++) {
+        AddCephPoolAsStorageBackend(config, *it);
+        enabledBackendLine << "," << *it;
     }
 
     config["DEFAULT"]["allowed_direct_url_schemes"] = "cinder";
@@ -901,7 +989,7 @@ StartCinderService(const bool enabled, const bool isHa, const bool isBootstrap, 
  * Create volume types.
  */
 static void
-CreateVolumeTypes(const TuningStringArray& storageBackends, const TuningStringArray& storageTiers)
+CreateVolumeTypes(const TuningStringArray& storageBackends, const std::vector<std::string>& storageTiers)
 {
     std::stringstream typesLine;
     typesLine << BUILTIN_VOLUME_TYPE;
@@ -926,14 +1014,9 @@ CreateVolumeTypes(const TuningStringArray& storageBackends, const TuningStringAr
      * and it has to be named on typesLine for a second reason: os_volume_type_clear
      * deletes every volume type that is not on it.
      */
-    for (std::vector<ConfigString>::const_iterator it = storageTiers.begin(); it != storageTiers.end(); it++) {
-        const std::string storageTierName = it->newValue();
-        if (storageTierName.length() == 0) {
-            continue;
-        }
-
-        typesLine << "," << storageTierName;
-        HexUtilSystemF(0, 0, HEX_SDK " os_volume_type_create %s %s", storageTierName.c_str(), storageTierName.c_str());
+    for (std::vector<std::string>::const_iterator it = storageTiers.begin(); it != storageTiers.end(); it++) {
+        typesLine << "," << *it;
+        HexUtilSystemF(0, 0, HEX_SDK " os_volume_type_create %s %s", it->c_str(), it->c_str());
     }
 
     HexUtilSystemF(0, 0, HEX_SDK " os_volume_type_clear %s", typesLine.str().c_str());
@@ -968,6 +1051,9 @@ Commit(bool modified, int dryLevel)
     std::string ctrlIp = G(CTRL_IP);
     std::string sharedId = G(SHARED_ID);
     std::string external = G(EXTERNAL);
+
+    // vetted once, so a rejected entry is reported once and every consumer below agrees
+    const std::vector<std::string> storageTiers = CollectStorageTiers(s_storageTiers, s_storageBackends);
 
     std::string cinderPass = GetSaltKey(s_saltkey, s_cinderPass.newValue(), s_seed.newValue());
     std::string dbPass = GetSaltKey(s_saltkey, s_dbPass.newValue(), s_seed.newValue());
@@ -1012,9 +1098,9 @@ Commit(bool modified, int dryLevel)
         SetNovaInfo(mainConfig, sharedId, s_cubeRegion, domain, novaPass);
         SetCeph(mainConfig, virshSecret);
         if (s_volumeTypeDefault.newValue() != "") {
-            SetStorageBackend(mainConfig, s_volumeTypeDefault);
+            SetStorageBackend(mainConfig, s_volumeTypeDefault, storageTiers);
         } else {
-            SetStorageBackend(mainConfig, BUILTIN_VOLUME_TYPE);
+            SetStorageBackend(mainConfig, BUILTIN_VOLUME_TYPE, storageTiers);
         }
         SetBackup(
             mainConfig,
@@ -1063,12 +1149,8 @@ Commit(bool modified, int dryLevel)
      * every pool it generates. Naming the tier on both sides would wait out the
      * full timeout on a host that never reports in.
      */
-    for (std::vector<ConfigString>::const_iterator it = s_storageTiers.begin(); it != s_storageTiers.end(); it++) {
-        if (it->newValue().length() == 0) {
-            continue;
-        }
-
-        enabledHostLine << "," << BUILTIN_STORAGE_HOST << "@" << it->newValue();
+    for (std::vector<std::string>::const_iterator it = storageTiers.begin(); it != storageTiers.end(); it++) {
+        enabledHostLine << "," << BUILTIN_STORAGE_HOST << "@" << *it;
     }
     HexUtilSystemF(
         0,
@@ -1079,7 +1161,7 @@ Commit(bool modified, int dryLevel)
 
     // create the volume type
     if (s_bStorageBackendChanged)
-        CreateVolumeTypes(s_storageBackends, s_storageTiers);
+        CreateVolumeTypes(s_storageBackends, storageTiers);
 
     return true;
 }

--- a/core/modules/config_cinder.cpp
+++ b/core/modules/config_cinder.cpp
@@ -691,6 +691,32 @@ SetBackup(
 }
 
 /**
+ * Add a Ceph pool as a storage backend.
+ */
+static void
+AddCephPoolAsStorageBackend(
+    Configs& config,
+    const std::string pool)
+{
+    config[pool]["backend_host"] = BUILTIN_STORAGE_HOST;
+    config[pool]["volume_backend_name"] = pool;
+    config[pool]["rbd_pool"] = pool;
+    config[pool]["volume_driver"] = "cinder.volume.drivers.rbd.RBDDriver";
+    config[pool]["rbd_ceph_conf"] = "/etc/ceph/ceph.conf";
+    config[pool]["rbd_user"] = "admin";
+    if (config.count(BUILTIN_STORAGE_BACKEND) > 0 && config[BUILTIN_STORAGE_BACKEND].count("rbd_secret_uuid") > 0) {
+        config[pool]["rbd_secret_uuid"] = config[BUILTIN_STORAGE_BACKEND]["rbd_secret_uuid"];
+    } else {
+        config[pool]["rbd_secret_uuid"] = HexUtilPOpen(HEX_SDK " os_virsh_secret_uuid %s", s_seed.c_str());
+    }
+    config[pool]["rados_connect_timeout"] = "-1";
+    config[pool]["rbd_store_chunk_size"] = "4";
+    config[pool]["rbd_max_clone_depth"] = "5";
+    config[pool]["rbd_flatten_volume_from_snapshot"] = "false";
+    config[pool]["image_upload_use_cinder_backend"] = "true";
+}
+
+/**
  * Set the storage backends.
  */
 static void
@@ -734,6 +760,23 @@ SetStorageBackend(
         }
 
         enabledBackendLine << "," << it->newValue();
+    }
+
+    /**
+     * Device tiers differ from the backends above in where their [section] comes
+     * from. An external backend ships one in its own ext_storage_*.conf, copied in
+     * just above; a device tier is an RBD pool in this cluster, so its section is
+     * generated here from the registry, the same way ReconfigMain generates one for
+     * a node group pool.
+     */
+    for (std::vector<ConfigString>::const_iterator it = s_storageTiers.begin(); it != s_storageTiers.end(); it++) {
+        const std::string tier = it->newValue();
+        if (tier.length() == 0) {
+            continue;
+        }
+
+        AddCephPoolAsStorageBackend(config, tier);
+        enabledBackendLine << "," << tier;
     }
 
     config["DEFAULT"]["allowed_direct_url_schemes"] = "cinder";
@@ -997,6 +1040,20 @@ Commit(bool modified, int dryLevel)
 
         enabledHostLine << "," << it->newValue() << "@" << it->newValue();
     }
+    /**
+     * A device tier's host is the built-in one, not its own name: the Host column
+     * of `openstack volume service list` is <backend_host>@<section>, and
+     * AddCephPoolAsStorageBackend sets backend_host to BUILTIN_STORAGE_HOST for
+     * every pool it generates. Naming the tier on both sides would wait out the
+     * full timeout on a host that never reports in.
+     */
+    for (std::vector<ConfigString>::const_iterator it = s_storageTiers.begin(); it != s_storageTiers.end(); it++) {
+        if (it->newValue().length() == 0) {
+            continue;
+        }
+
+        enabledHostLine << "," << BUILTIN_STORAGE_HOST << "@" << it->newValue();
+    }
     HexUtilSystemF(
         0,
         0,
@@ -1031,32 +1088,6 @@ RestartMain(int argc, char* argv[])
     StartCinderService(s_enabled, s_ha, IsBootstrap(), G(IS_MASTER));
 
     return EXIT_SUCCESS;
-}
-
-/**
- * Add a Ceph pool as a storage backend.
- */
-static void
-AddCephPoolAsStorageBackend(
-    Configs& config,
-    const std::string pool)
-{
-    config[pool]["backend_host"] = BUILTIN_STORAGE_HOST;
-    config[pool]["volume_backend_name"] = pool;
-    config[pool]["rbd_pool"] = pool;
-    config[pool]["volume_driver"] = "cinder.volume.drivers.rbd.RBDDriver";
-    config[pool]["rbd_ceph_conf"] = "/etc/ceph/ceph.conf";
-    config[pool]["rbd_user"] = "admin";
-    if (config.count(BUILTIN_STORAGE_BACKEND) > 0 && config[BUILTIN_STORAGE_BACKEND].count("rbd_secret_uuid") > 0) {
-        config[pool]["rbd_secret_uuid"] = config[BUILTIN_STORAGE_BACKEND]["rbd_secret_uuid"];
-    } else {
-        config[pool]["rbd_secret_uuid"] = HexUtilPOpen(HEX_SDK " os_virsh_secret_uuid %s", s_seed.c_str());
-    }
-    config[pool]["rados_connect_timeout"] = "-1";
-    config[pool]["rbd_store_chunk_size"] = "4";
-    config[pool]["rbd_max_clone_depth"] = "5";
-    config[pool]["rbd_flatten_volume_from_snapshot"] = "false";
-    config[pool]["image_upload_use_cinder_backend"] = "true";
 }
 
 static void

--- a/core/modules/include/policy_ext_storage.h
+++ b/core/modules/include/policy_ext_storage.h
@@ -10,6 +10,7 @@
 struct ExtStorageConfig {
     std::string volumeTypeDefault;
     std::vector<std::string> storageBackends;
+    std::vector<std::string> storageTiers;
     bool imageUseMultipath;
     bool imageEnforceMultipath;
 };

--- a/core/modules/policy_ext_storage.cpp
+++ b/core/modules/policy_ext_storage.cpp
@@ -56,6 +56,13 @@ bool ExtStoragePolicy::load(const char* policyFile)
         this->config.storageBackends.push_back(backendName);
     }
 
+    std::size_t tierCount = SizeOfYmlSeq(ymlRoot, "tiers");
+    for (std::size_t i = 1; i <= tierCount; i++) {
+        std::string tierName;
+        HexYmlParseString(tierName, this->ymlRoot, "tiers.%zu.name", i);
+        this->config.storageTiers.push_back(tierName);
+    }
+
     HexYmlParseBool(&(this->config.imageUseMultipath), this->ymlRoot, "image.multipath.use");
     HexYmlParseBool(&(this->config.imageEnforceMultipath), this->ymlRoot, "image.multipath.enforce");
 
@@ -87,6 +94,28 @@ bool ExtStoragePolicy::save(const char* policyFile)
         }
         std::string prefix = std::string("backends.").append(ymlIndex);
         if (AddYmlNode(this->ymlRoot, prefix.c_str(), "name", this->config.storageBackends[i].c_str()) != 0) {
+            return false;
+        }
+    }
+
+    if (DeleteYmlNode(this->ymlRoot, "tiers") != 0) {
+        return false;
+    }
+    AddYmlKey(this->ymlRoot, NULL, "tiers");
+
+    if (this->config.storageTiers.size() == 0) {
+        // the yml parser needs to set at least one blank child
+        // we would create a blank child if we do not have any
+        this->config.storageTiers.push_back("");
+    }
+    for (std::size_t i = 0; i < this->config.storageTiers.size(); i++) {
+        // yml index starts from 1
+        std::string ymlIndex = std::to_string(i + 1);
+        if (AddYmlKey(this->ymlRoot, "tiers", ymlIndex.c_str()) != 0) {
+            return false;
+        }
+        std::string prefix = std::string("tiers.").append(ymlIndex);
+        if (AddYmlNode(this->ymlRoot, prefix.c_str(), "name", this->config.storageTiers[i].c_str()) != 0) {
             return false;
         }
     }

--- a/core/modules/translate_ext_storage.cpp
+++ b/core/modules/translate_ext_storage.cpp
@@ -25,6 +25,11 @@ Translate(const char* policyFile, FILE* settings)
         fprintf(settings, "cinder.storage.backend.%zu.name = %s\n", i, config.storageBackends[i].c_str());
     }
 
+    // settings index starts from 0, while the yml sequence it comes from starts from 1
+    for (std::size_t i = 0; i < config.storageTiers.size(); i++) {
+        fprintf(settings, "cinder.storage.tier.%zu.name = %s\n", i, config.storageTiers[i].c_str());
+    }
+
     fprintf(settings, "glance.cinder.useMultipath = %s\n", (config.imageUseMultipath ? "true" : "false"));
     fprintf(settings, "glance.cinder.enforceMultipath = %s\n", (config.imageEnforceMultipath ? "true" : "false"));
 

--- a/core/policies/external_storage/external_storage1_0.yml
+++ b/core/policies/external_storage/external_storage1_0.yml
@@ -7,6 +7,8 @@ volumeType:
   default: CubeStorage
 backends:
   - name:
+tiers:
+  - name:
 image:
   multipath:
     use: true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

#840 replaces Ceph cache tiering with device tiers: a named set of OSDs carrying its own
CRUSH device class, CRUSH rule, RBD pool and Cinder volume type, all four sharing the tier's
name. The Ceph half of that is imperative and lives in `hex_sdk`. This PR is the half that
has to survive a reboot — the registry that remembers which tiers exist, and everything
`config_cinder` has to do with an entry in it.

Five commits, one per step, each with its own measurement.

**The registry** (`cinder.storage.tier.%d.name`)

A second indexed tuning array alongside the existing `cinder.storage.backend.%d.name`,
rather than more entries in that one, because the two are not the same kind of thing: an
entry in `.backend` is an external array that ships its own `ext_storage_*.conf`, an entry
in `.tier` is a pool in this cluster whose `[section]` this module generates.

It holds one field, the name. Class, rule, pool and volume type are that same name by
convention, and OSD membership is read out of `ceph osd crush class ls-osd <tier>`, where
Ceph is the authority. A second membership list here would be the one that goes stale after
any operator action taken outside the CLI.

**The policy chain** — `external_storage`, not a policy of its own. A new `ceph_tier` policy
directory would mean a second policy class, a second translate module and a second file for
an operator to reason about, to carry one list of names that ends up in the same
`cinder.conf` as the list already in this policy. What makes a device tier a device tier is
the tuning key it lands on, not the directory the yml sits in.

Two conventions in there are pre-existing and disagree with each other — the yml sequence is
1-based, `settings.txt` is 0-based — and the `tiers` block follows `backends` on both,
including the blank-child workaround `save()` needs to keep the yml parser happy.

**The backend** — an entry in the registry becomes a `cinder.conf` `[section]`, a slot in
`enabled_backends`, and an entry in the readiness wait. `ReconfigMain` already generates
exactly that section for a node group pool, so `AddCephPoolAsStorageBackend` is reused
rather than a second generator written — which is why it moves up the file. The move is
verbatim; `git show --color-moved` shows nothing else in it.

**The volume type** — `os_volume_type_clear` is not a garbage collector for volume types it
created; it deletes every volume type in the catalog that is not named on the line it is
handed. So a tier does not just need its volume type created, it needs to be on that line,
or the next commit that touches a storage backend deletes the one object a user actually
selects at volume-create time, while the tier stays in `cinder.conf` and in the registry.

**`enable_deferred_deletion` on a generated backend** — `a16a9c89` moved Cinder onto the RBD
trash system by setting it on the built-in `[ceph]` backend, and every backend generated
from a Ceph pool in this file was left behind. Before this PR `SetCeph` writes 13 keys and
`AddCephPoolAsStorageBackend` writes 12, and the difference is exactly this one. Reported as
defect 7 in the #840 briefing, and the only item on that list that turned out to be a real
gap on inspection.

**Rejecting a name this module cannot use** — the registry was written assuming the CLI is
the only writer, and this PR is what makes that assumption false: the policy chain above is
a second writer and `hex_config commit <settings>` is a third, neither of which goes through
`cli_ceph.cpp`. Nothing in between checks anything — `TuningStringArray` takes a
`ValidateType` and drops it, and the regex it is declared with is `^.*$` anyway — and the
other end is `HexUtilSystemF`, which is `/bin/bash -c` on a `vasprintf`ed string with the
name interpolated unquoted. So the checks that need nothing but this file are made on the
consuming side, once, where no writer can go around them: the charset, the `-pool` / `-ssd`
substrings, the two reserved names, an external backend's name, and a repeat. A rejected
entry is logged and skipped, not fatal — one bad name should cost that tier, not the
database and the message queue as well. The collisions that need to ask Ceph or the Cinder
catalog stay with the CLI.

#### Which issue(s) this PR fixes

Part of #840

Not a `Fixes`: this is the registry the story needs, not the story. The SDK execution layer,
the CLI with all of the input validation, the cache mutual-exclusion guard and the hardware
verification are still to come on the same issue.

#### Special notes for your reviewer

> **On an untouched system this changes one thing, and it is not the registry.** With an
> empty tier array every new loop skips, and a `hex_config commit` produces a `cinder.conf`
> byte-identical to the one before — measured on a 1cc. What does change on an existing
> install is `enable_deferred_deletion`: the node group `*-pool` / `*-ssd` sections come out
> of the same generator, so they pick it up on the next `reconfig_cinder`. That is the
> intended fix, but it is a behaviour change on installs that have node group pools, and
> those were not available to measure here.

> **The readiness wait is the part that would have failed quietly, so it is worth a look.**
> `cinder_are_services_up` matches the `Host` column of `openstack volume service list`
> literally, and that column is `<backend_host>@<section>`. External backends write
> `backend_host = <name>` (`sdk_cinder.sh:1248`), which is why the existing loop emits
> `name@name` — but `AddCephPoolAsStorageBackend` writes `BUILTIN_STORAGE_HOST` for every
> pool it generates, so a tier is `cube@<tier>`. Copying the existing form would have waited
> out the full timeout on every commit, on a host that does not exist, and then carried on.
> Measured: `cube@ceph` and `cube@seki1`.

> **`policy_ext_storage.o` and `translate_ext_storage.o` link into `hex_translate`, not
> `hex_config`** (`core/main/cube.mk`). Three artifacts, three deployment paths — the third
> being `external_storage1_0.yml` itself, which is installed into `/etc/policies`. Anyone
> hot-patching only `hex_config` to test this gets a half-working system: `commit` knows the
> key, `apply` never produces it. Found the hard way; noting it so the next person does not.

> **The registry is not a repair path for the Cinder catalog, and this PR does not make it
> one.** CreateVolumeTypes runs only when `s_bStorageBackendChanged` is set — a tuning
> changing, the default volume type changing, or an external backend's config file changing
> — never because the catalog lost a row. So a volume type deleted by hand does not come
> back on the next commit, and bootstrap does not reach that call at all: `CommitCheck`
> returns early with only `s_bConfigChanged` set, which is why the built-in `CubeStorage`
> type is created by `ClusterStartMain` instead. A node bootstrapped from a settings file
> that already names tiers therefore gets their sections and their `enabled_backends`
> entries but not their volume types. That gap is not new — the external backends in the
> loop above have always behaved the same way — and closing it means deciding on a
> reconciliation trigger, because the sweep at the end of that function is destructive and
> cannot simply be run unconditionally. Out of scope here, and stated rather than left to be
> discovered.

> **`CubeStorage-ssd` is still deleted by that same volume type sweep, and this PR does not
> fix it.** It comes from `ceph_create_group_ssdpool`, the legacy node group path, and
> nothing in a tuning knows it exists — the pools behind it are found by scanning Ceph for
> `*-pool` and `*-ssd` at reconfig time, not by a registry. Putting it back on the keep list
> would mean querying Ceph from a Cinder commit, which is neither in this PR's scope nor
> decided anywhere. It is a real defect, it is on the same line of code, and it is left
> alone deliberately rather than missed.

> **The last commit is a review finding, and it is the one worth the most attention.** The
> first five were written on the premise that `cli_ceph.cpp` is the only writer and therefore
> the only place a tier name has to be checked. That premise does not survive this PR, which
> adds a second writer. Measured on a 1cc against the fifth commit: a policy file carrying
> `tiers: [{name: "a;touch /tmp/wp1-injected"}]` translates clean, commits clean, creates the
> file, and leaves `enabled_backends = ceph,a;touch /tmp/wp1-injected`. Everyone on that path
> is root, so no privilege boundary is crossed — it is a config file that executes, silently.
> The guard is on the consuming side rather than in `Parse` so that every writer hits it, and
> it only makes the calls that can be answered from this file. Split into its own commit
> because it is its own decision, and because the reasoning belongs next to it rather than
> spread over the four commits it corrects.

> **What the tuning framework does and does not do, since the guard's existence depends on
> it.** `CONFIG_MODULE(cinder, Init, Parse, 0, 0, Commit)` has `0` in the validate slot, and
> `hex_config validate_tuning_value` compares the tuning name literally, so a key whose name
> contains `%d` never matches — that much was known. What was not: `TuningStringArray`'s
> constructor takes a `ValidateType` and never stores it, and so does `TuningString`, so no
> `CONFIG_TUNING_STR` in this tree is value-validated by the framework at all. `DFT_REGEX_STR`
> is `"^.*$"`, so it would change nothing if it were applied. Worth knowing beyond this PR.

> **Nothing writes the registry yet either.** The write path — the tier equivalent of
> `cinder_apply_storage_creation`'s `yq` plus `hex_config apply` chain — comes with the CLI.
> Until then a tier is registered by editing `settings.txt` or the policy file, which is
> exactly how it was measured below.

> **One thing the measurement turned up, for whoever reviews the delete path later.** The
> moment a backend leaves `enabled_backends` its `cinder-volume` service goes down, and a
> volume delete issued after that is never processed — the volume sits in `deleting` and its
> volume type cannot be removed either, so recovering it needs the backend put back, a state
> reset, and a second delete. Volumes have to be gone before the registry entry is. The SDK
> delete path already gates on `cinder_is_volume_type_in_use`; this is the evidence that the
> gate is necessary rather than defensive.

> **Measured on a 1cc** (Ceph 18.2.8 reef, 1 host / 2 OSD, all hdd), with the built
> hex_config installed over the running one and everything restored afterwards each time --
> hex_config back to its original sha, `cinder.conf` byte-identical to the pre-test copy,
> 25 pools, `rules=replicated_rule`, `classes=["hdd"]`, HEALTH_OK, volume types back to
> `CubeStorage` / `__DEFAULT__`.
>
> The happy path, with pool seki1 created first and `cinder.storage.tier.0.name = seki1`:
> ```
> commit               enabled_backends = ceph,seki1
>                      [seki1] generated; its 13 key names diff empty against [ceph]
>                      (values differ only for rbd_pool and volume_backend_name)
>                      enable_deferred_deletion = true present
> volume type          seki1 created and still there after the same commit's
>                      os_volume_type_clear
> service list         cinder-volume cube@seki1 up
> end to end           openstack volume create --type seki1 --size 1 -> available
>                      rbd -p seki1 ls shows it; os-vol-host-attr:host is cube@seki1#seki1
> reverse              key removed -> section, enabled_backends entry, volume type and
>                      service all gone
> policy path          same policy dir through the old and the new hex_translate:
>                        old -> no tier lines
>                        new -> cinder.storage.tier.0.name = gold
>                               cinder.storage.tier.1.name = silver
>                      (1-based yml sequence coming out 0-based, as the array parser needs)
> upgrade path         that 1cc's installed policy file has no `tiers` key at all; the new
>                      hex_translate reads it as zero tiers and translates it without error
> ```
>
> The guard, against a registry of ten entries -- two legal tiers with real pools, seven
> each breaking one rule, and one empty:
> ```
> tier.0 a;touch /tmp/wp1-injected    tier.5 CubeStorage
> tier.1 good1                        tier.6 good1  (repeat)
> tier.2 gold-pool                    tier.7 (empty)
> tier.3 has space                    tier.8 silver-ssd
> tier.4 ceph                         tier.9 good2
>
> /tmp/wp1-injected    not created    the same file against the fifth commit does create it
> enabled_backends     ceph,good1,good2
> sections             only [ceph], [good1], [good2]
> [ceph] rbd_pool      still cinder-volumes
> volume types         good1, good2, CubeStorage, __DEFAULT__
> services             cube@ceph, cube@good1, cube@good2 all up
> log                  exactly seven Error lines, each naming the rule it broke;
>                      none for the empty entry, which is skipped in silence
> end to end           volume create --type good2 -> cube@good2#good2, and
>                      rbd -p good1 is empty -- two live tiers, and it went to the named one
> ```
> The one rule that cannot be shown that way is a tier colliding with an external backend,
> because that name belongs in enabled_backends on its own account. It is shown by the
> section instead -- with `cinder.storage.backend.0.name = extbk` and a tier also named
> extbk, the log says so, `enabled_backends` is `ceph,extbk,good1` with extbk once, and no
> `[extbk]` section exists, which is the thing the guard alone decides.

> **Not verified here.** Survival across an A/B split and a reboot — that needs a full ISO
> and is part of the hardware verification still to come on #840. Anything that needs more
> than one host: this cluster puts every pool at size 1. And the guard's rules are shown by
> what does not appear rather than by intercepting the calls themselves — no stub or strace
> harness was built for this, so the evidence for five of the six is the absence of the
> section, the volume type, the service and the side effect.

#### Additional documentation

```docs

```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
