### PR TITLE
fix(ceph): five device tier defects from the #840 pre-delivery audit

### DIFF
--- a/core/modules/cli_ceph.cpp
+++ b/core/modules/cli_ceph.cpp
@@ -1228,6 +1228,20 @@ CephDeviceTierNameOk(const std::string& tier)
         return false;
     }
 
+    // The built-in backend and the built-in volume type, spelled out rather
+    // than taken from BUILTIN_STORAGE_BACKEND (config_cinder.cpp:87) and
+    // BUILTIN_VOLUME_TYPE (constant.hpp), neither of which this module has.
+    // config_cinder.cpp refuses these two as well, but only while generating
+    // backends -- by which point the class, the rule, the pool and the volume
+    // type exist under that name. "CubeStorage" is caught today only as a side
+    // effect of an object by that name already existing, which is not the same
+    // as refusing it, and "ceph" is caught by nothing until it is too late.
+    if (tier == "ceph" || tier == "CubeStorage") {
+        CliPrintf("Invalid device tier name '%s': it is reserved by the built-in storage backend.",
+            tier.c_str());
+        return false;
+    }
+
     return true;
 }
 

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -3990,6 +3990,17 @@ _ceph_device_tier_name_ok()
         echo "Error: device tier name $tier must not contain '-pool' or '-ssd'" >&2
         return 1
     fi
+    # The built-in backend and the built-in volume type, by name. config_cinder.cpp
+    # knows they are reserved (BUILTIN_STORAGE_BACKEND at :87, BUILTIN_VOLUME_TYPE
+    # from constant.hpp) but only refuses the registry entry, while generating
+    # backends -- which is after the class, the rule, the pool and the volume type
+    # have all been created under that name. A tier called "ceph" got built, took a
+    # volume type whose volume_backend_name resolves to the built-in backend, and
+    # reported success while its volumes went to cinder-volumes.
+    if [ "$tier" = "ceph" ] || [ "$tier" = "CubeStorage" ] ; then
+        echo "Error: device tier name $tier is reserved by the built-in storage backend" >&2
+        return 1
+    fi
     return 0
 }
 

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4830,18 +4830,49 @@ ceph_device_tier_list()
     local registry= registry_ok=0
     registry=$(_ceph_device_tier_registry) || registry_ok=1
 
+    # The four lists this table is built from, read once and checked once. The
+    # rule the queries further down this file follow applies here too: a list
+    # that could not be read is unknown, never empty. Reading them inside
+    # `for tier in $(... | jq ...)` threw the status away, and an enumeration
+    # that comes back empty because the mons were mid-election prints every
+    # registered tier as "registered-but-absent" -- which reads as "your tiers
+    # are gone" and sends the operator to rebuild what is already there.
+    local classes= class_names= rules= pools= vtypes=
+    classes=$($CEPH osd crush class ls 2>/dev/null) || {
+        echo "Error: cannot read the device class list; not listing device tiers" >&2
+        return 1
+    }
+    class_names=$(echo "$classes" | jq -r '.[]' 2>/dev/null) || {
+        echo "Error: cannot parse the device class list; not listing device tiers" >&2
+        return 1
+    }
+    rules=$($CEPH osd crush rule ls 2>/dev/null) || {
+        echo "Error: cannot read the CRUSH rule list; not listing device tiers" >&2
+        return 1
+    }
+    pools=$($CEPH osd pool ls 2>/dev/null) || {
+        echo "Error: cannot read the pool list; not listing device tiers" >&2
+        return 1
+    }
+    # A volume type list that cannot be read would put "no" in the VTYPE column
+    # of every row, which is the same false negative one column over.
+    vtypes=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) || {
+        echo "Error: cannot read the volume type list; not listing device tiers" >&2
+        return 1
+    }
+
     printf "%-16s %-8s %-6s %-11s %-10s %-6s %-6s %s\n" \
         DEVICE_TIER OSD HOSTS POOL_SZ/MIN POOL_RULE VTYPE REGIST NOTE
     local tier= osds= hosts= size= min_size= prule= vtype= reg= note= seen=
-    for tier in $($CEPH osd crush class ls 2>/dev/null | jq -r '.[]') ; do
-        _ceph_device_tier_has_rule $tier || continue
-        _ceph_device_tier_has_pool $tier || continue
+    for tier in $class_names ; do
+        printf '%s\n' "$rules" | grep -qxF -- "$tier" || continue
+        printf '%s\n' "$pools" | grep -qxF -- "$tier" || continue
         osds=$($CEPH osd crush class ls-osd $tier 2>/dev/null | tr '\n' ',' | sed 's/,$//')
         hosts=$(_ceph_device_tier_class_hosts $tier)
         size=$($CEPH osd pool get $tier size -f json 2>/dev/null | jq -r '.size | numbers')
         min_size=$($CEPH osd pool get $tier min_size -f json 2>/dev/null | jq -r '.min_size | numbers')
         prule=$($CEPH osd pool get $tier crush_rule -f json 2>/dev/null | jq -r .crush_rule)
-        _ceph_device_tier_has_vtype $tier && vtype=yes || vtype=no
+        printf '%s\n' "$vtypes" | grep -qxF -- "$tier" && vtype=yes || vtype=no
         note=
         [ "$prule" = "$tier" ] || note="$note pool-not-on-its-rule"
         [ "$vtype" = "yes" ] || note="$note no-volume-type"
@@ -4870,7 +4901,7 @@ ceph_device_tier_list()
     while IFS= read -r entry ; do
         [ -n "$entry" ] || continue
         printf '%s' "$seen" | grep -qxF -- "$entry" && continue
-        _ceph_device_tier_has_vtype "$entry" && vtype=yes || vtype=no
+        printf '%s\n' "$vtypes" | grep -qxF -- "$entry" && vtype=yes || vtype=no
         printf "%-16s %-8s %-6s %-11s %-10s %-6s %-6s %s\n" \
             "$entry" "-" "-" "-/-" "-" "$vtype" yes "registered-but-absent"
     done <<< "$registry"

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4243,6 +4243,27 @@ _ceph_device_tier_registry_del()
     $HEX_SDK cinder_apply_storage_tier_deletion "$1"
 }
 
+# Delete takes the registry entry out first, on purpose: while a backend is
+# still in enabled_backends its cinder-volume service keeps accepting volumes
+# into a store that is about to go, and a volume left mid-delete cannot be
+# cleaned up afterwards. The cost of that order is that every later failure
+# leaves Ceph objects with no registered owner -- and ownership is decided from
+# the registry, so the CLI then refuses to finish the job it started. Put the
+# entry back, so the operator can fix the underlying problem and retry.
+_ceph_device_tier_registry_restore()
+{
+    local tier=$1
+    if _ceph_device_tier_registry_add "$tier" ; then
+        echo "       Its registry entry has been put back; fix the above and run" >&2
+        echo "       'tier delete $tier' again." >&2
+        return 0
+    fi
+    echo "       WARNING: its registry entry could not be put back either, so this" >&2
+    echo "       device tier is now unowned. Re-register it with" >&2
+    echo "       'hex_sdk cinder_apply_storage_tier_creation $tier' before retrying." >&2
+    return 1
+}
+
 # undo only what this create actually made. $2 is a word list out of
 # "class rule pool vtype"; $3 is "<id>:<previous class>" pairs.
 _ceph_device_tier_unwind_create()
@@ -4733,7 +4754,9 @@ ceph_device_tier_delete()
         done
         if [ $gone -ne 0 ] ; then
             echo "Error: volume type $tier was not confirmed deleted -- still listed, or" >&2
-            echo "       the list stopped being readable; leaving device tier $tier in place" >&2
+            echo "       the list stopped being readable; the pool and CRUSH rule are" >&2
+            echo "       left alone." >&2
+            _ceph_device_tier_registry_restore "$tier"
             return 1
         fi
     fi
@@ -4743,11 +4766,13 @@ ceph_device_tier_delete()
         Quiet -n $CEPH osd pool delete $tier $tier --yes-i-really-really-mean-it
         if ! pools=$($CEPH osd pool ls 2>/dev/null) ; then
             echo "Error: cannot confirm pool $tier was deleted; leaving its rule and" >&2
-            echo "       OSD classes alone" >&2
+            echo "       OSD classes alone." >&2
+            _ceph_device_tier_registry_restore "$tier"
             return 1
         fi
         if echo "$pools" | grep -qx "$tier" ; then
-            echo "Error: pool $tier was not deleted; leaving its rule and OSD classes alone" >&2
+            echo "Error: pool $tier was not deleted; leaving its rule and OSD classes alone." >&2
+            _ceph_device_tier_registry_restore "$tier"
             return 1
         fi
     fi

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4013,10 +4013,15 @@ _ceph_device_tier_osd_ids()
     done
 }
 
+# Non-zero when the class could not be read, so that "no class" and "could not
+# ask" stay apart. The create path saves this value to put back if it has to
+# unwind: an empty answer that really means "the read failed" is how an OSD
+# ends up with no class at all after a rollback that was supposed to restore it.
 _ceph_device_tier_class_of_osd()
 {
-    $CEPH osd tree -f json 2>/dev/null \
-        | jq -r --argjson id "${1#osd.}" '.nodes[] | select(.id == $id) | .device_class // empty'
+    local tree=
+    tree=$($CEPH osd tree -f json 2>/dev/null) || return 1
+    echo "$tree" | jq -r --argjson id "${1#osd.}" '.nodes[] | select(.id == $id) | .device_class // empty' 2>/dev/null || return 1
 }
 
 # how many distinct hosts carry an OSD of this device class
@@ -4261,6 +4266,9 @@ _ceph_device_tier_unwind_create()
             id=${pair%%:*}
             cls=${pair#*:}
             Quiet -n $CEPH osd crush rm-device-class osd.$id
+            # Empty here means the OSD genuinely had no class: create refuses to
+            # touch an OSD whose class it could not read, so no entry is ever
+            # recorded for one.
             if [ -n "$cls" ] ; then
                 Quiet -n $CEPH osd crush set-device-class $cls osd.$id
             fi
@@ -4316,7 +4324,12 @@ ceph_device_tier_create()
     #    set-device-class on an OSD that already has one fails with EBUSY.
     #    Create only ever adds; taking an OSD out of a tier is ceph_device_tier_update.
     for i in $ids ; do
-        cls=$(_ceph_device_tier_class_of_osd $i)
+        if ! cls=$(_ceph_device_tier_class_of_osd $i) ; then
+            echo "Error: cannot read the current device class of osd.$i;" >&2
+            echo "       not changing it, because it could not be put back" >&2
+            _ceph_device_tier_unwind_create "$tier" "$made" "$saved"
+            return 1
+        fi
         [ "$cls" = "$tier" ] && continue
         saved="$saved $i:$cls"
         made="$made class"
@@ -4489,7 +4502,7 @@ ceph_device_tier_update()
     local moved=
     local cls=
     for i in $add ; do
-        cls=$(_ceph_device_tier_class_of_osd $i)
+        cls=$(_ceph_device_tier_class_of_osd $i) || cls="(unknown)"
         if ! $CEPH osd crush rm-device-class osd.$i >/dev/null 2>&1 || \
            ! $CEPH osd crush set-device-class $tier osd.$i >/dev/null 2>&1 ; then
             failed="$failed osd.$i"

--- a/core/sdk_sh/modules/sdk_ceph.sh
+++ b/core/sdk_sh/modules/sdk_ceph.sh
@@ -4250,15 +4250,40 @@ _ceph_device_tier_unwind_create()
     local tier=$1
     local made=$2
     local saved=$3
+    local left=
     echo "Error: device tier $tier was not completed; unwinding what this run created" >&2
     if echo "$made" | grep -qw vtype ; then
         Quiet -n $OPENSTACK volume type delete $tier
+        local vtypes=
+        if vtypes=$($OPENSTACK volume type list --long --format value -c Name 2>/dev/null) ; then
+            printf '%s\n' "$vtypes" | grep -qxF -- "$tier" && left="$left
+  volume type $tier    openstack volume type delete $tier"
+        else
+            left="$left
+  volume type $tier (could not be confirmed removed)"
+        fi
     fi
     if echo "$made" | grep -qw pool ; then
         Quiet -n $CEPH osd pool delete $tier $tier --yes-i-really-really-mean-it
+        local pools=
+        if pools=$($CEPH osd pool ls 2>/dev/null) ; then
+            printf '%s\n' "$pools" | grep -qxF -- "$tier" && left="$left
+  pool $tier           ceph osd pool delete $tier $tier --yes-i-really-really-mean-it"
+        else
+            left="$left
+  pool $tier (could not be confirmed removed)"
+        fi
     fi
     if echo "$made" | grep -qw rule ; then
         Quiet -n $CEPH osd crush rule rm $tier
+        local rules=
+        if rules=$($CEPH osd crush rule ls 2>/dev/null) ; then
+            printf '%s\n' "$rules" | grep -qxF -- "$tier" && left="$left
+  CRUSH rule $tier     ceph osd crush rule rm $tier"
+        else
+            left="$left
+  CRUSH rule $tier (could not be confirmed removed)"
+        fi
     fi
     if echo "$made" | grep -qw class ; then
         local id= cls=
@@ -4274,6 +4299,21 @@ _ceph_device_tier_unwind_create()
             fi
         done
     fi
+
+    # A rollback that could not roll back has to say so. Everything above runs
+    # through `Quiet -n`, which returns 0 whatever happened, so the only honest
+    # signal is a readback -- and a leftover rule and pool with no registry
+    # entry behind them are reported by nothing else: ceph_device_tier_names
+    # only calls a name unmanaged when all three of class, rule and pool are
+    # present, and the class has just been stripped. The operator would next
+    # meet this as "the name is already taken by a CRUSH rule" on their retry.
+    if [ -n "$left" ] ; then
+        echo "Error: the unwind did not remove everything. Still present:" >&2
+        echo "$left" >&2
+        echo "       Remove them before creating device tier $tier again." >&2
+        return 1
+    fi
+    return 0
 }
 
 # params:

--- a/core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_failure_paths.sh
@@ -26,6 +26,7 @@ SRC="$DIR/../modules/sdk_ceph.sh"
 for f in ceph_device_tier_delete ceph_device_tier_update \
          _ceph_device_tier_has_rule _ceph_device_tier_has_class \
          _ceph_device_tier_rule_state _ceph_device_tier_registry_del \
+         _ceph_device_tier_registry_add _ceph_device_tier_registry_restore \
          _ceph_device_tier_rule_users _ceph_device_tier_class_of_osd ; do
     eval "$(awk -v n="^$f\\\\(\\\\)" '$0 ~ n {f=1} f{print} f&&/^}/{exit}' "$SRC")"
     [ "$(type -t "$f")" = function ] || { echo "FAIL: $f not extracted"; exit 1; }
@@ -151,6 +152,9 @@ fake_openstack() {
             # $4, not ${*##* }: on "$*" the ## operator applies to each
             # positional parameter, so it hands back the whole command line
             echo "vtype_del $4" >> "$TMP/calls"
+            # VTYPE_DEL_STICKS=1 models the case the delete path is written for:
+            # the command is accepted and the type is still listed afterwards.
+            [ "${VTYPE_DEL_STICKS:-0}" = 0 ] || return 0
             grep -vx "$4" "$TMP/vtypes" > "$TMP/x"; mv "$TMP/x" "$TMP/vtypes" ;;
         *'volume type list'*) cat "$TMP/vtypes" ;;
         *'volume list'*)      echo '[]' ;;
@@ -183,6 +187,7 @@ HEX_SDK=fake_sdk
 pass=0 fail=0
 ck() { [ "$1" = "$2" ] && pass=$((pass+1)) || { fail=$((fail+1)); echo "FAIL: $3 -> got '$1' want '$2'"; }; }
 ckhas() { case "$1" in *"$2"*) pass=$((pass+1));; *) fail=$((fail+1)); echo "FAIL: $3 -> output lacks '$2'";; esac; }
+cklacks() { case "$1" in *"$2"*) fail=$((fail+1)); echo "FAIL: $3 -> output should not contain '$2'";; *) pass=$((pass+1));; esac; }
 
 # ==== R6 =================================================================
 
@@ -413,6 +418,38 @@ ck "$RC" 1 "8c an in-use volume type is still refused"
 ckhas "$OUT" "still in use" "8c keeps the pre-existing reason"
 ck "$(grep -c registry_del "$TMP/calls")" 0 "8c the registry was not touched"
 ck "$(grep -cx gold "$TMP/registry")" 1 "8c the registry entry survives"
+
+# ---- 8d. a delete that fails after deregistering puts the entry back ----
+# The registry entry goes first on purpose (8a) -- a backend still in
+# enabled_backends keeps accepting volumes into a store that is about to go.
+# The cost was that any later failure left the Ceph objects with no registered
+# owner, and ownership is decided from the registry, so the CLI then refused to
+# finish the job it had started: "This CLI does not manage objects it did not
+# register." The operator had to re-register by hand before they could retry.
+reset_cluster
+VTYPE_DEL_STICKS=1
+fake_sdk() {
+    case "$1" in
+        cinder_is_volume_type_in_use) return 1 ;;
+        cinder_apply_storage_tier_deletion)
+            echo "registry_del $2" >> "$TMP/calls"
+            grep -vx "$2" "$TMP/registry" > "$TMP/x" 2>/dev/null; mv "$TMP/x" "$TMP/registry"
+            return 0 ;;
+        cinder_apply_storage_tier_creation)
+            echo "registry_add $2" >> "$TMP/calls"
+            echo "$2" >> "$TMP/registry"
+            return 0 ;;
+    esac
+    return 1
+}
+OUT=$(ceph_device_tier_delete gold 2>&1); RC=$?
+ck "$RC" 1 "8d a volume type that will not go still fails the delete"
+ck "$(grep -c 'registry_add gold' "$TMP/calls")" 1 "8d the registry entry is put back"
+ck "$(grep -cx gold "$TMP/registry")" 1 "8d so the tier is owned again"
+ckhas "$OUT" "put back" "8d and the operator is told it can retry"
+cklacks "$OUT" "leaving device tier gold in place" "8d drops the claim that nothing changed"
+ck "$(grep -cx gold "$TMP/pools")" 1 "8d the pool was left alone"
+VTYPE_DEL_STICKS=0
 
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ] && { echo "OK: device tier delete/update failure reporting"; exit 0; } || exit 1

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -325,6 +325,39 @@ OUT=$(ceph_device_tier_list 2>&1)
 ck "$(echo "$OUT" | grep -c 'registered-but-absent')" 0 "2d the placeholder is not a missing tier"
 ck "$(echo "$OUT" | awk '$1 == "gold" { print $7 }')" "no" "2d and gold is genuinely unregistered"
 
+# ---- 2e. a list that cannot be read is unknown, not empty ----
+# `for tier in $(ceph osd crush class ls | jq ...)` threw the command's status
+# away, so a mon election emptied the enumeration and every registered tier was
+# reported "registered-but-absent" with rc 0 -- "your tiers are gone" to the
+# operator, when nothing had happened to them.
+reset_cluster
+DEAD_PAT='^osd crush class ls$'
+OUT=$(ceph_device_tier_list 2>&1) ; RC=$?
+ck "$RC" 1 "2e an unreadable class list refuses to list"
+ckhas "$OUT" "cannot read the device class list" "2e says which list"
+cklacks "$OUT" "registered-but-absent" "2e does not report live tiers as gone"
+
+reset_cluster
+DEAD_PAT='^osd crush rule ls$'
+OUT=$(ceph_device_tier_list 2>&1) ; RC=$?
+ck "$RC" 1 "2f an unreadable rule list refuses to list"
+cklacks "$OUT" "registered-but-absent" "2f invents no absent tiers either"
+
+reset_cluster
+DEAD_PAT='^osd pool ls$'
+OUT=$(ceph_device_tier_list 2>&1) ; RC=$?
+ck "$RC" 1 "2g an unreadable pool list refuses to list"
+
+# ---- 2h. the same rule one column over ----
+# An unreadable volume type list used to put "no" in VTYPE against every tier,
+# which is the identical false negative: the operator goes and recreates a
+# volume type that is already there.
+reset_cluster
+OS_DEAD=1
+OUT=$(ceph_device_tier_list 2>&1) ; RC=$?
+ck "$RC" 1 "2h an unreadable volume type list refuses to list"
+cklacks "$OUT" "no-volume-type" "2h does not claim the volume type is missing"
+
 # ==== the four queries the CLI validates against =========================
 #
 # Every one of these returns non-zero rather than an empty answer when it

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -317,6 +317,22 @@ ckhas "$OUT" "pool silver" "1g and names what is still there"
 ck "$(grep -cx silver "$TMP/pools")" 1 "1g the pool really is still there"
 ck "$(awk -F: '$1 == "0" { print $2 }' "$TMP/classes")" "hdd" "1g but the OSD classes were restored"
 
+# ---- 1h. the two reserved names are refused before anything is built ----
+# config_cinder.cpp refuses these while generating backends, which is one stage
+# too late: the class, the rule, the pool and the volume type all get created
+# first, and the volume type named "ceph" then resolves to the built-in backend
+# whose rbd_pool is cinder-volumes -- so the command reported success while the
+# tier it claimed to have built could never receive a volume.
+for reserved in ceph CubeStorage ; do
+    reset_cluster
+    OUT=$(ceph_device_tier_create $reserved 0 2>&1) ; RC=$?
+    ck "$RC" 1 "1h $reserved is refused"
+    ckhas "$OUT" "reserved" "1h $reserved says why"
+    ck "$(grep -cx "$reserved" "$TMP/rules")" 0 "1h $reserved built no rule"
+    ck "$(grep -c registry_add "$TMP/calls")" 0 "1h $reserved touched no registry"
+    ck "$(awk -F: -v c="$reserved" '$2 == c' "$TMP/classes" | wc -l | tr -d ' ')" 0 "1h $reserved reclassed no OSD"
+done
+
 # ==== ceph_device_tier_list: the two disagreements =======================
 
 # ---- 2a. a tier on Ceph that is not registered ----

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -301,6 +301,22 @@ ck "$(awk -F: '$1 == "0" { print $2 }' "$TMP/classes")" "hdd" "1f osd.0 still ha
 ck "$(awk -F: '$2 == "silver"' "$TMP/classes" | wc -l | tr -d ' ')" 0 "1f and nothing was reclassed"
 ck "$(grep -c registry_add "$TMP/calls")" 0 "1f the registry was never touched"
 
+# ---- 1g. an unwind that could not undo says what is left ----
+# Every step of the unwind runs through `Quiet -n`, which returns 0 whatever
+# happened, and nothing read back. A create that failed at the crush_rule bind
+# on a cluster where pool deletion is refused left a pool behind and reported
+# only "was not completed" -- and a leftover rule+pool with the class already
+# stripped is reported by nothing else, because ceph_device_tier_names calls a
+# name unmanaged only when all three objects are present.
+reset_cluster
+DEAD_PAT='osd pool set .* crush_rule|osd pool delete'
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 1 "1g the create still fails"
+ckhas "$OUT" "unwind did not remove everything" "1g the unwind admits it did not finish"
+ckhas "$OUT" "pool silver" "1g and names what is still there"
+ck "$(grep -cx silver "$TMP/pools")" 1 "1g the pool really is still there"
+ck "$(awk -F: '$1 == "0" { print $2 }' "$TMP/classes")" "hdd" "1g but the OSD classes were restored"
+
 # ==== ceph_device_tier_list: the two disagreements =======================
 
 # ---- 2a. a tier on Ceph that is not registered ----

--- a/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
+++ b/core/sdk_sh/tests/test_ceph_device_tier_registry.sh
@@ -284,6 +284,22 @@ ck "$RC" 1 "1e a failed rule create returns non-zero"
 ck "$(grep -c registry_add "$TMP/calls")" 0 "1e the registry was never touched"
 ckhas "$OUT" "unwinding" "1e the earlier steps were unwound"
 ck "$(awk -F: '$2 == "silver"' "$TMP/classes" | wc -l | tr -d ' ')" 0 "1e no OSD kept the class"
+ck "$(awk -F: '$1 == "0" { print $2 }' "$TMP/classes")" "hdd" "1e osd.0 got its own class back"
+
+# ---- 1f. an OSD whose current class cannot be read is not touched ----
+# `ceph osd tree` failing used to be indistinguishable from "this OSD has no
+# class": the pipeline's status was jq's, and `// empty` prints nothing either
+# way. Create saved "0:" as the class to restore, so when a later step failed
+# the unwind stripped the new class and put nothing back -- osd.0 came out of a
+# rolled-back create with no class at all, having had hdd before it started.
+reset_cluster
+DEAD_PAT='^osd tree -f json$|rule create-replicated'
+OUT=$(ceph_device_tier_create silver 0 1 2>&1) ; RC=$?
+ck "$RC" 1 "1f an unreadable device class refuses the create"
+ckhas "$OUT" "cannot read the current device class" "1f says why"
+ck "$(awk -F: '$1 == "0" { print $2 }' "$TMP/classes")" "hdd" "1f osd.0 still has the class it started with"
+ck "$(awk -F: '$2 == "silver"' "$TMP/classes" | wc -l | tr -d ' ')" 0 "1f and nothing was reclassed"
+ck "$(grep -c registry_add "$TMP/calls")" 0 "1f the registry was never touched"
 
 # ==== ceph_device_tier_list: the two disagreements =======================
 


### PR DESCRIPTION
## Which issue(s) does this PR fix?

Fixes #1472
Fixes #1473
Fixes #1474
Fixes #1475
Fixes #1476

All five came out of a pre-delivery audit of #840 / #1335 after #1458 merged — four of them from
an independent Codex review of the merged change set, one found while checking the ticket's QA
section against the code.

## What this changes

Five independent fixes to the device tier paths added by #1451 / #1458. One commit each; every
commit stands alone.

| Commit | Issue | What |
|---|---|---|
| `read the lists tier list is built from once, and check them` | #1476 | `ceph_device_tier_list` enumerated with `for tier in $(ceph … \| jq …)`, which discards the command's status. A failed class list emptied the enumeration and every registered tier was printed `registered-but-absent`, rc 0 |
| `do not touch an OSD whose current device class could not be read` | #1473 | `_ceph_device_tier_class_of_osd` returned jq's status and `// empty`, so a failed `osd tree` was indistinguishable from "no class". Create saved `<id>:` and the unwind then stripped the new class without restoring the old one — an OSD went into a failed create with `hdd` and came out with nothing |
| `report what the device tier create unwind could not remove` | #1474 | Every unwind step ran through `Quiet -n` with no readback. A refused `osd pool delete` (default `mon_allow_pool_delete=false`) left a pool behind and said only "was not completed" |
| `put the registry entry back when a device tier delete cannot finish` | #1475 | Delete deregisters first — correctly — but neither later failure path restored the entry, so the tier fell outside the CLI's ownership and a retry was refused. The message also claimed the tier was "left in place" when it was no longer registered |
| `refuse the two reserved device tier names before anything is built` | #1472 | `tier create ceph <osd>` was accepted, built all four objects and reported success; `config_cinder.cpp` then dropped the registry entry, so the volume type resolved to the built-in backend and its volumes went to `cinder-volumes` |

Three of the five (#1472, #1473, #1476) are the same family as the four rounds of review fixes on
#840: **a failed query treated as a definite negative answer**. The other two are its mirror: a
failure path that can itself fail, and does not say so.

## Testing

Offline regression, `core/sdk_sh/tests/`, on this branch:

```
test_ceph_device_tier_registry.sh          PASS=150 FAIL=0   (was 121)
test_ceph_device_tier_failure_paths.sh     PASS=76  FAIL=0   (was 70)
test_ceph_cache_switch_device_tier.sh      PASS=33  FAIL=0
test_cinder_storage_tier_registry.sh       PASS=42  FAIL=0
                                           ---------------
                                           301 assertions, 0 failures   (was 266)
```

Every new assertion was run against its parent commit and fails there:

| New cases | Against the parent |
|---|---|
| 1f (unreadable device class) | `osd.0`'s class reads back **empty** — the defect itself |
| 1g (unwind could not remove) | no "unwind did not remove everything"; the pool is silently left |
| 1h (reserved names, ×2) | both names build a rule, reclass an OSD and reach the registry |
| 2e–2h (unreadable lists) | 8 failures; live tiers printed `registered-but-absent`, rc 0 |
| 8d (delete deregistered then failed) | the registry file comes back without the tier in it |

For 8d and 1h the parent needed a no-op stub for the new helper so the same suite could extract
it; the behaviour under test is the parent's.

**Not verified here:** the `cli_ceph.cpp` change is not compiled — this is an x86 product and the
change was written on arm64, per team policy. It is a self-contained `if` in
`CephDeviceTierNameOk` copying the shape of the three checks above it; brace balance is unchanged
against `develop`. The SDK half of the same fix is covered by assertion 1h, and the two layers
are independent — a direct `hex_sdk ceph_device_tier_create ceph 0` is refused by the SDK check
alone.

No hardware run: none of these paths can be reached on demand on a healthy cluster (they need a
Ceph query to fail mid-command, or a pool deletion to be refused), which is why they are covered
by the offline suites instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
