### PR TITLE
fix(gpu): stop an unseeable card from breaking gpu_resource_set for the node

### DIFF
--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -890,9 +890,22 @@ WriteNovaGpuConf(void)
         const std::string gpuId = entry["id"].string_value();
         const std::string type = entry["type"].string_value();
 
+        // A card that cannot be described must not veto the other cards. This
+        // file is regenerated in full from config.json, so an early return here
+        // aborts a carve aimed at a completely different, healthy card - which
+        // is what makes a single card in a bad state block GPU management for
+        // the whole node (#1460, the mechanism behind #1452).
+        //
+        // Skipping is also the more accurate answer: GetPciVfs fails when the
+        // VFs are not there (no virtfn link, or no vendor/device id), so the
+        // card has nothing for nova to claim. Leaving it out keeps gpu.conf
+        // describing VFs that exist, instead of whitelisting addresses that do
+        // not. No running instance can be holding one of those VFs either.
+        // BuildNovaGpuConfContent already skips a GPU absent from the map.
         if (!entry["pciAddress"].is_string() || entry["pciAddress"].string_value().empty()) {
-            HexLogError("GPU %s has type %s but no recorded pciAddress", gpuId.c_str(), type.c_str());
-            return false;
+            HexLogWarning("GPU %s has type %s but no recorded pciAddress; leaving it out of %s",
+                          gpuId.c_str(), type.c_str(), NOVA_GPU_CONF);
+            continue;
         }
 
         size_t assigned = 0;
@@ -902,8 +915,9 @@ WriteNovaGpuConf(void)
 
         std::vector<PciVf> vfs;
         if (!GetPciVfs(SysfsPciAddr(entry["pciAddress"].string_value()), assigned, &vfs)) {
-            HexLogError("Failed to resolve VFs of GPU %s for %s", gpuId.c_str(), NOVA_GPU_CONF);
-            return false;
+            HexLogWarning("Failed to resolve VFs of GPU %s; leaving it out of %s",
+                          gpuId.c_str(), NOVA_GPU_CONF);
+            continue;
         }
 
         vfsByGpuId[gpuId] = vfs;

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -1084,6 +1084,15 @@ gpu_sriov_disable_vfs()
 {
     local pci_addr="$1"
 
+    # An empty address would reach sriov-manage as a blank argument, and its
+    # own error ("no devices were found: lspci: -s: Invalid slot number") then
+    # lands where the address belongs in the message below - which reads as if
+    # the error text were the device name.
+    if [ -z "$pci_addr" ]; then
+        echo "Error: gpu_sriov_disable_vfs: no PCI address given" >&2
+        return 1
+    fi
+
     local attempt output rc
     for attempt in 1 2 3 4 5; do
         output=$($NVIDIA_SRIOV -d "$pci_addr" 2>&1)
@@ -1113,8 +1122,24 @@ gpu_sysfs_pci_addr()
 {
     local gpu_id="$1"
 
-    $NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null \
-        | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]'
+    local addr
+    addr=$($NVIDIA_SMI --query-gpu=pci.bus_id -i "$gpu_id" --format=csv,noheader,nounits 2>/dev/null \
+        | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]')
+
+    # nvidia-smi cannot see a card whose PF is held by another driver: vfio-pci
+    # for a pgpu, or pci-pf-stub for an SR-IOV PF that currently has no VFs
+    # enabled. config.json records the address either way and sysfs keeps it
+    # readable, so fall back to the truth file rather than returning nothing.
+    # The pgpu branch of gpu_unset_current_type has always read the address
+    # this way for the same reason.
+    if [ -z "$addr" ]; then
+        addr=$(jq -r --arg id "$gpu_id" \
+            'map(select(.id == $id)) | if length > 0 then (.[0].pciAddress // "") else "" end' \
+            "$GPU_CONFIG_FILE_PATH" 2>/dev/null \
+            | sed 's/^[0-9a-fA-F]\{4\}//' | tr '[:upper:]' '[:lower:]')
+    fi
+
+    echo "$addr"
 }
 
 gpu_unset_current_type()
@@ -1129,6 +1154,11 @@ gpu_unset_current_type()
     if [ "$current_type" = "sriovVgpu" ]; then
         local pci_addr
         pci_addr=$(gpu_sysfs_pci_addr "$gpu_id")
+
+        if [ -z "$pci_addr" ]; then
+            echo "Error: GPU $gpu_id has type sriovVgpu but no PCI address could be resolved" >&2
+            exit 1
+        fi
 
         if ! gpu_sriov_disable_vfs "$pci_addr"; then
             exit 1


### PR DESCRIPTION
Closes #1459. Closes #1460.

Two failures in `gpu_resource_set`'s error paths, both found while verifying
#827 on cn13. They are filed separately but fixed together because they are the
same failure seen from two ends: a card `nvidia-smi` cannot see, and what the
rest of the node does about it.

## #1459 — the address comes back empty and gets interpolated

`gpu_sysfs_pci_addr` asked `nvidia-smi` for the address, and `nvidia-smi` cannot
see a card whose PF is held by another driver. For a `pgpu` that driver is
`vfio-pci`, which `gpu_unset_current_type`'s pgpu branch already works around by
reading `config.json` — but an SR-IOV PF sitting on `pci-pf-stub` with no VFs
enabled is invisible the same way, and the `sriovVgpu` branch had no fallback
and no empty check. The blank address reached `sriov-manage`, whose own
complaint then landed where the address belongs:

```
Error: failed to disable SR-IOV VFs on no devices were found: lspci: -s: Invalid slot number
```

Read literally, that names a device *"no devices were found: lspci: -s: Invalid
slot number"*. Once a card was in this state it could not be re-typed at all.

Three narrow changes: the fallback to `config.json` (the same source the pgpu
branch has always used), the missing empty check on the `sriovVgpu` branch (it
was the only one of the three without it), and `gpu_sriov_disable_vfs` refusing
a blank address rather than interpolating it.

## #1460 — one card vetoes the whole node

`WriteNovaGpuConf()` regenerates `gpu.conf` from `config.json` as a whole, so it
walks every VF-backed card. Either failure in that loop returned false and took
the entire `gpu_resource_set` with it — **including carves aimed at other cards
that were in perfect shape**:

```
Error: Failed to resolve VFs of GPU GPU-0a5ba9ad-... for /etc/nova/nova.d/gpu.conf
Error: gpu_resource_set: failed to regenerate gpu.conf for GPU GPU-171566b8-...
```

The operation was on `GPU-171566b8`. It died on `GPU-0a5ba9ad`.

**This is the mechanism behind #1452**, where the UI reported a 500 for an edit
to a card that was itself healthy. Two things hid it: `hex_config` exits 1 with
nothing on stdout or stderr unless invoked with `-e`, so cube-cos-api can only
report `exit status 1`; and the error names the *other* card.

Log and skip instead. That is also the more accurate result — `GetPciVfs` fails
precisely when the VFs are absent, so the card has nothing for nova to claim and
no instance can be holding one. Leaving it out keeps `gpu.conf` describing VFs
that exist rather than whitelisting addresses that do not.
`BuildNovaGpuConfContent` already skips a GPU missing from the map, so the
other side needed no change.

## Verification

On cn13 (RTX PRO 6000 Blackwell), A/B against the unmodified binaries.

**#1459** — `NVIDIA_SMI` pointed at `/bin/false` to simulate the blind spot, no
hardware touched:

| | result |
|---|---|
| control, `nvidia-smi` working | `0001:c8:00.0` |
| old, `nvidia-smi` blind | `` (empty) |
| **new, `nvidia-smi` blind** | **`0001:c8:00.0`** — identical to control |
| new, `gpu_sriov_disable_vfs ""` | `rc=1`, `no PCI address given` |

**#1460** — reproduced with a *phantom* card rather than by breaking a real one:
a `sriovVgpu` entry for `00000009:99:00.0` added to `config.json`, whose VFs can
never resolve. Then a carve applied to a real card's own current profile:

| | old `hex_config` | new `hex_config` |
|---|---|---|
| rc | **1** (died at 13s) | **0** (completed in 31s) |
| message | `Error: Failed to resolve VFs …` + `failed to regenerate gpu.conf` | `Warning: … leaving it out of gpu.conf` |
| phantom entries in `gpu.conf` | — | **0** |
| real entries in `gpu.conf` | — | **13** |

The old column reproduces exactly what was seen on a genuinely dirty node
earlier that day.

Afterwards the phantom entry was removed, `hex_config` rolled back, and
`gpu.conf` regenerated with the stock binary; the node's four cards are in the
state they started in.

## Note on the workaround these replace

A reboot recovers a node in this state — boot-time `Commit()` re-applies every
card from `config.json` and the PFs return to the `nvidia` driver. That was
measured too, but it is a workaround, not a fix: it requires taking every
instance on the node down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
