### PR TITLE
feat(gpu): record a card's framebuffer so a pgpu can still report it

### DIFF
--- a/core/modules/config_gpu.cpp
+++ b/core/modules/config_gpu.cpp
@@ -1412,6 +1412,33 @@ ResourceSetMain(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
+    // Record the card's framebuffer while it is still readable. The card is
+    // back on the nvidia driver at this point (gpu_unset_current_type above
+    // released whatever it was carved into), and for newType == pgpu the
+    // vfio-pci binding below is what makes it disappear from nvidia-smi - so
+    // this is the last moment the number can be read.
+    //
+    // It is persisted rather than recomputed on demand because nothing
+    // readable under a vfio binding yields it. Measured on cn13:
+    //   - the driver's vgpuConfig.xml carries per-vGPU-type framebuffers only,
+    //     with no card total;
+    //   - the largest vGPU profile is the nominal size - 98304 MiB against the
+    //     97887 nvidia-smi reports for the same card - so offering it to the UI
+    //     would let a user pick a carve that ValidateVgpuProfiles, which reads
+    //     the real number, then rejects;
+    //   - PCI BAR2 is a 131072 MiB address aperture, unrelated to VRAM.
+    //
+    // Consumers must treat it as the last known value: null when it could not
+    // be read, and stale for a card that was already pgpu before this field
+    // existed, until its next resource change.
+    const long totalVramMiB = GetGpuTotalVramMiB(gpuId);
+    if (totalVramMiB <= 0) {
+        HexLogWarning("gpu_resource_set: could not read the total framebuffer of GPU %s; "
+                      "recording it as unknown", gpuId);
+    }
+    const std::string totalVramArg =
+        (totalVramMiB > 0) ? std::to_string(totalVramMiB) : std::string("null");
+
     if (strcmp(newType, "pgpu") == 0) {
         if (HexUtilSystemF(0, 0, HEX_SDK " gpu_bind_vfio_pci %s", pciAddress.c_str()) != 0) {
             HexLogError("gpu_resource_set: failed to bind GPU %s to vfio-pci for passthrough", gpuId);
@@ -1426,9 +1453,9 @@ ResourceSetMain(int argc, char* argv[])
         tmpFile.close();
 
         if (HexUtilSystemF(0, 0,
-                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" "
-                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"pgpu\", pciAddress:$pciAddress, profiles:null}]' %s > %s",
-                gpuId, name.c_str(), pciAddress.c_str(), GPU_CONFIG_FILE, tmpFile.path()) != 0) {
+                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" --argjson totalVramMiB %s "
+                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"pgpu\", pciAddress:$pciAddress, totalVramMiB:$totalVramMiB, profiles:null}]' %s > %s",
+                gpuId, name.c_str(), pciAddress.c_str(), totalVramArg.c_str(), GPU_CONFIG_FILE, tmpFile.path()) != 0) {
             HexLogError("gpu_resource_set: failed to build updated GPU config for %s", gpuId);
             return EXIT_FAILURE;
         }
@@ -1533,9 +1560,9 @@ ResourceSetMain(int argc, char* argv[])
         const std::string profilesDump = json11::Json(persistedProfiles).dump();
 
         if (HexUtilSystemF(0, 0,
-                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" --argjson profiles '%s' "
-                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"sriovVgpu\", pciAddress:$pciAddress, profiles:$profiles}]' %s > %s",
-                gpuId, name.c_str(), pciAddress.c_str(), profilesDump.c_str(),
+                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" --argjson profiles '%s' --argjson totalVramMiB %s "
+                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"sriovVgpu\", pciAddress:$pciAddress, totalVramMiB:$totalVramMiB, profiles:$profiles}]' %s > %s",
+                gpuId, name.c_str(), pciAddress.c_str(), profilesDump.c_str(), totalVramArg.c_str(),
                 GPU_CONFIG_FILE, tmpFile.path()) != 0) {
             HexLogError("gpu_resource_set: failed to build updated GPU config for %s", gpuId);
             return EXIT_FAILURE;
@@ -1604,9 +1631,9 @@ ResourceSetMain(int argc, char* argv[])
         const std::string profilesDump = json11::Json(persistedProfiles).dump();
 
         if (HexUtilSystemF(0, 0,
-                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" --argjson profiles '%s' "
-                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"migBackedVgpu\", pciAddress:$pciAddress, profiles:$profiles}]' %s > %s",
-                gpuId, name.c_str(), pciAddress.c_str(), profilesDump.c_str(),
+                "jq -c --arg id \"%s\" --arg name \"%s\" --arg pciAddress \"%s\" --argjson profiles '%s' --argjson totalVramMiB %s "
+                "'map(select(.id != $id)) + [{id:$id, name:$name, type:\"migBackedVgpu\", pciAddress:$pciAddress, totalVramMiB:$totalVramMiB, profiles:$profiles}]' %s > %s",
+                gpuId, name.c_str(), pciAddress.c_str(), profilesDump.c_str(), totalVramArg.c_str(),
                 GPU_CONFIG_FILE, tmpFile.path()) != 0) {
             HexLogError("gpu_resource_set: failed to build updated GPU config for %s", gpuId);
             return EXIT_FAILURE;

--- a/core/sdk_sh/modules/sdk_gpu.sh
+++ b/core/sdk_sh/modules/sdk_gpu.sh
@@ -490,16 +490,25 @@ gpu_device_list()
     fi
 
     local gpu_csv
-    gpu_csv=$($NVIDIA_SMI --query-gpu=uuid,name,pci.bus_id --format=csv,noheader,nounits 2>/dev/null)
+    gpu_csv=$($NVIDIA_SMI --query-gpu=uuid,name,pci.bus_id,memory.total --format=csv,noheader,nounits 2>/dev/null)
 
     local output="[]"
 
-    while IFS=',' read -r uuid name pci_bus_id; do
+    while IFS=',' read -r uuid name pci_bus_id mem_total_mib; do
         [ -z "$uuid" ] && continue
 
         uuid=$(echo "$uuid" | xargs)
         name=$(echo "$name" | xargs)
         pci_bus_id=$(echo "$pci_bus_id" | xargs)
+
+        # The card is visible here, so its framebuffer is measured rather than
+        # remembered. A card nvidia-smi cannot see is handled in the pgpu pass
+        # below, which reads the value config.json recorded at carve time.
+        local total_vram_mib
+        total_vram_mib=$(echo "$mem_total_mib" | xargs)
+        case "$total_vram_mib" in
+            ''|*[!0-9]*) total_vram_mib="null" ;;
+        esac
 
         # Keep the probe's exit status instead of dropping it. On failure
         # support_types stays at its hardcoded ["pgpu"] below, so a
@@ -541,7 +550,8 @@ gpu_device_list()
                 --arg name "$name" \
                 --arg pciAddress "$pci_bus_id" \
                 --argjson supportTypes "$support_types" \
-                '. + [{ id: $id, name: $name, type:"unset", supportTypes: $supportTypes, pciAddress: $pciAddress, sriovVgpuProfileCountLimit: null, status: "unassigned", allocation: null }]')
+                --argjson totalVramMiB "$total_vram_mib" \
+                '. + [{ id: $id, name: $name, type:"unset", supportTypes: $supportTypes, pciAddress: $pciAddress, totalVramMiB: $totalVramMiB, sriovVgpuProfileCountLimit: null, status: "unassigned", allocation: null }]')
             continue
         fi
 
@@ -617,7 +627,8 @@ gpu_device_list()
             --argjson sriovVgpuProfileCountLimit "${sriov_vgpu_profile_count_limit:-null}" \
             --arg status "$status" \
             --argjson allocation "$allocation" \
-            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, sriovVgpuProfileCountLimit:$sriovVgpuProfileCountLimit, status:$status, allocation:$allocation}]')
+            --argjson totalVramMiB "$total_vram_mib" \
+            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, totalVramMiB:$totalVramMiB, sriovVgpuProfileCountLimit:$sriovVgpuProfileCountLimit, status:$status, allocation:$allocation}]')
     done <<< "$gpu_csv"
 
     # GPUs already bound to vfio-pci (type "pgpu") are no longer enumerable
@@ -673,7 +684,8 @@ gpu_device_list()
             --arg status "$status" \
             --argjson supportTypes "$support_types" \
             --argjson allocation "$allocation" \
-            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, profileCountLimit:null, status:$status, allocation:$allocation}]')
+            --argjson totalVramMiB "$total_vram_mib" \
+            '. + [{id:$id, name:$name, type:$type, supportTypes:$supportTypes, pciAddress:$pciAddress, totalVramMiB:$totalVramMiB, profileCountLimit:null, status:$status, allocation:$allocation}]')
     done <<< "$(echo "$pgpu_ids" | jq -c '.[]' 2>/dev/null)"
 
     # The union above only catches vfio-pci-bound GPUs that config.json
@@ -735,6 +747,14 @@ gpu_device_list()
         local support_types
         support_types=$(gpu_support_types_from_xml "$pci_address")
 
+        # This card is bound to vfio-pci and invisible to nvidia-smi, so its
+        # framebuffer cannot be measured here - report what config.json recorded
+        # while it was last readable. null for a card carved before the field
+        # existed, or one whose framebuffer could not be read at carve time.
+        local recorded_vram
+        recorded_vram=$(echo "$entry" | jq -c '.totalVramMiB // null' 2>/dev/null)
+        [ -z "$recorded_vram" ] && recorded_vram="null"
+
         output=$(echo "$output" | jq -c \
             --arg id "$uuid" \
             --arg name "$name" \
@@ -742,7 +762,8 @@ gpu_device_list()
             --arg status "$status" \
             --argjson supportTypes "$support_types" \
             --argjson allocation "$allocation" \
-            '. + [{id:$id, name:$name, type:"pgpu", supportTypes:$supportTypes, pciAddress:$pciAddress, profileCountLimit:null, status:$status, allocation:$allocation}]')
+            --argjson totalVramMiB "$recorded_vram" \
+            '. + [{id:$id, name:$name, type:"pgpu", supportTypes:$supportTypes, pciAddress:$pciAddress, totalVramMiB:$totalVramMiB, profileCountLimit:null, status:$status, allocation:$allocation}]')
     done
 
     # Every step above rebuilds $output through jq, so a single failed jq call


### PR DESCRIPTION
The hex half of bigstack-oss/cubecos#1424. Pairs with
bigstack-oss/cube-cos-api#654, which consumes what this records.

A `pgpu` is bound to vfio-pci and invisible to `nvidia-smi`, so `gpu_device_list`
had no framebuffer to report for it. The Web UI draws that as a capacity of `0`,
and its Edit GPU Resource screen then refuses to let the operator switch the card
to a vGPU type — the profile/count control has nothing to size itself against.

## Why it has to be recorded rather than computed

Nothing readable under a vfio binding yields the number. All three measured on
cn13 (RTX PRO 6000 Blackwell):

| candidate source | what it gives | verdict |
|---|---|---|
| driver's `vgpuConfig.xml` | per-vGPU-type `framebuffer` only, no card total | ✗ |
| largest vGPU profile | `98304 MiB` — the nominal size | ✗ see below |
| PCI BAR2 (sysfs, readable under vfio) | `131072 MiB` — an address aperture | ✗ |

The second one deserves care, because it looks usable. `nvidia-smi` reports
**97887 MiB** for that card — 417 MiB less than the nominal 98304, after ECC and
other reservations. `ValidateVgpuProfiles` checks the request against
`nvidia-smi`'s number. So handing the UI 98304 would let an operator pick
`DC-96Q ×1` and have `gpu_resource_set` reject it — worse than showing 0,
because the failure arrives after the card has been torn down.

## What this does

`gpu_resource_set` captures the framebuffer **after** `gpu_unset_current_type`
has returned the card to the nvidia driver and **before** the pgpu path binds it
to vfio-pci — the last moment the value is readable — and writes it into
`config.json` next to the type. `gpu_device_list` then reports the measured value
for a card `nvidia-smi` can see, and the recorded one for a card it cannot.

`config.json` gains one field:

```jsonc
{"id":"GPU-…","name":"…","type":"pgpu","pciAddress":"00000001:C8:00.0",
 "totalVramMiB":97887,"profiles":null}
```

## Known limits

The recorded value is a **snapshot**, and the field is `null` when it could not
be read — including for a card that was **already `pgpu` before this change**,
until its next resource change. Consumers must treat `null` as "not known",
which is what cube-cos-api#654 does.

## Verification (cn13)

- Switching `00000001:C8:00.0` to `pgpu` recorded `{"type":"pgpu","totalVramMiB":97887}`
- With the card then confirmed invisible to `nvidia-smi`, `gpu_device_list`
  reported `totalVramMiB=97887`, where the previous build reported `null` —
  same node, same card, A/B against the stock binary
- Every visible card's value matches `nvidia-smi --query-gpu=memory.total` byte
  for byte (four cards, all `97887`)
- The card was switched back to its original `sriovVgpu` carve afterwards and
  the node's binaries rolled back to stock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
