### PR TITLE
feat(ceph): 840 add the device tier CLI, its registry writes and a usable health gate

### DIFF
--- a/core/modules/cli_ceph.cpp
+++ b/core/modules/cli_ceph.cpp
@@ -1102,15 +1102,30 @@ struct CephOsdRow {
 
 // Run one of sdk_ceph.sh's device tier queries and split its stdout into lines.
 //
+// Arguments are passed as arguments. ExecBashSync -- the obvious tool here --
+// runs `/bin/bash -c "set -o pipefail && " + command`, so anything appended to
+// a command string is shell syntax, not data. Two of these queries take a
+// name that came out of the registry, and the registry is writable without
+// passing through this file at all: the policy chain and `hex_config commit
+// <settings>` both write it, which is why _ceph_device_tier_registry says an
+// entry can hold any byte. A tier called `x; rm -rf /` would be a second
+// command. ExecSync execvp()s the program with an argv, so it cannot be.
+//
 // False means the question was not answered. Every one of those queries returns
 // non-zero instead of an empty answer when it cannot read the cluster, and the
 // callers here refuse to decide on that: a name checked against a list that
 // failed to load is not checked, and reading "cannot tell" as "nothing there"
 // is the whole family of bugs #840 kept finding in the layer below.
 static bool
-CephDeviceTierQuery(const std::string& cmd, std::vector<std::string>& lines)
+CephDeviceTierQuery(const std::vector<std::string>& args, std::vector<std::string>& lines)
 {
-    const ExecSyncResult r = ExecBashSync(0, true, true, {}, cmd);
+    Cmd c;
+    c.path = HEX_SDK;
+    c.args = args;
+    c.captureStdout = true;
+    c.captureStderr = true;
+
+    const ExecSyncResult r = ExecSync(0, c);
     if (r.exitCode != 0) {
         return false;
     }
@@ -1118,6 +1133,50 @@ CephDeviceTierQuery(const std::string& cmd, std::vector<std::string>& lines)
     for (const auto& l : hex_string_util::split(r.stdoutOutput, '\n')) {
         if (l.length()) {
             lines.push_back(l);
+        }
+    }
+
+    return true;
+}
+
+// The three states ceph_device_tier_names reports, and what this CLI may do
+// with each. Ownership is the registry, never the shape of the Ceph objects:
+// a device class with a same-named rule and pool is what a device tier looks
+// like, and customers hand-build exactly that shape, so treating a lookalike
+// as one of ours is how this CLI would come to delete someone else's storage.
+enum CephDeviceTierState {
+    TIER_NONE,          // this CLI has never heard of the name
+    TIER_REGISTERED,    // ours, and Ceph has the objects
+    TIER_REGISTRY_ONLY, // ours, but nothing of that shape on the Ceph side
+    TIER_UNMANAGED,     // Ceph has the shape; the registry does not list it
+};
+
+// Read the state of every name ceph_device_tier_names knows.
+static bool
+CephDeviceTierStates(std::vector<std::pair<CephDeviceTierState, std::string>>& tiers)
+{
+    std::vector<std::string> lines;
+
+    if (!CephDeviceTierQuery({ "ceph_device_tier_names" }, lines)) {
+        return false;
+    }
+
+    for (const auto& l : lines) {
+        const std::size_t bar = l.find('|');
+        if (bar == std::string::npos) {
+            return false;
+        }
+        const std::string state = l.substr(0, bar);
+        const std::string name = l.substr(bar + 1);
+        if (state == "registered") {
+            tiers.push_back({ TIER_REGISTERED, name });
+        } else if (state == "registry-only") {
+            tiers.push_back({ TIER_REGISTRY_ONLY, name });
+        } else if (state == "unmanaged") {
+            tiers.push_back({ TIER_UNMANAGED, name });
+        } else {
+            // An unrecognised state is not a state to guess at
+            return false;
         }
     }
 
@@ -1175,28 +1234,39 @@ CephDeviceTierNameOk(const std::string& tier)
 // existence check is an unanchored grep, which answers yes for "seki1" when
 // only "seki1-ssd" exists, so it cannot be reused to decide this.
 //
-// A name that is already a device tier is not a collision with itself, and
-// *existing says so: re-running create is how a tier whose Ceph objects exist
-// but whose registry entry does not gets completed, and hex_sdk's create is
-// idempotent step by step.
+// A name the registry already lists is not a collision with itself, and
+// *existing says so: re-running create is how a tier of ours that is missing a
+// piece gets completed, and hex_sdk's create is idempotent step by step.
+//
+// A name that merely LOOKS like a device tier on the Ceph side is a collision.
+// It is reported like any other, because that is what it is: the registry says
+// this CLI did not build it, and a class with a same-named rule and pool is a
+// shape customers hand-build. Adopting it would make someone else's storage
+// into a Cinder backend, and then offer it for deletion.
 static bool
 CephDeviceTierNameFree(const std::string& tier, bool* existing)
 {
     std::vector<std::string> taken;
-    std::vector<std::string> tiers;
+    std::vector<std::pair<CephDeviceTierState, std::string>> tiers;
 
     *existing = false;
 
-    if (!CephDeviceTierQuery(HEX_SDK " ceph_device_tier_names_taken", taken)
-        || !CephDeviceTierQuery(HEX_SDK " ceph_device_tier_names", tiers)) {
-        CliPrintf("Cannot read the existing device class, CRUSH rule, pool and volume type names, so it cannot be established that '%s' is free. Not creating anything.",
+    if (!CephDeviceTierQuery({ "ceph_device_tier_names_taken" }, taken)
+        || !CephDeviceTierStates(tiers)) {
+        CliPrintf("Cannot read the device tier registry and the existing device class, CRUSH rule, pool and volume type names, so it cannot be established that '%s' is free. Not creating anything.",
             tier.c_str());
         return false;
     }
 
-    if (std::find(tiers.begin(), tiers.end(), tier) != tiers.end()) {
-        *existing = true;
-        return true;
+    for (const auto& t : tiers) {
+        if (t.second != tier) {
+            continue;
+        }
+        if (t.first == TIER_REGISTERED || t.first == TIER_REGISTRY_ONLY) {
+            *existing = true;
+            return true;
+        }
+        break;
     }
 
     for (const auto& t : taken) {
@@ -1222,7 +1292,11 @@ CephDeviceTierNameFree(const std::string& tier, bool* existing)
 
         CliPrintf("The name '%s' is already taken by a %s. A device tier's name has to be free as all four of a device class, a CRUSH rule, a pool and a volume type.",
             tier.c_str(), what.c_str());
-        CliPrintf("If '%s' is a half-created device tier, remove it with 'tier delete %s' and try again.",
+        // Deliberately not offered as something this CLI will take over. If
+        // those objects were built here and only the registry entry is
+        // missing, the repair is one explicit command that says what it is
+        // doing; if they were not, nothing here should touch them.
+        CliPrintf("This CLI does not manage objects it did not register. If '%s' is a device tier built here whose registration did not complete, finish it with 'hex_sdk ceph_device_tier_create %s <osd id>...'.",
             tier.c_str(), tier.c_str());
         return false;
     }
@@ -1236,7 +1310,7 @@ CephDeviceTierOsdTable(std::vector<CephOsdRow>& rows)
 {
     std::vector<std::string> lines;
 
-    if (!CephDeviceTierQuery(HEX_SDK " ceph_device_tier_osd_table", lines)) {
+    if (!CephDeviceTierQuery({ "ceph_device_tier_osd_table" }, lines)) {
         CliPrintf("Cannot read the OSD list. Not going any further -- an OSD id that has not been checked against the cluster would have CRUSH invent a bucket for it.");
         return false;
     }
@@ -1358,8 +1432,13 @@ static bool
 CephDeviceTierPrintImpact(const std::vector<std::string>& classes)
 {
     for (const auto& c : classes) {
-        const ExecSyncResult r = ExecBashSync(0, true, true, {},
-            std::string(HEX_SDK " ceph_device_tier_class_users ") + c);
+        Cmd cmd;
+        cmd.path = HEX_SDK;
+        cmd.args = { "ceph_device_tier_class_users", c };
+        cmd.captureStdout = true;
+        cmd.captureStderr = true;
+
+        const ExecSyncResult r = ExecSync(0, cmd);
         if (r.exitCode != 0) {
             CliPrintf("Cannot tell which pools select OSDs through device class '%s', so the effect of this change cannot be shown. Not proceeding.",
                 c.c_str());
@@ -1431,44 +1510,95 @@ CephDeviceTierSpawn(const char* subcmd, const std::string& tier, const std::vect
     return HexExitStatus(HexSpawnV(0, (char* const*)&args[0]));
 }
 
-// Name an existing device tier: from the arguments, or by picking one.
+// Name a device tier this CLI owns: from the arguments, or by picking one.
+// *state comes back so the caller can tell a tier whose objects are there from
+// one that is only a registry entry.
+//
+// Only registered names are offered and only registered names are accepted.
+// A Ceph structure that merely has the shape of a device tier is refused by
+// name here rather than listed and acted on -- update and delete are the two
+// commands that would otherwise remap or destroy it.
+//
+// The name is put through the same guard create uses even though it came from
+// the registry, because that is exactly why: the registry is written by the
+// policy chain and by `hex_config commit <settings>` without passing through
+// this file, so an entry can hold any byte. Nothing downstream builds a shell
+// command out of it any more, but a name Ceph itself will not accept is not
+// one to hand to Ceph, and a name starting with '-' is an option to everything
+// it reaches.
 //
 // Refusing when the list cannot be read is deliberate -- "no such device tier"
 // and "the cluster did not answer" are different answers, and reporting the
 // second as the first is what sends an operator to re-create something that
 // already exists.
 static bool
-CephDeviceTierPick(int argc, const char** argv, int argidx, std::string& tier)
+CephDeviceTierPick(int argc, const char** argv, int argidx, std::string& tier,
+    CephDeviceTierState* state)
 {
-    std::vector<std::string> names;
+    std::vector<std::pair<CephDeviceTierState, std::string>> tiers;
+    std::vector<std::string> owned;
 
-    if (!CephDeviceTierQuery(HEX_SDK " ceph_device_tier_names", names)) {
-        CliPrintf("Cannot read the device tier list. Not going any further.");
+    *state = TIER_NONE;
+
+    if (!CephDeviceTierStates(tiers)) {
+        CliPrintf("Cannot read the device tier registry. Not going any further -- which device tiers this CLI manages cannot be established without it.");
         return false;
     }
-    if (names.empty()) {
-        CliPrintf("There are no device tiers.");
-        return false;
+
+    for (const auto& t : tiers) {
+        if (t.first == TIER_REGISTERED || t.first == TIER_REGISTRY_ONLY) {
+            owned.push_back(t.second);
+        }
     }
 
     if (argc > argidx) {
+        // A name was given, so its own state is the answer -- checked before
+        // the "nothing to pick from" case, because a named lookalike deserves
+        // to be told it is a lookalike rather than that no tiers exist.
         tier = argv[argidx];
     } else {
-        for (std::size_t i = 0; i < names.size(); i++) {
-            CliPrintf("   %lu) %s", (unsigned long)(i + 1), names[i].c_str());
+        if (owned.empty()) {
+            CliPrintf("There are no device tiers.");
+            return false;
+        }
+        for (std::size_t i = 0; i < owned.size(); i++) {
+            CliPrintf("   %lu) %s", (unsigned long)(i + 1), owned[i].c_str());
         }
         std::string input;
         std::size_t index = 0;
         CliReadLine("Enter the index of the device tier: ", input);
-        if (!HexParseUInt(input.c_str(), 1, names.size(), &index)) {
+        if (!HexParseUInt(input.c_str(), 1, owned.size(), &index)) {
             CliPrintf("Invalid index.");
             return false;
         }
-        tier = names[index - 1];
+        tier = owned[index - 1];
     }
 
-    if (std::find(names.begin(), names.end(), tier) == names.end()) {
-        CliPrintf("No such device tier: '%s'.", tier.c_str());
+    for (const auto& t : tiers) {
+        if (t.second == tier) {
+            *state = t.first;
+            break;
+        }
+    }
+
+    if (*state == TIER_UNMANAGED) {
+        CliPrintf("'%s' is a device class with a CRUSH rule and a pool of the same name, but it is not in the storage tier registry -- so it was not created here and this CLI does not manage it. Nothing has been changed.",
+            tier.c_str());
+        CliPrintf("If it was created here and only its registration is missing, register it with 'hex_sdk cinder_apply_storage_tier_creation %s'; hex_sdk's ceph_device_tier_* functions operate on it directly if that is really what you want.",
+            tier.c_str());
+        return false;
+    }
+    if (*state == TIER_NONE) {
+        if (owned.empty()) {
+            CliPrintf("There are no device tiers.");
+        } else {
+            CliPrintf("No such device tier: '%s'.", tier.c_str());
+        }
+        return false;
+    }
+
+    if (!CephDeviceTierNameOk(tier)) {
+        CliPrintf("That name is in the storage tier registry but is not one this CLI can act on. It was written by something other than this command -- the policy file, or 'hex_config commit'. Remove it with 'hex_sdk cinder_apply_storage_tier_deletion' and register a valid name instead.");
         return false;
     }
 
@@ -1587,8 +1717,18 @@ CephDeviceTierUpdate(int argc, const char** argv)
 {
     /* [0]="update" [1]=<tier name> [2...]=<osd id> */
     std::string tier;
+    CephDeviceTierState state = TIER_NONE;
 
-    if (!CephDeviceTierPick(argc, argv, 1, tier)) {
+    if (!CephDeviceTierPick(argc, argv, 1, tier, &state)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    // Registered, but there is no class or rule to move members between yet.
+    // hex_sdk would say "no such device tier", which is true of Ceph and
+    // misleading about the registry.
+    if (state == TIER_REGISTRY_ONLY) {
+        CliPrintf("Device tier '%s' is registered but has nothing on the Ceph side, so it has no members to change. Build it with 'tier create %s <osd id>...', or take the registry entry out with 'tier delete %s'.",
+            tier.c_str(), tier.c_str(), tier.c_str());
         return CLI_INVALID_ARGS;
     }
 
@@ -1677,8 +1817,29 @@ CephDeviceTierDelete(int argc, const char** argv)
     }
 
     std::string tier;
-    if (!CephDeviceTierPick(argc, argv, 1, tier)) {
+    CephDeviceTierState state = TIER_NONE;
+    if (!CephDeviceTierPick(argc, argv, 1, tier, &state)) {
         return CLI_INVALID_ARGS;
+    }
+
+    // Nothing on the Ceph side to tear down, so this is the registry entry and
+    // the backend generated from it -- which is the whole problem with that
+    // state: Cinder advertises a volume type whose pool does not exist. The
+    // Ceph-side delete would refuse here, because it cannot read the members of
+    // a class that is not there.
+    if (state == TIER_REGISTRY_ONLY) {
+        CliPrintf("\nDevice tier '%s' has nothing on the Ceph side: no device class, CRUSH rule or pool. Only its registry entry and the Cinder backend generated from it will be removed. No data is affected.",
+            tier.c_str());
+        if (!CliReadConfirmation()) {
+            return CLI_SUCCESS;
+        }
+        if (CephDeviceTierSpawn("cinder_apply_storage_tier_deletion", tier, {})) {
+            HexLogError("Failed to unregister device tier %s", tier.c_str());
+            CliPrintf("\n--\nFailed to unregister device tier %s.", tier.c_str());
+            return CLI_FAILURE;
+        }
+        CliPrintf("device tier %s unregistered", tier.c_str());
+        return CLI_SUCCESS;
     }
 
     std::vector<CephOsdRow> rows;

--- a/core/modules/cli_ceph.cpp
+++ b/core/modules/cli_ceph.cpp
@@ -1139,16 +1139,17 @@ CephDeviceTierQuery(const std::vector<std::string>& args, std::vector<std::strin
     return true;
 }
 
-// The three states ceph_device_tier_names reports, and what this CLI may do
+// The states ceph_device_tier_names reports, and what this CLI may do
 // with each. Ownership is the registry, never the shape of the Ceph objects:
 // a device class with a same-named rule and pool is what a device tier looks
 // like, and customers hand-build exactly that shape, so treating a lookalike
 // as one of ours is how this CLI would come to delete someone else's storage.
 enum CephDeviceTierState {
-    TIER_NONE,          // this CLI has never heard of the name
-    TIER_REGISTERED,    // ours, and Ceph has the objects
-    TIER_REGISTRY_ONLY, // ours, but nothing of that shape on the Ceph side
-    TIER_UNMANAGED,     // Ceph has the shape; the registry does not list it
+    TIER_NONE,             // this CLI has never heard of the name
+    TIER_REGISTERED,       // ours, and Ceph has the class, the rule and the pool
+    TIER_REGISTRY_PARTIAL, // ours, and Ceph has some of those three
+    TIER_REGISTRY_ONLY,    // ours, and Ceph is known to have none of them
+    TIER_UNMANAGED,        // Ceph has all three; the registry does not list it
 };
 
 // Read the state of every name ceph_device_tier_names knows.
@@ -1170,6 +1171,8 @@ CephDeviceTierStates(std::vector<std::pair<CephDeviceTierState, std::string>>& t
         const std::string name = l.substr(bar + 1);
         if (state == "registered") {
             tiers.push_back({ TIER_REGISTERED, name });
+        } else if (state == "registry-partial") {
+            tiers.push_back({ TIER_REGISTRY_PARTIAL, name });
         } else if (state == "registry-only") {
             tiers.push_back({ TIER_REGISTRY_ONLY, name });
         } else if (state == "unmanaged") {
@@ -1262,11 +1265,24 @@ CephDeviceTierNameFree(const std::string& tier, bool* existing)
         if (t.second != tier) {
             continue;
         }
-        if (t.first == TIER_REGISTERED || t.first == TIER_REGISTRY_ONLY) {
-            *existing = true;
-            return true;
+        if (t.first == TIER_UNMANAGED) {
+            // Terminal here, decided from THIS snapshot. Breaking out to the
+            // collision loop below would settle ownership using `taken`, which
+            // was read BEFORE this list: a lookalike that became complete
+            // between the two reads is absent from `taken`, the name comes
+            // back free, and the idempotent create adopts the foreign objects
+            // -- exactly what telling the states apart is here to prevent.
+            CliPrintf("The name '%s' is a device class with a CRUSH rule and a pool of the same name, but it is not in the storage tier registry -- so it was not created here. Not creating anything.",
+                tier.c_str());
+            CliPrintf("This CLI does not manage objects it did not register. If '%s' is a device tier built here whose registration did not complete, finish it with 'hex_sdk ceph_device_tier_create %s <osd id>...'.",
+                tier.c_str(), tier.c_str());
+            return false;
         }
-        break;
+        // registered, registry-partial or registry-only: the registry says
+        // this one is ours, and re-running create is how a tier that is
+        // missing a piece gets completed.
+        *existing = true;
+        return true;
     }
 
     for (const auto& t : taken) {
@@ -1514,10 +1530,11 @@ CephDeviceTierSpawn(const char* subcmd, const std::string& tier, const std::vect
 // *state comes back so the caller can tell a tier whose objects are there from
 // one that is only a registry entry.
 //
-// Only registered names are offered and only registered names are accepted.
-// A Ceph structure that merely has the shape of a device tier is refused by
-// name here rather than listed and acted on -- update and delete are the two
-// commands that would otherwise remap or destroy it.
+// Only names the registry lists are offered, and only those are accepted --
+// whether Ceph has all, some or none of their objects. A Ceph structure that
+// merely has the shape of a device tier is refused by name here rather than
+// listed and acted on: update and delete are the two commands that would
+// otherwise remap or destroy it.
 //
 // The name is put through the same guard create uses even though it came from
 // the registry, because that is exactly why: the registry is written by the
@@ -1546,7 +1563,8 @@ CephDeviceTierPick(int argc, const char** argv, int argidx, std::string& tier,
     }
 
     for (const auto& t : tiers) {
-        if (t.first == TIER_REGISTERED || t.first == TIER_REGISTRY_ONLY) {
+        if (t.first == TIER_REGISTERED || t.first == TIER_REGISTRY_PARTIAL
+            || t.first == TIER_REGISTRY_ONLY) {
             owned.push_back(t.second);
         }
     }
@@ -1726,6 +1744,10 @@ CephDeviceTierUpdate(int argc, const char** argv)
     // Registered, but there is no class or rule to move members between yet.
     // hex_sdk would say "no such device tier", which is true of Ceph and
     // misleading about the registry.
+    //
+    // A partial tier does not come in here either: one holding a class and a
+    // rule but no pool has members and can have them changed, and hex_sdk's
+    // update checks the two objects it needs itself.
     if (state == TIER_REGISTRY_ONLY) {
         CliPrintf("Device tier '%s' is registered but has nothing on the Ceph side, so it has no members to change. Build it with 'tier create %s <osd id>...', or take the registry entry out with 'tier delete %s'.",
             tier.c_str(), tier.c_str(), tier.c_str());
@@ -1827,6 +1849,14 @@ CephDeviceTierDelete(int argc, const char** argv)
     // state: Cinder advertises a volume type whose pool does not exist. The
     // Ceph-side delete would refuse here, because it cannot read the members of
     // a class that is not there.
+    //
+    // TIER_REGISTRY_PARTIAL deliberately does NOT come in here, and the state
+    // exists to keep it out. This branch tells the operator there is nothing
+    // on the Ceph side and then removes only the registry entry, so it has to
+    // be reached only when that is known to be true: a tier still holding a
+    // class, a rule or a pool would be silently orphaned by it -- objects with
+    // no owner and no record. A partial one goes down the full path below,
+    // where hex_sdk's delete takes each piece it actually finds.
     if (state == TIER_REGISTRY_ONLY) {
         CliPrintf("\nDevice tier '%s' has nothing on the Ceph side: no device class, CRUSH rule or pool. Only its registry entry and the Cinder backend generated from it will be removed. No data is affected.",
             tier.c_str());

--- a/core/modules/cli_ceph.cpp
+++ b/core/modules/cli_ceph.cpp
@@ -1,5 +1,6 @@
 // CUBE SDK
 
+#include <algorithm>
 #include <cube/cubesys.h>
 #include <hex/cli_module.h>
 #include <hex/cli_util.h>
@@ -1065,6 +1066,668 @@ static int CephRemoveSsdPool(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
+
+// ---------------------------------------------------------------------------
+// Device tiers (#840).
+//
+// A device tier is a named set of OSDs that gets its own CRUSH device class,
+// its own CRUSH rule, its own pool and its own Cinder volume type -- all four
+// carrying the tier's name -- plus an entry in the storage tier registry, which
+// is what generates its Cinder backend.
+//
+// Every rule about what a tier may be called and which OSDs it may hold is
+// enforced here, and nowhere else, because there is nowhere else it can be:
+// the registry is an indexed tuning array (cinder.storage.tier.%d.name), the
+// cinder CONFIG_MODULE has no validate slot, ConfigString::parse always returns
+// true, TuningStringArray drops its ValidateType, and `hex_config
+// validate_tuning_value` compares the literal key name -- which never equals
+// an indexed one. The CLI is the gatekeeper.
+//
+// The rules also all come from measurement rather than caution; each one below
+// says which one.
+// ---------------------------------------------------------------------------
+
+#define TIER_OSD_H_FMT " %6s  %14s  %14s  %8s\n--\n"
+#define TIER_OSD_FMT " %6s  %14s  %14s  %8s\n"
+
+static const char* LABEL_TIER_NAME = "Enter the device tier name (required): ";
+static const char* LABEL_TIER_OSDS = "Enter the OSD ids, space separated (required): ";
+
+struct CephOsdRow {
+    std::string id;
+    std::string host;
+    std::string cls;
+    std::string status;
+};
+
+// Run one of sdk_ceph.sh's device tier queries and split its stdout into lines.
+//
+// False means the question was not answered. Every one of those queries returns
+// non-zero instead of an empty answer when it cannot read the cluster, and the
+// callers here refuse to decide on that: a name checked against a list that
+// failed to load is not checked, and reading "cannot tell" as "nothing there"
+// is the whole family of bugs #840 kept finding in the layer below.
+static bool
+CephDeviceTierQuery(const std::string& cmd, std::vector<std::string>& lines)
+{
+    const ExecSyncResult r = ExecBashSync(0, true, true, {}, cmd);
+    if (r.exitCode != 0) {
+        return false;
+    }
+
+    for (const auto& l : hex_string_util::split(r.stdoutOutput, '\n')) {
+        if (l.length()) {
+            lines.push_back(l);
+        }
+    }
+
+    return true;
+}
+
+// A tier's name becomes a device class, a CRUSH rule, a pool and a volume type,
+// so what it may contain is the intersection of what those four accept. Ceph is
+// the strict side: `osd crush class create` rejects '.', ' ', '/', ':' and
+// non-ASCII (measured, F10). What it does NOT reject is the empty string -- it
+// returns 0 and creates a class with no name -- so the check cannot be left to
+// the layer that will actually run the command.
+static bool
+CephDeviceTierNameOk(const std::string& tier)
+{
+    if (tier.empty()) {
+        CliPrintf("A device tier name is required.");
+        return false;
+    }
+
+    for (std::size_t i = 0; i < tier.length(); i++) {
+        const char c = tier[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                || c == '-' || c == '_')) {
+            CliPrintf("Invalid device tier name '%s': Ceph accepts only letters, digits, '-' and '_' in a device class name.",
+                tier.c_str());
+            return false;
+        }
+    }
+
+    // A leading '-' is read as an option by everything the name is handed to,
+    // starting with `ceph osd crush set-device-class`.
+    if (tier[0] == '-') {
+        CliPrintf("Invalid device tier name '%s': it cannot start with '-'.", tier.c_str());
+        return false;
+    }
+
+    // config_cinder.cpp's scan for the legacy tiering layout matches "-pool"
+    // and "-ssd" as substrings, not as suffixes (the grep at :1070 and the
+    // find() at :1077), so a tier holding either would be claimed by that scan
+    // as well as by the registry and end up with two conflicting Cinder
+    // backends.
+    if (tier.find("-pool") != std::string::npos || tier.find("-ssd") != std::string::npos) {
+        CliPrintf("Invalid device tier name '%s': it must not contain '-pool' or '-ssd', which the legacy tiering scan claims.",
+            tier.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+// Is this name free to become a device tier?
+//
+// The comparison is whole-name, never a substring: os_volume_type_create's own
+// existence check is an unanchored grep, which answers yes for "seki1" when
+// only "seki1-ssd" exists, so it cannot be reused to decide this.
+//
+// A name that is already a device tier is not a collision with itself, and
+// *existing says so: re-running create is how a tier whose Ceph objects exist
+// but whose registry entry does not gets completed, and hex_sdk's create is
+// idempotent step by step.
+static bool
+CephDeviceTierNameFree(const std::string& tier, bool* existing)
+{
+    std::vector<std::string> taken;
+    std::vector<std::string> tiers;
+
+    *existing = false;
+
+    if (!CephDeviceTierQuery(HEX_SDK " ceph_device_tier_names_taken", taken)
+        || !CephDeviceTierQuery(HEX_SDK " ceph_device_tier_names", tiers)) {
+        CliPrintf("Cannot read the existing device class, CRUSH rule, pool and volume type names, so it cannot be established that '%s' is free. Not creating anything.",
+            tier.c_str());
+        return false;
+    }
+
+    if (std::find(tiers.begin(), tiers.end(), tier) != tiers.end()) {
+        *existing = true;
+        return true;
+    }
+
+    for (const auto& t : taken) {
+        const std::size_t bar = t.find('|');
+        if (bar == std::string::npos) {
+            continue;
+        }
+        if (t.substr(bar + 1) != tier) {
+            continue;
+        }
+
+        const std::string kind = t.substr(0, bar);
+        std::string what = kind;
+        if (kind == "class") {
+            what = "CRUSH device class";
+        } else if (kind == "rule") {
+            what = "CRUSH rule";
+        } else if (kind == "pool") {
+            what = "Ceph pool";
+        } else if (kind == "vtype") {
+            what = "Cinder volume type";
+        }
+
+        CliPrintf("The name '%s' is already taken by a %s. A device tier's name has to be free as all four of a device class, a CRUSH rule, a pool and a volume type.",
+            tier.c_str(), what.c_str());
+        CliPrintf("If '%s' is a half-created device tier, remove it with 'tier delete %s' and try again.",
+            tier.c_str(), tier.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+// Every OSD the cluster knows, with its host, its device class and its state.
+static bool
+CephDeviceTierOsdTable(std::vector<CephOsdRow>& rows)
+{
+    std::vector<std::string> lines;
+
+    if (!CephDeviceTierQuery(HEX_SDK " ceph_device_tier_osd_table", lines)) {
+        CliPrintf("Cannot read the OSD list. Not going any further -- an OSD id that has not been checked against the cluster would have CRUSH invent a bucket for it.");
+        return false;
+    }
+
+    for (const auto& l : lines) {
+        const std::vector<std::string> f = hex_string_util::split(l, '|');
+        if (f.size() < 4) {
+            CliPrintf("Cannot read the OSD list: unexpected row '%s'.", l.c_str());
+            return false;
+        }
+        rows.push_back({ f[0], f[1], f[2], f[3] });
+    }
+
+    if (rows.empty()) {
+        CliPrintf("This cluster has no OSDs.");
+        return false;
+    }
+
+    return true;
+}
+
+static void
+CephDeviceTierPrintOsdTable(const std::vector<CephOsdRow>& rows)
+{
+    printf(TIER_OSD_H_FMT, "osd", "host", "device class", "state");
+    for (const auto& r : rows) {
+        printf(TIER_OSD_FMT, r.id.c_str(), r.host.c_str(),
+            r.cls.length() ? r.cls.c_str() : "-", r.status.c_str());
+    }
+}
+
+// "0" and "osd.0" both name OSD 0. Ids the cluster does not know are refused
+// here, and repeats are folded, so that what is confirmed below is what is
+// asked for.
+static bool
+CephDeviceTierParseOsds(const std::vector<std::string>& args,
+    const std::vector<CephOsdRow>& rows,
+    std::vector<std::string>& ids,
+    std::vector<CephOsdRow>& chosen)
+{
+    for (const auto& a : args) {
+        std::string id = a;
+        if (id.compare(0, 4, "osd.") == 0) {
+            id = id.substr(4);
+        }
+        if (id.empty() || id.find_first_not_of("0123456789") != std::string::npos) {
+            CliPrintf("Invalid OSD id: '%s'. Give an id as 0 or osd.0.", a.c_str());
+            return false;
+        }
+
+        const CephOsdRow* found = NULL;
+        for (const auto& r : rows) {
+            if (r.id == id) {
+                found = &r;
+                break;
+            }
+        }
+        if (found == NULL) {
+            CliPrintf("No such OSD: '%s'.", a.c_str());
+            return false;
+        }
+
+        if (std::find(ids.begin(), ids.end(), id) == ids.end()) {
+            ids.push_back(id);
+            chosen.push_back(*found);
+        }
+    }
+
+    if (ids.empty()) {
+        CliPrintf("At least one OSD is required.");
+        return false;
+    }
+
+    return true;
+}
+
+// Read the OSD list from the arguments, or list the candidates and ask.
+static bool
+CephDeviceTierReadOsds(int argc, const char** argv, int argidx,
+    const std::vector<CephOsdRow>& rows,
+    std::vector<std::string>& ids,
+    std::vector<CephOsdRow>& chosen)
+{
+    std::vector<std::string> args;
+
+    if (argc > argidx) {
+        for (int i = argidx; i < argc; i++) {
+            args.push_back(argv[i]);
+        }
+    } else {
+        CephDeviceTierPrintOsdTable(rows);
+        std::string input;
+        CliReadLine(LABEL_TIER_OSDS, input);
+        for (const auto& a : hex_string_util::split(input, ' ')) {
+            if (a.length()) {
+                args.push_back(a);
+            }
+        }
+    }
+
+    return CephDeviceTierParseOsds(args, rows, ids, chosen);
+}
+
+// What starts moving the moment these OSDs change device class.
+//
+// This is the impact the operator is being asked to accept, and it is not the
+// same question as "which pool will the new tier serve". A class-restricted
+// rule loses a candidate as soon as the class changes, so the pools bound to
+// that rule start remapping at the first step -- not at the later one that
+// binds the tier's own pool. On the 1cc, where every pool is on the
+// class-agnostic replicated_rule, this list is empty and nothing moves until
+// that later step; on mixed hardware with rule-ssd / rule-hdd in use it is not
+// (measured, F3 and F13).
+//
+// False means one of those lists could not be read. Showing "(none)" for an
+// answer nobody got would be asking for consent to an unknown blast radius, so
+// it stops instead.
+static bool
+CephDeviceTierPrintImpact(const std::vector<std::string>& classes)
+{
+    for (const auto& c : classes) {
+        const ExecSyncResult r = ExecBashSync(0, true, true, {},
+            std::string(HEX_SDK " ceph_device_tier_class_users ") + c);
+        if (r.exitCode != 0) {
+            CliPrintf("Cannot tell which pools select OSDs through device class '%s', so the effect of this change cannot be shown. Not proceeding.",
+                c.c_str());
+            return false;
+        }
+
+        // Trimmed by hand: hex_string_util::strip does nothing at all when the
+        // whole string is in its character set (find_first_not_of returns npos
+        // and neither end is erased), so an answer of just a newline -- which
+        // is what "no pool selects through this class" looks like -- would keep
+        // its length and print as a blank list instead of as nothing.
+        std::string pools = r.stdoutOutput;
+        const std::size_t first = pools.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos) {
+            pools.clear();
+        } else {
+            pools.erase(0, first);
+            pools.erase(pools.find_last_not_of(" \t\r\n") + 1);
+        }
+
+        CliPrintf("   %s: %s", c.c_str(),
+            pools.length() ? pools.c_str() : "no pool selects through this class");
+    }
+
+    return true;
+}
+
+// The distinct device classes the chosen OSDs carry now, in the order they
+// first appear. An OSD with no class contributes nothing: there is no rule
+// selecting through a class it does not have.
+static std::vector<std::string>
+CephDeviceTierClassesOf(const std::vector<CephOsdRow>& chosen)
+{
+    std::vector<std::string> classes;
+
+    for (const auto& r : chosen) {
+        if (r.cls.length() && std::find(classes.begin(), classes.end(), r.cls) == classes.end()) {
+            classes.push_back(r.cls);
+        }
+    }
+
+    return classes;
+}
+
+// Hand the work to hex_sdk without a shell. The name and the ids have already
+// been validated, so this is not the last line of defence -- but passing them
+// as separate arguments means a name that reaches this from somewhere else
+// still cannot become shell syntax.
+static int
+CephDeviceTierSpawn(const char* subcmd, const std::string& tier, const std::vector<std::string>& ids)
+{
+    std::vector<const char*> args;
+
+    args.push_back(HEX_SDK);
+    args.push_back(subcmd);
+    args.push_back(tier.c_str());
+    for (const auto& i : ids) {
+        args.push_back(i.c_str());
+    }
+    args.push_back(NULL);
+
+    // The child writes straight to the terminal while anything CliPrintf left
+    // in this process's buffer is still sitting there -- and when stdout is
+    // not a tty (a piped session, a script) that buffer is not flushed per
+    // line, so a warning printed before this call can come out after the
+    // output of the command it was warning about.
+    fflush(stdout);
+
+    return HexExitStatus(HexSpawnV(0, (char* const*)&args[0]));
+}
+
+// Name an existing device tier: from the arguments, or by picking one.
+//
+// Refusing when the list cannot be read is deliberate -- "no such device tier"
+// and "the cluster did not answer" are different answers, and reporting the
+// second as the first is what sends an operator to re-create something that
+// already exists.
+static bool
+CephDeviceTierPick(int argc, const char** argv, int argidx, std::string& tier)
+{
+    std::vector<std::string> names;
+
+    if (!CephDeviceTierQuery(HEX_SDK " ceph_device_tier_names", names)) {
+        CliPrintf("Cannot read the device tier list. Not going any further.");
+        return false;
+    }
+    if (names.empty()) {
+        CliPrintf("There are no device tiers.");
+        return false;
+    }
+
+    if (argc > argidx) {
+        tier = argv[argidx];
+    } else {
+        for (std::size_t i = 0; i < names.size(); i++) {
+            CliPrintf("   %lu) %s", (unsigned long)(i + 1), names[i].c_str());
+        }
+        std::string input;
+        std::size_t index = 0;
+        CliReadLine("Enter the index of the device tier: ", input);
+        if (!HexParseUInt(input.c_str(), 1, names.size(), &index)) {
+            CliPrintf("Invalid index.");
+            return false;
+        }
+        tier = names[index - 1];
+    }
+
+    if (std::find(names.begin(), names.end(), tier) == names.end()) {
+        CliPrintf("No such device tier: '%s'.", tier.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+static int
+CephDeviceTierCreate(int argc, const char** argv)
+{
+    /* [0]="create" [1]=<tier name> [2...]=<osd id> */
+    std::string tier;
+
+    if (argc > 1) {
+        tier = argv[1];
+    } else {
+        CliReadLine(LABEL_TIER_NAME, tier);
+    }
+
+    if (!CephDeviceTierNameOk(tier)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::vector<CephOsdRow> rows;
+    if (!CephDeviceTierOsdTable(rows)) {
+        return CLI_FAILURE;
+    }
+
+    bool existing = false;
+    if (!CephDeviceTierNameFree(tier, &existing)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    // Already known as a device tier -- by the registry, by Ceph, or by both.
+    std::vector<std::string> members;
+    if (existing) {
+        for (const auto& r : rows) {
+            if (r.cls == tier) {
+                members.push_back(r.id);
+            }
+        }
+    }
+
+    // The Ceph side is there. Creating it again cannot change which OSDs it
+    // holds -- that is update -- but it is how a tier that got as far as its
+    // Ceph objects and then failed at the volume type or the registry gets
+    // completed, which is the state tier list flags. Nothing moves, so there
+    // is nothing to confirm and no reason to ask which OSDs; the tier's own
+    // members are what hex_sdk is given, because its usage requires at least
+    // one and passing none would be rejected before it could do anything.
+    //
+    // A tier that is in the registry with nothing on the Ceph side has no
+    // members to pass, and building it IS a real create -- so that case falls
+    // through to the ordinary path below, confirmation included.
+    if (!members.empty()) {
+        if (argc > 2) {
+            CliPrintf("Device tier '%s' already exists. 'tier create' cannot change which OSDs it holds -- use 'tier update %s <osd id>...' for that. Completing whatever is missing instead.",
+                tier.c_str(), tier.c_str());
+        }
+        if (CephDeviceTierSpawn("ceph_device_tier_create", tier, members)) {
+            HexLogError("Failed to complete device tier %s", tier.c_str());
+            CliPrintf("\n--\nFailed to complete device tier %s.", tier.c_str());
+            return CLI_FAILURE;
+        }
+        return CLI_SUCCESS;
+    }
+
+    std::vector<std::string> ids;
+    std::vector<CephOsdRow> chosen;
+    if (!CephDeviceTierReadOsds(argc, argv, 2, rows, ids, chosen)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::vector<std::string> hosts;
+    std::string osdLine;
+    for (const auto& r : chosen) {
+        osdLine.append(" osd.").append(r.id);
+        if (std::find(hosts.begin(), hosts.end(), r.host) == hosts.end()) {
+            hosts.push_back(r.host);
+        }
+    }
+
+    CliPrintf("\nDevice tier '%s' will be created on:", tier.c_str());
+    CephDeviceTierPrintOsdTable(chosen);
+    CliPrintf("Its pool is replicated across the %lu host(s) those OSDs are on, with a replication size of whichever is smaller: that host count, or the replication size of %s.",
+        (unsigned long)hosts.size(), BUILTIN_BACKPOOL.c_str());
+
+    // The confirmation goes here, before the first call that changes anything,
+    // rather than before the step that binds the pool to the rule. Taking an
+    // OSD out of a class that some rule selects through starts moving data at
+    // that first step, so a confirmation after it would be asking about
+    // something already under way. Cancelling leaves no class change behind
+    // because no SDK call has been made yet.
+    const std::vector<std::string> classes = CephDeviceTierClassesOf(chosen);
+    if (classes.size()) {
+        CliPrintf("\nThose OSDs are leaving the device classes they carry now. Data starts moving as soon as this is confirmed, for every pool whose CRUSH rule selects through one of them:");
+        if (!CephDeviceTierPrintImpact(classes)) {
+            return CLI_FAILURE;
+        }
+    }
+
+    if (!CliReadConfirmation()) {
+        return CLI_SUCCESS;
+    }
+
+    if (CephDeviceTierSpawn("ceph_device_tier_create", tier, ids)) {
+        HexLogError("Failed to create device tier %s on%s", tier.c_str(), osdLine.c_str());
+        CliPrintf("\n--\nFailed to create device tier %s.", tier.c_str());
+        return CLI_FAILURE;
+    }
+
+    return CLI_SUCCESS;
+}
+
+static int
+CephDeviceTierUpdate(int argc, const char** argv)
+{
+    /* [0]="update" [1]=<tier name> [2...]=<osd id> */
+    std::string tier;
+
+    if (!CephDeviceTierPick(argc, argv, 1, tier)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::vector<CephOsdRow> rows;
+    if (!CephDeviceTierOsdTable(rows)) {
+        return CLI_FAILURE;
+    }
+
+    std::vector<std::string> before;
+    for (const auto& r : rows) {
+        if (r.cls == tier) {
+            before.push_back(r.id);
+        }
+    }
+
+    std::vector<std::string> ids;
+    std::vector<CephOsdRow> chosen;
+    if (!CephDeviceTierReadOsds(argc, argv, 2, rows, ids, chosen)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string leaving;
+    for (const auto& id : before) {
+        if (std::find(ids.begin(), ids.end(), id) == ids.end()) {
+            leaving.append(" osd.").append(id);
+        }
+    }
+    std::string joining;
+    for (const auto& id : ids) {
+        if (std::find(before.begin(), before.end(), id) == before.end()) {
+            joining.append(" osd.").append(id);
+        }
+    }
+
+    // Nothing to consent to when the membership is not changing; hex_sdk says
+    // so itself and does nothing.
+    if (leaving.empty() && joining.empty()) {
+        if (CephDeviceTierSpawn("ceph_device_tier_update", tier, ids)) {
+            CliPrintf("\n--\nFailed to update device tier %s.", tier.c_str());
+            return CLI_FAILURE;
+        }
+        return CLI_SUCCESS;
+    }
+
+    CliPrintf("\nDevice tier '%s' will consist of:", tier.c_str());
+    CephDeviceTierPrintOsdTable(chosen);
+    if (joining.length()) {
+        CliPrintf("joining:%s", joining.c_str());
+    }
+    if (leaving.length()) {
+        CliPrintf("leaving:%s -- left with no device class, not put back to what they carried before this tier",
+            leaving.c_str());
+    }
+
+    // Unlike create, this tier's CRUSH rule already exists, so its own pool
+    // starts remapping at the first class change too, not only the pools bound
+    // to the classes the joining OSDs are leaving (F13).
+    std::vector<std::string> classes = CephDeviceTierClassesOf(chosen);
+    if (std::find(classes.begin(), classes.end(), tier) == classes.end()) {
+        classes.push_back(tier);
+    }
+    CliPrintf("\nData starts moving as soon as this is confirmed, for every pool whose CRUSH rule selects through one of these device classes:");
+    if (!CephDeviceTierPrintImpact(classes)) {
+        return CLI_FAILURE;
+    }
+
+    if (!CliReadConfirmation()) {
+        return CLI_SUCCESS;
+    }
+
+    if (CephDeviceTierSpawn("ceph_device_tier_update", tier, ids)) {
+        HexLogError("Failed to update device tier %s", tier.c_str());
+        CliPrintf("\n--\nFailed to update device tier %s.", tier.c_str());
+        return CLI_FAILURE;
+    }
+
+    return CLI_SUCCESS;
+}
+
+static int
+CephDeviceTierDelete(int argc, const char** argv)
+{
+    /* [0]="delete" [1]=<tier name> */
+    if (argc > 2) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::string tier;
+    if (!CephDeviceTierPick(argc, argv, 1, tier)) {
+        return CLI_INVALID_ARGS;
+    }
+
+    std::vector<CephOsdRow> rows;
+    if (!CephDeviceTierOsdTable(rows)) {
+        return CLI_FAILURE;
+    }
+
+    std::string members;
+    for (const auto& r : rows) {
+        if (r.cls == tier) {
+            members.append(" osd.").append(r.id);
+        }
+    }
+
+    CliPrintf("\nWarning: ALL DATA IN POOL %s WILL BE LOST!", tier.c_str());
+    CliPrintf("The Cinder backend is taken out of service first, so the volume type stops being served before the pool goes; a tier with volumes still on it is refused rather than half deleted.");
+    if (members.length()) {
+        CliPrintf("Afterwards the OSDs it holds (%s ) are left with no device class -- they are not restored to whatever they carried before this tier.",
+            members.c_str());
+    }
+
+    if (!CliReadConfirmation()) {
+        return CLI_SUCCESS;
+    }
+
+    if (CephDeviceTierSpawn("ceph_device_tier_delete", tier, {})) {
+        HexLogError("Failed to delete device tier %s", tier.c_str());
+        CliPrintf("\n--\nFailed to delete device tier %s.", tier.c_str());
+        return CLI_FAILURE;
+    }
+
+    return CLI_SUCCESS;
+}
+
+static int
+CephDeviceTierList(int argc, const char** argv)
+{
+    if (argc > 1) {
+        return CLI_INVALID_ARGS;
+    }
+
+    if (HexExitStatus(HexSpawn(0, HEX_SDK, "ceph_device_tier_list", NULL))) {
+        CliPrintf("Failed to list the device tiers.");
+        return CLI_FAILURE;
+    }
+
+    return CLI_SUCCESS;
+}
+
 static int
 CreateRestfulKeyMain(int argc, const char** argv)
 {
@@ -1490,6 +2153,26 @@ CLI_MODE_COMMAND("storage", "add_ssdpool", CephCreateSsdPool, NULL,
 CLI_MODE_COMMAND("storage", "remove_ssdpool", CephRemoveSsdPool, NULL,
     "Remove SSD pool of specified group.",
     "remove_ssdpool group");
+
+CLI_MODE("storage", "tier",
+    "Work with storage device tiers: named sets of OSDs, each with its own CRUSH device class, pool and Cinder volume type. Not the same thing as cache tiering, which lives under storage > cache.",
+    !HexStrictIsErrorState() && !FirstTimeSetupRequired() && CubeSysCommitAll());
+
+CLI_MODE_COMMAND("tier", "create", CephDeviceTierCreate, NULL,
+    "Create a device tier over a set of OSDs and a Cinder volume type for it.",
+    "create <tier> <osd id> [<osd id>...]");
+
+CLI_MODE_COMMAND("tier", "update", CephDeviceTierUpdate, NULL,
+    "Change which OSDs a device tier consists of.",
+    "update <tier> <osd id> [<osd id>...]");
+
+CLI_MODE_COMMAND("tier", "delete", CephDeviceTierDelete, NULL,
+    "Delete a device tier, its pool and its Cinder volume type.",
+    "delete <tier>");
+
+CLI_MODE_COMMAND("tier", "list", CephDeviceTierList, NULL,
+    "List the device tiers and where the registry and Ceph disagree.",
+    "list");
 
 CLI_MODE("storage", "restful",
     "Work with stroage restful API settings.",

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4128,6 +4128,27 @@ _ceph_device_tier_health_ok()
     return 0
 }
 
+# Step 6 of the create order, and step 2 of the delete order: the registry entry
+# the Cinder backend is generated from. config_cinder.cpp reads
+# cinder.storage.tier.%d.name out of settings.txt; the policy chain in
+# sdk_cinder.sh is what puts a name there.
+#
+# Reached through $HEX_SDK rather than called directly. hex_sdk sources only the
+# module matching the command's own prefix (see /usr/sbin/hex_sdk:
+# MOD=$(echo $1 | cut -d_ -f1)), so under a ceph_* command the sdk_cinder.sh
+# functions are not defined at all -- a direct call would be a command-not-found
+# 127, which is indistinguishable from an apply that failed. Same reason
+# ceph_device_tier_delete reaches cinder_is_volume_type_in_use this way.
+_ceph_device_tier_registry_add()
+{
+    $HEX_SDK cinder_apply_storage_tier_creation "$1"
+}
+
+_ceph_device_tier_registry_del()
+{
+    $HEX_SDK cinder_apply_storage_tier_deletion "$1"
+}
+
 # undo only what this create actually made. $2 is a word list out of
 # "class rule pool vtype"; $3 is "<id>:<previous class>" pairs.
 _ceph_device_tier_unwind_create()
@@ -4183,6 +4204,16 @@ ceph_device_tier_create()
        _ceph_device_tier_has_pool $tier && _ceph_device_tier_has_vtype $tier ; then
         echo "device tier $tier already exists (osd: $($CEPH osd crush class ls-osd $tier 2>/dev/null | tr '\n' ' '))"
         echo "use 'hex_sdk ceph_device_tier_update $tier <osd id>...' to change its members"
+        # Registering is part of existing, so the idempotent branch has to do it
+        # too: a run that built every Ceph and Cinder object and then failed at
+        # step 6 leaves a tier whose volume type has no backend, and re-running
+        # create is how that gets completed. Returning 0 here without this would
+        # make the repair unreachable and the failure permanent.
+        if ! _ceph_device_tier_registry_add "$tier" ; then
+            echo "Error: device tier $tier exists but is not registered as a Cinder" >&2
+            echo "       backend; its volume type has no backend until this is re-run" >&2
+            return 1
+        fi
         return 0
     fi
 
@@ -4278,9 +4309,21 @@ ceph_device_tier_create()
         made="$made vtype"
     fi
 
+    # 6) the registry entry, which is what generates the Cinder backend.
+    #
+    #    Everything before this point is already consistent between Ceph and
+    #    Cinder, so a failure here is reported and left repairable rather than
+    #    unwound: destroying a correct tier because a config apply failed is
+    #    worse than a tier whose volume type has no backend yet, which
+    #    ceph_device_tier_list flags and re-running create fixes.
+    if ! _ceph_device_tier_registry_add "$tier" ; then
+        echo "Error: device tier $tier was created on$osd_list but could not be" >&2
+        echo "       registered as a Cinder backend; the volume type exists with no" >&2
+        echo "       backend behind it -- re-run this command to finish" >&2
+        return 1
+    fi
+
     echo "device tier $tier created on$osd_list (pool size $size)"
-    echo "note: the Cinder backend for $tier is generated from the tuning registry;"
-    echo "      until that is in place the volume type exists but has no backend."
     return 0
 }
 
@@ -4522,8 +4565,18 @@ ceph_device_tier_delete()
         fi
     fi
 
-    # 2) the registry entry and the Cinder backend come out first once WP-1
-    #    lands, so that Cinder stops pointing at a pool that is about to go.
+    # 2) the registry entry, and with it the generated Cinder backend, come out
+    #    before the volume type and the pool do. Cinder pointing at a pool that
+    #    has already been deleted is the one ordering here that cannot be
+    #    repaired by re-running: the backend keeps accepting volumes into a
+    #    store that is gone, and the volume type cannot be deleted once they
+    #    exist. Nothing has been destroyed yet at this point, so a failure just
+    #    stops.
+    if ! _ceph_device_tier_registry_del "$tier" ; then
+        echo "Error: cannot take device tier $tier out of the storage registry;" >&2
+        echo "       nothing else has been deleted" >&2
+        return 1
+    fi
 
     # 3) volume type. The poll has to re-read, because it is waiting for a
     #    change -- but a read that fails is "unknown", never "gone".
@@ -4667,16 +4720,30 @@ ceph_device_tier_delete()
     return 0
 }
 
-# Lists what the Ceph side actually has. A tier is recognised here by its own
-# shape -- a device class with a CRUSH rule and a pool of the same name -- which
-# is a derivation, not a source of truth; the authoritative list is the tuning
-# registry, and comparing the two is what this grows into once WP-1 lands.
+# Lists what the Ceph side has against what the registry says, because the two
+# disagree in both directions and each direction has its own consequence: a
+# tier Ceph has but the registry does not is a volume type with no backend
+# behind it, and a registry entry with nothing on the Ceph side is a Cinder
+# backend pointing at a pool that does not exist.
+#
+# A tier is recognised on the Ceph side by its own shape -- a device class with
+# a CRUSH rule and a pool of the same name -- which is a derivation. The
+# registry is the authority for what was meant to be there.
 ceph_device_tier_list()
 {
     $CEPH -s >/dev/null 2>&1 || return 1
-    printf "%-16s %-8s %-6s %-11s %-10s %-6s %s\n" \
-        DEVICE_TIER OSD HOSTS POOL_SZ/MIN POOL_RULE VTYPE NOTE
-    local tier= osds= hosts= size= min_size= prule= vtype= note=
+
+    # An unreadable registry is unknown, never "no tiers registered". Printing
+    # not-registered against every tier because settings.txt could not be read
+    # would send the operator to re-run create on tiers that are registered --
+    # the same mistake in reverse as the sweeps in ceph_osd_create_cache, which
+    # is why _ceph_device_tier_registry reports the difference at all.
+    local registry= registry_ok=0
+    registry=$(_ceph_device_tier_registry) || registry_ok=1
+
+    printf "%-16s %-8s %-6s %-11s %-10s %-6s %-6s %s\n" \
+        DEVICE_TIER OSD HOSTS POOL_SZ/MIN POOL_RULE VTYPE REGIST NOTE
+    local tier= osds= hosts= size= min_size= prule= vtype= reg= note= seen=
     for tier in $($CEPH osd crush class ls 2>/dev/null | jq -r '.[]') ; do
         _ceph_device_tier_has_rule $tier || continue
         _ceph_device_tier_has_pool $tier || continue
@@ -4691,7 +4758,131 @@ ceph_device_tier_list()
         [ "$vtype" = "yes" ] || note="$note no-volume-type"
         [ -n "$size" ] && [ -n "$hosts" ] && [ "$size" -gt "$hosts" ] && note="$note rf-above-host-count"
         [ "${size:-0}" = "1" ] && note="$note no-redundancy"
-        printf "%-16s %-8s %-6s %-11s %-10s %-6s %s\n" \
-            "$tier" "${osds:--}" "${hosts:-?}" "${size:-?}/${min_size:-?}" "$prule" "$vtype" "${note:- ok}"
+        if [ $registry_ok -ne 0 ] ; then
+            reg="?"
+            note="$note registry-unreadable"
+        elif _ceph_device_tier_is_registered "$tier" "$registry" ; then
+            reg=yes
+        else
+            reg=no
+            note="$note not-registered"
+        fi
+        seen="$seen$tier
+"
+        printf "%-16s %-8s %-6s %-11s %-10s %-6s %-6s %s\n" \
+            "$tier" "${osds:--}" "${hosts:-?}" "${size:-?}/${min_size:-?}" "$prule" "$vtype" "$reg" "${note:- ok}"
     done
+
+    # Registry entries with no device tier behind them. Whole-line matching
+    # against what was printed above, never a shell pattern: these names have
+    # not been through the CLI's guard, so one of them can be any byte at all.
+    [ $registry_ok -eq 0 ] || return 0
+    local entry=
+    while IFS= read -r entry ; do
+        [ -n "$entry" ] || continue
+        printf '%s' "$seen" | grep -qxF -- "$entry" && continue
+        _ceph_device_tier_has_vtype "$entry" && vtype=yes || vtype=no
+        printf "%-16s %-8s %-6s %-11s %-10s %-6s %-6s %s\n" \
+            "$entry" "-" "-" "-/-" "-" "$vtype" yes "registered-but-absent"
+    done <<< "$registry"
+}
+
+# ---------------------------------------------------------------------------
+# Data queries for cli_ceph.cpp.
+#
+# The device tier CLI is the only place input can be validated -- an indexed
+# tuning array cannot be checked by hex_config, whose cinder CONFIG_MODULE has
+# no validate slot -- so the rules live there and these only answer questions.
+#
+# What they all have in common: each returns non-zero rather than an empty
+# answer when it cannot answer, so the CLI can refuse to decide on a reading it
+# did not get. A name checked against a list that failed to load is not
+# checked. Command substitution keeps the command's own exit status, which is
+# what makes that possible here; a pipeline would throw it away.
+# ---------------------------------------------------------------------------
+
+# Every name a new device tier must not reuse, as "<kind>|<name>": its name
+# becomes all four of a device class, a CRUSH rule, a pool and a Cinder volume
+# type, so a collision with any one of them is a collision.
+ceph_device_tier_names_taken()
+{
+    local classes= names= rules= pools= vtypes=
+    classes=$($CEPH osd crush class ls 2>/dev/null) || return 1
+    names=$(echo "$classes" | jq -r '.[]' 2>/dev/null) || return 1
+    rules=$($CEPH osd crush rule ls 2>/dev/null) || return 1
+    pools=$($CEPH osd pool ls 2>/dev/null) || return 1
+    vtypes=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) || return 1
+    echo "$names"  | awk 'length {print "class|" $0}'
+    echo "$rules"  | awk 'length {print "rule|" $0}'
+    echo "$pools"  | awk 'length {print "pool|" $0}'
+    echo "$vtypes" | awk 'length {print "vtype|" $0}'
+    return 0
+}
+
+# The device tiers that exist, one name per line: the Ceph side by shape, plus
+# whatever the registry lists, deduped. Both halves are needed -- a tier can be
+# registered with its Ceph objects already gone, and it still has to be
+# selectable so it can be deleted.
+ceph_device_tier_names()
+{
+    $CEPH -s >/dev/null 2>&1 || return 1
+    local out= tier= registry=
+    for tier in $($CEPH osd crush class ls 2>/dev/null | jq -r '.[]') ; do
+        _ceph_device_tier_has_rule $tier || continue
+        _ceph_device_tier_has_pool $tier || continue
+        out="$out$tier
+"
+    done
+    if registry=$(_ceph_device_tier_registry) ; then
+        out="$out$registry"
+    fi
+    printf '%s\n' "$out" | awk 'length && !seen[$0]++'
+    return 0
+}
+
+# "<id>|<host>|<device class>|<status>" for every OSD the cluster knows.
+#
+# The CLI needs all four: to refuse an OSD that does not exist rather than let
+# CRUSH invent a bucket for it, to show which hosts a tier would be carved
+# across, to say out loud that an OSD is being taken out of the class it
+# already carries, and to work out a tier's current members without a second
+# round trip.
+ceph_device_tier_osd_table()
+{
+    local tree=
+    tree=$($CEPH osd tree -f json 2>/dev/null) || return 1
+    echo "$tree" | jq -e '.nodes | type == "array"' >/dev/null 2>&1 || return 1
+    echo "$tree" | jq -r '
+        [ .nodes[] | select(.type == "host") ] as $hosts
+        | .nodes[] | select(.type == "osd") | . as $osd
+        | ( [ $hosts[] | select( any(.children[]?; . == $osd.id) ) | .name ] | first // "?" ) as $host
+        | "\($osd.id)|\($host)|\($osd.device_class // "")|\($osd.status // "?")"'
+}
+
+# The pools whose CRUSH rule selects OSDs through device class $1.
+#
+# This is the impact of taking an OSD out of that class, and it is what the
+# CLI's confirmation has to show. A class-restricted rule loses a candidate the
+# moment the class changes, so these pools start moving data then -- not at the
+# later step that binds the new tier's pool to its own rule. When no rule
+# selects by this class the answer is genuinely empty, which is why an
+# unreadable one has to be a non-zero return instead.
+ceph_device_tier_class_users()
+{
+    local cls=$1
+    [ -n "$cls" ] || return 1
+    local rules= pools= ids=
+    rules=$($CEPH osd crush rule dump -f json 2>/dev/null) || return 1
+    pools=$($CEPH osd pool ls detail -f json 2>/dev/null) || return 1
+    echo "$rules" | jq -e 'type == "array"' >/dev/null 2>&1 || return 1
+    echo "$pools" | jq -e 'type == "array"' >/dev/null 2>&1 || return 1
+    # "default~ssd" is how a class-restricted step names its root. Split on the
+    # tilde and compare the whole tail: a suffix match would let class "sd"
+    # answer for "default~ssd".
+    ids=$(echo "$rules" | jq -c --arg c "$cls" \
+        '[ .[] | select( any(.steps[]?;
+             ((.item_name // "") | split("~")) as $p
+             | ($p | length) > 1 and ($p | last) == $c) ) | .rule_id ]') || return 1
+    echo "$pools" | jq -r --argjson ids "$ids" \
+        '[ .[] | select( .crush_rule as $r | $ids | index($r) != null ) | .pool_name ] | join(" ")'
 }

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4908,24 +4908,55 @@ ceph_device_tier_names_taken()
     return 0
 }
 
-# The device tiers that exist, one name per line: the Ceph side by shape, plus
-# whatever the registry lists, deduped. Both halves are needed -- a tier can be
-# registered with its Ceph objects already gone, and it still has to be
-# selectable so it can be deleted.
+# The device tiers, as "<state>|<name>", one per line. The state is what says
+# whether this CLI owns the thing:
+#
+#   registered    in the registry, and Ceph has the class + rule + pool
+#   registry-only in the registry, nothing of that shape on the Ceph side --
+#                 a Cinder backend advertising a pool that does not exist
+#   unmanaged     Ceph has the shape, the registry does not list it
+#
+# The distinction is the ownership boundary the design draws, not a detail. A
+# device class with a same-named rule and pool is what a device tier looks
+# like, but looking like one is not being one: customers hand-build exactly
+# that shape (#1335 lists computehdd / computessd / smarthealth on one site),
+# and the registry -- not the shape -- is what says a tier came from here. A
+# caller that cannot tell the two apart will offer someone else's storage for
+# deletion.
+#
+# An unreadable registry is a hard failure rather than "nothing is registered":
+# ownership cannot be decided without it, and every name would come back
+# unmanaged, which reads as "this CLI owns none of these".
 ceph_device_tier_names()
 {
     $CEPH -s >/dev/null 2>&1 || return 1
-    local out= tier= registry=
+
+    local registry=
+    registry=$(_ceph_device_tier_registry) || return 1
+
+    local tier= shaped=
     for tier in $($CEPH osd crush class ls 2>/dev/null | jq -r '.[]') ; do
         _ceph_device_tier_has_rule $tier || continue
         _ceph_device_tier_has_pool $tier || continue
-        out="$out$tier
+        shaped="$shaped$tier
 "
+        if _ceph_device_tier_is_registered "$tier" "$registry" ; then
+            echo "registered|$tier"
+        else
+            echo "unmanaged|$tier"
+        fi
     done
-    if registry=$(_ceph_device_tier_registry) ; then
-        out="$out$registry"
-    fi
-    printf '%s\n' "$out" | awk 'length && !seen[$0]++'
+
+    # Whole-line matching, never a shell pattern: a registry entry has not been
+    # through the CLI's name guard and can hold any byte, including one that
+    # would be a glob.
+    local entry=
+    while IFS= read -r entry ; do
+        [ -n "$entry" ] || continue
+        printf '%s' "$shaped" | grep -qxF -- "$entry" && continue
+        echo "registry-only|$entry"
+    done <<< "$registry"
+
     return 0
 }
 

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4909,12 +4909,13 @@ ceph_device_tier_names_taken()
 }
 
 # The device tiers, as "<state>|<name>", one per line. The state is what says
-# whether this CLI owns the thing:
+# whether this CLI owns the thing, and how much of it Ceph still has:
 #
-#   registered    in the registry, and Ceph has the class + rule + pool
-#   registry-only in the registry, nothing of that shape on the Ceph side --
-#                 a Cinder backend advertising a pool that does not exist
-#   unmanaged     Ceph has the shape, the registry does not list it
+#   registered       in the registry, and Ceph has the class + rule + pool
+#   registry-partial in the registry, and Ceph has SOME of the three
+#   registry-only    in the registry, and Ceph is known to have NONE of them --
+#                    a Cinder backend advertising a pool that does not exist
+#   unmanaged        Ceph has all three, the registry does not list it
 #
 # The distinction is the ownership boundary the design draws, not a detail. A
 # device class with a same-named rule and pool is what a device tier looks
@@ -4923,6 +4924,23 @@ ceph_device_tier_names_taken()
 # and the registry -- not the shape -- is what says a tier came from here. A
 # caller that cannot tell the two apart will offer someone else's storage for
 # deletion.
+#
+# registry-partial is separate from registry-only because the caller does
+# different things with them: registry-only licenses taking the registry entry
+# out on the stated grounds that there is nothing on the Ceph side, and that
+# statement has to be true. A tier holding a class and a rule but no pool is
+# not "nothing on the Ceph side"; unregistering it would leave those objects
+# with no owner and no record.
+#
+# Every read here is fail-closed, and none of them may be a bare pipeline.
+# _ceph_device_tier_has_rule and friends cannot be used: a pipeline carries
+# only its last command's status, so their non-zero means "not there" AND "the
+# mon did not answer" -- see _ceph_device_tier_rule_state's comment, which
+# calls that tolerable for a caller that only skips work and wrong for the
+# delete path. This caller is the delete path's evidence, so it takes the
+# strict reading: three lists, read once each, each with its own status kept.
+# Answering "registry-only" because a query blipped is how a live tier gets
+# unregistered and its pool orphaned.
 #
 # An unreadable registry is a hard failure rather than "nothing is registered":
 # ownership cannot be decided without it, and every name would come back
@@ -4934,28 +4952,47 @@ ceph_device_tier_names()
     local registry=
     registry=$(_ceph_device_tier_registry) || return 1
 
-    local tier= shaped=
-    for tier in $($CEPH osd crush class ls 2>/dev/null | jq -r '.[]') ; do
-        _ceph_device_tier_has_rule $tier || continue
-        _ceph_device_tier_has_pool $tier || continue
-        shaped="$shaped$tier
-"
-        if _ceph_device_tier_is_registered "$tier" "$registry" ; then
-            echo "registered|$tier"
-        else
-            echo "unmanaged|$tier"
-        fi
-    done
+    local classes= class_names= rules= pools=
+    classes=$($CEPH osd crush class ls 2>/dev/null) || return 1
+    class_names=$(echo "$classes" | jq -r '.[]' 2>/dev/null) || return 1
+    rules=$($CEPH osd crush rule ls 2>/dev/null) || return 1
+    pools=$($CEPH osd pool ls 2>/dev/null) || return 1
 
-    # Whole-line matching, never a shell pattern: a registry entry has not been
-    # through the CLI's name guard and can hold any byte, including one that
-    # would be a glob.
-    local entry=
-    while IFS= read -r entry ; do
-        [ -n "$entry" ] || continue
-        printf '%s' "$shaped" | grep -qxF -- "$entry" && continue
-        echo "registry-only|$entry"
-    done <<< "$registry"
+    # Every name either side knows about: the classes Ceph has, plus whatever
+    # the registry lists. A registry entry has not been through the CLI's name
+    # guard and can hold any byte, so every comparison below is -F and -x --
+    # whole-line, literal, never a shell pattern and never a substring.
+    local candidates=
+    candidates=$(printf '%s\n%s\n' "$class_names" "$registry" | awk 'length && !seen[$0]++')
+
+    local name= has_class= has_rule= has_pool=
+    while IFS= read -r name ; do
+        [ -n "$name" ] || continue
+
+        has_class=1 ; has_rule=1 ; has_pool=1
+        printf '%s\n' "$class_names" | grep -qxF -- "$name" && has_class=0
+        printf '%s\n' "$rules"       | grep -qxF -- "$name" && has_rule=0
+        printf '%s\n' "$pools"       | grep -qxF -- "$name" && has_pool=0
+
+        if _ceph_device_tier_is_registered "$name" "$registry" ; then
+            if [ $has_class -eq 0 ] && [ $has_rule -eq 0 ] && [ $has_pool -eq 0 ] ; then
+                echo "registered|$name"
+            elif [ $has_class -ne 0 ] && [ $has_rule -ne 0 ] && [ $has_pool -ne 0 ] ; then
+                echo "registry-only|$name"
+            else
+                echo "registry-partial|$name"
+            fi
+        elif [ $has_class -eq 0 ] && [ $has_rule -eq 0 ] && [ $has_pool -eq 0 ] ; then
+            # A lookalike. Reported so the CLI can refuse it by name rather
+            # than fall through to a collision message that does not say why.
+            echo "unmanaged|$name"
+        fi
+
+        # An unregistered name with only some of the three is not listed at
+        # all: a device class with no rule and no pool of its own name is just
+        # a device class, which every cluster has, and none of this CLI's
+        # business.
+    done <<< "$candidates"
 
     return 0
 }

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4113,18 +4113,107 @@ _ceph_device_tier_wait_recovery()
     return 1
 }
 
-# preflight shared by device tier create and update: both start data movement,
+# Preflight shared by device tier create and update: both start data movement,
 # and Ceph is much worse at two overlapping remappings than at one.
+#
+# What this refuses on is deliberately narrower than "not HEALTH_OK". Requiring
+# HEALTH_OK sounds safe and is not usable: measured on the 1cc, a single
+# BlueStore slow operation raises BLUESTORE_SLOW_OP_ALERT with
+# bluestore_slow_ops_warn_threshold = 1 and bluestore_slow_ops_warn_lifetime =
+# 86400, so one slow op blocks every device tier command for a day while all
+# 945 PGs sit active+clean. A gate that has to be worked around by restarting
+# OSDs is a gate operators learn to bypass.
+#
+# So the refusal is about the thing this operation can actually make worse: a
+# replica or a PG that is missing NOW, a failure domain that is down, or a
+# cluster with nowhere to put the data about to be moved. Everything else is
+# reported and allowed through.
+#
+# Three things are deliberately NOT in that list:
+#   - POOL_NO_REDUNDANCY, OSD_NEARFULL, POOL_NEARFULL: standing properties of
+#     how a cluster is configured or filled, not a replica that went missing.
+#     Blocking on those would rebuild the same trap -- a warning that never
+#     clears on its own.
+#   - the BlueStore / SLOW_OPS family and OSDMAP_FLAGS: latency and operator
+#     flags, no bearing on redundancy.
+#   - anything unrecognised: a check this list has not heard of is warned about,
+#     not blocked. HEALTH_ERR is the backstop -- every error-level check refuses
+#     regardless of its name, so an unknown severe condition still stops here.
+#
+# Reading the health is itself fail-closed: a status that cannot be read or
+# parsed is unknown, never OK.
 _ceph_device_tier_health_ok()
 {
-    if [ "$($CEPH -s -f json | jq -r .health.status)" != "HEALTH_OK" ] ; then
-        echo "Error: ceph health has to be OK to change device tier membership" >&2
+    # Checks meaning redundancy or availability is compromised right now, or
+    # that the cluster cannot accept the data this is about to move.
+    local unsafe="PG_AVAILABILITY PG_DEGRADED PG_DEGRADED_FULL PG_RECOVERY_FULL
+                  PG_BACKFILL_FULL PG_DAMAGED OBJECT_UNFOUND
+                  OSD_DOWN OSD_HOST_DOWN OSD_ROOT_DOWN OSD_FULL OSD_BACKFILLFULL
+                  POOL_FULL MON_DOWN"
+
+    local health=
+    health=$($CEPH -s -f json 2>/dev/null) || {
+        echo "Error: cannot read ceph status, so it cannot be established that changing" >&2
+        echo "       device tier membership is safe; not proceeding" >&2
+        return 1
+    }
+
+    local status=
+    status=$(echo "$health" | jq -r '.health.status // empty' 2>/dev/null)
+    if [ -z "$status" ] ; then
+        echo "Error: ceph status could not be parsed, so it cannot be established that" >&2
+        echo "       changing device tier membership is safe; not proceeding" >&2
         return 1
     fi
-    if [ "x$($CEPH -s -f json | jq -r .pgmap.recovering_objects_per_sec)" != "xnull" ] ; then
+
+    # An absent checks object is an empty one; a checks object that cannot be
+    # read is not.
+    local names=
+    names=$(echo "$health" | jq -r '.health.checks // {} | keys[]' 2>/dev/null) || {
+        echo "Error: the ceph health checks could not be read; not changing device tier" >&2
+        echo "       membership" >&2
+        return 1
+    }
+
+    # Anchored, whole-name matching against the list above -- a check called
+    # PG_DEGRADED_FULL must not be recognised as PG_DEGRADED, and neither must
+    # a substring of anything else.
+    local unsafe_list=
+    unsafe_list=$(echo $unsafe | tr ' ' '\n')
+
+    local blocking= advisory= n=
+    for n in $names ; do
+        if echo "$unsafe_list" | grep -qxF -- "$n" ; then
+            blocking="$blocking $n"
+        else
+            advisory="$advisory $n"
+        fi
+    done
+
+    if [ "$status" = "HEALTH_ERR" ] ; then
+        local firing="$blocking$advisory"
+        echo "Error: ceph is in HEALTH_ERR (${firing# }); not changing device tier" >&2
+        echo "       membership" >&2
+        return 1
+    fi
+
+    if [ -n "$blocking" ] ; then
+        echo "Error: ceph reports${blocking} -- data redundancy or availability is already" >&2
+        echo "       compromised, and changing device tier membership moves data. Not" >&2
+        echo "       proceeding until that clears." >&2
+        return 1
+    fi
+
+    if [ "x$(echo "$health" | jq -r .pgmap.recovering_objects_per_sec)" != "xnull" ] ; then
         echo "Error: cannot change device tier membership while ceph is recovering" >&2
         return 1
     fi
+
+    if [ -n "$advisory" ] ; then
+        echo "Warning: ceph is $status (${advisory# }), but none of those checks is" >&2
+        echo "         about data redundancy or availability, so this is going ahead." >&2
+    fi
+
     return 0
 }
 

--- a/core/sdk_sh/modules/sdk_cinder.sh
+++ b/core/sdk_sh/modules/sdk_cinder.sh
@@ -1705,6 +1705,95 @@ cinder_apply_storage_creation()
     return 0
 }
 
+# The write end of the device tier registry (#840): put a device tier's name
+# into the cinder.storage.tier.%d.name array config_cinder.cpp generates its
+# Cinder backend, volume type keep-list entry and readiness wait from. That
+# array is translated out of the tiers: sequence in the external storage policy,
+# so this edits the policy and applies it -- the same chain
+# cinder_apply_storage_creation uses for external backends, which is the only
+# existing precedent for a CLI writing an indexed tuning array.
+#
+# Two deliberate differences from that precedent:
+#   - a name already in the sequence is not written again, so re-running the
+#     CLI's create cannot grow a second entry for one tier
+#   - nothing is applied when nothing changed, because $HEX_CFG apply restarts
+#     Cinder; a no-op create must not bounce a live service
+#
+# The name is NOT validated here. cli_ceph.cpp is the gatekeeper -- an indexed
+# tuning array cannot be validated by hex_config, whose cinder CONFIG_MODULE has
+# no validate slot and whose validate_tuning_value compares the literal key
+# name -- and config_cinder.cpp guards again on the way out. A caller that has
+# not been through the CLI is why that second guard exists.
+cinder_apply_storage_tier_creation()
+{
+    local exec_output=""
+    local exec_error=""
+
+    local tier_name="${1:-""}"
+
+    if [ -z "$tier_name" ] ; then
+        return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+    fi
+
+    # edit the policy file
+    local input_dir="$(MakeTempDir)"
+    mkdir -p "${input_dir}/external_storage"
+    if ! cp -f "$POLICY_DIR/external_storage/external_storage1_0.yml" "${input_dir}/external_storage/" ; then
+        return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+    fi
+    local ext_storage_policy_file="${input_dir}/external_storage/external_storage1_0.yml"
+
+    # How long the sequence is. A read that failed is not "there are no tiers":
+    # taking it as zero would append over index 0 and drop an existing tier's
+    # backend, so an unreadable policy stops here.
+    if ! _hex_function exec_output exec_error yq '.tiers | length' "$ext_storage_policy_file" ; then
+        return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+    fi
+    local tier_count="$exec_output"
+    if ! echo "$tier_count" | grep -qE '^[0-9]+$' ; then
+        return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+    fi
+
+    # The empty entry an empty list is encoded as (policy_ext_storage.cpp adds
+    # one back whenever the vector is empty, because the yml parser needs at
+    # least one child) is a slot to write into, not something to append after.
+    local tier_index="0"
+    local blank_tier_index=""
+    local existing_name=""
+    for tier_index in $(seq 0 $((tier_count - 1))) ; do
+        if ! _hex_function exec_output exec_error \
+            yq -r ".tiers[${tier_index}].name" \
+            "$ext_storage_policy_file" ; then
+            return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+        fi
+        existing_name="$exec_output"
+        # yq prints a nameless entry as the string "null"
+        if [ "$existing_name" == "null" ] ; then
+            existing_name=""
+        fi
+        if [ "$existing_name" == "$tier_name" ] ; then
+            # already registered -- and so is its backend
+            return 0
+        fi
+        if [ -z "$existing_name" ] && [ -z "$blank_tier_index" ] ; then
+            blank_tier_index="$tier_index"
+        fi
+    done
+
+    if ! _hex_function_ret yq -i \
+        ".tiers[${blank_tier_index:-$tier_count}].name = \"${tier_name}\"" \
+        "$ext_storage_policy_file" ; then
+        return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+    fi
+
+    # apply configs, and restart services
+    if ! $HEX_CFG apply "$input_dir" ; then
+        return "$ERROR_CINDER_APPLY_EXT_STORAGE_FAILED"
+    fi
+
+    return 0
+}
+
 cinder_is_volume_type_in_use()
 {
     local volume_type="${1:-""}"
@@ -2761,6 +2850,100 @@ cinder_apply_storage_deletion()
         ".volumeType.default = \"${new_volume_type_default}\"" \
         "$ext_storage_policy_file" ; then
         return 1
+    fi
+
+    # apply configs, and restart services
+    if ! $HEX_CFG apply "$input_dir" ; then
+        return 1
+    fi
+
+    return 0
+}
+
+# The other half of the write end (#840): take a device tier out of the
+# cinder.storage.tier.%d.name array, which is what makes its Cinder backend
+# stop being generated.
+#
+# Ordering matters to the caller, not here: ceph_device_tier_delete runs this
+# before it deletes the volume type and the pool, so that Cinder stops
+# advertising a store that is about to go rather than pointing at one that
+# already went.
+#
+# Deliberately NOT written the way cinder_apply_storage_deletion writes the
+# backends array. That one round-trips the whole policy through
+# `yq -p=yaml -o=json` -> jq -> `yq -p=json -o=yaml`, which rewrites every
+# other key on the way past. Measured on the 1cc: `version: 1.0` comes back as
+# `version: 1`, and the empty placeholder `- name:` comes back as
+# `- name: null` -- which HexYmlParseString then reads as the four-character
+# string "null", putting a backend called null into enabled_backends. Editing
+# in place with `yq -i`, the way cinder_apply_storage_creation does, touches
+# only the node named.
+#
+# The name is compared in the shell rather than inside a jq filter, so a
+# registry entry holding a quote is data. It can: every other writer of this
+# array -- the policy chain, and `hex_config commit <settings>` -- writes it
+# without passing through cli_ceph.cpp's name guard.
+cinder_apply_storage_tier_deletion()
+{
+    local exec_output=""
+    local exec_error=""
+
+    local tier_name="${1:-""}"
+
+    if [ -z "$tier_name" ] ; then
+        return 1
+    fi
+
+    # edit the policy file
+    local input_dir="$(MakeTempDir)"
+    mkdir -p "${input_dir}/external_storage"
+    if ! cp -f "$POLICY_DIR/external_storage/external_storage1_0.yml" "${input_dir}/external_storage/" ; then
+        return 1
+    fi
+    local ext_storage_policy_file="${input_dir}/external_storage/external_storage1_0.yml"
+
+    if ! _hex_function exec_output exec_error yq '.tiers | length' "$ext_storage_policy_file" ; then
+        return 1
+    fi
+    local tier_count="$exec_output"
+    if ! echo "$tier_count" | grep -qE '^[0-9]+$' ; then
+        return 1
+    fi
+
+    local tier_index="0"
+    local found_index=""
+    local existing_name=""
+    for tier_index in $(seq 0 $((tier_count - 1))) ; do
+        if ! _hex_function exec_output exec_error \
+            yq -r ".tiers[${tier_index}].name" \
+            "$ext_storage_policy_file" ; then
+            return 1
+        fi
+        existing_name="$exec_output"
+        if [ "$existing_name" == "$tier_name" ] ; then
+            found_index="$tier_index"
+            break
+        fi
+    done
+
+    # Not registered. Said plainly rather than applied anyway: $HEX_CFG apply
+    # restarts Cinder, and ceph_device_tier_delete calls this unconditionally --
+    # including for a tier that never got as far as being registered.
+    if [ -z "$found_index" ] ; then
+        return 0
+    fi
+
+    if ! _hex_function_ret yq -i "del(.tiers[${found_index}])" "$ext_storage_policy_file" ; then
+        return 1
+    fi
+
+    # the yml parser needs at least one child, so an emptied list keeps a blank
+    # entry -- the same one policy_ext_storage.cpp writes back when its vector
+    # is empty
+    if [ "$tier_count" -le 1 ] ; then
+        if ! _hex_function_ret yq -i '.tiers[0].name = ""' "$ext_storage_policy_file" ; then
+            return 1
+        fi
     fi
 
     # apply configs, and restart services

--- a/core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh
@@ -8,6 +8,9 @@
 #                              set size but left min_size at its old value,
 #                              which is the half that decides whether the pool
 #                              still accepts writes with a host down (#840 R7)
+#   ceph_device_tier_delete -- must take the registry entry, and with it the
+#                              Cinder backend, out BEFORE the volume type and
+#                              the pool, and must stop if it cannot (#840 WP-5)
 #
 # Both functions drive Ceph through commands that swallow their own failures, so
 # the property under test is that each step is checked and then confirmed by
@@ -22,7 +25,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC="$DIR/../modules/sdk_ceph.sh"
 for f in ceph_device_tier_delete ceph_device_tier_update \
          _ceph_device_tier_has_rule _ceph_device_tier_has_class \
-         _ceph_device_tier_rule_state \
+         _ceph_device_tier_rule_state _ceph_device_tier_registry_del \
          _ceph_device_tier_rule_users _ceph_device_tier_class_of_osd ; do
     eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$SRC")"
     [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
@@ -67,6 +70,9 @@ reset_cluster() {
     printf 'gold:3:2\ncinder-volumes:3:2\n' > "$TMP/poolattr"   # name:size:min_size
     printf 'gold\nCubeStorage\n' > "$TMP/vtypes"
     printf 'cinder-volumes:replicated_rule\ngold:gold\n' > "$TMP/poolrule"
+    printf 'gold\n' > "$TMP/registry"
+    : > "$TMP/calls"
+    REGISTRY_DEL_RC=0
     FAIL_PAT='^$'
     CEPH_DEAD=0
     RULE_LS_DEAD_AFTER_RM=0
@@ -144,6 +150,7 @@ fake_openstack() {
         *'volume type delete'*)
             # $4, not ${*##* }: on "$*" the ## operator applies to each
             # positional parameter, so it hands back the whole command line
+            echo "vtype_del $4" >> "$TMP/calls"
             grep -vx "$4" "$TMP/vtypes" > "$TMP/x"; mv "$TMP/x" "$TMP/vtypes" ;;
         *'volume type list'*) cat "$TMP/vtypes" ;;
         *'volume list'*)      echo '[]' ;;
@@ -151,8 +158,26 @@ fake_openstack() {
     return 0
 }
 OPENSTACK=fake_openstack
-# hex_sdk cinder_is_volume_type_in_use: non-zero == not in use
-fake_sdk() { return 1; }
+# hex_sdk, which the module shells back out to for the two things that live in
+# sdk_cinder.sh. Dispatching on the subcommand rather than answering everything
+# the same way is load-bearing: cinder_is_volume_type_in_use returns non-zero
+# for "not in use", while cinder_apply_storage_tier_deletion returns non-zero
+# for "the registry could not be edited", so one blanket return value would
+# make step 2 look like a failure and stop every delete before it started.
+# REGISTRY_DEL_RC arms that failure deliberately.
+REGISTRY_DEL_RC=0
+fake_sdk() {
+    case "$1" in
+        cinder_is_volume_type_in_use)
+            return 1 ;;
+        cinder_apply_storage_tier_deletion)
+            echo "registry_del $2" >> "$TMP/calls"
+            [ "$REGISTRY_DEL_RC" = 0 ] || return "$REGISTRY_DEL_RC"
+            grep -vx "$2" "$TMP/registry" > "$TMP/x" 2>/dev/null; mv "$TMP/x" "$TMP/registry"
+            return 0 ;;
+    esac
+    return 1
+}
 HEX_SDK=fake_sdk
 
 pass=0 fail=0
@@ -341,6 +366,53 @@ UOUT=$(ceph_device_tier_update gold 2 6 10 3 2>&1); URC=$?
 ck "$URC" 1 "7g unreadable readback returns non-zero"
 ckhas "$UOUT" "could not be" "7g reports unknown"
 _ceph_device_tier_wait_recovery() { return 0; }
+
+# ==== step 2, the registry (#840 WP-5) ===================================
+#
+# The registry entry has to come out before the volume type and the pool do,
+# and a failure to take it out has to stop the delete. Ordering is the property
+# under test, not decoration: a Cinder backend left pointing at a pool that has
+# already been deleted keeps accepting volumes into a store that is gone, and
+# the volume type then cannot be deleted at all -- the one state here that
+# re-running cannot repair.
+
+# ---- 8a. the registry comes out first ----
+reset_cluster
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 0 "8a delete still succeeds with the registry step in place"
+ck "$(sed -n '1p' "$TMP/calls")" "registry_del gold" "8a the registry is edited first"
+ck "$(sed -n '2p' "$TMP/calls")" "vtype_del gold" "8a the volume type goes after it"
+ck "$(grep -cx gold "$TMP/registry")" 0 "8a the registry entry is gone"
+
+# ---- 8b. the registry edit fails: nothing else may be deleted ----
+reset_cluster
+REGISTRY_DEL_RC=1
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "8b a failed registry edit returns non-zero"
+ckhas "$OUT" "nothing else has been deleted" "8b says nothing was destroyed"
+ck "$(grep -cx gold "$TMP/vtypes")" 1 "8b the volume type is untouched"
+ck "$(grep -cx gold "$TMP/pools")" 1 "8b the pool is untouched"
+ck "$(grep -cx gold "$TMP/rules")" 1 "8b the rule is untouched"
+ck "$(sort "$TMP/classes" | tr '\n' ',')" "10:gold,2:gold,6:gold," "8b every OSD kept the class"
+ck "$(grep -c vtype_del "$TMP/calls")" 0 "8b the volume type delete was never reached"
+
+# ---- 8c. the in-use gate still comes first ----
+# A tier with volumes on it must be refused before the registry is touched:
+# once the backend is gone there is nobody left to service the deletes that
+# would have freed those volumes.
+reset_cluster
+fake_sdk() {
+    case "$1" in
+        cinder_is_volume_type_in_use) return 0 ;;
+        cinder_apply_storage_tier_deletion) echo "registry_del $2" >> "$TMP/calls"; return 0 ;;
+    esac
+    return 1
+}
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "8c an in-use volume type is still refused"
+ckhas "$OUT" "still in use" "8c keeps the pre-existing reason"
+ck "$(grep -c registry_del "$TMP/calls")" 0 "8c the registry was not touched"
+ck "$(grep -cx gold "$TMP/registry")" 1 "8c the registry entry survives"
 
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ] && { echo "OK: device tier delete/update failure reporting"; exit 0; } || exit 1

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -16,6 +16,11 @@
 #                                   rather than an empty answer when it cannot
 #                                   read, because the CLI refuses to decide on
 #                                   an answer nobody got
+#   _ceph_device_tier_health_ok  -- refuses on the checks that mean redundancy
+#                                   or availability is compromised right now,
+#                                   and only warns on the rest, so that one
+#                                   slow op cannot block a tier command for a
+#                                   day
 #
 # That last property is what the whole CLI layer rests on: it is the only
 # gatekeeper for device tier input (an indexed tuning array has no hex_config
@@ -110,6 +115,22 @@ JSON
     DEAD_PAT='^$'
     OS_DEAD=0
     REGISTRY_ADD_RC=0
+    HEALTH_STATUS=HEALTH_OK
+    HEALTH_CHECKS=
+    RECOVERING=null
+}
+
+# `ceph -s -f json` as this cluster model sees it. The checks are an object
+# keyed by check name, which is the shape _ceph_device_tier_health_ok reads.
+status_json() {
+    local checks="{}" n=
+    for n in $HEALTH_CHECKS ; do
+        checks=$(echo "$checks" | jq -c --arg n "$n" \
+            '. + {($n): {severity: "HEALTH_WARN", summary: {message: "stub"}}}')
+    done
+    jq -n -c --arg s "$HEALTH_STATUS" --argjson c "$checks" --arg r "$RECOVERING" \
+        '{health: {status: $s, checks: $c},
+          pgmap: {recovering_objects_per_sec: (if $r == "null" then null else ($r | tonumber) end)}}'
 }
 
 # osd tree, built from the class model so that a class change is visible to the
@@ -133,7 +154,7 @@ fake_ceph() {
     local pool= attr= id=
     case "$cmd" in
         '-s')                          : ;;
-        '-s -f json')                  echo '{"health":{"status":"HEALTH_OK"},"pgmap":{"recovering_objects_per_sec":null}}' ;;
+        '-s -f json')                  status_json ;;
         'osd crush class ls')          cut -d: -f2 "$TMP/classes" | awk 'length && !seen[$0]++' | jq -R . | jq -s -c . ;;
         'osd crush rule ls')           cat "$TMP/rules" ;;
         'osd pool ls')                 cat "$TMP/pools" ;;
@@ -381,6 +402,117 @@ ck "$(echo "$OUT" | sort | tr '\n' ',')" "bronze,gold," "3f the union of Ceph an
 reset_cluster
 rm -f "$SETTINGS_TXT"
 ck "$(ceph_device_tier_names)" "gold" "3f an unreadable registry still lists what Ceph has"
+
+# ==== the health gate (#840 WP-5) ========================================
+#
+# Requiring HEALTH_OK is not usable: measured on the 1cc, one BlueStore slow
+# operation raises BLUESTORE_SLOW_OP_ALERT for 24 hours (warn_threshold 1,
+# warn_lifetime 86400) while every PG is active+clean, and that blocked every
+# device tier command for a day. What the gate refuses on is a replica or PG
+# missing now, a failure domain down, or nowhere to put the data being moved.
+# Everything else is reported and let through.
+
+# ---- 4a. HEALTH_OK with nothing firing ----
+reset_cluster
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 0 "4a HEALTH_OK proceeds"
+ck "$OUT" "" "4a and says nothing"
+
+# ---- 4b. the slow-op family is a warning, not a refusal ----
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="BLUESTORE_SLOW_OP_ALERT SLOW_OPS"
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 0 "4b a slow-op warning proceeds"
+ckhas "$OUT" "BLUESTORE_SLOW_OP_ALERT" "4b names the check it let through"
+ckhas "$OUT" "SLOW_OPS" "4b names both checks"
+ckhas "$OUT" "going ahead" "4b says it is going ahead"
+cklacks "$OUT" "Error" "4b is not an error"
+
+# ---- 4c. redundancy checks refuse ----
+for c in PG_AVAILABILITY PG_DEGRADED PG_DEGRADED_FULL PG_BACKFILL_FULL \
+         OSD_DOWN OSD_HOST_DOWN OSD_FULL POOL_FULL MON_DOWN OBJECT_UNFOUND ; do
+    reset_cluster
+    HEALTH_STATUS=HEALTH_WARN
+    HEALTH_CHECKS="$c"
+    OUT=$(_ceph_device_tier_health_ok 2>&1)
+    ck "$?" 1 "4c $c refuses"
+done
+
+# ---- 4d. a blocking check alongside a harmless one still refuses ----
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="SLOW_OPS PG_DEGRADED OSDMAP_FLAGS"
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 1 "4d one blocking check is enough"
+ckhas "$OUT" "PG_DEGRADED" "4d names the blocking check"
+cklacks "$OUT" "going ahead" "4d does not claim it went ahead"
+
+# ---- 4e. the standing-property warnings are deliberately not blocking ----
+# Blocking on these would rebuild the trap this change exists to remove: they
+# describe how a cluster is configured or filled and do not clear on their own.
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="POOL_NO_REDUNDANCY OSD_NEARFULL POOL_NEARFULL OSDMAP_FLAGS RECENT_CRASH"
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 0 "4e standing warnings proceed"
+ckhas "$OUT" "POOL_NO_REDUNDANCY" "4e still reports them"
+
+# ---- 4f. an unrecognised check is warned about, not blocked ----
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="SOME_FUTURE_CHECK"
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 0 "4f an unknown check proceeds"
+ckhas "$OUT" "SOME_FUTURE_CHECK" "4f and is named"
+
+# ---- 4g. HEALTH_ERR is the backstop for everything unrecognised ----
+# An error-level check refuses whatever its name is, so an unknown severe
+# condition still stops here even though unknown warnings do not.
+reset_cluster
+HEALTH_STATUS=HEALTH_ERR
+HEALTH_CHECKS="SOME_FUTURE_CHECK"
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 1 "4g HEALTH_ERR refuses on any check"
+ckhas "$OUT" "HEALTH_ERR" "4g says why"
+ckhas "$OUT" "SOME_FUTURE_CHECK" "4g names what is firing"
+
+# ---- 4h. active recovery still refuses ----
+reset_cluster
+RECOVERING=42
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 1 "4h recovery in progress refuses"
+ckhas "$OUT" "while ceph is recovering" "4h keeps the pre-existing reason"
+
+# ---- 4i. a name matched whole, not as a substring ----
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="PG_DEGRADED_SOMETHING_ELSE"
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 0 "4i PG_DEGRADED_SOMETHING_ELSE is not PG_DEGRADED"
+
+# ---- 4j. an unreadable or unparseable status is unknown, never OK ----
+reset_cluster
+DEAD_PAT='^-s -f json$'
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 1 "4j an unreadable status refuses"
+ckhas "$OUT" "cannot read ceph status" "4j says why"
+reset_cluster
+ceph_garbage() { case "$*" in '-s -f json') echo 'not json' ; return 0 ;; esac ; fake_ceph "$@" ; }
+CEPH=ceph_garbage
+OUT=$(_ceph_device_tier_health_ok 2>&1) ; ck "$?" 1 "4k an unparseable status refuses"
+ckhas "$OUT" "could not be parsed" "4k says why"
+CEPH=fake_ceph
+
+# ---- 4l. end to end: create runs with only a slow-op warning firing ----
+# The behaviour change, at the level an operator meets it.
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="BLUESTORE_SLOW_OP_ALERT"
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 0 "4l create proceeds under a slow-op warning"
+ckhas "$OUT" "created on osd.0 osd.1" "4l and builds the tier"
+ck "$(grep -c 'registry_add silver' "$TMP/calls")" 1 "4l and registers it"
+
+# ---- 4m. end to end: create refuses with a degraded PG ----
+reset_cluster
+HEALTH_STATUS=HEALTH_WARN
+HEALTH_CHECKS="PG_DEGRADED"
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 1 "4m create refuses while a PG is degraded"
+ck "$(grep -c registry_add "$TMP/calls")" 0 "4m and touched nothing"
+ck "$(awk -F: '$2 == "silver"' "$TMP/classes" | wc -l | tr -d ' ')" 0 "4m no OSD changed class"
 
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ] && { echo "OK: device tier registry, list and CLI queries"; exit 0; } || exit 1

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -436,6 +436,58 @@ ck "$(echo "$OUT" | grep -c '^registered|')" 0 "3i and the glob did not match go
 ck "$(echo "$OUT" | grep -c '^unmanaged|gold$')" 1 "3i gold is unmanaged, not registered by a glob"
 [ -e "$TMP/marker" ] && { fail=$((fail+1)); echo "FAIL: 3i the marker command must never run"; } || pass=$((pass+1))
 
+# ---- 3j. a Ceph read that fails is a refusal, never "nothing on the Ceph side" ----
+#
+# This state is what licenses `tier delete` to take a registry entry out while
+# telling the operator Ceph has none of the objects, so the reads behind it are
+# fail-closed. They used to be the opposite: the class list went through a
+# `for x in $(ceph ... | jq ...)` whose status is discarded, and the rule and
+# pool checks were bare pipelines whose non-zero means "not there" AND "the mon
+# did not answer" -- so one blipped query emptied the shaped set and every
+# registered tier came back registry-only with rc 0. A live tier would then be
+# unregistered, its backend taken out of service and its pool orphaned.
+for dead in '^osd crush class ls$' '^osd crush rule ls$' '^osd pool ls$' ; do
+    reset_cluster
+    DEAD_PAT="$dead"
+    OUT=$(ceph_device_tier_names 2>/dev/null) ; RC=$?
+    ck "$RC" 1 "3j $dead failing is a refusal"
+    cklacks "$OUT" "registry-only|gold" "3j $dead must not report a live tier as absent"
+done
+
+# ---- 3k. a registered tier missing only SOME of its objects is partial ----
+#
+# Not registry-only: that answer says Ceph has none of the three, and the CLI
+# acts on it by removing just the registry entry. A tier still holding a class
+# and a rule would be silently orphaned by that -- objects with no owner and no
+# record -- so it gets its own state and goes down the full delete path, where
+# hex_sdk takes each piece it actually finds.
+reset_cluster
+grep -vx 'gold' "$TMP/pools" > "$TMP/p.new" && mv "$TMP/p.new" "$TMP/pools"
+ck "$(ceph_device_tier_names)" "registry-partial|gold" "3k class and rule but no pool is partial"
+
+reset_cluster
+grep -vx 'gold' "$TMP/pools" > "$TMP/p.new" && mv "$TMP/p.new" "$TMP/pools"
+grep -vx 'gold' "$TMP/rules" > "$TMP/r.new" && mv "$TMP/r.new" "$TMP/rules"
+ck "$(ceph_device_tier_names)" "registry-partial|gold" "3k class alone is partial"
+
+# ---- 3l. with none of the three it is registry-only, as before ----
+reset_cluster
+grep -vx 'gold' "$TMP/pools" > "$TMP/p.new" && mv "$TMP/p.new" "$TMP/pools"
+grep -vx 'gold' "$TMP/rules" > "$TMP/r.new" && mv "$TMP/r.new" "$TMP/rules"
+sed -i.bak 's/^\([0-9]*\):gold$/\1:/' "$TMP/classes"
+ck "$(ceph_device_tier_names)" "registry-only|gold" "3l nothing on the Ceph side stays registry-only"
+
+# ---- 3m. an unregistered name with only some of the three is not listed ----
+# A device class with no rule and no pool of its own name is just a device
+# class, which every cluster has. Listing it would put "ssd" and "hdd" in front
+# of an operator as things to delete.
+reset_cluster
+: > "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_names)
+cklacks "$OUT" "|hdd" "3m a bare device class is not a device tier"
+cklacks "$OUT" "|ssd" "3m nor is one whose rule is named differently"
+ck "$(echo "$OUT" | wc -l | tr -d ' ')" 1 "3m only the full-shape lookalike is listed"
+
 # ==== the health gate (#840 WP-5) ========================================
 #
 # Requiring HEALTH_OK is not usable: measured on the 1cc, one BlueStore slow

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+#
+# Unit test for the storage tier registry side of ../modules/sdk_ceph.sh (#840
+# WP-5) -- the registry is where a device tier's Cinder backend comes from, so
+# a tier that exists on Ceph and not in the registry is a volume type nobody
+# serves:
+#   ceph_device_tier_create      -- step 6 registers the tier; a failure there
+#                                   is reported and left repairable, never
+#                                   unwound, and the idempotent branch
+#                                   registers too so re-running completes a
+#                                   tier that got as far as step 5
+#   ceph_device_tier_list        -- shows the registry against Ceph in both
+#                                   directions, and never reads "the registry
+#                                   could not be read" as "nothing registered"
+#   the four queries cli_ceph.cpp validates against -- each returns non-zero
+#                                   rather than an empty answer when it cannot
+#                                   read, because the CLI refuses to decide on
+#                                   an answer nobody got
+#
+# That last property is what the whole CLI layer rests on: it is the only
+# gatekeeper for device tier input (an indexed tuning array has no hex_config
+# validate slot to put a check in), and a name checked against a list that
+# failed to load is not checked at all.
+#
+# Self-contained: extracts those functions and their helpers, stubs ceph /
+# openstack / hex_sdk / Quiet against a small cluster model, so it needs no
+# cluster.
+#   Run: bash test_ceph_device_tier_registry.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_ceph.sh"
+for f in ceph_device_tier_create ceph_device_tier_list \
+         ceph_device_tier_names ceph_device_tier_names_taken \
+         ceph_device_tier_osd_table ceph_device_tier_class_users \
+         _ceph_device_tier_name_ok _ceph_device_tier_osd_ids \
+         _ceph_device_tier_registry _ceph_device_tier_is_registered \
+         _ceph_device_tier_registry_add _ceph_device_tier_unwind_create \
+         _ceph_device_tier_class_of_osd _ceph_device_tier_class_hosts \
+         _ceph_device_tier_health_ok \
+         _ceph_device_tier_has_class _ceph_device_tier_has_rule \
+         _ceph_device_tier_has_pool _ceph_device_tier_has_vtype ; do
+    eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$SRC")"
+    [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
+done
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+SETTINGS_TXT="$TMP/settings.txt"
+BUILTIN_BACKPOOL=cinder-volumes
+
+# The real Quiet returns the command's status, EXCEPT with -n, which forces 0.
+# Reproducing that exactly is the point: `Quiet -n cmd || handler` is dead
+# code, and a suite whose Quiet returned the status would not notice a
+# regression to it.
+Quiet() {
+    if [ "${1:-}" = -n ] ; then shift; "$@" >/dev/null 2>&1; return 0; fi
+    "$@" >/dev/null 2>&1
+}
+sleep() { : ; }
+
+# The pool size a tier's own rule can reach is not the property under test
+# here, so it is answered rather than derived.
+_ceph_device_tier_target_pool_size() { echo 2 ; }
+
+# Two sdk_ceph.sh functions of its own that create leans on. They are stubbed
+# rather than extracted because what they do to a real cluster (create a pool
+# with an explicit size, then adjust it) is outside what a model can say
+# anything true about; what matters here is only that the pool appears.
+ceph_create_pool() {
+    echo "ceph_create_pool $*" >> "$TMP/calls"
+    grep -qx "$1" "$TMP/pools" || echo "$1" >> "$TMP/pools"
+    grep -q "^$1:" "$TMP/poolattr" || echo "$1:${3:-1}:1:replicated_rule" >> "$TMP/poolattr"
+}
+ceph_adjust_pool_size() { echo "ceph_adjust_pool_size $*" >> "$TMP/calls" ; }
+
+# ---- cluster model -------------------------------------------------------
+# classes    : "<osd id>:<class>" per line, the authority for class queries
+# rules      : rule names, one per line
+# pools      : pool names, one per line
+# poolattr   : "<pool>:<size>:<min_size>:<crush rule>"
+# vtypes     : volume type names, one per line
+# ruledump   : `osd crush rule dump -f json`
+# pooldetail : `osd pool ls detail -f json`
+# settings   : the registry, as translate_ext_storage.cpp writes it
+# DEAD_PAT   : a regex; any ceph command matching it fails and changes
+#              nothing. Naming the command that breaks, rather than a call
+#              index, keeps a case readable when the module reads one more
+#              time than it used to.
+# OS_DEAD    : 1 makes every openstack call fail
+# REGISTRY_ADD_RC : what the policy edit in sdk_cinder.sh returns
+reset_cluster() {
+    printf '0:hdd\n1:hdd\n2:gold\n3:ssd\n4:\n6:gold\n10:gold\n' > "$TMP/classes"
+    printf 'replicated_rule\nrule-ssd\ngold\n' > "$TMP/rules"
+    printf 'cinder-volumes\nk8s-volumes\ngold\n' > "$TMP/pools"
+    printf 'cinder-volumes:3:2:replicated_rule\nk8s-volumes:3:2:rule-ssd\ngold:2:1:gold\n' > "$TMP/poolattr"
+    printf 'CubeStorage\ngold\n' > "$TMP/vtypes"
+    cat > "$TMP/ruledump.json" <<'JSON'
+[{"rule_id":0,"rule_name":"replicated_rule","steps":[{"op":"take","item_name":"default"},{"op":"emit"}]},
+ {"rule_id":1,"rule_name":"rule-ssd","steps":[{"op":"take","item_name":"default~ssd"},{"op":"emit"}]},
+ {"rule_id":2,"rule_name":"gold","steps":[{"op":"take","item_name":"default~gold"},{"op":"emit"}]}]
+JSON
+    cat > "$TMP/pooldetail.json" <<'JSON'
+[{"pool_name":"cinder-volumes","crush_rule":0},
+ {"pool_name":"k8s-volumes","crush_rule":1},
+ {"pool_name":"gold","crush_rule":2}]
+JSON
+    printf 'cinder.storage.tier.0.name = gold\n' > "$SETTINGS_TXT"
+    : > "$TMP/calls"
+    DEAD_PAT='^$'
+    OS_DEAD=0
+    REGISTRY_ADD_RC=0
+}
+
+# osd tree, built from the class model so that a class change is visible to the
+# next read. osd.4 carries no class, which is what an OSD looks like after a
+# tier it belonged to was deleted.
+osd_tree_json() {
+    jq -n --arg model "$(cat "$TMP/classes")" '
+        ($model | split("\n") | map(select(length > 0) | split(":"))) as $osds
+        | { nodes:
+            ( [ { id: -1, name: "default", type: "root", children: [-3,-5,-7] },
+                { id: -3, name: "cube451", type: "host", children: [0,2,3] },
+                { id: -5, name: "cube452", type: "host", children: [1,6] },
+                { id: -7, name: "cube453", type: "host", children: [4,10] } ]
+              + [ $osds[] | { id: (.[0] | tonumber), name: ("osd." + .[0]), type: "osd",
+                              device_class: (.[1] // ""), status: "up" } ] ) }'
+}
+
+fake_ceph() {
+    local cmd="$*"
+    echo "$cmd" | grep -qE "$DEAD_PAT" && return 1
+    local pool= attr= id=
+    case "$cmd" in
+        '-s')                          : ;;
+        '-s -f json')                  echo '{"health":{"status":"HEALTH_OK"},"pgmap":{"recovering_objects_per_sec":null}}' ;;
+        'osd crush class ls')          cut -d: -f2 "$TMP/classes" | awk 'length && !seen[$0]++' | jq -R . | jq -s -c . ;;
+        'osd crush rule ls')           cat "$TMP/rules" ;;
+        'osd pool ls')                 cat "$TMP/pools" ;;
+        'osd pool ls detail -f json')  cat "$TMP/pooldetail.json" ;;
+        'osd crush rule dump'*)        cat "$TMP/ruledump.json" ;;
+        'osd tree -f json')            osd_tree_json ;;
+        'osd ls')                      cut -d: -f1 "$TMP/classes" ;;
+        'osd crush class ls-osd '*)    awk -F: -v c="${cmd##* }" '$2 == c { print $1 }' "$TMP/classes" ;;
+        'osd crush rm-device-class osd.'*)
+            id=${cmd##*osd.}
+            sed -i.bak "s/^$id:.*/$id:/" "$TMP/classes" ;;
+        'osd crush set-device-class '*)
+            id=$(echo "$cmd" | awk '{print $NF}') ; id=${id#osd.}
+            sed -i.bak "s/^$id:.*/$id:$(echo "$cmd" | awk '{print $4}')/" "$TMP/classes" ;;
+        'osd crush rule create-replicated '*)
+            echo "$cmd" | awk '{print $5}' >> "$TMP/rules" ;;
+        'osd pool set '*' crush_rule '*)
+            pool=$(echo "$cmd" | awk '{print $4}')
+            sed -i.bak "s/^$pool:\([^:]*\):\([^:]*\):.*/$pool:\1:\2:$(echo "$cmd" | awk '{print $6}')/" "$TMP/poolattr" ;;
+        'osd pool delete '*)
+            pool=$(echo "$cmd" | awk '{print $4}')
+            grep -vx "$pool" "$TMP/pools" > "$TMP/x" ; mv "$TMP/x" "$TMP/pools"
+            grep -v "^$pool:" "$TMP/poolattr" > "$TMP/x" ; mv "$TMP/x" "$TMP/poolattr" ;;
+        'osd crush rule rm '*)
+            grep -vx "${cmd##* }" "$TMP/rules" > "$TMP/x" ; mv "$TMP/x" "$TMP/rules" ;;
+        'osd pool get '*)
+            pool=$(echo "$cmd" | awk '{print $4}')
+            attr=$(grep "^$pool:" "$TMP/poolattr")
+            [ -n "$attr" ] || return 1
+            case "$cmd" in
+                *' size -f json')       echo "{\"size\":$(echo "$attr" | cut -d: -f2)}" ;;
+                *' min_size -f json')   echo "{\"min_size\":$(echo "$attr" | cut -d: -f3)}" ;;
+                *' crush_rule -f json') echo "{\"crush_rule\":\"$(echo "$attr" | cut -d: -f4)\"}" ;;
+            esac ;;
+        *) echo "unstubbed ceph: $cmd" >> "$TMP/calls" ;;
+    esac
+    return 0
+}
+CEPH=fake_ceph
+
+fake_openstack() {
+    [ "$OS_DEAD" = 0 ] || return 1
+    case "$*" in
+        *'volume type list'*)   cat "$TMP/vtypes" ;;
+        *'volume type delete'*) grep -vx "$4" "$TMP/vtypes" > "$TMP/x" ; mv "$TMP/x" "$TMP/vtypes" ;;
+    esac
+    return 0
+}
+OPENSTACK=fake_openstack
+
+# hex_sdk: the two things sdk_ceph.sh has to shell back out for. hex_sdk sources
+# only the module matching the command's own prefix, so under a ceph_* command
+# neither os_volume_type_create nor the sdk_cinder.sh policy edit is defined at
+# all -- which is why they are reached this way and why this stub dispatches on
+# the subcommand instead of answering everything alike.
+fake_sdk() {
+    case "$1" in
+        os_volume_type_create)
+            echo "$2" >> "$TMP/vtypes" ; return 0 ;;
+        cinder_apply_storage_tier_creation)
+            echo "registry_add $2" >> "$TMP/calls"
+            [ "$REGISTRY_ADD_RC" = 0 ] || return "$REGISTRY_ADD_RC"
+            echo "cinder.storage.tier.$(wc -l < "$SETTINGS_TXT" | tr -d ' ').name = $2" >> "$SETTINGS_TXT"
+            return 0 ;;
+    esac
+    return 1
+}
+HEX_SDK=fake_sdk
+
+pass=0 fail=0
+ck() { [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+ckhas() { case "$1" in *"$2"*) pass=$((pass+1));; *) fail=$((fail+1)); echo "FAIL: $3 -> output lacks '$2'";; esac; }
+cklacks() { case "$1" in *"$2"*) fail=$((fail+1)); echo "FAIL: $3 -> output should not contain '$2'";; *) pass=$((pass+1));; esac; }
+
+# ==== step 6: create registers the tier ==================================
+
+# ---- 1a. the happy path registers exactly once ----
+reset_cluster
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 0 "1a create succeeds"
+ck "$(grep -c 'registry_add silver' "$TMP/calls")" 1 "1a the tier is registered once"
+ckhas "$OUT" "created on osd.0 osd.1" "1a reports the tier"
+cklacks "$OUT" "unwinding" "1a nothing was unwound"
+ck "$(grep -cx silver "$TMP/pools")" 1 "1a the pool is there"
+ck "$(grep -cx silver "$TMP/vtypes")" 1 "1a the volume type is there"
+
+# ---- 1b. the registry edit fails: reported, and NOT unwound ----
+# Everything before step 6 is consistent between Ceph and Cinder, so deleting a
+# correct tier because a config apply failed destroys good work to no purpose.
+# The repairable state is the better one: list flags it, re-running finishes it.
+reset_cluster
+REGISTRY_ADD_RC=1
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 1 "1b a failed registry edit returns non-zero"
+ckhas "$OUT" "could not be" "1b says the registration did not happen"
+ckhas "$OUT" "re-run" "1b says how to finish"
+cklacks "$OUT" "unwinding" "1b did not unwind"
+ck "$(grep -cx silver "$TMP/pools")" 1 "1b the pool is kept"
+ck "$(grep -cx silver "$TMP/rules")" 1 "1b the rule is kept"
+ck "$(grep -cx silver "$TMP/vtypes")" 1 "1b the volume type is kept"
+ck "$(awk -F: '$2 == "silver"' "$TMP/classes" | wc -l | tr -d ' ')" 2 "1b both OSDs kept the class"
+
+# ---- 1c. re-running after 1b completes the registration ----
+# The same state 1b left behind, reached the way an operator would: every
+# object exists, so create takes its idempotent branch -- which still has to
+# register, or the failure in 1b would be permanent.
+REGISTRY_ADD_RC=0
+: > "$TMP/calls"
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 0 "1c re-running an existing tier succeeds"
+ckhas "$OUT" "already exists" "1c says it already exists"
+ck "$(grep -c 'registry_add silver' "$TMP/calls")" 1 "1c the idempotent branch registers"
+ck "$(grep -c 'cinder.storage.tier' "$SETTINGS_TXT")" 2 "1c the registry now holds both tiers"
+ck "$(grep -cx silver "$TMP/pools")" 1 "1c nothing was built a second time"
+
+# ---- 1d. the idempotent branch reports a registry failure ----
+REGISTRY_ADD_RC=1
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 1 "1d an existing tier that cannot be registered returns non-zero"
+ckhas "$OUT" "is not registered" "1d says the backend is missing"
+
+# ---- 1e. a create that fails earlier never reaches the registry ----
+reset_cluster
+DEAD_PAT='rule create-replicated'
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 1 "1e a failed rule create returns non-zero"
+ck "$(grep -c registry_add "$TMP/calls")" 0 "1e the registry was never touched"
+ckhas "$OUT" "unwinding" "1e the earlier steps were unwound"
+ck "$(awk -F: '$2 == "silver"' "$TMP/classes" | wc -l | tr -d ' ')" 0 "1e no OSD kept the class"
+
+# ==== ceph_device_tier_list: the two disagreements =======================
+
+# ---- 2a. a tier on Ceph that is not registered ----
+reset_cluster
+: > "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_list 2>&1)
+ckhas "$OUT" "not-registered" "2a flags a tier missing from the registry"
+ck "$(echo "$OUT" | awk '$1 == "gold" { print $7 }')" "no" "2a the REGIST column says no"
+
+# ---- 2b. a registry entry with nothing on the Ceph side ----
+# This is the direction only the registry can show, and the one that has Cinder
+# advertising a volume type whose pool does not exist.
+reset_cluster
+printf 'cinder.storage.tier.0.name = gold\ncinder.storage.tier.1.name = bronze\n' > "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_list 2>&1)
+ckhas "$OUT" "registered-but-absent" "2b flags a registry entry with no tier"
+ck "$(echo "$OUT" | awk '$1 == "bronze" { print $7 }')" "yes" "2b the absent tier is still shown as registered"
+ck "$(echo "$OUT" | awk '$1 == "gold" { print $7 }')" "yes" "2b the real tier is registered"
+cklacks "$(echo "$OUT" | grep '^gold')" "not-registered" "2b the real tier is not flagged"
+
+# ---- 2c. an unreadable registry is unknown, not empty ----
+# Printing not-registered against every tier because settings.txt could not be
+# read sends the operator to re-run create on tiers that are registered.
+reset_cluster
+rm -f "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_list 2>&1)
+ckhas "$OUT" "registry-unreadable" "2c says the registry could not be read"
+ck "$(echo "$OUT" | awk '$1 == "gold" { print $7 }')" "?" "2c the REGIST column says unknown"
+cklacks "$OUT" "not-registered" "2c does not claim the tier is unregistered"
+cklacks "$OUT" "registered-but-absent" "2c invents no rows from a list it does not have"
+
+# ---- 2d. an empty registry entry is the empty-list placeholder ----
+# policy_ext_storage.cpp writes one back whenever the vector is empty, so it is
+# how "no tiers" is encoded -- not a tier with no name.
+reset_cluster
+printf 'cinder.storage.tier.0.name = \n' > "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_list 2>&1)
+ck "$(echo "$OUT" | grep -c 'registered-but-absent')" 0 "2d the placeholder is not a missing tier"
+ck "$(echo "$OUT" | awk '$1 == "gold" { print $7 }')" "no" "2d and gold is genuinely unregistered"
+
+# ==== the four queries the CLI validates against =========================
+#
+# Every one of these returns non-zero rather than an empty answer when it
+# cannot read. That is the whole contract: cli_ceph.cpp refuses to create a
+# tier when a query fails, and would otherwise accept a name it never checked.
+
+# ---- 3a. names_taken lists all four kinds ----
+reset_cluster
+OUT=$(ceph_device_tier_names_taken) ; RC=$?
+ck "$RC" 0 "3a names_taken succeeds"
+ckhas "$OUT" "class|gold" "3a lists device classes"
+ckhas "$OUT" "rule|replicated_rule" "3a lists CRUSH rules"
+ckhas "$OUT" "pool|cinder-volumes" "3a lists pools"
+ckhas "$OUT" "vtype|CubeStorage" "3a lists volume types"
+ck "$(echo "$OUT" | grep -c '^class|$')" 0 "3a the classless OSD contributes no empty name"
+
+# ---- 3b. each of the four reads failing is a refusal ----
+for probe in 'osd crush class ls' 'osd crush rule ls' 'osd pool ls' ; do
+    reset_cluster
+    DEAD_PAT="^$probe\$"
+    ceph_device_tier_names_taken >/dev/null 2>&1
+    ck "$?" 1 "3b names_taken refuses when '$probe' fails"
+done
+reset_cluster
+OS_DEAD=1
+ceph_device_tier_names_taken >/dev/null 2>&1
+ck "$?" 1 "3b names_taken refuses when the volume type list fails"
+
+# ---- 3c. a read that succeeds and still answers nothing ----
+# `ceph` exiting 0 with output jq cannot parse is an answer nobody got, and
+# letting it fall through would hand the CLI a shorter list of taken names.
+reset_cluster
+fake_ceph_garbage() { case "$*" in 'osd crush class ls') echo 'not json' ; return 0 ;; esac ; fake_ceph "$@" ; }
+CEPH_SAVE=$CEPH ; CEPH=fake_ceph_garbage
+ceph_device_tier_names_taken >/dev/null 2>&1
+ck "$?" 1 "3c unparseable class list is a refusal, not a short list"
+CEPH=$CEPH_SAVE
+
+# ---- 3d. the OSD table ----
+reset_cluster
+OUT=$(ceph_device_tier_osd_table) ; RC=$?
+ck "$RC" 0 "3d osd_table succeeds"
+ck "$(echo "$OUT" | grep -c '^')" 7 "3d one row per OSD"
+ck "$(echo "$OUT" | grep '^2|')" "2|cube451|gold|up" "3d id, host, class and state"
+ck "$(echo "$OUT" | grep '^4|')" "4|cube453||up" "3d an OSD with no class has an empty class field"
+reset_cluster
+DEAD_PAT='osd tree'
+ceph_device_tier_osd_table >/dev/null 2>&1
+ck "$?" 1 "3d an unreadable tree is a refusal"
+
+# ---- 3e. which pools select through a class ----
+# The empty answer and the unreadable one are different, and this is the query
+# whose answer the CLI shows before asking for confirmation.
+reset_cluster
+ck "$(ceph_device_tier_class_users ssd)" "k8s-volumes" "3e finds the pool on a class-restricted rule"
+ck "$(ceph_device_tier_class_users gold)" "gold" "3e finds the tier's own pool"
+OUT=$(ceph_device_tier_class_users hdd) ; RC=$?
+ck "$RC" 0 "3e a class no rule selects through is a successful empty answer"
+ck "$OUT" "" "3e and the answer is empty"
+reset_cluster
+DEAD_PAT='osd crush rule dump'
+ceph_device_tier_class_users ssd >/dev/null 2>&1
+ck "$?" 1 "3e an unreadable rule dump is a refusal"
+reset_cluster
+DEAD_PAT='osd pool ls detail'
+ceph_device_tier_class_users ssd >/dev/null 2>&1
+ck "$?" 1 "3e an unreadable pool list is a refusal"
+
+# ---- 3f. the device tier names, for the CLI's selection prompts ----
+reset_cluster
+printf 'cinder.storage.tier.0.name = gold\ncinder.storage.tier.1.name = bronze\n' > "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_names) ; RC=$?
+ck "$RC" 0 "3f names succeeds"
+ck "$(echo "$OUT" | sort | tr '\n' ',')" "bronze,gold," "3f the union of Ceph and the registry, deduped"
+reset_cluster
+rm -f "$SETTINGS_TXT"
+ck "$(ceph_device_tier_names)" "gold" "3f an unreadable registry still lists what Ceph has"
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: device tier registry, list and CLI queries"; exit 0; } || exit 1

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -393,15 +393,48 @@ DEAD_PAT='osd pool ls detail'
 ceph_device_tier_class_users ssd >/dev/null 2>&1
 ck "$?" 1 "3e an unreadable pool list is a refusal"
 
-# ---- 3f. the device tier names, for the CLI's selection prompts ----
+# ---- 3f. the device tier names, and which of them this CLI owns ----
+#
+# Ownership is the registry, never the shape of the Ceph objects. A device
+# class with a same-named rule and pool is what a device tier looks like, and
+# customers hand-build exactly that shape (#1335 lists computehdd / computessd
+# / smarthealth on one site) -- so "looks like one" and "is one" have to come
+# back as different answers, or the CLI ends up offering someone else's
+# storage for deletion.
 reset_cluster
 printf 'cinder.storage.tier.0.name = gold\ncinder.storage.tier.1.name = bronze\n' > "$SETTINGS_TXT"
 OUT=$(ceph_device_tier_names) ; RC=$?
 ck "$RC" 0 "3f names succeeds"
-ck "$(echo "$OUT" | sort | tr '\n' ',')" "bronze,gold," "3f the union of Ceph and the registry, deduped"
+ck "$(echo "$OUT" | sort | tr '\n' ',')" "registered|gold,registry-only|bronze," "3f registered and registry-only are told apart"
+
+# ---- 3g. a Ceph structure the registry does not list is unmanaged ----
+reset_cluster
+: > "$SETTINGS_TXT"
+ck "$(ceph_device_tier_names)" "unmanaged|gold" "3g an unregistered lookalike is not ours"
+
+# ---- 3h. an unreadable registry is a refusal, not "nothing is ours" ----
+# Answering "unmanaged" for everything because settings.txt could not be read
+# would tell the CLI it owns none of these, which is not an answer anybody got.
 reset_cluster
 rm -f "$SETTINGS_TXT"
-ck "$(ceph_device_tier_names)" "gold" "3f an unreadable registry still lists what Ceph has"
+ceph_device_tier_names >/dev/null 2>&1
+ck "$?" 1 "3h an unreadable registry refuses"
+
+# ---- 3i. a registry entry is data, whatever bytes it holds ----
+# The registry is written by the policy chain and by `hex_config commit
+# <settings>` without going through the CLI's name guard, so an entry can hold
+# any byte. Two of them are traps: a shell metacharacter, which the CLI must
+# never let become a command, and a glob, which must not match every tier.
+reset_cluster
+printf 'cinder.storage.tier.0.name = bad; touch %s/marker\ncinder.storage.tier.1.name = *\n' \
+    "$TMP" > "$SETTINGS_TXT"
+OUT=$(ceph_device_tier_names) ; RC=$?
+ck "$RC" 0 "3i names still succeeds"
+ckhas "$OUT" "registry-only|bad; touch $TMP/marker" "3i the entry comes back verbatim"
+ckhas "$OUT" "registry-only|*" "3i a glob entry comes back as itself"
+ck "$(echo "$OUT" | grep -c '^registered|')" 0 "3i and the glob did not match gold"
+ck "$(echo "$OUT" | grep -c '^unmanaged|gold$')" 1 "3i gold is unmanaged, not registered by a glob"
+[ -e "$TMP/marker" ] && { fail=$((fail+1)); echo "FAIL: 3i the marker command must never run"; } || pass=$((pass+1))
 
 # ==== the health gate (#840 WP-5) ========================================
 #

--- a/core/sdk_sh/tests/test_cinder_storage_tier_registry.sh
+++ b/core/sdk_sh/tests/test_cinder_storage_tier_registry.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+#
+# Unit test for the write end of the device tier registry in
+# ../modules/sdk_cinder.sh (#840 WP-5):
+#   cinder_apply_storage_tier_creation -- puts a name into the tiers: sequence
+#                                         the Cinder backend is generated from,
+#                                         exactly once, and applies only when
+#                                         something changed
+#   cinder_apply_storage_tier_deletion -- takes it out, keeps the blank child
+#                                         the yml parser needs when the list
+#                                         empties, and leaves the policy alone
+#                                         when the name was never there
+#
+# Why the "only when something changed" half is a property and not a nicety:
+# $HEX_CFG apply restarts Cinder. A create that is a no-op, or a delete of a
+# tier that was never registered, must not bounce volume service.
+#
+# WHAT THIS DOES NOT COVER: yq itself. The stub below stores the policy as
+# JSON and answers the expression shapes these two functions use, so what is
+# under test is their decisions -- which index gets written, whether apply is
+# reached, what happens when a read fails -- not YAML round-tripping.
+#
+# One consequence is worth naming, because it cost a deploy cycle: the reason
+# the deletion path edits in place instead of round-tripping the document
+# through JSON (the way cinder_apply_storage_deletion does for backends) is
+# that the round trip rewrites unrelated keys. Measured on the 1cc, not here:
+# `version: 1.0` came back as `version: 1`, and the blank placeholder
+# `- name:` came back as `- name: null`, which HexYmlParseString reads as the
+# string "null" -- putting a backend called null into enabled_backends. A jq
+# stub cannot show that; only real yq can. What the suite CAN hold is the
+# weaker property that neither function writes to a key it was not asked to
+# touch (2b, 2h).
+#   Run: bash test_cinder_storage_tier_registry.sh
+#
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$DIR/../modules/sdk_cinder.sh"
+for f in cinder_apply_storage_tier_creation cinder_apply_storage_tier_deletion ; do
+    eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$SRC")"
+    [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
+done
+# the two capture helpers from core/main/proj_functions, taken from the tree
+# rather than reimplemented: both paths lean on _hex_function keeping a
+# command's own exit status, which a naive stub would flatten
+PROG=test_cinder_storage_tier_registry
+for f in _hex_function _hex_function_ret ; do
+    eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$DIR/../../main/proj_functions")"
+    [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
+done
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+POLICY_DIR="$TMP/policies"
+ERROR_CINDER_APPLY_EXT_STORAGE_FAILED=6
+POLICY="$POLICY_DIR/external_storage/external_storage1_0.yml"
+
+MakeTempDir() { mktemp -d "$TMP/work.XXXXXX" ; }
+
+# yq stood in with jq, over a policy stored as JSON. Only the five shapes the
+# functions under test use are answered; anything else is a loud failure rather
+# than a quiet empty string, because a stub that silently answers nothing is
+# how a suite passes without running the code.
+yq() {
+    local inplace=0 args=()
+    while [ $# -gt 0 ] ; do
+        case "$1" in
+            -i)        inplace=1 ;;
+            -r|-e)     ;;
+            -p=*|-o=*) ;;
+            *)         args+=("$1") ;;
+        esac
+        shift
+    done
+    local expr="${args[0]}" file="${args[1]:-}"
+    if [ -z "$file" ] ; then
+        # `yq -p=yaml -o=json FILE` and `yq -p=json -o=yaml FILE`: one argument,
+        # and with the policy stored as JSON both are a copy
+        cat "$expr"
+        return $?
+    fi
+    if [ "$inplace" = 1 ] ; then
+        jq "$expr" "$file" > "$file.new" || return 1
+        mv "$file.new" "$file"
+        return 0
+    fi
+    case "$expr" in
+        '.tiers | length'|'.tiers['*'].name')
+            jq -r "$expr" "$file" ;;
+        *)
+            echo "yq stub: unhandled expression '$expr'" >&2 ; return 3 ;;
+    esac
+}
+
+# $HEX_CFG apply <dir> commits the edited policy into POLICY_DIR and restarts
+# the services that read it. Copying it back is what makes a second call see
+# the first one's result, which is the only way an idempotence claim can be
+# tested at all.
+HEX_CFG=fake_cfg
+APPLY_RC=0
+fake_cfg() {
+    echo "apply $2" >> "$TMP/calls"
+    cp -f "$2/external_storage/external_storage1_0.yml" "$TMP/applied.json"
+    [ "$APPLY_RC" = 0 ] || return "$APPLY_RC"
+    cp -f "$TMP/applied.json" "$POLICY"
+    return 0
+}
+
+reset_policy() {
+    mkdir -p "$POLICY_DIR/external_storage"
+    cat > "$POLICY" <<'JSON'
+{"name":"external_storage","version":"1.0","volumeType":{"default":"CubeStorage"},
+ "backends":[{"name":"extbk"}],"tiers":[{"name":"gold"}],
+ "image":{"multipath":{"use":true,"enforce":true}}}
+JSON
+    : > "$TMP/calls"
+    rm -f "$TMP/applied.json"
+    APPLY_RC=0
+}
+
+applied() { jq -c "$1" "$TMP/applied.json" 2>/dev/null ; }
+
+pass=0 fail=0
+ck() { [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
+
+# ==== creation ============================================================
+
+# ---- 1a. a new name is appended, and applied ----
+reset_policy
+cinder_apply_storage_tier_creation silver ; ck "$?" 0 "1a a new tier is registered"
+ck "$(grep -c '^apply ' "$TMP/calls")" 1 "1a the policy was applied once"
+ck "$(applied '.tiers')" '[{"name":"gold"},{"name":"silver"}]' "1a appended after the existing tier"
+ck "$(applied '.backends')" '[{"name":"extbk"}]' "1a the backends are untouched"
+ck "$(applied '.volumeType.default')" '"CubeStorage"' "1a the default volume type is untouched"
+
+# ---- 1b. an empty list writes into the blank child, not after it ----
+# policy_ext_storage.cpp keeps one nameless entry when the vector is empty,
+# because the yml parser needs at least one child. Appending after it would
+# leave a stray empty entry in the settings array for good.
+reset_policy
+jq -c '.tiers = [{"name":null}]' "$POLICY" > "$TMP/x" ; mv "$TMP/x" "$POLICY"
+cinder_apply_storage_tier_creation silver ; ck "$?" 0 "1b registering into an empty list succeeds"
+ck "$(applied '.tiers')" '[{"name":"silver"}]' "1b the blank child was reused"
+
+# ---- 1c. re-registering the same name changes nothing and applies nothing ----
+# Run as a sequence, against the policy the first call actually committed:
+# checking the source file after a single no-op call would pass even if the
+# name had been appended, because the edit happens on a copy.
+reset_policy
+cinder_apply_storage_tier_creation silver ; ck "$?" 0 "1c the first registration succeeds"
+ck "$(jq -c '.tiers' "$POLICY")" '[{"name":"gold"},{"name":"silver"}]' "1c and is committed"
+: > "$TMP/calls"
+cinder_apply_storage_tier_creation silver ; ck "$?" 0 "1c re-registering it succeeds"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "1c Cinder was not restarted to change nothing"
+ck "$(jq -c '.tiers' "$POLICY")" '[{"name":"gold"},{"name":"silver"}]' "1c no second copy was added"
+cinder_apply_storage_tier_creation gold ; ck "$?" 0 "1c the tier that was there all along too"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "1c still nothing applied"
+
+# ---- 1d. an empty name is refused ----
+reset_policy
+cinder_apply_storage_tier_creation "" ; ck "$?" 6 "1d an empty tier name is refused"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "1d nothing was applied"
+
+# ---- 1e. an unreadable policy is not "no tiers yet" ----
+# Reading a failed length as zero would write over index 0 and drop the tier
+# already there, taking its Cinder backend with it.
+reset_policy
+jq -c 'del(.tiers)' "$POLICY" > "$TMP/x" ; mv "$TMP/x" "$POLICY"
+printf 'this is not json\n' > "$POLICY"
+cinder_apply_storage_tier_creation silver ; ck "$?" 6 "1e an unparseable policy is refused"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "1e nothing was applied"
+
+# ---- 1f. a missing policy file is refused ----
+reset_policy
+rm -f "$POLICY"
+# cp's own complaint on stderr is the expected behaviour, not a test failure
+cinder_apply_storage_tier_creation silver 2>/dev/null ; ck "$?" 6 "1f a missing policy file is refused"
+
+# ---- 1g. a failed apply is reported ----
+reset_policy
+APPLY_RC=1
+cinder_apply_storage_tier_creation silver ; ck "$?" 6 "1g a failed apply returns non-zero"
+
+# ==== deletion ============================================================
+
+# ---- 2a. the name comes out, and it is applied ----
+reset_policy
+jq -c '.tiers = [{"name":"gold"},{"name":"silver"}]' "$POLICY" > "$TMP/x" ; mv "$TMP/x" "$POLICY"
+cinder_apply_storage_tier_deletion gold ; ck "$?" 0 "2a a registered tier is removed"
+ck "$(applied '.tiers')" '[{"name":"silver"}]' "2a only that entry went"
+ck "$(grep -c '^apply ' "$TMP/calls")" 1 "2a the policy was applied once"
+
+# ---- 2b. emptying the list leaves the blank child ----
+reset_policy
+cinder_apply_storage_tier_deletion gold ; ck "$?" 0 "2b removing the last tier succeeds"
+ck "$(applied '.tiers')" '[{"name":""}]' "2b the blank child the yml parser needs is kept"
+ck "$(applied '.backends')" '[{"name":"extbk"}]' "2b the backends are untouched"
+ck "$(applied '.version')" '"1.0"' "2b the version is untouched"
+ck "$(applied '.volumeType')" '{"default":"CubeStorage"}' "2b the default volume type is untouched"
+ck "$(applied '.image')" '{"multipath":{"use":true,"enforce":true}}' "2b the image settings are untouched"
+
+# ---- 2c. a name that is not registered is a no-op, not an error ----
+# ceph_device_tier_delete calls this unconditionally, including for a tier that
+# never got as far as step 6, and that must not restart Cinder either.
+reset_policy
+cinder_apply_storage_tier_deletion bronze ; ck "$?" 0 "2c an unregistered name succeeds"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "2c nothing was applied"
+ck "$(jq -c '.tiers' "$POLICY")" '[{"name":"gold"}]' "2c the policy is unchanged"
+
+# ---- 2d. an empty name is refused ----
+reset_policy
+cinder_apply_storage_tier_deletion "" ; ck "$?" 1 "2d an empty tier name is refused"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "2d nothing was applied"
+
+# ---- 2e. a name with a quote in it is data, not filter syntax ----
+# Every other writer of this array -- the policy chain and `hex_config commit
+# <settings>` -- writes it without passing through the CLI's name guard, so an
+# entry can hold any byte at all. Spliced into a jq filter, this one would
+# rewrite the filter that is meant to be matching it.
+reset_policy
+jq -c '.tiers = [{"name":"gold"},{"name":"a\"b"}]' "$POLICY" > "$TMP/x" ; mv "$TMP/x" "$POLICY"
+cinder_apply_storage_tier_deletion 'a"b' ; ck "$?" 0 "2e a quoted name is removed"
+ck "$(applied '.tiers')" '[{"name":"gold"}]' "2e and only it"
+
+# ---- 2f. an unreadable policy is refused ----
+reset_policy
+printf 'this is not json\n' > "$POLICY"
+cinder_apply_storage_tier_deletion gold ; ck "$?" 1 "2f an unparseable policy is refused"
+ck "$(grep -c '^apply ' "$TMP/calls")" 0 "2f nothing was applied"
+
+# ---- 2g. a failed apply is reported ----
+reset_policy
+APPLY_RC=1
+cinder_apply_storage_tier_deletion gold ; ck "$?" 1 "2g a failed apply returns non-zero"
+
+# ---- 2h. a blank placeholder alongside a real entry survives the deletion ----
+# The registry can hold the empty-list placeholder and a real tier at the same
+# time (policy_ext_storage.cpp only drops the blank one when it rewrites), and
+# the entry that is not being removed -- blank or not -- must come out the
+# other side unchanged.
+reset_policy
+jq -c '.tiers = [{"name":""},{"name":"gold"},{"name":"silver"}]' "$POLICY" > "$TMP/x" ; mv "$TMP/x" "$POLICY"
+cinder_apply_storage_tier_deletion gold ; ck "$?" 0 "2h removing the middle entry succeeds"
+ck "$(applied '.tiers')" '[{"name":""},{"name":"silver"}]' "2h only that entry went"
+ck "$(applied '.backends')" '[{"name":"extbk"}]' "2h nothing else was rewritten"
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && { echo "OK: cinder storage tier registry writes"; exit 0; } || exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

#840 replaces Ceph cache tiering with device tiers: a named set of OSDs carrying its own
CRUSH device class, CRUSH rule, RBD pool and Cinder volume type, all four sharing the tier's
name. #1446 added the part that survives a reboot — the registry, and what `config_cinder`
generates from an entry in it. #1451 added the imperative part — the `hex_sdk` functions that
build, resize and tear a tier down. Neither of them could be reached by an operator, and
neither of them ever wrote to the registry.

This PR closes both gaps. Four commits, in dependency order.

**`cinder_apply_storage_tier_creation` / `_deletion`** — the write end of the registry.
`config_cinder.cpp` has read `cinder.storage.tier.%d.name` since #1446; nothing put a name
there, so the break had only moved from "there is no tuning key" to "nobody writes it",
which looks identical from the CLI. These follow the chain
`cinder_apply_storage_creation` uses for external backends — copy the policy into a temp
dir, edit, `hex_config apply` — because that is the only existing precedent for a CLI
writing an indexed tuning array.

Two differences from that precedent are deliberate: a name already in the sequence is not
written again, so re-running create cannot grow a second entry for one tier; and nothing is
applied when nothing changed, because `apply` restarts Cinder and a no-op create must not
interrupt volume service. Measured — a second registration of the same tier takes a second,
leaves `settings.txt` md5-identical and `cinder.conf` byte-identical.

**Registry wiring, and a list that compares the two sides.** Step 6 of create registers the
tier; a failure there is reported and left repairable rather than unwound, because everything
before it is already consistent between Ceph and Cinder and destroying a correct tier over a
failed config apply is the worse outcome. The idempotent branch registers too — without that,
a run that failed at step 6 would return 0 for ever and the failure would be permanent.

Step 2 of delete takes the registry entry, and with it the generated backend, out **before**
the volume type and the pool. That ordering is the one thing here that re-running cannot
repair: a backend pointing at a pool that has already been deleted keeps accepting volumes
into a store that is gone, and the volume type then cannot be deleted at all. It comes after
the in-use gate, not before, so a tier that still has volumes is refused while its backend is
still up.

`ceph_device_tier_list` now shows the registry beside Ceph, because the two disagree in both
directions and each direction has its own consequence — a tier Ceph has and the registry does
not is a volume type with no backend behind it; a registry entry with nothing on the Ceph
side is a backend pointing at a pool that does not exist. An unreadable registry is reported
as unknown, never as "nothing is registered".

**The `storage > tier` CLI** — create, update, delete, list. Every rule about what a tier may
be called and which OSDs it may hold is enforced here, and there is nowhere else it could
be: the registry is an indexed tuning array, the cinder `CONFIG_MODULE` has no validate slot,
`ConfigString::parse` always returns true, `TuningStringArray` drops its `ValidateType`, and
`hex_config validate_tuning_value` compares the literal key name, which never equals an
indexed one.

Each rule comes from a measurement, not from caution. Ceph rejects `.`, ` `, `/`, `:` and
non-ASCII in a class name but **accepts the empty string and returns 0**, so emptiness cannot
be left to the layer that runs the command. A leading `-` would be read as an option by every
command the name is handed to. `config_cinder.cpp` matches `-pool` and `-ssd` as substrings
rather than suffixes, so a tier holding either gets claimed by the legacy scan as well as by
the registry and ends up with two conflicting backends. Collisions are checked whole-name
against the device classes, CRUSH rules, pools and volume types that exist —
`os_volume_type_create`'s own check is an unanchored grep that answers yes for `seki1` when
only `seki1-ssd` is there, so it cannot be reused for this.

The confirmation prompt goes before the first call that changes anything, not before the step
that binds the pool to its rule: taking an OSD out of a class some rule selects through
starts moving that rule's pools at the first step, so a prompt after it would be asking about
something already under way. What the prompt shows is which pools select through the classes
those OSDs carry now — and if that cannot be read, the command stops rather than showing an
empty list, which would be asking for consent to an unknown blast radius.

**A health gate that can actually be satisfied.** ⚠️ This changes behaviour introduced in
#1451, and it is the one thing in this PR a reviewer should look at with the code in front of
them. #1451's own description flagged it as a known sharp edge; this is the narrowing.

`ceph_device_tier_create` and `_update` refused on any `HEALTH_WARN`. Measured on the 1cc:
one BlueStore slow operation raises `BLUESTORE_SLOW_OP_ALERT`, and with
`bluestore_slow_ops_warn_threshold = 1` and `bluestore_slow_ops_warn_lifetime = 86400` that
single event blocks every device tier command **for a full day**, while all 945 PGs sit
`active+clean` and the data is in no danger at all. Finishing the acceptance run needed the
OSDs restarted to clear the alert — which is how a gate becomes something operators learn to
bypass rather than something that protects them.

The refusal is now about what the operation can actually make worse: a replica or a PG
missing right now, a failure domain down, or a cluster with nowhere to put the data about to
be moved.

```
refuse:  PG_AVAILABILITY  PG_DEGRADED  PG_DEGRADED_FULL  PG_RECOVERY_FULL
         PG_BACKFILL_FULL  PG_DAMAGED  OBJECT_UNFOUND  OSD_DOWN  OSD_HOST_DOWN
         OSD_ROOT_DOWN  OSD_FULL  OSD_BACKFILLFULL  POOL_FULL  MON_DOWN
warn:    everything else, named in the output
refuse:  HEALTH_ERR, whatever the check is called
```

Three exclusions are deliberate. `POOL_NO_REDUNDANCY`, `OSD_NEARFULL` and `POOL_NEARFULL`
describe how a cluster is configured or how full it is, not a replica that went missing, and
they do not clear on their own — blocking on those would rebuild exactly the trap this
removes. The BlueStore / `SLOW_OPS` family and `OSDMAP_FLAGS` are latency and operator flags
with no bearing on redundancy. And a check this list has never heard of is warned about
rather than blocked, with `HEALTH_ERR` as the backstop: every error-level check refuses
whatever its name is, so an unknown severe condition still stops there.

Reading the health is itself fail-closed — a status that cannot be read or parsed is unknown,
never OK — and the existing refusal while recovery is in flight is unchanged.

**Two things this CLI is deliberately not allowed to do.** Both came out of an
independent review, and both are cases of trusting an input that had not earned it.

The registry is written by the policy chain and by `hex_config commit <settings>` as
well as by this CLI, so an entry in it can hold any byte —
`_ceph_device_tier_registry` says so in as many words. The impact query used to build
its command by string concatenation and hand it to `ExecBashSync`, which runs
`/bin/bash -c "set -o pipefail && " + command`; `update` and `delete` never validated
the name they were handed, because only `create` did. Measured on the 1cc: with
`cinder.storage.tier.1.name = bad; touch /tmp/wp5-injected` in `settings.txt`,
`tier update` created that file, owned by root — `hex_cli` is 4755 — **before** the
confirmation prompt, so answering anything but YES did not prevent it. Now every
device tier query passes its arguments as arguments (`ExecSync` execvp()s hex_sdk;
there is no shell left in this path), and the name from the picker goes through the
same guard `create` uses. Re-measured with the same entry: both commands refuse, no
file appears, nothing on the cluster changes.

And ownership is the registry, never the shape of the Ceph objects. A device class
with a same-named CRUSH rule and pool is what a device tier looks like — but
customers hand-build exactly that shape; #1335 lists `computehdd`, `computessd` and
`smarthealth` on one site. Recognising a tier by shape would have let `tier create`
adopt one of those as a Cinder backend and `tier delete` destroy its volume type,
pool, rule and class. `ceph_device_tier_names` now reports a state with each name —
`registered`, `registry-only`, `unmanaged` — an unreadable registry is a failure
rather than "nothing is registered", and `update` and `delete` only ever act on the
first two. What that must not break is the repair path for a tier of ours whose
registration did not complete, since it is shape-identical to a lookalike; that is
now an explicit command (`hex_sdk cinder_apply_storage_tier_creation <tier>`) named
in the refusal rather than an implicit adoption. Verified by hand-building a
lookalike on the 1cc: create, update and delete all refuse it and leave every object
in place, and the explicit registration then hands it to the CLI, which tears it
down normally.

#### Which issue(s) this PR fixes

Part of #840

Not a `Fixes`: WP-6, the migration of an existing cache-tiered cluster and the operator
documentation are still to come on the same issue.

#### Special notes for your reviewer

**The whole stack was run on a 1cc (Ceph 18.2.8 reef), and the node was restored to
baseline afterwards** — six files back to their baseline md5s with SUID bits intact,
`cinder.conf` byte-identical to the backup, 25 pools, `classes ["hdd"]`, `replicated_rule`
only, two volume types, zero tier keys, `HEALTH_OK` with 945 PGs `active+clean`.

`storage> tier create seki1 0` builds all six layers in one command:

```
policy yml       tiers: / - name: seki1
settings.txt     cinder.storage.tier.0.name = seki1
cinder.conf      enabled_backends = ceph,seki1   +  a complete [seki1] section
Ceph             class ["hdd","seki1"], rule seki1, pool seki1 bound to rule seki1
Cinder           volume type seki1 {'volume_backend_name': 'seki1'}
service          cinder-volume cube@seki1 up
tier list        seki1  0  1  1/1  seki1  yes  yes   no-redundancy
```

and a volume opened on it lands where it should: `openstack volume create --type seki1`
becomes `volume-46b05fa2-…` under `rbd -p seki1`. (`no-redundancy` is correct on that node —
one host, so the tier pool's size is `min(base RF, host count) = 1`.)

`update` moves a member in and out; `delete` is refused while a volume exists — with
`settings.txt`, `cinder.conf`, the pool and the volume type all verified untouched after the
refusal — and tears everything down in reverse when it is not. **Every validation rule above
has a negative test on that node**, each one showing the framework's `Invalid arguments.` or
`command failure` line rather than a silent `CLI_SUCCESS`:

```
create seki.1 0        Ceph accepts only letters, digits, '-' and '_'
create "" 0            A device tier name is required.
create gold-ssd 0      must not contain '-pool' or '-ssd'
create my-poolish 0    same rule, matched as a substring
create 數位 0           character set
create cinder-volumes 0 / hdd 0 / replicated_rule 0 / CubeStorage 0
                       already taken by a Ceph pool / CRUSH device class / CRUSH rule /
                       Cinder volume type
create seki1 99        No such OSD: '99'.
create seki1 osd.x     Invalid OSD id: 'osd.x'.
update nosuch 0        There are no device tiers.
```

**On the health gate specifically**, both branches were exercised against conditions Ceph
raised itself, with nothing injected: `ceph osd set noscrub` gives `OSDMAP_FLAGS` and create
proceeds with *"none of those checks is about data redundancy or availability, so this is
going ahead"*; a `tier update` that moves data leaves the cluster genuinely degraded, and the
next `update` refuses with *"ceph reports PG_DEGRADED — data redundancy or availability is
already compromised"*. The `.health.checks` shape this parses — an object keyed by check
name — was confirmed against what that cluster actually emits.

**Three offline suites, all checked against the unpatched code.** A test that passes on both
the fixed and unfixed revision asserts nothing:

```
core/sdk_sh/tests/test_ceph_device_tier_registry.sh        109 assertions   (new)
core/sdk_sh/tests/test_cinder_storage_tier_registry.sh      42 assertions   (new)
core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh     70 assertions   (55 -> 70)
```

Against the parent of each commit: 39 red in the registry suite, another 18 red for the
health gate alone, 6 red for the ownership states and the poisoned-registry cases, 10 red
for the delete-ordering cases. The two `sdk_cinder` functions do
not exist in any earlier revision, so those were checked by mutation instead — removing the
idempotence short-circuit turns three assertions red and prints
`[{"name":"gold"},{"name":"silver"},{"name":"silver"}]`. The first version of that assertion
passed under the mutation, because it checked the source policy file while the function edits
a copy; it now runs as a sequence against what `apply` actually committed.

**Three real bugs were found by running it, not by reading it**, and all three are fixed in
this PR:

1. `hex_string_util::strip()` does nothing at all when the whole string is in its character
   set (`find_first_not_of` returns `npos`, neither end is erased). The correct answer for
   "no pool selects through this class" is a lone `\n`, which kept its length — so the
   confirmation printed a blank list where it should have said nothing was affected.
2. The deletion path originally copied `cinder_apply_storage_deletion`'s YAML→JSON→YAML round
   trip, which rewrites every key on the way past: `version: 1.0` came back as `version: 1`
   and the empty placeholder `- name:` came back as `- name: null`, which
   `HexYmlParseString` reads as the four-character string `"null"` — putting a backend called
   `null` into `enabled_backends` and a permanently down `cinder-volume cc1@null` into the
   service list. Rewritten to edit in place with `yq -i`, which touches only the node named.
   **The pre-existing occurrence in `cinder_apply_storage_deletion` is left alone here and
   filed as #1454** — it is a live external-storage path, outside this story.
3. The CLI's "already a device tier" shortcut called `hex_sdk ceph_device_tier_create` with
   an empty OSD list, which its usage guard rejects, so the documented repair path for a
   half-registered tier could not actually be walked. It now passes the tier's own members.

**One finding from that review is filed rather than fixed here: #1456.** All four
writers of the external storage policy — the two this PR adds and the two that have
been there since 2025 — copy the whole policy, edit the copy, and only then call
`hex_config apply`, whose lock is taken inside `MainApply()` long after both
snapshots exist. Two concurrent changes therefore lose one of the two. It is more
reachable than two operators on two shells: `cube-cos-api` shells out to
`cinder_put_storage` / `cinder_delete_storage` per request
(`internal/cubecos/integration.go:148,210`), so two HTTP calls are enough. Fixing it
means an outer lock — necessarily a different one from `hex_config`'s own apply lock,
or the holder waits for itself — shared by all four writers, plus a re-read of the
policy after taking it. That is a change to two live external-storage paths and the
lock discipline they share, which is why it is a ticket and not a hunk in this PR.
The two device tier writers are the least exposed of the four (interactive CLI, behind
a confirmation prompt); they are in the ticket because they write the same file.

**On a cluster with no device tier this changes nothing.** The CLI is additive, the registry
functions are only reachable from it and from the SDK functions #1451 added, and the health
gate only ever loosens a refusal — it never allows something the previous version refused for
a redundancy reason.

#### Additional documentation

None in this PR. Operator-facing documentation and the handbook note land with WP-6, together
with the reboot-persistence and regression runs (AC-4, AC-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
