### PR TITLE
feat(ceph): 840 add the device tier SDK layer and keep the cache switch off it

### DIFF
--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3853,3 +3853,780 @@ ceph_mgr_dashboard_ensure()
     echo "ceph-mgr dashboard on $active not serving after module bounce" >&2
     return 1
 }
+
+# ---------------------------------------------------------------------------
+# Device tiering (#840)
+#
+# "tier" means three unrelated things around this file, so everything below
+# says device tier in full and nothing below is about the other two:
+#
+#   device tier   a named set of OSDs -- what these functions build
+#   cache tier    Ceph's cache tiering (osd tier add, cachepool, target_max_bytes),
+#                 the mechanism #840 exists to move away from
+#   daemon tier   the mon / osd / mgr grouping in `ceph versions`, which is what
+#                 the pre-existing ceph_tier_releases means by tier
+#
+# A device tier is a named set of OSDs carrying its own CRUSH device class,
+# CRUSH rule, RBD pool and Cinder volume type -- all four share the tier's
+# name. The order below is forced by Ceph: a rule cannot select a class that no
+# OSD carries, so the class has to come first.
+#
+# Where the data starts moving depends on what the OSDs were doing before. For
+# an OSD whose old class no rule selects through, nothing moves until step 4
+# binds the pool. But if any rule is class-restricted to that old class -- the
+# cache tiering path's rule-ssd / rule-hdd, or another device tier -- then
+# step 1's
+# rm-device-class changes that rule's OSD set immediately, and its pools start
+# remapping right there. So the CLI layer's confirmation has to come before the
+# first call into here, not before step 4; see the WP-5 contract in spec.md.
+#
+#   1  crush rm-device-class + set-device-class <name> <osd...>
+#   2  crush rule create-replicated <name> default host <name>
+#   3  ceph_create_pool <name> rbd <size>       -- never bare, see below
+#   4  osd pool set <name> crush_rule <name>    -- the pool joins the tier here
+#   5  os_volume_type_create <name> <name>
+#   6  tuning registry -> hex_config -> Cinder backend      *** not done here ***
+#
+# Step 6 is what makes the volume type usable by Cinder. It belongs to the
+# hex_config side and is deliberately absent: a device tier built by these
+# functions is complete on the Ceph side and present in the Cinder catalog,
+# and has no backend behind it yet.
+#
+# A bare `osd pool create` yields size 1 / min_size 1, and this cluster runs
+# with `mon warn on pool no redundancy = false` so Ceph does not even warn --
+# hence ceph_create_pool with an explicit size, then ceph_adjust_pool_size for
+# the (size, min_size) pair, everywhere below.
+#
+# Ceph is imperative, so a failed create unwinds in reverse over what that
+# invocation actually made: a half-built device tier is worse than a failed
+# one. Note
+# the asymmetry with ceph_device_tier_delete -- an unwind restores each OSD's
+# previous device class, while a deliberate delete leaves the OSDs classless
+# (settled on #840: the product does not guess what an OSD used to be).
+#
+# Input validation beyond argument sanity -- name collisions against existing
+# rules / pools / volume types, "that OSD already belongs to another device
+# tier" --
+# lives in the CLI layer and is not duplicated here.
+# ---------------------------------------------------------------------------
+
+# A device tier's name becomes a pool name, and config_cinder.cpp's scan for
+# legacy tiering matches "-pool" / "-ssd" as substrings rather than suffixes, so
+# a device tier called "gold-ssd-1" would be picked up by that scan as well as
+# by the registry. Everything else about the name is the CLI layer's business.
+_ceph_device_tier_name_ok()
+{
+    local tier=$1
+    if [ -z "$tier" ] ; then
+        echo "Error: device tier name is empty" >&2
+        return 1
+    fi
+    if echo "$tier" | grep -q -e '-pool' -e '-ssd' ; then
+        echo "Error: device tier name $tier must not contain '-pool' or '-ssd'" >&2
+        return 1
+    fi
+    return 0
+}
+
+# normalize "0" / "osd.0" to bare ids, one per line; fail on anything the
+# cluster does not know rather than letting crush invent a bucket for it
+_ceph_device_tier_osd_ids()
+{
+    local known=$($CEPH osd ls 2>/dev/null)
+    if [ -z "$known" ] ; then
+        echo "Error: cannot read the OSD list" >&2
+        return 1
+    fi
+    local id=
+    for a in "$@" ; do
+        id=${a#osd.}
+        if ! echo "$known" | grep -qx "$id" ; then
+            echo "Error: no such OSD: $a" >&2
+            return 1
+        fi
+        echo "$id"
+    done
+}
+
+_ceph_device_tier_class_of_osd()
+{
+    $CEPH osd tree -f json 2>/dev/null \
+        | jq -r --argjson id "${1#osd.}" '.nodes[] | select(.id == $id) | .device_class // empty'
+}
+
+# how many distinct hosts carry an OSD of this device class
+_ceph_device_tier_class_hosts()
+{
+    $CEPH osd tree -f json 2>/dev/null | jq -r --arg C "$1" '
+        ([ .nodes[] | select(.type == "osd" and .device_class == $C) | .id ]) as $o
+        | [ .nodes[] | select(.type == "host")
+            | select( any(.children[]; . as $c | ($o | index($c)) != null) ) | .name ]
+        | length'
+}
+
+# RF for a tier pool: the base pool's, because a tier carries user volumes just
+# like the base pool does -- but never more replicas than there are hosts the
+# tier's own rule can select. That rule is class-restricted, so a tier living on
+# two of three hosts cannot reach the base pool's 3 and would sit undersized
+# forever; `osd pool set size` fails quietly, so nothing would say so.
+_ceph_device_tier_target_pool_size()
+{
+    local tier=$1
+    local base=$($CEPH osd pool get $BUILTIN_BACKPOOL size -f json 2>/dev/null | jq -r '.size | numbers')
+    local hosts=$(_ceph_device_tier_class_hosts $tier)
+    if [ -z "$base" ] || [ -z "$hosts" ] || [ "$hosts" -lt 1 ] ; then
+        echo "Error: cannot size device tier $tier (base pool size '${base:-?}', hosts '${hosts:-?}')" >&2
+        return 1
+    fi
+    if [ "$base" -le "$hosts" ] ; then
+        echo -n "$base"
+    else
+        echo -n "$hosts"
+    fi
+}
+
+# anchored existence checks. os_volume_type_create's own check is an unanchored
+# grep, so "seki1" matches an existing "seki1-ssd" there -- never reuse it to
+# decide whether something is already present.
+_ceph_device_tier_has_class() { $CEPH osd crush class ls 2>/dev/null | jq -r '.[]' | grep -qx "$1" ; }
+_ceph_device_tier_has_rule()  { $CEPH osd crush rule ls 2>/dev/null | grep -qx "$1" ; }
+_ceph_device_tier_has_pool()  { $CEPH osd pool ls 2>/dev/null | grep -qx "$1" ; }
+_ceph_device_tier_has_vtype() { $OPENSTACK volume type list --long --format value -c Name 2>/dev/null | grep -qx "$1" ; }
+
+# Tri-state CRUSH rule readback: 0 present, 1 read and absent, 2 unreadable.
+#
+# _ceph_device_tier_has_rule cannot answer this. A pipeline carries only the
+# last command's status, so its non-zero is "the rule is not there" AND "the
+# mon did not answer" -- fine for a caller that only skips work, wrong for the
+# delete path, which uses the answer to license stripping the device class the
+# rule selects through. Reading into a variable first keeps the command's own
+# status, which is what tells absent from unknown.
+_ceph_device_tier_rule_state()
+{
+    local rules=
+    rules=$($CEPH osd crush rule ls 2>/dev/null) || return 2
+    echo "$rules" | grep -qx "$1"
+}
+
+# pools bound to CRUSH rule $1, excluding pool $2. Returns non-zero when the
+# question cannot be answered, so a caller can refuse to act on an answer it
+# did not get. `.rule_id | numbers` keeps rule_id 0 -- a valid id -- from
+# reading as absent, and `osd pool ls detail` reports crush_rule as an id while
+# `osd pool get` reports a name, which is why the id is resolved first.
+_ceph_device_tier_rule_users()
+{
+    local rule=$1
+    local except=$2
+    local pools_json=$($CEPH osd pool ls detail -f json 2>/dev/null)
+    local rule_id=$($CEPH osd crush rule dump $rule -f json 2>/dev/null | jq -r '.rule_id | numbers')
+    [ -n "$rule_id" ] || return 1
+    echo "$pools_json" | jq -e 'length > 0' >/dev/null 2>&1 || return 1
+    echo "$pools_json" | jq -r --argjson rid "$rule_id" --arg ex "$except" \
+        '[ .[] | select(.crush_rule == $rid) | .pool_name | select(. != $ex) ] | join(" ")'
+}
+
+# wait for a class change to finish moving data. Same shape as
+# ceph_osd_promote_disk: recovering_objects_per_sec goes null, confirm once,
+# then stop. Bounded -- a caller that times out is told, not left believing the
+# cluster settled.
+_ceph_device_tier_wait_recovery()
+{
+    local tries=${1:-60}
+    local recovering=
+    for i in $(seq $tries) ; do
+        sleep 10
+        recovering=$($CEPH -s -f json | jq -r .pgmap.recovering_objects_per_sec)
+        if [ "x$recovering" = "xnull" ] ; then
+            sleep 5
+            recovering=$($CEPH -s -f json | jq -r .pgmap.recovering_objects_per_sec)
+            [ "x$recovering" = "xnull" ] && return 0
+        else
+            echo "recovering $recovering obj/sec"
+        fi
+    done
+    echo "Warning: still recovering after $((tries * 10))s; data movement continues in the background" >&2
+    return 1
+}
+
+# preflight shared by device tier create and update: both start data movement,
+# and Ceph is much worse at two overlapping remappings than at one.
+_ceph_device_tier_health_ok()
+{
+    if [ "$($CEPH -s -f json | jq -r .health.status)" != "HEALTH_OK" ] ; then
+        echo "Error: ceph health has to be OK to change device tier membership" >&2
+        return 1
+    fi
+    if [ "x$($CEPH -s -f json | jq -r .pgmap.recovering_objects_per_sec)" != "xnull" ] ; then
+        echo "Error: cannot change device tier membership while ceph is recovering" >&2
+        return 1
+    fi
+    return 0
+}
+
+# undo only what this create actually made. $2 is a word list out of
+# "class rule pool vtype"; $3 is "<id>:<previous class>" pairs.
+_ceph_device_tier_unwind_create()
+{
+    local tier=$1
+    local made=$2
+    local saved=$3
+    echo "Error: device tier $tier was not completed; unwinding what this run created" >&2
+    if echo "$made" | grep -qw vtype ; then
+        Quiet -n $OPENSTACK volume type delete $tier
+    fi
+    if echo "$made" | grep -qw pool ; then
+        Quiet -n $CEPH osd pool delete $tier $tier --yes-i-really-really-mean-it
+    fi
+    if echo "$made" | grep -qw rule ; then
+        Quiet -n $CEPH osd crush rule rm $tier
+    fi
+    if echo "$made" | grep -qw class ; then
+        local id= cls=
+        for pair in $saved ; do
+            id=${pair%%:*}
+            cls=${pair#*:}
+            Quiet -n $CEPH osd crush rm-device-class osd.$id
+            if [ -n "$cls" ] ; then
+                Quiet -n $CEPH osd crush set-device-class $cls osd.$id
+            fi
+        done
+    fi
+}
+
+# params:
+# $1    - tier name
+# $2... - OSD ids ("0" or "osd.0")
+ceph_device_tier_create()
+{
+    local tier=$1
+    shift
+    if [ -z "$tier" ] || [ $# -lt 1 ] ; then
+        # $0 inside hex_sdk is /usr/sbin/hex_sdk, which names the wrong thing
+        echo "Usage: hex_sdk ${FUNCNAME[0]} <tier-name> <osd id> [<osd id>...]"
+        ceph_device_tier_list
+        return 1
+    fi
+    _ceph_device_tier_name_ok "$tier" || return 1
+
+    local ids=
+    ids=$(_ceph_device_tier_osd_ids "$@") || return 1
+    local osd_list=
+    for i in $ids ; do osd_list="$osd_list osd.$i" ; done
+
+    # re-running the same command must not build a second copy of anything
+    if _ceph_device_tier_has_class $tier && _ceph_device_tier_has_rule $tier && \
+       _ceph_device_tier_has_pool $tier && _ceph_device_tier_has_vtype $tier ; then
+        echo "device tier $tier already exists (osd: $($CEPH osd crush class ls-osd $tier 2>/dev/null | tr '\n' ' '))"
+        echo "use 'hex_sdk ceph_device_tier_update $tier <osd id>...' to change its members"
+        return 0
+    fi
+
+    _ceph_device_tier_health_ok || return 1
+
+    local made=
+    local saved=
+    local cls=
+
+    # 1) device class. rm first: an OSD carries exactly one class, and
+    #    set-device-class on an OSD that already has one fails with EBUSY.
+    #    Create only ever adds; taking an OSD out of a tier is ceph_device_tier_update.
+    for i in $ids ; do
+        cls=$(_ceph_device_tier_class_of_osd $i)
+        [ "$cls" = "$tier" ] && continue
+        saved="$saved $i:$cls"
+        made="$made class"
+        if ! $CEPH osd crush rm-device-class osd.$i >/dev/null 2>&1 ; then
+            echo "Error: cannot clear the device class of osd.$i" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
+        if ! $CEPH osd crush set-device-class $tier osd.$i >/dev/null 2>&1 ; then
+            echo "Error: cannot set device class $tier on osd.$i" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
+    done
+
+    # 2) rule. Only possible once some OSD carries the class.
+    if ! _ceph_device_tier_has_rule $tier ; then
+        if ! $CEPH osd crush rule create-replicated $tier default host $tier >/dev/null 2>&1 ; then
+            echo "Error: cannot create CRUSH rule $tier" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
+        made="$made rule"
+    fi
+
+    # 3) pool, with an explicit RF
+    local size=
+    size=$(_ceph_device_tier_target_pool_size $tier) || {
+        _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+        return 1
+    }
+    if ! _ceph_device_tier_has_pool $tier ; then
+        Quiet -n ceph_create_pool $tier rbd $size
+        if ! _ceph_device_tier_has_pool $tier ; then
+            echo "Error: pool $tier was not created" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
+        made="$made pool"
+    fi
+    Quiet -n ceph_adjust_pool_size $tier $size
+
+    # 4) bind the pool to the rule -- data starts moving here
+    if [ "$($CEPH osd pool get $tier crush_rule -f json 2>/dev/null | jq -r .crush_rule)" != "$tier" ] ; then
+        if ! $CEPH osd pool set $tier crush_rule $tier >/dev/null 2>&1 ; then
+            echo "Error: cannot bind pool $tier to CRUSH rule $tier" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
+    fi
+
+    # 5) Cinder volume type. The catalog is read with its exit status kept: an
+    #    existence helper would fold "OpenStack is broken" into "the volume type
+    #    is not there", and here that reads as a failed create -- which would
+    #    unwind and delete the pool this run just built.
+    #
+    #    So an unreadable answer does NOT unwind. Everything on the Ceph side is
+    #    already correct at this point, ceph_device_tier_list flags the tier as
+    #    no-volume-type, and re-running create completes it. Keeping repairable
+    #    state beats destroying good work over a blip. Only a catalog that is
+    #    readable AND does not list the type is a real failure.
+    local vtypes=
+    if ! vtypes=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) ; then
+        echo "Error: cannot read the volume type list; device tier $tier is complete on" >&2
+        echo "       the Ceph side but has no volume type yet -- re-run this command" >&2
+        return 1
+    fi
+    if ! echo "$vtypes" | grep -qx "$tier" ; then
+        Quiet -n $HEX_SDK os_volume_type_create $tier $tier
+        if ! vtypes=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) ; then
+            echo "Error: cannot confirm volume type $tier was created; re-run this command" >&2
+            return 1
+        fi
+        if ! echo "$vtypes" | grep -qx "$tier" ; then
+            echo "Error: volume type $tier was not created" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
+        made="$made vtype"
+    fi
+
+    echo "device tier $tier created on$osd_list (pool size $size)"
+    echo "note: the Cinder backend for $tier is generated from the tuning registry;"
+    echo "      until that is in place the volume type exists but has no backend."
+    return 0
+}
+
+# params:
+# $1    - tier name
+# $2... - the OSD ids the tier should consist of afterwards
+ceph_device_tier_update()
+{
+    local tier=$1
+    shift
+    if [ -z "$tier" ] || [ $# -lt 1 ] ; then
+        echo "Usage: hex_sdk ${FUNCNAME[0]} <tier-name> <osd id> [<osd id>...]"
+        ceph_device_tier_list
+        return 1
+    fi
+    if ! _ceph_device_tier_has_class $tier || ! _ceph_device_tier_has_rule $tier ; then
+        echo "Error: no such device tier: $tier" >&2
+        ceph_device_tier_list
+        return 1
+    fi
+
+    local want= have=
+    want=$(_ceph_device_tier_osd_ids "$@") || return 1
+    # Not `local have=$(...)`: local's own status masks the command's. An
+    # unreadable membership list would read as an empty tier -- every requested
+    # OSD an addition (so members already in it get taken out and re-added,
+    # which moves data), every existing member missing from the removal list,
+    # and the success line at the end a statement about a set nobody read.
+    if ! have=$($CEPH osd crush class ls-osd $tier 2>/dev/null) ; then
+        echo "Error: cannot read the members of device tier $tier; not changing it" >&2
+        return 1
+    fi
+
+    local add= remove=
+    for i in $want ; do
+        echo "$have" | grep -qx "$i" || add="$add $i"
+    done
+    for i in $have ; do
+        echo "$want" | grep -qx "$i" || remove="$remove $i"
+    done
+
+    if [ -z "$add" ] && [ -z "$remove" ] ; then
+        echo "device tier $tier already consists of $(echo $want)"
+        return 0
+    fi
+    # the rule would select nothing, and every pool bound to it would go dark
+    if [ -z "$want" ] ; then
+        echo "Error: a device tier cannot be left with no OSD; use ceph_device_tier_delete instead" >&2
+        return 1
+    fi
+
+    _ceph_device_tier_health_ok || return 1
+
+    # Unlike create, the rule already exists here, so a class change starts
+    # moving data the moment it lands. Take the OSDs out first so the movement
+    # is one remapping rather than two.
+    #
+    # Nothing below is allowed to fail quietly. There is no data-level rollback
+    # -- objects that have moved cannot be moved back, and pretending otherwise
+    # would be the worse lie -- so the contract is: check every step, stop at
+    # the first failure, say what state that leaves behind, and return non-zero.
+    # The one thing that must always be attempted is bringing the OSDs back in:
+    # an OSD left `out` is a cluster quietly running short.
+    local touched=
+    for i in $add $remove ; do touched="$touched osd.$i" ; done
+
+    if ! $CEPH osd out $touched >/dev/null 2>&1 ; then
+        echo "Error: cannot take$touched out; nothing has been changed" >&2
+        return 1
+    fi
+
+    local rc=0
+    local failed=
+    local moved=
+    local cls=
+    for i in $add ; do
+        cls=$(_ceph_device_tier_class_of_osd $i)
+        if ! $CEPH osd crush rm-device-class osd.$i >/dev/null 2>&1 || \
+           ! $CEPH osd crush set-device-class $tier osd.$i >/dev/null 2>&1 ; then
+            failed="$failed osd.$i"
+            break
+        fi
+        echo "osd.$i: ${cls:-(no class)} -> $tier"
+        moved="$moved osd.$i"
+    done
+    if [ -z "$failed" ] ; then
+        for i in $remove ; do
+            if ! $CEPH osd crush rm-device-class osd.$i >/dev/null 2>&1 ; then
+                failed="$failed osd.$i"
+                break
+            fi
+            echo "osd.$i: $tier -> (no class)"
+            moved="$moved osd.$i"
+        done
+    fi
+    if [ -n "$failed" ] ; then
+        echo "Error: device class change failed on$failed; stopped there" >&2
+        [ -n "$moved" ] && echo "       already changed:$moved" >&2
+        rc=1
+    fi
+
+    # data can be moving whether or not a step failed, so this is not skipped
+    _ceph_device_tier_wait_recovery || rc=1
+    if ! $CEPH osd in $touched >/dev/null 2>&1 ; then
+        echo "Error: could not bring$touched back in -- THOSE OSDs ARE STILL OUT" >&2
+        echo "       run 'ceph osd in$touched' once the cluster is reachable" >&2
+        rc=1
+    fi
+
+    # membership changed, so the achievable RF may have too. ceph_adjust_pool_size
+    # swallows its own failures, so the result is read back rather than trusted.
+    #
+    # Both halves are read back, because that function sets a pair --
+    # (size, min_size = max(1, size - 1)) -- and they fail independently. A pool
+    # that took the new size and kept the old min_size passes a size-only check
+    # while being the half that actually decides whether the pool still accepts
+    # writes with a host down: a tier resized 3 -> 2 whose min_size stayed 2 is a
+    # pool that stops on the first failure, reported as a successful update.
+    local size=
+    if size=$(_ceph_device_tier_target_pool_size $tier) ; then
+        Quiet -n ceph_adjust_pool_size $tier $size
+        local want_min=$(( size - 1 ))
+        [ $want_min -lt 1 ] && want_min=1
+        local got=$($CEPH osd pool get $tier size -f json 2>/dev/null | jq -r '.size | numbers')
+        local got_min=$($CEPH osd pool get $tier min_size -f json 2>/dev/null | jq -r '.min_size | numbers')
+        if [ "$got" != "$size" ] ; then
+            echo "Error: pool $tier size is ${got:-unreadable}, expected $size" >&2
+            rc=1
+        fi
+        if [ "$got_min" != "$want_min" ] ; then
+            echo "Error: pool $tier min_size is ${got_min:-unreadable}, expected $want_min" >&2
+            rc=1
+        fi
+    else
+        echo "Error: device tier $tier membership changed but its pool could not be resized" >&2
+        rc=1
+    fi
+
+    if [ $rc -ne 0 ] ; then
+        echo "Error: device tier $tier update did not complete; it now consists of" >&2
+        echo "       [$($CEPH osd crush class ls-osd $tier 2>/dev/null | tr '\n' ' ')]" >&2
+        return $rc
+    fi
+
+    # The line below is a statement about what the tier now holds, so it is read
+    # back rather than inferred from the steps having returned 0 -- the same
+    # reason the delete path reads the class list back after stripping it. A
+    # set-device-class that returns 0 without taking effect is otherwise
+    # reported as a completed membership change.
+    local now=
+    if ! now=$($CEPH osd crush class ls-osd $tier 2>/dev/null) ; then
+        echo "Error: device tier $tier was changed but its membership could not be" >&2
+        echo "       read back; it may not consist of $(echo $want)" >&2
+        return 1
+    fi
+    if [ "$(echo $now | tr ' ' '\n' | sort -n | tr '\n' ' ')" != \
+         "$(echo $want | tr ' ' '\n' | sort -n | tr '\n' ' ')" ] ; then
+        echo "Error: device tier $tier consists of [$(echo $now)], not the requested" >&2
+        echo "       [$(echo $want)]" >&2
+        return 1
+    fi
+    echo "device tier $tier now consists of $(echo $want) (pool size $size)"
+    return 0
+}
+
+# params:
+# $1 - tier name
+ceph_device_tier_delete()
+{
+    local tier=$1
+    if [ -z "$tier" ] ; then
+        echo "Usage: hex_sdk ${FUNCNAME[0]} <tier-name>"
+        ceph_device_tier_list
+        return 1
+    fi
+
+    # 0) Read everything this function will decide on, once, up front, and stop
+    #    if any of it cannot be read.
+    #
+    #    Re-querying was the bug. An existence helper folds "the service is
+    #    broken" and "it is not there" into the same non-zero, so a Keystone
+    #    blip between the readability probe and the in-use gate read as "there
+    #    is no volume type", the guard was skipped, and the pool went anyway.
+    #    Command substitution carries the command's own exit status, which is
+    #    what tells the two apart -- so the answer is one query kept, not more
+    #    probes.
+    local vtypes= pools= rules= members=
+    if ! vtypes=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) ; then
+        echo "Error: cannot read the volume type list, so 'not in use' cannot be" >&2
+        echo "       established; not deleting device tier $tier" >&2
+        return 1
+    fi
+    if ! pools=$($CEPH osd pool ls 2>/dev/null) ; then
+        echo "Error: cannot read the pool list; not deleting device tier $tier" >&2
+        return 1
+    fi
+    if ! rules=$($CEPH osd crush rule ls 2>/dev/null) ; then
+        echo "Error: cannot read the CRUSH rule list; not deleting device tier $tier" >&2
+        return 1
+    fi
+    if ! members=$($CEPH osd crush class ls-osd $tier 2>/dev/null) ; then
+        echo "Error: cannot read the members of device tier $tier; not deleting it" >&2
+        return 1
+    fi
+
+    local has_vtype=1 has_pool=1 has_rule=1
+    echo "$vtypes" | grep -qx "$tier" && has_vtype=0
+    echo "$pools"  | grep -qx "$tier" && has_pool=0
+    echo "$rules"  | grep -qx "$tier" && has_rule=0
+
+    # 1) refuse while volumes still use it.
+    #
+    #    cinder_is_volume_type_in_use exits 0 for "in use" AND for "could not
+    #    tell", which is the right answer on a destructive path -- so it is not
+    #    wrapped in Quiet and its return value is not discarded.
+    #
+    #    It has to be reached by shelling back out through hex_sdk. hex_sdk
+    #    sources only the module matching the command's own prefix (see
+    #    /usr/sbin/hex_sdk: MOD=$(echo $1 | cut -d_ -f1)), so under
+    #    ceph_device_tier_delete the sdk_cinder.sh functions are simply not defined --
+    #    calling one directly would be a command-not-found returning 127, which
+    #    reads as "not in use". Same reason ceph_create_group_ssdpool reaches
+    #    os_volume_type_create through $HEX_SDK.
+    #
+    #    That shell-out also returns 1 when hex_sdk could not run the function
+    #    at all, which is indistinguishable from "no volumes", so a negative
+    #    answer is only trusted once the volume list is known to be readable.
+    if [ $has_vtype -eq 0 ] ; then
+        if $HEX_SDK cinder_is_volume_type_in_use "$tier" ; then
+            echo "Error: volume type $tier is still in use by at least one volume," >&2
+            echo "       or the volume list could not be read; not deleting device tier $tier" >&2
+            return 1
+        fi
+        if ! $OPENSTACK volume list --all-projects -f json 2>/dev/null \
+             | jq -e 'type == "array"' >/dev/null 2>&1 ; then
+            echo "Error: cannot read the volume list, so 'not in use' cannot be trusted;" >&2
+            echo "       not deleting device tier $tier" >&2
+            return 1
+        fi
+    fi
+
+    # 2) the registry entry and the Cinder backend come out first once WP-1
+    #    lands, so that Cinder stops pointing at a pool that is about to go.
+
+    # 3) volume type. The poll has to re-read, because it is waiting for a
+    #    change -- but a read that fails is "unknown", never "gone".
+    if [ $has_vtype -eq 0 ] ; then
+        Quiet -n $OPENSTACK volume type delete $tier
+        local gone=1 probe=
+        for i in {1..15} ; do
+            if probe=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) ; then
+                echo "$probe" | grep -qx "$tier" || { gone=0 ; break ; }
+            fi
+            sleep 1
+        done
+        if [ $gone -ne 0 ] ; then
+            echo "Error: volume type $tier was not confirmed deleted -- still listed, or" >&2
+            echo "       the list stopped being readable; leaving device tier $tier in place" >&2
+            return 1
+        fi
+    fi
+
+    # 4) pool
+    if [ $has_pool -eq 0 ] ; then
+        Quiet -n $CEPH osd pool delete $tier $tier --yes-i-really-really-mean-it
+        if ! pools=$($CEPH osd pool ls 2>/dev/null) ; then
+            echo "Error: cannot confirm pool $tier was deleted; leaving its rule and" >&2
+            echo "       OSD classes alone" >&2
+            return 1
+        fi
+        if echo "$pools" | grep -qx "$tier" ; then
+            echo "Error: pool $tier was not deleted; leaving its rule and OSD classes alone" >&2
+            return 1
+        fi
+    fi
+
+    # 5) CRUSH rule, once no pool is left using it. CRUSH refuses to remove a
+    #    rule that is still in use, and an orphan rule is not harmless: a later
+    #    create-replicated on the same name is a silent no-op that returns 0
+    #    even when the arguments differ.
+    local rule_kept=1 rule_why= rule_subject="the CRUSH rule and "
+    if [ $has_rule -eq 0 ] ; then
+        local users=
+        if ! users=$(_ceph_device_tier_rule_users $tier $tier) ; then
+            echo "Warning: cannot tell whether CRUSH rule $tier is still in use;" >&2
+            echo "         keeping the rule and the device class that makes it work" >&2
+            rule_kept=0
+            rule_why="it cannot be confirmed that nothing else selects through it"
+        elif [ -n "$users" ] ; then
+            echo "Keeping CRUSH rule $tier and its device class: still used by $users"
+            rule_kept=0
+            rule_why="something else still selects through that rule"
+        else
+            # Not Quiet -n, and then read back anyway. This is the step whose
+            # success licenses stripping the device class below, and it can go
+            # wrong three ways: the rm returns non-zero, the rm returns 0
+            # without the rule going away, or the readback itself is
+            # unavailable so neither can be established. Only a read that
+            # succeeded and did not find the rule licenses the next step --
+            # anything else followed by the class removal leaves a rule
+            # selecting nothing, which is the outage the next step's comment
+            # exists to avoid.
+            local rm_rc=0 rule_state=0
+            Quiet $CEPH osd crush rule rm $tier
+            rm_rc=$?
+            _ceph_device_tier_rule_state $tier
+            rule_state=$?
+            if [ $rule_state -eq 0 ] ; then
+                echo "Error: CRUSH rule $tier is still present after removing it;" >&2
+                echo "       keeping the device class so the rule keeps selecting" >&2
+                rule_kept=0
+                rule_why="removing the rule did not take effect"
+            elif [ $rule_state -ne 1 ] ; then
+                echo "Error: the CRUSH rule list stopped being readable, so it cannot be" >&2
+                echo "       established that rule $tier went; keeping the device class" >&2
+                echo "       that makes it work" >&2
+                rule_kept=0
+                rule_why="it cannot be confirmed that the rule went"
+            elif [ $rm_rc -ne 0 ] ; then
+                # The rule is provably gone, so saying it was kept would be a
+                # lie -- but an rm that failed and yet took effect is not
+                # understood, and the classes are the half that can still be
+                # put back by hand.
+                echo "Error: removing CRUSH rule $tier reported a failure even though the" >&2
+                echo "       rule is gone; keeping the device class until that is understood" >&2
+                rule_kept=0
+                rule_subject=
+                rule_why="removing the rule reported a failure"
+            fi
+        fi
+    fi
+
+    # 6) the OSDs go back to having no device class -- but only if the rule
+    #    actually went. Stripping the class while keeping the rule would leave
+    #    that rule selecting nothing and every pool still bound to it would go
+    #    dark: refusing to remove a rule because someone uses it and then
+    #    destroying what makes it work is worse than doing either alone.
+    #
+    #    They are deliberately not restored to hdd/ssd -- what an OSD used to be
+    #    is not recorded anywhere, and guessing was ruled out on #840.
+    if [ $rule_kept -eq 0 ] ; then
+        echo "device tier $tier partially deleted: the volume type and the pool are gone,"
+        echo "${rule_subject}osd$(for i in $members ; do echo -n ".$i" ; done) keep the"
+        echo "device class $tier because $rule_why."
+        return 1
+    fi
+
+    # Each removal is checked, and then the membership is read back, for the
+    # same reason as the rule above: an OSD that silently kept the class is
+    # still selected by anything reaching for it, and the line below is a
+    # statement about every member. Reporting a clean delete over a partial one
+    # is how an OSD ends up carrying a class nobody is looking for.
+    local failed=
+    for i in $members ; do
+        Quiet $CEPH osd crush rm-device-class osd.$i || failed="$failed osd.$i"
+    done
+
+    # An unreadable class list is "unknown", never "gone" -- command
+    # substitution carries the command's own status, which is what tells the two
+    # apart here as it does on the delete path above. The parse is the second
+    # half of that read and gets the same treatment: `ceph` exiting 0 with
+    # output jq cannot parse is an answer nobody got, and letting it fall
+    # through the grep would report a clean delete on the strength of it.
+    local stuck= classes= names=
+    if classes=$($CEPH osd crush class ls 2>/dev/null) && \
+       names=$(echo "$classes" | jq -r '.[]' 2>/dev/null) ; then
+        if echo "$names" | grep -qx "$tier" ; then
+            stuck=$($CEPH osd crush class ls-osd $tier 2>/dev/null | sed 's/^/osd./' | tr '\n' ' ')
+            [ -n "$stuck" ] || stuck="(the class is still there but its members could not be listed)"
+        fi
+    else
+        stuck="(the device class list could not be read)"
+    fi
+
+    if [ -n "$failed" ] || [ -n "$stuck" ] ; then
+        echo "Error: device tier $tier only partially deleted -- the volume type, the" >&2
+        echo "       pool and the CRUSH rule are gone, but the device class is not" >&2
+        [ -n "$failed" ] && echo "       rm-device-class failed on:$failed" >&2
+        [ -n "$stuck" ]  && echo "       still carrying device class $tier: $stuck" >&2
+        return 1
+    fi
+
+    echo "device tier $tier deleted; osd$(for i in $members ; do echo -n ".$i" ; done) left with no device class"
+    return 0
+}
+
+# Lists what the Ceph side actually has. A tier is recognised here by its own
+# shape -- a device class with a CRUSH rule and a pool of the same name -- which
+# is a derivation, not a source of truth; the authoritative list is the tuning
+# registry, and comparing the two is what this grows into once WP-1 lands.
+ceph_device_tier_list()
+{
+    $CEPH -s >/dev/null 2>&1 || return 1
+    printf "%-16s %-8s %-6s %-11s %-10s %-6s %s\n" \
+        DEVICE_TIER OSD HOSTS POOL_SZ/MIN POOL_RULE VTYPE NOTE
+    local tier= osds= hosts= size= min_size= prule= vtype= note=
+    for tier in $($CEPH osd crush class ls 2>/dev/null | jq -r '.[]') ; do
+        _ceph_device_tier_has_rule $tier || continue
+        _ceph_device_tier_has_pool $tier || continue
+        osds=$($CEPH osd crush class ls-osd $tier 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+        hosts=$(_ceph_device_tier_class_hosts $tier)
+        size=$($CEPH osd pool get $tier size -f json 2>/dev/null | jq -r '.size | numbers')
+        min_size=$($CEPH osd pool get $tier min_size -f json 2>/dev/null | jq -r '.min_size | numbers')
+        prule=$($CEPH osd pool get $tier crush_rule -f json 2>/dev/null | jq -r .crush_rule)
+        _ceph_device_tier_has_vtype $tier && vtype=yes || vtype=no
+        note=
+        [ "$prule" = "$tier" ] || note="$note pool-not-on-its-rule"
+        [ "$vtype" = "yes" ] || note="$note no-volume-type"
+        [ -n "$size" ] && [ -n "$hosts" ] && [ "$size" -gt "$hosts" ] && note="$note rf-above-host-count"
+        [ "${size:-0}" = "1" ] && note="$note no-redundancy"
+        printf "%-16s %-8s %-6s %-11s %-10s %-6s %s\n" \
+            "$tier" "${osds:--}" "${hosts:-?}" "${size:-?}/${min_size:-?}" "$prule" "$vtype" "${note:- ok}"
+    done
+}

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -1672,6 +1672,20 @@ ceph_osd_disable_cache()
     $CEPH osd pool ls | grep -q "^${cachepool}$" || exit 1
     [ "x$(ceph_osd_test_cache $backpool)" = "xon" ] || exit 1
 
+    # The sweep at the bottom of the $BUILTIN_BACKPOOL branch resets crush_rule
+    # on every pool it does not recognize, and a device tier pool is named by its
+    # operator, so it matches none of the suffixes in that skip list. Read the
+    # registry here, before the first mutation: once the overlay is off there is
+    # no way to stop half way, so "cannot read it" has to fail while failing is
+    # still free. The other branches do not sweep and do not need it.
+    local devtiers=
+    if [ "$backpool" = "$BUILTIN_BACKPOOL" ] ; then
+        if ! devtiers=$(_ceph_device_tier_registry) ; then
+            echo "Error: cannot read the device tier registry from $SETTINGS_TXT"
+            return 1
+        fi
+    fi
+
     # set to forward so no more dirty objects
     rados -p $cachepool cache-flush-evict-all &>/dev/null || true
     Quiet -n $CEPH osd tier cache-mode $cachepool none --yes-i-really-mean-it
@@ -1685,6 +1699,9 @@ ceph_osd_disable_cache()
 
     if [ "$backpool" = "$BUILTIN_BACKPOOL" ] ; then
         for p in $($CEPH osd pool ls) ; do
+            if _ceph_device_tier_is_registered "$p" "$devtiers" ; then
+                continue
+            fi
             case $p in
                 *-pool|*-cache|*-ssd)
                     continue
@@ -1739,6 +1756,18 @@ ceph_osd_create_cache()
         local rule_hdd=rule-hdd
     fi
 
+    # Paired with the read in ceph_osd_disable_cache -- the sweep below is the
+    # other half of the same rewrite, and guarding only one of them leaves the
+    # damage one-directional instead of absent. Same reason for reading it up
+    # front: enable_cache is the first mutation and there is no way back over it.
+    local devtiers=
+    if [ "$backpool" = "$BUILTIN_BACKPOOL" ] ; then
+        if ! devtiers=$(_ceph_device_tier_registry) ; then
+            echo "Error: cannot read the device tier registry from $SETTINGS_TXT"
+            return 1
+        fi
+    fi
+
     Quiet -n ceph_osd_enable_cache $backpool
 
     if ! ($CEPH osd crush rule list | grep -q $rule_ssd) ; then
@@ -1759,6 +1788,9 @@ ceph_osd_create_cache()
             Quiet -n $CEPH osd pool set $fsmetapool crush_rule $rule_ssd
         fi
         for p in $($CEPH osd pool ls) ; do
+            if _ceph_device_tier_is_registered "$p" "$devtiers" ; then
+                continue
+            fi
             case $p in
                 $BUILTIN_CACHEPOOL|cephfs_metadata)
                     continue
@@ -3909,6 +3941,39 @@ ceph_mgr_dashboard_ensure()
 # tier" --
 # lives in the CLI layer and is not duplicated here.
 # ---------------------------------------------------------------------------
+
+# The device tier registry, read the way config_cinder.cpp reads it: the
+# cinder.storage.tier.%d.name array in settings.txt, one name per line in index
+# order. An empty entry is how the policy file encodes an empty list, not a
+# mistake, so it is dropped rather than reported.
+#
+# A non-zero return means the registry could not be read, which is a different
+# answer from "there are no device tiers". The bulk crush_rule rewrites in
+# ceph_osd_create_cache / ceph_osd_disable_cache have to tell those two apart:
+# reading "cannot tell" as "none" is what silently overwrites a device tier's
+# placement, which is the whole reason they consult this.
+_ceph_device_tier_registry()
+{
+    [ -r "$SETTINGS_TXT" ] || return 1
+    awk '/^[[:space:]]*cinder\.storage\.tier\.[0-9]+\.name[[:space:]]*=/ {
+             sub(/^[^=]*=[[:space:]]*/, "")
+             sub(/[[:space:]]+$/, "")
+             if ($0 != "") print
+         }' "$SETTINGS_TXT"
+}
+
+# $1 - a pool name, $2 - the registry as _ceph_device_tier_registry printed it.
+#
+# Exact whole-line match, never a shell pattern: the names in settings.txt have
+# not been through _ceph_device_tier_name_ok -- the policy chain and
+# `hex_config commit <settings>` both write this array without passing through
+# the CLI -- so a registry entry can hold any byte at all, and one holding "*"
+# used as a case pattern would skip every pool in the cluster.
+_ceph_device_tier_is_registered()
+{
+    [ -n "$2" ] || return 1
+    printf '%s\n' "$2" | grep -qxF -- "$1"
+}
 
 # A device tier's name becomes a pool name, and config_cinder.cpp's scan for
 # legacy tiering matches "-pool" / "-ssd" as substrings rather than suffixes, so

--- a/core/sdk_sh/tests/test_ceph_cache_switch_device_tier.sh
+++ b/core/sdk_sh/tests/test_ceph_cache_switch_device_tier.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Unit test for the device tier guard in ../modules/sdk_ceph.sh:
+#   ceph_osd_disable_cache / ceph_osd_create_cache -- the two symmetric sweeps
+#   that rewrite crush_rule on every pool they do not recognize must leave a
+#   pool named in the cinder.storage.tier.%d.name registry alone (#840).
+#
+# Without the guard a device tier pool -- whose name the operator chooses, so it
+# matches none of the *-pool / *-cache / *-ssd suffixes in the skip list -- gets
+# pinned to rule-hdd by `cache switch on` and reset to replicated_rule by
+# `cache switch off`, both silently, which permanently destroys its placement.
+#
+# Self-contained: extracts just those functions plus their two registry helpers,
+# stubs ceph / rados / Quiet, so it needs no cluster.
+#   Run: bash test_ceph_cache_switch_device_tier.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_ceph.sh"
+for f in ceph_osd_disable_cache ceph_osd_create_cache \
+         _ceph_device_tier_registry _ceph_device_tier_is_registered ; do
+    eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$SRC")"
+    [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
+done
+
+# constants the extracted functions read, copied from the top of sdk_ceph.sh /
+# modules.pre/sdk_01-var-static.sh
+BUILTIN_BACKPOOL=cinder-volumes
+BUILTIN_CACHEPOOL=cachepool
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+SETTINGS_TXT="$TMP/settings.txt"
+
+# The pool set every case runs against: one device tier (gold), one legacy node
+# group triplet, the built-in cache path, an EC pool, and cephfs_metadata.
+POOLS='cinder-volumes
+cachepool
+cephfs_metadata
+glance-images
+gold
+grp1-pool
+grp1-cache
+grp1-ssd
+default.rgw.buckets.data.ec'
+
+# ceph stub. Records every mutating call in $TRACE and answers the reads the two
+# functions make. crush_rule state lives in $TMP/rule.<pool> so a set is visible
+# to the get that follows it, which is what both sweeps branch on.
+fake_ceph() {
+    case "$*" in
+        'osd pool ls')
+            printf '%s\n' "$POOLS" ;;
+        'osd crush rule list'|'osd crush rule ls')
+            printf '%s\n' "$RULES" ;;
+        'osd pool get '*' erasure_code_profile')
+            # only the EC pool has one; everything else is replicated, and the
+            # sweeps read a non-zero here as "replicated, carry on"
+            [ "$4" = default.rgw.buckets.data.ec ] || return 1
+            echo "erasure_code_profile: default" ;;
+        'osd pool get '*' crush_rule')
+            echo "crush_rule: $(cat "$TMP/rule.$4" 2>/dev/null || echo replicated_rule)" ;;
+        'osd pool set '*' crush_rule '*)
+            echo "SET $4 -> $6" >> "$TRACE"
+            echo "$6" > "$TMP/rule.$4" ;;
+        'osd tier remove '*)
+            rm -f "$TMP/overlay.$4"
+            echo "OTHER $*" >> "$TRACE" ;;
+        *)
+            echo "OTHER $*" >> "$TRACE" ;;
+    esac
+    return 0
+}
+CEPH=fake_ceph
+RULES='replicated_rule rule-ssd rule-hdd gold'
+
+# The rest of what the two functions reach for. None of it is under test here --
+# these cases are about which pools the sweeps touch.
+Quiet() { [ "${1:-}" = -n ] && shift; "$@"; }
+rados() { return 0; }
+ceph_get_cache_by_backpool() {
+    case "${1:-$BUILTIN_BACKPOOL}" in
+        "$BUILTIN_BACKPOOL") echo "$BUILTIN_CACHEPOOL" ;;
+        grp1-pool)           echo grp1-cache ;;
+    esac
+}
+# "on" only for a pool that still has its overlay -- which is what decides
+# whether the switch-off sweep rewrites a pool's crush_rule, and which the
+# `osd tier remove` above clears part way through ceph_osd_disable_cache.
+ceph_osd_test_cache() {
+    local b=${1:-$BUILTIN_BACKPOOL}
+    [ -n "$(ceph_get_cache_by_backpool "$b")" ] || { echo -n off; return 1; }
+    [ -f "$TMP/overlay.$b" ] && echo -n on || echo -n off
+}
+ceph_osd_enable_cache() { echo "OTHER enable_cache $*" >> "$TRACE"; return 0; }
+
+registry() { # write the given names into the registry as hex_translate would
+    : > "$SETTINGS_TXT"
+    echo 'cinder.enabled = true' >> "$SETTINGS_TXT"
+    local i=0
+    for n in "$@" ; do
+        echo "cinder.storage.tier.$i.name = $n" >> "$SETTINGS_TXT"
+        i=$((i+1))
+    done
+}
+
+run() { # $1 = create|disable ; sets TRACE contents in $OUT and rc in $RC
+    TRACE="$TMP/trace"; : > "$TRACE"
+    rm -f "$TMP"/rule.*
+    local p
+    while read -r p ; do [ -n "$p" ] && echo "$INITIAL_RULE" > "$TMP/rule.$p" ; done <<< "$POOLS"
+    echo gold > "$TMP/rule.gold"          # the tier pool is bound to its own rule
+    rm -f "$TMP"/overlay.*
+    touch "$TMP/overlay.$BUILTIN_BACKPOOL" "$TMP/overlay.grp1-pool"
+    if [ "$1" = create ] ; then
+        ceph_osd_create_cache "$BUILTIN_BACKPOOL" >/dev/null 2>&1
+    else
+        ceph_osd_disable_cache "$BUILTIN_BACKPOOL" >/dev/null 2>&1
+    fi
+    RC=$?
+    OUT=$(cat "$TRACE")
+}
+INITIAL_RULE=replicated_rule
+
+pass=0 fail=0
+ck() { [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+
+# ---- 1. registry with a device tier: both sweeps skip it ----
+registry gold
+run create
+ck "$RC" 0 "switch on: rc 0"
+ck "$(grep -c '^SET gold ' <<< "$OUT")" 0 "switch on leaves the device tier pool alone"
+ck "$(cat "$TMP/rule.gold")" gold "switch on: gold still bound to rule gold"
+ck "$(grep -c '^SET glance-images -> rule-hdd' <<< "$OUT")" 1 "switch on still pins an ordinary pool"
+
+run disable
+ck "$RC" 0 "switch off: rc 0"
+ck "$(grep -c '^SET gold ' <<< "$OUT")" 0 "switch off leaves the device tier pool alone"
+ck "$(cat "$TMP/rule.gold")" gold "switch off: gold still bound to rule gold"
+
+# ---- 2. the legacy skip list is untouched (regression) ----
+# Every pool the sweeps skipped before must still be skipped, and the EC arm
+# must still hold -- ak-coscp51p has a real EC pool behind it.
+for case in create disable ; do
+    run $case
+    ck "$(grep -c '^SET grp1-pool ' <<< "$OUT")" 0 "$case: *-pool skipped"
+    ck "$(grep -c '^SET grp1-cache ' <<< "$OUT")" 0 "$case: *-cache skipped"
+    ck "$(grep -c '^SET grp1-ssd ' <<< "$OUT")" 0 "$case: *-ssd skipped"
+    ck "$(grep -c '^SET default.rgw.buckets.data.ec ' <<< "$OUT")" 0 "$case: EC pool skipped"
+done
+run create
+ck "$(grep -c '^SET cephfs_metadata -> rule-hdd' <<< "$OUT")" 0 "switch on: cephfs_metadata not swept to rule-hdd"
+ck "$(grep -c '^SET cachepool -> rule-hdd' <<< "$OUT")" 0 "switch on: \$BUILTIN_CACHEPOOL not swept to rule-hdd"
+
+# ---- 3. an empty registry behaves exactly as before the guard existed ----
+# The device tier pool is meant to be swept when nobody registered it: that is
+# the pre-#840 behaviour and the guard must not widen it.
+registry ''
+run create
+ck "$RC" 0 "empty registry: switch on rc 0"
+ck "$(grep -c '^SET gold -> rule-hdd' <<< "$OUT")" 1 "empty registry: an unregistered pool is still swept"
+: > "$SETTINGS_TXT"
+run disable
+ck "$(grep -c '^SET gold -> replicated_rule' <<< "$OUT")" 1 "no registry key at all: reads as zero device tiers, sweep unchanged"
+
+# ---- 4. an unreadable registry stops before the first mutation ----
+# "cannot tell" is not "there are none": acting on the wrong one is what
+# destroys a tier, and neither function can be resumed from the middle.
+rm -f "$SETTINGS_TXT"
+for case in create disable ; do
+    run $case
+    ck "$RC" 1 "$case: unreadable registry returns non-zero"
+    ck "$(grep -c '^SET ' <<< "$OUT")" 0 "$case: unreadable registry mutates nothing"
+    ck "$(grep -c 'enable_cache' <<< "$OUT")" 0 "$case: unreadable registry does not even enable the cache"
+done
+
+# ---- 5. a registry entry is matched literally, never as a shell pattern ----
+# config_cinder.cpp vets these names, but the policy chain and
+# `hex_config commit <settings>` write the array without going through the CLI,
+# so a "*" reaching here must skip nothing rather than every pool.
+registry '*'
+run create
+ck "$(grep -c '^SET glance-images -> rule-hdd' <<< "$OUT")" 1 "a '*' entry does not skip every pool"
+ck "$(grep -c '^SET gold -> rule-hdd' <<< "$OUT")" 1 "a '*' entry does not skip the tier pool either"
+
+# ---- 6. registry parsing ----
+registry gold silver
+ck "$(_ceph_device_tier_registry | tr '\n' ',')" "gold,silver," "both entries, in index order"
+printf 'cinder.storage.tier.0.name =  gold  \ncinder.storage.tier.1.name =\n' > "$SETTINGS_TXT"
+ck "$(_ceph_device_tier_registry | tr '\n' ',')" "gold," "surrounding blanks trimmed, empty entry dropped"
+printf 'cinder.storage.backend.0.name = ext1\ncinder.storage.tier.10.name = t10\n' > "$SETTINGS_TXT"
+ck "$(_ceph_device_tier_registry | tr '\n' ',')" "t10," "the backend array is a different key; index is not one digit"
+_ceph_device_tier_registry >/dev/null ; ck "$?" 0 "a readable registry returns 0"
+rm -f "$SETTINGS_TXT"
+_ceph_device_tier_registry >/dev/null 2>&1 ; ck "$?" 1 "a missing registry returns non-zero"
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: cache switch device tier guard"; exit 0; } || exit 1

--- a/core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh
@@ -1,0 +1,346 @@
+#!/bin/bash
+#
+# Unit test for the failure reporting in ../modules/sdk_ceph.sh:
+#   ceph_device_tier_delete -- must not report a clean delete when the CRUSH
+#                              rule removal or any device class removal did not
+#                              actually happen (#840 R6)
+#   ceph_device_tier_update -- must not report success when ceph_adjust_pool_size
+#                              set size but left min_size at its old value,
+#                              which is the half that decides whether the pool
+#                              still accepts writes with a host down (#840 R7)
+#
+# Both functions drive Ceph through commands that swallow their own failures, so
+# the property under test is that each step is checked and then confirmed by
+# reading the result back -- not that the happy path works.
+#
+# Self-contained: extracts just those two functions and their helpers, stubs
+# ceph / openstack / hex_sdk / Quiet, so it needs no cluster.
+#   Run: bash test_ceph_device_tier_failure_paths.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_ceph.sh"
+for f in ceph_device_tier_delete ceph_device_tier_update \
+         _ceph_device_tier_has_rule _ceph_device_tier_has_class \
+         _ceph_device_tier_rule_state \
+         _ceph_device_tier_rule_users _ceph_device_tier_class_of_osd ; do
+    eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$SRC")"
+    [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
+done
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# The real Quiet (hex/scripts/functions) returns the command's status, EXCEPT
+# with -n, which forces 0. Reproducing that exactly is the point: a check
+# written as `Quiet -n cmd || handler` is dead code, and this suite would not
+# notice if the module regressed to it.
+Quiet() {
+    if [ "${1:-}" = -n ] ; then shift; "$@" >/dev/null 2>&1; return 0; fi
+    "$@" >/dev/null 2>&1
+}
+
+# ---- cluster model -------------------------------------------------------
+# CLASSES  : "<osd id>:<class>" per line, the authority for both class queries
+# RULES    : one rule name per line
+# POOLS    : one pool name per line
+# FAIL_PAT : a regex; any ceph command matching it fails and changes nothing
+# CEPH_DEAD: 1 makes every read fail, standing in for an unreachable cluster
+# RULE_LS_DEAD_AFTER_RM: 1 makes `osd crush rule ls` fail from the moment a
+#            rule rm has been attempted. Failing it outright would abort the
+#            delete at its own up-front read instead of at the readback, and
+#            counting calls would break the moment the module reads the list
+#            one more time -- arming it on the rm names the state under test
+#            ("the readback is unavailable") rather than a call index.
+# RM_LIES  : 1 makes `osd crush rule rm` remove the rule and still return
+#            non-zero, the one shape a readback alone cannot object to
+# LSOSD_DEAD: 1 makes `osd crush class ls-osd` fail, standing in for a
+#            membership query that cannot be answered
+# CLASS_LS_GARBAGE: 1 makes `osd crush class ls` exit 0 with output jq cannot
+#            parse -- a read that succeeded and still answered nothing
+# SETCLASS_LIES: 1 makes `osd crush set-device-class` return 0 without moving
+#            the OSD, the shape only a membership readback can object to
+reset_cluster() {
+    printf '2:gold\n6:gold\n10:gold\n' > "$TMP/classes"
+    printf 'replicated_rule\ngold\n' > "$TMP/rules"
+    printf 'cinder-volumes\ngold\n' > "$TMP/pools"
+    printf 'gold:3:2\ncinder-volumes:3:2\n' > "$TMP/poolattr"   # name:size:min_size
+    printf 'gold\nCubeStorage\n' > "$TMP/vtypes"
+    printf 'cinder-volumes:replicated_rule\ngold:gold\n' > "$TMP/poolrule"
+    FAIL_PAT='^$'
+    CEPH_DEAD=0
+    RULE_LS_DEAD_AFTER_RM=0
+    RM_LIES=0
+    RM_ATTEMPTED=0
+    LSOSD_DEAD=0
+    CLASS_LS_GARBAGE=0
+    SETCLASS_LIES=0
+}
+
+classes_json() { awk -F: '{print $2}' "$TMP/classes" | sort -u | jq -R . | jq -s .; }
+
+fake_ceph() {
+    [ "$CEPH_DEAD" = 1 ] && return 1
+    local all="$*"
+    case "$all" in
+        'osd crush class ls')
+            [ "$CLASS_LS_GARBAGE" = 1 ] && { printf 'Error EPERM: mon down\n'; return 0; }
+            classes_json ;;
+        'osd crush class ls-osd '*)
+            [ "$LSOSD_DEAD" = 1 ] && return 1
+            local c=${all##* }
+            grep ":$c\$" "$TMP/classes" >/dev/null || return 1
+            awk -F: -v c="$c" '$2==c{print $1}' "$TMP/classes" ;;
+        'osd crush rule ls')
+            [ "$RULE_LS_DEAD_AFTER_RM" = 1 ] && [ "$RM_ATTEMPTED" = 1 ] && return 1
+            cat "$TMP/rules" ;;
+        'osd pool ls')             cat "$TMP/pools" ;;
+        'osd crush rule rm '*)
+            RM_ATTEMPTED=1
+            echo "$all" | grep -qE "$FAIL_PAT" && return 1
+            local r=${all##* }; grep -vx "$r" "$TMP/rules" > "$TMP/x"; mv "$TMP/x" "$TMP/rules"
+            [ "$RM_LIES" = 1 ] && return 1 ;;
+        'osd crush rm-device-class '*)
+            echo "$all" | grep -qE "$FAIL_PAT" && return 1
+            local o=${all##*osd.}; grep -v "^$o:" "$TMP/classes" > "$TMP/x"; mv "$TMP/x" "$TMP/classes" ;;
+        'osd crush set-device-class '*)
+            # $4 = class, $5 = osd.N. A no-op stub here would make every
+            # membership readback assert nothing: the model would never show the
+            # OSD arriving, so the check could not tell a working set-device-class
+            # from one that silently did nothing.
+            [ "$SETCLASS_LIES" = 1 ] && return 0
+            local nc=$4 no=${5#osd.}
+            grep -v "^$no:" "$TMP/classes" > "$TMP/x"; mv "$TMP/x" "$TMP/classes"
+            echo "$no:$nc" >> "$TMP/classes" ;;
+        'osd pool delete '*)
+            grep -vx "$4" "$TMP/pools" > "$TMP/x"; mv "$TMP/x" "$TMP/pools"
+            grep -v "^$4:" "$TMP/poolrule" > "$TMP/x"; mv "$TMP/x" "$TMP/poolrule" ;;
+        'osd crush rule dump '*)
+            local rid=$(grep -nx "$5" "$TMP/rules" | cut -d: -f1)
+            [ -n "$rid" ] || return 1
+            echo "{\"rule_id\": $((rid - 1))}" ;;
+        'osd pool ls detail -f json')
+            awk -F: -v R="$TMP/rules" '
+              BEGIN{ n=0; while((getline l < R)>0){ id[l]=n; n++ }; printf "[" }
+              { printf "%s{\"pool_name\":\"%s\",\"crush_rule\":%d}", (c++?",":""), $1, id[$2] }
+              END{ printf "]\n" }' "$TMP/poolrule" ;;
+        'osd pool get '*' size -f json')
+            awk -F: -v p="$(echo "$all" | awk '{print $4}')" '$1==p{printf "{\"size\":%s}\n",$2}' "$TMP/poolattr" ;;
+        'osd pool get '*' min_size -f json')
+            awk -F: -v p="$(echo "$all" | awk '{print $4}')" '$1==p{printf "{\"min_size\":%s}\n",$3}' "$TMP/poolattr" ;;
+        'osd out '*|'osd in '*|'-s') : ;;
+        *) : ;;
+    esac
+    return 0
+}
+CEPH=fake_ceph
+
+# openstack: a stateful volume type catalog with no volumes on it. The delete
+# path polls the catalog for the type to disappear, so a stub that always
+# answers the same thing would make every run take the full 15 s timeout and
+# then fail for the wrong reason.
+fake_openstack() {
+    case "$*" in
+        *'volume type delete'*)
+            # $4, not ${*##* }: on "$*" the ## operator applies to each
+            # positional parameter, so it hands back the whole command line
+            grep -vx "$4" "$TMP/vtypes" > "$TMP/x"; mv "$TMP/x" "$TMP/vtypes" ;;
+        *'volume type list'*) cat "$TMP/vtypes" ;;
+        *'volume list'*)      echo '[]' ;;
+    esac
+    return 0
+}
+OPENSTACK=fake_openstack
+# hex_sdk cinder_is_volume_type_in_use: non-zero == not in use
+fake_sdk() { return 1; }
+HEX_SDK=fake_sdk
+
+pass=0 fail=0
+ck() { [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+ckhas() { case "$1" in *"$2"*) pass=$((pass+1));; *) fail=$((fail+1)); echo "FAIL: $3 -> output lacks '$2'";; esac; }
+
+# ==== R6 =================================================================
+
+# ---- 6a. happy path: everything goes, clean delete reported ----
+reset_cluster
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 0 "6a delete succeeds when every step takes effect"
+ckhas "$OUT" "left with no device class" "6a reports the clean delete"
+ck "$(wc -l < "$TMP/classes" | tr -d ' ')" 0 "6a every OSD lost the class"
+ck "$(grep -cx gold "$TMP/rules")" 0 "6a the rule is gone"
+
+# ---- 6b. the rule removal fails: the class must survive ----
+# Stripping the class while the rule stands leaves that rule selecting nothing,
+# and every pool bound to it goes dark -- the exact outage the module refuses
+# elsewhere, reachable here only because the rm was unchecked.
+reset_cluster
+FAIL_PAT='rule rm'
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6b rule rm failure returns non-zero"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "6b every OSD kept the class"
+ck "$(grep -cx gold "$TMP/rules")" 1 "6b the rule is still there"
+ckhas "$OUT" "did not take effect" "6b says why the class was kept"
+case "$OUT" in *"left with no device class"*) fail=$((fail+1)); echo "FAIL: 6b must not claim a clean delete";; *) pass=$((pass+1));; esac
+
+# ---- 6c. one of the three class removals fails ----
+reset_cluster
+FAIL_PAT='rm-device-class osd\.6$'
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6c partial class removal returns non-zero"
+ckhas "$OUT" "osd.6" "6c names the OSD that kept the class"
+ck "$(cat "$TMP/classes")" "6:gold" "6c only the failed OSD kept it"
+case "$OUT" in *"left with no device class"*) fail=$((fail+1)); echo "FAIL: 6c must not claim a clean delete";; *) pass=$((pass+1));; esac
+
+# ---- 6d. the rule is still used by another pool: unchanged behaviour ----
+# The real helper is driven through the model here rather than overridden, so
+# this also covers the query it makes.
+reset_cluster
+printf 'cinder-volumes\ngold\nsomeone-else\n' > "$TMP/pools"
+printf 'gold:3:2\ncinder-volumes:3:2\nsomeone-else:3:2\n' > "$TMP/poolattr"
+printf 'cinder-volumes:replicated_rule\ngold:gold\nsomeone-else:gold\n' > "$TMP/poolrule"
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6d a shared rule still returns non-zero"
+ckhas "$OUT" "still selects through that rule" "6d keeps the pre-existing reason"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "6d the class survives with the rule"
+ck "$(grep -cx gold "$TMP/rules")" 1 "6d the shared rule is not removed"
+
+# ---- 6e. the rule removal fails AND the readback is unavailable ----
+# The pair is the point. An existence check written as a pipeline answers
+# non-zero to "not there" and to "the mon did not answer" alike, so a delete
+# that trusts it strips every device class exactly when it knows least.
+reset_cluster
+FAIL_PAT='rule rm'
+RULE_LS_DEAD_AFTER_RM=1
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6e unreadable readback after a failed rm returns non-zero"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "6e every OSD kept the class"
+ck "$(grep -cx gold "$TMP/rules")" 1 "6e the rule is still there"
+ckhas "$OUT" "cannot be confirmed that the rule went" "6e reports unknown, not removed"
+case "$OUT" in *"left with no device class"*) fail=$((fail+1)); echo "FAIL: 6e must not claim a clean delete";; *) pass=$((pass+1));; esac
+
+# ---- 6f. the rule removal returns 0 AND the readback is unavailable ----
+# Same unknown, reached the other way: nothing here proves the rm took effect,
+# so the class that makes the rule work has to stay until something does.
+reset_cluster
+RULE_LS_DEAD_AFTER_RM=1
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6f unreadable readback after a clean rm returns non-zero"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "6f every OSD kept the class"
+ckhas "$OUT" "cannot be confirmed that the rule went" "6f reports unknown, not removed"
+case "$OUT" in *"left with no device class"*) fail=$((fail+1)); echo "FAIL: 6f must not claim a clean delete";; *) pass=$((pass+1));; esac
+
+# ---- 6g. the rm removes the rule and still reports failure ----
+# The readback alone cannot object to this one -- the rule really is gone --
+# but an rm whose status disagrees with its effect is not understood, and the
+# device class is the half that can still be put back by hand. The report has
+# to stay accurate: the rule did NOT keep the class here.
+reset_cluster
+RM_LIES=1
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6g a failing rm that took effect still returns non-zero"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "6g every OSD kept the class"
+ck "$(grep -cx gold "$TMP/rules")" 0 "6g the rule really did go"
+ckhas "$OUT" "reported a failure" "6g says the rm disagreed with itself"
+case "$OUT" in *"the CRUSH rule and osd"*) fail=$((fail+1)); echo "FAIL: 6g must not claim the rule kept the class";; *) pass=$((pass+1));; esac
+case "$OUT" in *"left with no device class"*) fail=$((fail+1)); echo "FAIL: 6g must not claim a clean delete";; *) pass=$((pass+1));; esac
+
+# ---- 6i. the class list reads back as exit 0 with unparseable output ----
+# The rc half of this read is already fail-closed; the parse half is the other
+# half of the same answer. `ceph` exiting 0 with something jq cannot read is an
+# answer nobody got, and letting it fall through the grep reports a clean delete
+# on the strength of it.
+reset_cluster
+CLASS_LS_GARBAGE=1
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "6i unparseable class list returns non-zero"
+ckhas "$OUT" "could not be read" "6i reports unknown, not gone"
+case "$OUT" in *"left with no device class"*) fail=$((fail+1)); echo "FAIL: 6i must not claim a clean delete";; *) pass=$((pass+1));; esac
+
+# ---- 6h. the tri-state helper itself ----
+# present / absent / unreadable have to be three answers, not two: this is the
+# distinction the whole of 6e and 6f rests on.
+reset_cluster
+_ceph_device_tier_rule_state gold          ; ck "$?" 0 "6h present -> 0"
+_ceph_device_tier_rule_state no-such-rule  ; ck "$?" 1 "6h read and absent -> 1"
+CEPH_DEAD=1
+_ceph_device_tier_rule_state gold          ; ck "$?" 2 "6h unreadable -> 2"
+_ceph_device_tier_rule_state no-such-rule  ; ck "$?" 2 "6h unreadable is never absent"
+reset_cluster
+
+# ==== R7 =================================================================
+# ceph_adjust_pool_size sets the pair (size, min_size = max(1, size - 1)) and
+# swallows its own failures, so a pool that took one and not the other is the
+# case that has to be caught.
+# The membership asked for has to differ from what the model holds: an update
+# that changes nothing short-circuits with "already consists of" and never
+# reaches the resize, so a test that passes the current members would assert
+# nothing at all.
+run_update() {  # $1 = size in the model, $2 = min_size in the model
+    # The membership is reset too, not just the pool attributes: set-device-class
+    # really moves the OSD in the model, so without this the second call onwards
+    # would find nothing to do, short-circuit on "already consists of", and never
+    # reach the resize the assertion is about -- the trap named just above.
+    printf '2:gold\n6:gold\n10:gold\n' > "$TMP/classes"
+    printf 'gold:%s:%s\ncinder-volumes:3:2\n' "$1" "$2" > "$TMP/poolattr"
+    UOUT=$(ceph_device_tier_update gold 2 6 10 3 2>&1); URC=$?
+}
+reset_cluster
+_ceph_device_tier_target_pool_size() { echo 3; }
+_ceph_device_tier_wait_recovery() { return 0; }
+_ceph_device_tier_health_ok() { return 0; }
+_ceph_device_tier_osd_ids() { for a in "$@" ; do echo "${a#osd.}" ; done ; }
+_ceph_device_tier_class_of_osd() { echo gold; }
+ceph_adjust_pool_size() { return 0; }
+
+run_update 3 2
+ck "$URC" 0 "7a both halves at target -> success"
+
+run_update 3 1
+ck "$URC" 1 "7b size right, min_size stale -> non-zero"
+ckhas "$UOUT" "min_size is 1, expected 2" "7b prints actual and expected"
+
+run_update 2 2
+ck "$URC" 1 "7c size wrong -> non-zero (unchanged behaviour)"
+ckhas "$UOUT" "size is 2, expected 3" "7c prints actual and expected"
+
+# min_size floors at 1, so a single-replica tier must not demand 0
+_ceph_device_tier_target_pool_size() { echo 1; }
+run_update 1 1
+ck "$URC" 0 "7d size 1 expects min_size 1, not 0"
+run_update 1 2
+ck "$URC" 1 "7d' size 1 with min_size 2 is still caught"
+
+# ---- 7e. the membership query cannot be answered ----
+# An empty `have` is not an empty tier: every requested OSD becomes an addition,
+# so members already in the tier get taken out and re-added (which moves data),
+# every existing member missing from the request stays in, and the success line
+# is a statement about a set nobody read.
+reset_cluster
+LSOSD_DEAD=1
+UOUT=$(ceph_device_tier_update gold 2 6 10 3 2>&1); URC=$?
+ck "$URC" 1 "7e unreadable membership returns non-zero"
+ckhas "$UOUT" "cannot read the members" "7e says why it refused"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "7e nothing was changed"
+case "$UOUT" in *"now consists of"*) fail=$((fail+1)); echo "FAIL: 7e must not claim the membership changed";; *) pass=$((pass+1));; esac
+
+# ---- 7f. set-device-class returns 0 without moving the OSD ----
+# Every step returned 0, so only reading the membership back can object.
+reset_cluster
+_ceph_device_tier_target_pool_size() { echo 3; }
+SETCLASS_LIES=1
+UOUT=$(ceph_device_tier_update gold 2 6 10 3 2>&1); URC=$?
+ck "$URC" 1 "7f a silent set-device-class is caught by the readback"
+ckhas "$UOUT" "not the requested" "7f prints actual and requested"
+case "$UOUT" in *"now consists of 2 6 10 3"*) fail=$((fail+1)); echo "FAIL: 7f must not claim success";; *) pass=$((pass+1));; esac
+
+# ---- 7g. the readback itself cannot be answered ----
+reset_cluster
+_ceph_device_tier_target_pool_size() { echo 3; }
+_ceph_device_tier_wait_recovery() { LSOSD_DEAD=1 ; return 0 ; }
+UOUT=$(ceph_device_tier_update gold 2 6 10 3 2>&1); URC=$?
+ck "$URC" 1 "7g unreadable readback returns non-zero"
+ckhas "$UOUT" "could not be" "7g reports unknown"
+_ceph_device_tier_wait_recovery() { return 0; }
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: device tier delete/update failure reporting"; exit 0; } || exit 1


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

#840 replaces Ceph cache tiering with device tiers: a named set of OSDs carrying its own
CRUSH device class, CRUSH rule, RBD pool and Cinder volume type, all four sharing the tier's
name. #1446 added the half that survives a reboot — the registry, and what `config_cinder`
does with an entry in it. This PR is the imperative half: the `hex_sdk` functions that
actually build, resize, list and tear down a tier, and the one change to existing code
without which those tiers do not survive contact with the cache switch.

Two commits, and they cannot be split.

**`ceph_device_tier_create / update / delete / list`** — four new functions at the tail of
`sdk_ceph.sh` plus their helpers. **No existing function is touched.**

They are `ceph_device_tier_*`, not `ceph_tier_*`, because "tier" already means two other
things in this file: Ceph's cache tiering, which is the mechanism #840 exists to move away
from, and the mon / osd / mgr grouping the pre-existing `ceph_tier_releases` reads out of
`ceph versions`. Three senses of one word, one of them the thing being deprecated, is how
someone reads the wrong function during an incident — so the block opens with a glossary and
every message, column heading and comment says device tier in full.

The create order is forced by Ceph, not chosen: a rule cannot select a class no OSD carries,
so the class comes first. Because Ceph is imperative rather than declarative, a failure
unwinds in reverse over what that invocation actually made — tracked explicitly, so a step
that found an object already present does not remove it on the way out.

RF comes from the base pool, clamped to the number of hosts the tier's own rule can select.
That rule is class-restricted, so a tier living on two of three hosts cannot reach the base
pool's 3; `osd pool set size` fails quietly, so an unclamped value would leave the pool
undersized forever with nothing saying why.

**`cache switch on` / `off` must step over a registered tier.** This is the change to
existing code, and it is why the two commits ship together. Both switches are symmetric
sweeps over every pool in the cluster, and both force `crush_rule` on anything they do not
recognise. What they recognise is a fixed list — `$BUILTIN_CACHEPOOL`, `cephfs_metadata`,
`*-pool`, `*-cache`, `*-ssd` — and #840's name guard forbids exactly the two suffixes that
would have saved a tier pool. So a tier pool lands in the `*)` arm of both, every time:

```
built                crush_rule = sekitier        placement = ssd only
cache switch on      crush_rule = rule-hdd        pinned away
cache switch off     crush_rule = replicated_rule not restored, reset
```

One on→off round trip permanently destroys the tier's placement, and neither direction says
anything, because both run under `Quiet -n`. Measured on a 1cc and on cube4510, where the
mixed hardware shows the OSD set really going from ssd-only to mixed. That is not a corner
case the registry makes possible; it is what the registry makes *reachable*, which is why
the SDK layer cannot ship without it.

This is also the remainder of AC-3. The gap Jim marked was "the off-switch has to cleanly
unwind the `rule-hdd` pinning", and the measurement says it unwinds very cleanly — the
problem is that it unwinds more than it pinned. So the unwind logic is not rewritten; it is
taught to recognise the registry and step over it.

**The spine of both commits is that a query that failed is not an answer.** An existence
helper written as a pipeline folds "the service is broken" and "it is not there" into the
same non-zero, and every destructive step here decides on the strength of one. Concretely:

- the delete path reads everything it will decide on once, up front, and stops if any of it
  cannot be read — re-querying was the hazard, because a blip between the readability probe
  and the in-use gate reads as "there is no volume type" and the pool goes anyway;
- the CRUSH rule readback before stripping device classes is tri-state — present / read and
  absent / unreadable — because only a read that succeeded and did not find the rule
  licenses removing what that rule selects through. Stripping the class while the rule
  stands leaves it selecting nothing and every pool bound to it goes dark;
- `update` refuses to act on an unreadable membership list. An empty `have` is not an empty
  tier: it makes every requested OSD an addition (so members already in the tier get taken
  out and re-added, which moves data) and leaves every member that should have been removed
  in place, while reporting the requested set as fact;
- both `update` and `delete` read the result back before claiming success, because
  `ceph_adjust_pool_size` and `set-device-class` can return 0 without taking effect;
- `_ceph_device_tier_registry` separates "cannot read it" from "there are none" in its
  return status, and the registry is read *before* the first mutation, not at the sweep —
  neither sweep can be resumed from the middle, so "the registry cannot be read" has to fail
  while failing is still free.

Matching against the registry is `grep -qxF`, never a `case` pattern. `config_cinder.cpp`
vets these names, but it is not the only writer — the `external_storage` policy chain and
`hex_config commit <settings>` both reach the tuning without passing through
`cli_ceph.cpp`. An entry holding `*` used as a shell pattern would skip every pool in the
cluster, turning a guard into the outage it was added to prevent.

#### Which issue(s) this PR fixes

Part of #840

Not a `Fixes`: the CLI layer with its input validation and confirmation prompts, the
registry write path, and the migration of an existing cache-tiered cluster are still to come
on the same issue.

#### Special notes for your reviewer

> **On a cluster with no registered tier this changes nothing.** With an empty registry both
> sweeps behave exactly as before — that is a committed test case, not an assertion of
> intent. The four new functions are additive and unreachable until the CLI layer lands.

**Two committed offline suites, and both were checked against the unpatched code.** They
extract the functions under test and stub `ceph` / `rados` / `openstack` / `hex_sdk` /
`Quiet`, so they need no cluster:

```
core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh    55 assertions
core/sdk_sh/tests/test_ceph_cache_switch_device_tier.sh     33 assertions
```

A test that passes on both the fixed and unfixed code asserts nothing, so each suite was run
against the pre-fix revision. Two of those failures reproduce the measured symptom verbatim:

```
switch on:  gold still bound to rule gold -> got 'rule-hdd'        want 'gold'
switch off: gold still bound to rule gold -> got 'replicated_rule' want 'gold'
```

and one shows the delete path stripping every OSD's device class while the CRUSH rule's fate
was unknown, then returning 0 and printing `left with no device class`.

The `Quiet` stub reproduces `-n` forcing 0 exactly. That is deliberate: a check written as
`Quiet -n cmd || handler` is dead code, and a stub that let `-n` propagate the status would
not notice a regression back to it.

**Eight false passes were found and fixed while building those suites** — six in the
failure-path stubs, two in the cache-switch ones — all of which would have made assertions
decorative. Among them a `ceph` stub reading the
pool name from the wrong positional (`osd pool get <p> crush_rule` puts it in `$4`), a
`ceph_osd_test_cache` stub that always answered "on" so the switch-off body never executed,
and a `set-device-class` stub that was a no-op so no membership readback could ever fail.

**Hardware evidence.** The cache-switch commit is measured on a 1cc (Ceph 18.2.8 reef) and
on cube4510, both restored to baseline afterwards:

```
1cc        cache switch on   22 pools pinned to rule-hdd;    seki1 still on rule seki1
           cache switch off  23 pools reset to replicated;   seki1 still on rule seki1
cube4510   wp4tier (osd.2/6/10) pg map identical across three snapshots, while
           23 pools were pinned and 25 reset in the same run
           20 instances ACTIVE, 49 volumes unchanged, cephfs unchanged
```

The 22 / 23 / 25 counts are there to show the sweeps demonstrably ran rather than being
skipped whole; `rc=0` alone would not have said that. cube4510 is the part a 1cc cannot
show — on a 1cc both rules select the same OSDs.

**One known sharp edge, deliberately unchanged.** `ceph_device_tier_create` refuses on any
`HEALTH_WARN`, and BlueStore's slow-op warning has `warn_threshold=1` /
`warn_lifetime=86400` — so a single slow op can block tier creation for a day even with
every PG `active+clean`. Whether that threshold should be narrowed is a product decision, so
it is left as-is here rather than loosened in passing. Flagging it because it will be the
first thing an operator hits.

#### Additional documentation

None. The operator-facing documentation belongs with the CLI layer, which is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
