### PR TITLE
feat(gpu): give hex_cli the GPU resource commands and retire the generation-1 surface

### DIFF
--- a/core/modules/cli_gpu.cpp
+++ b/core/modules/cli_gpu.cpp
@@ -19,43 +19,6 @@ GpuStatusMain(int argc, const char** argv)
 }
 
 static int
-GpuTypeListMain(int argc, const char** argv)
-{
-    if (argc > 1 /* [0]="supported_type_list" */)
-        return CLI_INVALID_ARGS;
-
-    HexSystemF(0, HEX_SDK " -v gpu_supported_type_list");
-
-    return CLI_SUCCESS;
-}
-
-static int
-GpuVfEnableMain(int argc, const char** argv)
-{
-    if (argc > 1 /* [0]="virtual_function_enable" */)
-        return CLI_INVALID_ARGS;
-
-    HexSystemF(0, HEX_SDK " gpu_vf_enable");
-    CliPrintf("\nGPU IOMMU Group List");
-    HexSystemF(0, HEX_SDK " -v gpu_iommu_list");
-
-    return CLI_SUCCESS;
-}
-
-static int
-GpuVfDisableMain(int argc, const char** argv)
-{
-    if (argc > 1 /* [0]="virtual_function_disable" */)
-        return CLI_INVALID_ARGS;
-
-    HexSystemF(0, HEX_SDK " gpu_vf_disable");
-    CliPrintf("\nGPU IOMMU Group List");
-    HexSystemF(0, HEX_SDK " -v gpu_iommu_list");
-
-    return CLI_SUCCESS;
-}
-
-static int
 GpuCreateDpMain(int argc, const char** argv)
 {
     if (argc > 2 /* [0]="create_device_profile", [1]=<unit> */)
@@ -88,18 +51,6 @@ CLI_MODE(CLI_TOP_MODE, "gpu",
 CLI_MODE_COMMAND("gpu", "status", GpuStatusMain, NULL,
     "Show GPU and virtual GPU status.",
     "status");
-
-CLI_MODE_COMMAND("gpu", "supported_type_list", GpuTypeListMain, NULL,
-    "List supported GPU types instances could get.",
-    "supported_type_list");
-
-CLI_MODE_COMMAND("gpu", "virtual_function_enable", GpuVfEnableMain, NULL,
-    "Enable GPU virtual function for this node.",
-    "virtual_function_enable");
-
-CLI_MODE_COMMAND("gpu", "virtual_function_disable", GpuVfDisableMain, NULL,
-    "Disable GPU virtual function for this node.",
-    "virtual_function_disable");
 
 CLI_MODE_COMMAND("gpu", "device_profile_create", GpuCreateDpMain, NULL,
     "Create device profile for all GPU devices by giving unit or 1 if unit is absent.",

--- a/core/modules/cli_gpu.cpp
+++ b/core/modules/cli_gpu.cpp
@@ -44,6 +44,135 @@ GpuDeleteDpMain(int argc, const char** argv)
     return CLI_SUCCESS;
 }
 
+static int
+GpuResourceListMain(int argc, const char** argv)
+{
+    if (argc > 1 /* [0]="resource_list" */)
+        return CLI_INVALID_ARGS;
+
+    HexSpawn(0, HEX_SDK, "gpu_resource_summary", NULL);
+
+    return CLI_SUCCESS;
+}
+
+static int
+GpuProfileListMain(int argc, const char** argv)
+{
+    /*
+     * [0]="profile_list", [1]=<gpu uuid>
+     */
+    if (argc > 2)
+        return CLI_INVALID_ARGS;
+
+    std::string uuid;
+    int index;
+
+    std::string optCmd = HEX_SDK " gpu_device_uuid_list";
+    std::string descCmd = HEX_SDK " -v gpu_device_uuid_list";
+
+    if (CliMatchCmdDescHelper(argc, argv, 1, optCmd, descCmd, &index, &uuid,
+                              "Select a GPU card: ") != CLI_SUCCESS) {
+        CliPrintf("GPU card is missing or not found");
+        return CLI_INVALID_ARGS;
+    }
+
+    HexSpawn(0, HEX_SDK, "gpu_vgpu_profile_summary", uuid.c_str(), NULL);
+
+    return CLI_SUCCESS;
+}
+
+static int
+GpuResourceSetMain(int argc, const char** argv)
+{
+    /*
+     * [0]="resource_set", [1]=<gpu uuid>, [2]=<resource type>, [3]=<profiles>
+     */
+    if (argc > 4)
+        return CLI_INVALID_ARGS;
+
+    std::string uuid, type;
+    int index;
+
+    std::string optCmd = HEX_SDK " gpu_device_uuid_list";
+    std::string descCmd = HEX_SDK " -v gpu_device_uuid_list";
+
+    if (CliMatchCmdDescHelper(argc, argv, 1, optCmd, descCmd, &index, &uuid,
+                              "Select a GPU card: ") != CLI_SUCCESS) {
+        CliPrintf("GPU card is missing or not found");
+        return CLI_INVALID_ARGS;
+    }
+
+    CliList types;
+    types.push_back("pgpu");
+    types.push_back("sriovVgpu");
+    types.push_back("migBackedVgpu");
+
+    if (CliMatchListHelper(argc, argv, 2, types, &index, &type) != 0) {
+        CliPrintf("resource type is missing or not found");
+        return CLI_INVALID_ARGS;
+    }
+
+    /*
+     * profiles is a JSON array of {id, count}, required by the two vGPU types
+     * and omitted for pgpu. It is passed through untouched: every rule about
+     * what a valid carve is - the card's own supported types, the profile ids,
+     * the total VRAM - is enforced fail-closed inside hex_config's
+     * gpu_resource_set, after it has released the card from vfio-pci. Checking
+     * any of it a second time here would run before that release, i.e. at the
+     * one point in the sequence where the answer cannot be read.
+     *
+     * HexSpawn is execv-based, so the JSON crosses as one argv element and
+     * never meets a shell. Its stdout and stderr go straight to the terminal:
+     * a carve takes 25-60s and reports as it goes, and a rejection has to say
+     * why rather than leaving the operator with a bare exit code.
+     */
+    std::string profiles;
+    if (argc == 4) {
+        profiles = argv[3];
+    }
+    else if (type != "pgpu") {
+        /*
+         * Both vGPU types require profiles, so an interactive run that stopped
+         * after the type would be able to set nothing but pgpu. Print what the
+         * card offers first - the ids are vGPU type ids, not something an
+         * operator can be expected to produce from memory.
+         */
+        CliPrintf("\nvGPU profiles available on this card:");
+        HexSpawn(0, HEX_SDK, "gpu_vgpu_profile_summary", uuid.c_str(), NULL);
+
+        if (!CliReadInputStr(argc, argv, 3,
+                             "Profiles as a JSON array of {id, count}: ",
+                             &profiles) || profiles.length() == 0) {
+            CliPrintf("profiles are required for %s", type.c_str());
+            return CLI_INVALID_ARGS;
+        }
+    }
+
+    /*
+     * -e makes hex_config log to stderr as well as syslog. Without it
+     * gpu_resource_set exits 1 with nothing on stdout or stderr - measured on
+     * cn13 - and the operator is left with hex_cli's bare "command failure"
+     * while the actual reason ("profiles must be a non-empty JSON array of
+     * { id, count } objects") sits in /var/log/hex_config.log. HexSpawn passes
+     * stderr straight through, so this one flag is what makes a refusal
+     * explain itself. The same flag is what cube-cos-api needs to stop
+     * answering 500 "exit status 1" (#1452).
+     */
+    int ret;
+    if (!profiles.empty()) {
+        ret = HexSpawn(0, HEX_CFG, "-e", "gpu_resource_set",
+                       uuid.c_str(), type.c_str(), profiles.c_str(), NULL);
+    } else {
+        ret = HexSpawn(0, HEX_CFG, "-e", "gpu_resource_set",
+                       uuid.c_str(), type.c_str(), NULL);
+    }
+
+    if (ret != 0)
+        return CLI_FAILURE;
+
+    return CLI_SUCCESS;
+}
+
 CLI_MODE(CLI_TOP_MODE, "gpu",
     "Work with GPU settings.",
     !HexStrictIsErrorState() && !FirstTimeSetupRequired());
@@ -51,6 +180,18 @@ CLI_MODE(CLI_TOP_MODE, "gpu",
 CLI_MODE_COMMAND("gpu", "status", GpuStatusMain, NULL,
     "Show GPU and virtual GPU status.",
     "status");
+
+CLI_MODE_COMMAND("gpu", "resource_list", GpuResourceListMain, NULL,
+    "List the GPU resources of this node and their resource types.",
+    "resource_list");
+
+CLI_MODE_COMMAND("gpu", "profile_list", GpuProfileListMain, NULL,
+    "List the vGPU profiles a GPU card supports.",
+    "profile_list [<gpu uuid>]");
+
+CLI_MODE_COMMAND("gpu", "resource_set", GpuResourceSetMain, NULL,
+    "Set the resource type of a GPU card.",
+    "resource_set [<gpu uuid>] [<pgpu|sriovVgpu|migBackedVgpu>] [<profiles>]");
 
 CLI_MODE_COMMAND("gpu", "device_profile_create", GpuCreateDpMain, NULL,
     "Create device profile for all GPU devices by giving unit or 1 if unit is absent.",

--- a/core/modules/config_nova.cpp
+++ b/core/modules/config_nova.cpp
@@ -586,9 +586,6 @@ UpdateCfg(std::string domain, std::string region, std::string mcacheconn, std::s
         cfg["DEFAULT"]["instance_usage_audit_period"] = "hour";
         cfg["notifications"]["notify_on_state_change"] = "vm_and_task_state";
 
-        std::string gpuType = HexUtilPOpen(HEX_SDK " gpu_default_type_get");
-        if (gpuType.length())
-            cfg["devices"]["enabled_vgpu_types"] = gpuType;
         if (s_gpuType.length())
             cfg["devices"]["enabled_vgpu_types"] = s_gpuType.newValue();
 
@@ -876,7 +873,6 @@ CommitCheck(bool modified, int dryLevel)
 {
     if (IsBootstrap()) {
         s_bConfigChanged = true;
-        HexUtilSystemF(0, 0, HEX_SDK " os_nova_mdev_instance_sync");
         return true;
     }
 

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -55,55 +55,6 @@ gpu_is_installed()
     /usr/bin/nvidia-smi >/dev/null
 }
 
-gpu_vf_enable()
-{
-    local bus=${1:-ALL}
-
-    $NVIDIA_SRIOV -e $bus
-
-    # persist the change after reboot
-    rm -f /etc/modprobe.d/gpu-vfio.conf
-
-    for g in $(find /sys/kernel/iommu_groups/* -maxdepth 0 -type d 2>/dev/null | sort -V); do
-        for d in $g/devices/*; do
-            source $d/uevent
-            # nvidia vender id: 10de
-            if echo $PCI_ID | grep -iq "10de:"; then
-                pci_id=$(echo $PCI_ID | tr '[:upper:]' '[:lower:]')
-                echo "set device $pci_id at $PCI_SLOT_NAME driver to nvidia"
-                echo $PCI_SLOT_NAME > /sys/bus/pci/drivers/$DRIVER/unbind 2>/dev/null
-                echo $PCI_SLOT_NAME > /sys/bus/pci/drivers/nvidia/bind 2>/dev/null
-            fi
-        done
-    done
-}
-
-gpu_vf_disable()
-{
-    local bus=${1:-ALL}
-
-    $NVIDIA_SRIOV -d $bus
-
-    # pci passthrough support
-    modprobe vfio-pci
-
-    # persist the change after reboot
-    echo "options vfio-pci ids=$(gpu_iommu_list)" > /etc/modprobe.d/gpu-vfio.conf
-
-    for g in $(find /sys/kernel/iommu_groups/* -maxdepth 0 -type d 2>/dev/null | sort -V); do
-        for d in $g/devices/*; do
-            source $d/uevent
-            # nvidia vender id: 10de
-            if echo $PCI_ID | grep -iq "10de:"; then
-                pci_id=$(echo $PCI_ID | tr '[:upper:]' '[:lower:]')
-                echo "set device $pci_id at $PCI_SLOT_NAME driver to vfio-pci"
-                echo $PCI_SLOT_NAME > /sys/bus/pci/drivers/$DRIVER/unbind 2>/dev/null
-                echo $PCI_SLOT_NAME > /sys/bus/pci/drivers/vfio-pci/bind 2>/dev/null
-            fi
-        done
-    done
-}
-
 gpu_service_config()
 {
     if gpu_is_installed; then
@@ -113,6 +64,30 @@ gpu_service_config()
         /usr/bin/systemctl stop nvidia-vgpud
         /usr/bin/systemctl stop nvidia-vgpu-mgr
     fi
+}
+
+# Renders the per-card resource types recorded in the truth file for
+# gpu_device_status. Replaces the pre-#894 pair (gpu_nova_type_show reading
+# nova.conf's mdev-era enabled_vgpu_types, and gpu_supported_type_list emitting
+# mdev "nvidia-<decimal>" names) - neither of which reflects what the three
+# current resource types actually use, and neither of which reads config.json.
+gpu_resource_summary()
+{
+    local devices
+    if ! devices=$(gpu_device_list); then
+        echo "GPU resource configuration unavailable"
+        return 0
+    fi
+
+    if [ "$(echo "$devices" | jq -r 'length')" = "0" ]; then
+        echo "No GPU cards reported"
+        return 0
+    fi
+
+    echo "$devices" | jq -r '.[] |
+        "pci: \(.pciAddress), type: \(.type), status: \(.status), " +
+        "allocation: \(if .allocation == null then "-" else "\(.allocation.current)/\(.allocation.total)" end), " +
+        "name: \(.name)"'
 }
 
 gpu_device_status()
@@ -139,10 +114,8 @@ gpu_device_status()
         $NVIDIA_SMI vgpu
         printf "\n"
         $NVIDIA_SMI vgpu -m
-        printf "\nVirtualization:\n"
-        gpu_nova_type_show
-        printf "\nSupported vGPU types:\n"
-        VERBOSE=1 gpu_supported_type_list
+        printf "\nGPU resource types:\n"
+        gpu_resource_summary
     else
         echo "No Nvidia GPU managed by the host"
     fi
@@ -156,44 +129,6 @@ gpu_device_status()
     hex_sdk -v -f none health_cyborg_report
 
     printf "\n"
-}
-
-gpu_nova_type_show()
-{
-    local type=$(grep enabled_vgpu_types /etc/nova/nova.conf | awk '{print $3}')
-    if [ -n "$type" ]; then
-        echo "Using vGPU type \"$type\""
-    else
-        echo "No vGPU type configured"
-    fi
-}
-
-gpu_supported_type_list()
-{
-    for t in $($NVIDIA_SMI vgpu -s -v | grep "vGPU Type ID" | awk '{print $5}' | sort | uniq) ; do
-        local type=$(echo $t | awk '{print "nvidia-" strtonum($0)}')
-        if [ -z "$t" ]; then
-            continue
-        fi
-        if [ "$VERBOSE" == "1" ]; then
-            local desc=$($NVIDIA_SMI vgpu -s -v | grep $t -A 12 | head -n 13)
-            local name=$(echo "$desc"| grep "Name" | awk '{ s = ""; for (i = 3; i <= NF; i++) s = s $i " "; print s }' | awk '{$1=$1;print}')
-            local heads=$(echo "$desc"| grep "Display Heads" | awk '{ print $4 }')
-            local frl=$(echo "$desc"| grep "Frame Rate Limit" | awk '{ print $5 }')
-            local buffer=$(echo "$desc"| grep "FB Memory" | awk '{ print $4 "M" }')
-            local max_x=$(echo "$desc"| grep "Maximum X Resolution" | awk '{ print $5 }')
-            local max_y=$(echo "$desc"| grep "Maximum Y Resolution" | awk '{ print $5 }')
-            local max_ins=$(echo "$desc"| grep "Max Instances" | awk '{ print $4 }')
-            printf "type: %s, name: %s, spec: heads=%s, frame_rate_limit=%s, framebuffer=%s, max_resolution=%sx%s, max_instance=%s\n" "$type" "$name" "$heads" "$frl" "$buffer" "$max_x" "$max_y" "$max_ins"
-        else
-            echo $type
-        fi
-    done
-}
-
-gpu_default_type_get()
-{
-    $HEX_SDK gpu_supported_type_list | head -n 1
 }
 
 # Slices `nvidia-smi -q` / `nvidia-smi vgpu -q` (on stdin) into whole records and
@@ -1095,9 +1030,10 @@ gpu_resource_set_check()
 # exact moment - retry briefly to absorb that race. A failure that isn't this
 # specific message is not retried and fails immediately.
 #
-# Unlike gpu_vf_disable() near the top of this file, this touches only the
-# given PF: it never rebinds anything to vfio-pci and never writes
-# modprobe.d persistence.
+# This touches only the given PF: it never rebinds anything to vfio-pci and
+# never writes modprobe.d persistence. The node-wide gpu_vf_disable that did
+# both was removed in #827 - it acted on every card behind config.json's back
+# and fought Commit()'s per-card re-apply on the next boot.
 gpu_sriov_disable_vfs()
 {
     local pci_addr="$1"

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -773,6 +773,30 @@ gpu_device_list()
 #   alias: string | null
 #   vmCountLimit: number | null
 # }
+
+# Card picker feed for hex_cli's CliMatchCmdDescHelper, which runs two commands
+# and pairs them line by line: the plain form emits the value it hands back
+# (the GPU UUID), VERBOSE=1 emits the line shown to the operator for the same
+# card in the same order. Same shape as os_nova_gpu_server_list.
+#
+# Failure propagates rather than degrading to an empty list, for the reason
+# gpu_device_list itself gives: an empty list reads as "this node has no GPUs",
+# which here would be an empty picker with no explanation.
+gpu_device_uuid_list()
+{
+    local devices
+    if ! devices=$(gpu_device_list); then
+        return 1
+    fi
+
+    if [ "$VERBOSE" == "1" ]; then
+        echo "$devices" | jq -r '.[] |
+            "\(.name) [\(.pciAddress)] \(.type)/\(.status)"'
+    else
+        echo "$devices" | jq -r '.[].id'
+    fi
+}
+
 gpu_vgpu_profile_list()
 {
     local gpu_id="$1"
@@ -935,6 +959,28 @@ EOF
 
         { sriov: ($sriovProfiles | withCountAndAlias), migBacked: ($migProfiles | withCountAndAlias) }
         '
+}
+
+# Human-readable rendering of gpu_vgpu_profile_list for hex_cli. The JSON that
+# function returns is the contract config_gpu.cpp and cube-cos-api read, and a
+# card offers ~73 profiles - as one unwrapped line it is unreadable in an
+# interactive shell, which is exactly what this story is trying to fix.
+gpu_vgpu_profile_summary()
+{
+    local gpu_id="$1"
+
+    local profiles
+    if ! profiles=$(gpu_vgpu_profile_list "$gpu_id"); then
+        return 1
+    fi
+
+    local group
+    for group in sriov migBacked; do
+        echo "$group:"
+        echo "$profiles" | jq -r --arg g "$group" '.[$g][]? |
+            "  id: \(.id), name: \(.name), vram: \(.vramMiB) MiB, count: \(.count)"
+            + (if .alias == null then "" else ", alias: \(.alias)" end)'
+    done
 }
 
 gpu_pgpu_attached_instance_get()

--- a/core/sdk_sh/modules/sdk_os.sh
+++ b/core/sdk_sh/modules/sdk_os.sh
@@ -1375,21 +1375,6 @@ os_nova_hci_reserved_mem_mb()
     echo -n $reserved_mem_mb
 }
 
-os_nova_mdev_instance_sync()
-{
-    local type=$(cat /etc/nova/nova.conf | grep enabled_vgpu_types | awk '{print $3}' | tr -d '\n')
-
-    for i in $(virsh list --all | grep instance- | awk '{print $2}') ; do
-        if virsh dumpxml $i | grep -q mdev ; then
-            local mdev_loc=$(find /sys/devices/ -name $type -type d | sort -R | head -n 1)
-            local uuid=$(virsh dumpxml $i | grep mdev -A 2 | grep uuid | awk -F\' '{print $2}')
-            if [ -n "$uuid" -a -n "$mdev_loc" -a ! -d "/sys/bus/mdev/devices/$uuid"  ] ; then
-                echo $uuid > $mdev_loc/create
-            fi
-        fi
-    done
-}
-
 os_nova_instance_reset_pass()
 {
     local srv_id=${1:-NOSUCHSERVERID}


### PR DESCRIPTION
Closes #827.

`hex_cli` was the one GPU surface that had not moved since the per-card
`config.json` model landed. The resource-type feature lives entirely in
`hex_sdk` (read) and `hex_config` (write), so an operator working from a shell
had to know which of the three CLIs owns each step — and the one reached for by
habit owned none of it. That is what QA reported as "the GPU CLI documentation
is not sufficient"; the root cause was the surface, not the docs.

Three commits, each a complete change that builds on its own:

| commit | what |
|---|---|
| `retire the generation-1 GPU CLI surface` | remove three `hex_cli gpu` commands and the five sdk functions behind them; `gpu status` now reads `config.json` |
| `drop the mdev-era vGPU type auto-detection` | `config_nova.cpp` stops auto-writing `enabled_vgpu_types`; `os_nova_mdev_instance_sync` goes |
| `give hex_cli the GPU resource list, profile and set commands` | `resource_list` / `profile_list` / `resource_set` |

## What is gone, and why

- **`virtual_function_enable` / `virtual_function_disable`** — node-wide and
  all-cards. Despite taking a bus argument their rebind loop walks every `10de:`
  device in every IOMMU group and ignores it, and `hex_cli` called them with no
  argument anyway. `_disable` also writes `/etc/modprobe.d/gpu-vfio.conf` for
  persistence. Neither touches `config.json`, and `Commit()` re-applies from
  that file on every boot — so the two fight.
- **`supported_type_list`** — emits mdev-era `nvidia-<decimal>` names node-wide.
  mdev vGPU is unsupported (#813, 4/22 scrum).
- **`gpu status`'s mdev lines** — reported `enabled_vgpu_types` from `nova.conf`
  and the mdev type list, and showed nothing from `config.json`.
- **The auto-detected `enabled_vgpu_types`** — `UpdateCfg()` ran
  `gpu_default_type_get` (= `gpu_supported_type_list | head -1`) and wrote the
  first mdev type `nvidia-smi` happened to report into `nova.conf` on every
  commit. None of `pgpu` / `sriovVgpu` / `migBackedVgpu` consumes that key. The
  value was picked automatically, written persistently, and read by nothing.
- **`os_nova_mdev_instance_sync`** — ran on every bootstrap to re-create mdev
  devices; on a current node the loop finds nothing.

`device_profile_create` / `_delete` stay (Cyborg is still the pGPU consumption
path), `nvlink_*` stay, and the `nova.gpu.type` tuning stays — it is part of
cube-cos-api's tuning surface and its OpenAPI contract, so removing it is a
cross-repo change and not this story's.

## Three decisions worth flagging for review

1. **The two list commands render for a human** rather than forwarding the sdk's
   JSON. `gpu_device_list` and `gpu_vgpu_profile_list` keep emitting JSON
   untouched — the first is `config_gpu.cpp`'s single source of truth, the second
   cube-cos-api's contract — so `gpu_resource_summary` and
   `gpu_vgpu_profile_summary` render alongside them. Forwarding the JSON gave one
   700-character line and one 8000-character line covering 73 profiles, and
   `resource_set` prints that list before prompting. This story exists because
   the CLI was reported unusable.
2. **`hex_config` is invoked with `-e`.** Without it `gpu_resource_set` exits 1
   with nothing on stdout or stderr and the reason reaches only
   `/var/log/hex_config.log`. `HexSpawn` passes stderr through, so the flag is
   what makes a refusal explain itself.
3. **Nothing is validated in the CLI.** Which types a card supports, which
   profile ids are real, whether the VRAM adds up — all of it is enforced
   fail-closed inside `gpu_resource_set`, *after* it releases the card from
   vfio-pci. The same check on this side would run at the one point in the
   sequence where `nvidia-smi` cannot see the card at all.

## Verification

Built from `seki.xu/cn13-deploy-base` and hot-patched onto cn13 (RTX PRO 6000
Blackwell, 4 cards). Each commit was compiled on its own.

- `hex_cli -c gpu ?` — the three old commands gone, the three new ones present
- `gpu status` — lists all four cards from `config.json`
- Interactive card picker and type picker, both positional and prompted
- `resource_set … sriovVgpu '[{"id":1523,"count":1}]'` — completed in 44s;
  `config.json`, the VF's `current_vgpu_type`, `gpu.conf` and `gpu_device_list`
  all agreed afterwards; nova-compute stayed up. Reverting the carve also
  succeeded (37s)
- A refused carve now prints its reason instead of a bare exit code
- Reboot — `Bootstrap succeeded`, post script rc=0, so dropping
  `os_nova_mdev_instance_sync` does not affect boot
- `enabled_vgpu_types = nvidia-1518` (auto-detected; no `nova.gpu.type` in
  `settings.txt`) is gone from `nova.conf` after a nova commit

Two behaviours found while verifying, both filed separately rather than folded
in here — they are in the `unset` and `gpu.conf` paths, not the CLI surface:

- #1459 — `gpu_unset_current_type` passes an empty PCI address to `sriov-manage`
  when a PF is held by `pci-pf-stub`
- #1460 — one card with unresolvable VFs makes `gpu_resource_set` fail for every
  other card on the node (this is the mechanism behind #1452)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
